### PR TITLE
Fix GJ step-doubling bootstrap: use cycle_dyndt instead of raw dt

### DIFF
--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -225,36 +225,58 @@ impl GaussJacksonState {
     /// - Priming: 4 calls per step (staged RK4)
     /// - BootstrapEdit: 1 call per edit point (time_scale=0, no time advance)
     /// - BootstrapStep/Operational: 2 calls per step (predict, correct)
+    ///
+    /// # Arguments
+    /// - `sim_dt`: simulation timestep (JEOD: `sim_dt` passed to integration controls)
+    /// - `time_scale_factor`: ratio of dynamic time to simulation time
+    ///   (JEOD: `TimeDyn::scale_factor`, read via `TimeInterface::get_time_scale_factor()`).
+    ///   1.0 for real-time, >1.0 for fast-forward.
+    /// - `acc`: acceleration at current `state.position`
+    /// - `state`: translational state (mutated in place)
     pub fn integrate(
         &mut self,
-        dt: f64,
+        sim_dt: f64,
+        time_scale_factor: f64,
         acc: DVec3,
         state: &mut TranslationalState,
     ) -> IntegratorResult {
         self.current_stage += 1;
         let stage = self.current_stage;
 
+        // JEOD dt variables (gauss_jackson_integration_controls.cc:144-149):
+        //   cycle_simdt = sim_dt * cycle_scale
+        //   cycle_dyndt = cycle_simdt * time_scale_factor
+        // cycle_scale may change during start_cycle (via downsample), so we
+        // compute cycle_dyndt after start_cycle for stage-1 paths. For
+        // operational fast-path and primer stages 2-4, cycle_scale is stable.
+        let cycle_dyndt = sim_dt * self.state_machine.cycle_scale() * time_scale_factor;
+
         // ── Operational fast path ──
         if self.fsm_state == FsmState::Operational {
-            return self.integrate_operational(dt, stage, acc, state);
+            return self.integrate_operational(cycle_dyndt, stage, acc, state);
         }
 
         // ── Priming: stages 2-4 of RK4 (stage 1 handled after start_cycle) ──
         if self.fsm_state == FsmState::Priming && stage > 1 {
-            return self.primer_step(dt, stage, acc, state);
+            return self.primer_step(cycle_dyndt, stage, acc, state);
         }
 
         // ── Start of cycle (stage 1 for all non-operational states) ──
-        if stage == 1 {
-            self.start_cycle(dt, acc, state);
-            // FSM may have transitioned in start_cycle.
-        }
+        // start_cycle may trigger a downsample which changes cycle_scale,
+        // so we must recompute cycle_dyndt afterwards.
+        let cycle_dyndt = if stage == 1 {
+            self.start_cycle(cycle_dyndt, acc, state);
+            // Recompute: cycle_scale may have changed via downsample.
+            sim_dt * self.state_machine.cycle_scale() * time_scale_factor
+        } else {
+            cycle_dyndt
+        };
 
         // ── Dispatch based on FSM state after start_cycle ──
         match self.fsm_state {
             FsmState::Priming => {
                 // Stage 1 of RK4 primer.
-                self.primer_step(dt, 1, acc, state)
+                self.primer_step(cycle_dyndt, 1, acc, state)
             }
 
             FsmState::BootstrapEdit => {
@@ -266,7 +288,7 @@ impl GaussJacksonState {
                 //
                 // JEOD: if edit fails convergence, set_bootstrap_edit_redo_needed()
                 // triggers a redo on the next FSM transition.
-                let passed = self.edit_point(dt, state);
+                let passed = self.edit_point(cycle_dyndt, state);
                 if !passed {
                     self.state_machine.set_bootstrap_edit_redo_needed();
                 }
@@ -276,12 +298,12 @@ impl GaussJacksonState {
 
             FsmState::BootstrapStep => {
                 // Predict/correct using GJ at current (possibly reduced) order.
-                self.integrate_bootstrap_step(dt, stage, acc, state)
+                self.integrate_bootstrap_step(cycle_dyndt, stage, acc, state)
             }
 
             FsmState::Operational => {
                 // Just transitioned to operational (first step after bootstrap).
-                self.integrate_operational(dt, stage, acc, state)
+                self.integrate_operational(cycle_dyndt, stage, acc, state)
             }
 
             FsmState::Reset => {
@@ -293,7 +315,7 @@ impl GaussJacksonState {
     /// Operational mode: predict (stage 1) then correct (stage 2).
     fn integrate_operational(
         &mut self,
-        dt: f64,
+        cycle_dyndt: f64,
         stage: usize,
         acc: DVec3,
         state: &mut TranslationalState,
@@ -304,7 +326,7 @@ impl GaussJacksonState {
         }
 
         let passed = self.integrate_gj(
-            dt,
+            cycle_dyndt,
             stage,
             self.order as isize,
             self.order as isize,
@@ -317,7 +339,13 @@ impl GaussJacksonState {
             IntegratorResult::more_stages()
         } else {
             self.current_stage = 0;
-            IntegratorResult::complete(passed)
+            // Operational mode always has at_end_of_tour=true (scale_factor=1),
+            // but check for consistency with bootstrap paths.
+            if self.state_machine.at_end_of_tour() {
+                IntegratorResult::complete(passed)
+            } else {
+                IntegratorResult::more_stages()
+            }
         }
     }
 
@@ -325,7 +353,7 @@ impl GaussJacksonState {
     /// Note: start_cycle has already been called for stage 1 by integrate().
     fn integrate_bootstrap_step(
         &mut self,
-        dt: f64,
+        cycle_dyndt: f64,
         stage: usize,
         acc: DVec3,
         state: &mut TranslationalState,
@@ -333,13 +361,25 @@ impl GaussJacksonState {
         let hist_len = self.history_length as isize;
         let offset = (hist_len - (self.order as isize + 1)) as usize;
 
-        let passed = self.integrate_gj(dt, stage, hist_len - 1, hist_len, acc, Some(offset), state);
+        let passed = self.integrate_gj(
+            cycle_dyndt,
+            stage,
+            hist_len - 1,
+            hist_len,
+            acc,
+            Some(offset),
+            state,
+        );
 
         if stage == 1 {
             IntegratorResult::more_stages()
         } else {
             self.current_stage = 0;
-            IntegratorResult::complete(passed)
+            if self.state_machine.at_end_of_tour() {
+                IntegratorResult::complete(passed)
+            } else {
+                IntegratorResult::more_stages()
+            }
         }
     }
 
@@ -622,11 +662,12 @@ impl GaussJacksonState {
 
     /// One stage of the RK4 primer.
     ///
-    /// Returns `more_stages()` for stages 1-3, `complete(true)` for stage 4.
+    /// Returns `more_stages()` for stages 1-3, `complete(true)` for stage 4
+    /// (or `more_stages()` if the tour is not yet complete during subcycling).
     /// Between calls, the caller must evaluate acceleration at `state.position`.
     fn primer_step(
         &mut self,
-        dt: f64,
+        cycle_dyndt: f64,
         target_stage: usize,
         acc: DVec3,
         state: &mut TranslationalState,
@@ -640,8 +681,8 @@ impl GaussJacksonState {
                 self.primer_k_pos[0] = state.velocity; // v_n
 
                 // Move state to midpoint 1 for next derivative eval
-                state.position = self.primer_base_pos + 0.5 * dt * self.primer_k_pos[0];
-                state.velocity = self.primer_base_vel + 0.5 * dt * self.primer_k_vel[0];
+                state.position = self.primer_base_pos + 0.5 * cycle_dyndt * self.primer_k_pos[0];
+                state.velocity = self.primer_base_vel + 0.5 * cycle_dyndt * self.primer_k_vel[0];
 
                 IntegratorResult::more_stages()
             }
@@ -651,8 +692,8 @@ impl GaussJacksonState {
                 self.primer_k_pos[1] = state.velocity;
 
                 // Move state to midpoint 2
-                state.position = self.primer_base_pos + 0.5 * dt * self.primer_k_pos[1];
-                state.velocity = self.primer_base_vel + 0.5 * dt * self.primer_k_vel[1];
+                state.position = self.primer_base_pos + 0.5 * cycle_dyndt * self.primer_k_pos[1];
+                state.velocity = self.primer_base_vel + 0.5 * cycle_dyndt * self.primer_k_vel[1];
 
                 IntegratorResult::more_stages()
             }
@@ -662,8 +703,8 @@ impl GaussJacksonState {
                 self.primer_k_pos[2] = state.velocity;
 
                 // Move state to endpoint
-                state.position = self.primer_base_pos + dt * self.primer_k_pos[2];
-                state.velocity = self.primer_base_vel + dt * self.primer_k_vel[2];
+                state.position = self.primer_base_pos + cycle_dyndt * self.primer_k_pos[2];
+                state.velocity = self.primer_base_vel + cycle_dyndt * self.primer_k_vel[2];
 
                 IntegratorResult::more_stages()
             }
@@ -674,14 +715,14 @@ impl GaussJacksonState {
 
                 // Combine: x_{n+1} = x_n + dt/6 * (k1 + 2*k2 + 2*k3 + k4)
                 state.velocity = self.primer_base_vel
-                    + (dt / 6.0)
+                    + (cycle_dyndt / 6.0)
                         * (self.primer_k_vel[0]
                             + 2.0 * self.primer_k_vel[1]
                             + 2.0 * self.primer_k_vel[2]
                             + self.primer_k_vel[3]);
 
                 state.position = self.primer_base_pos
-                    + (dt / 6.0)
+                    + (cycle_dyndt / 6.0)
                         * (self.primer_k_pos[0]
                             + 2.0 * self.primer_k_pos[1]
                             + 2.0 * self.primer_k_pos[2]
@@ -691,7 +732,11 @@ impl GaussJacksonState {
                 self.pos_hist.set_dvec3(self.history_length, state.position);
 
                 self.current_stage = 0; // Reset for next step
-                IntegratorResult::complete(true)
+                if self.state_machine.at_end_of_tour() {
+                    IntegratorResult::complete(true)
+                } else {
+                    IntegratorResult::more_stages()
+                }
             }
             _ => panic!("RK4 primer: invalid target_stage {target_stage} (expected 1-4)"),
         }
@@ -719,7 +764,7 @@ mod tests {
         for _ in 0..steps {
             loop {
                 let acc = -state.position;
-                let result = gj.integrate(dt, acc, &mut state);
+                let result = gj.integrate(dt, 1.0, acc, &mut state);
                 if result.time_scale > 0.0 {
                     break;
                 }
@@ -763,7 +808,7 @@ mod tests {
             loop {
                 let r = state.position.length();
                 let acc = -mu / (r * r * r) * state.position;
-                let result = gj.integrate(dt, acc, &mut state);
+                let result = gj.integrate(dt, 1.0, acc, &mut state);
                 if result.time_scale > 0.0 {
                     break;
                 }
@@ -798,7 +843,7 @@ mod tests {
 
         for _ in 0..20 {
             loop {
-                let result = gj.integrate(dt, DVec3::ZERO, &mut state);
+                let result = gj.integrate(dt, 1.0, DVec3::ZERO, &mut state);
                 if result.time_scale > 0.0 {
                     break;
                 }
@@ -834,7 +879,7 @@ mod tests {
         for _ in 0..steps {
             loop {
                 let acc = -state_gj.position;
-                let result = gj.integrate(dt, acc, &mut state_gj);
+                let result = gj.integrate(dt, 1.0, acc, &mut state_gj);
                 if result.time_scale > 0.0 {
                     break;
                 }
@@ -850,5 +895,137 @@ mod tests {
             err_gj < err_rk4,
             "GJ8 ({err_gj:.2e}) should be more accurate than RK4 ({err_rk4:.2e})"
         );
+    }
+
+    #[test]
+    fn gj_harmonic_oscillator_bootstrap() {
+        // Full bootstrap path: initial_order=4, final_order=12, ndoubling_steps=4.
+        // With ndoubling_steps=4, tour_count=16, so the bootstrap phase uses
+        // subcycled steps at dt/16, dt/8, dt/4, dt/2, then full dt.
+        // This exercises the cycle_dyndt scaling and at_end_of_tour gating.
+        let dt: f64 = 0.01;
+        let total_time = 10.0;
+        let steps = (total_time / dt).round() as usize;
+
+        let mut state = TranslationalState {
+            position: DVec3::new(1.0, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        };
+
+        let mut gj = GaussJacksonState::new(GaussJacksonConfig::default());
+
+        for _ in 0..steps {
+            loop {
+                let acc = -state.position;
+                let result = gj.integrate(dt, 1.0, acc, &mut state);
+                if result.time_scale > 0.0 {
+                    break;
+                }
+            }
+        }
+
+        let exact_pos = total_time.cos();
+        let exact_vel = -total_time.sin();
+        let pos_error = (state.position.x - exact_pos).abs();
+        let vel_error = (state.velocity.x - exact_vel).abs();
+
+        println!(
+            "GJ12 bootstrap harmonic oscillator: pos_err={pos_error:.2e}, vel_err={vel_error:.2e}"
+        );
+        // GJ12 with full bootstrap should be very accurate
+        assert!(
+            pos_error < 1e-10,
+            "GJ12 bootstrap position error {pos_error:.2e} exceeds 1e-10"
+        );
+        assert!(
+            vel_error < 1e-10,
+            "GJ12 bootstrap velocity error {vel_error:.2e} exceeds 1e-10"
+        );
+    }
+
+    #[test]
+    fn gj_kepler_orbit_standard() {
+        // GaussJacksonConfig::standard(): initial=8, final=12, ndoubling=2.
+        // Tests bootstrap with smaller ndoubling (tour_count=4).
+        let mu: f64 = 3.986_004_415e14;
+        let r0: f64 = 7_000_000.0;
+        let v0 = (mu / r0).sqrt();
+
+        let dt: f64 = 10.0;
+        let period = 2.0 * std::f64::consts::PI * (r0.powi(3) / mu).sqrt();
+        let steps = (period / dt).round() as usize;
+
+        let mut state = TranslationalState {
+            position: DVec3::new(r0, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v0, 0.0),
+        };
+
+        let mut gj = GaussJacksonState::new(GaussJacksonConfig::standard());
+
+        for _ in 0..steps {
+            loop {
+                let r = state.position.length();
+                let acc = -mu / (r * r * r) * state.position;
+                let result = gj.integrate(dt, 1.0, acc, &mut state);
+                if result.time_scale > 0.0 {
+                    break;
+                }
+            }
+        }
+
+        let pos_error = (state.position - DVec3::new(r0, 0.0, 0.0)).length();
+        println!("GJ standard Kepler orbit: pos_err={pos_error:.2e} m (1 period)");
+        // GJ12 with bootstrap should have smaller orbit closure error than GJ8 fixed.
+        assert!(
+            pos_error < 15_000.0,
+            "GJ standard orbit position error {pos_error:.2e} m exceeds 15 km"
+        );
+    }
+
+    #[test]
+    fn gj_cycle_scale_progression() {
+        // Verify that cycle_scale follows the expected doubling sequence
+        // during bootstrap.
+        use state_machine::StateMachine;
+
+        // ndoubling_steps=3, tour_count=8
+        let config = GaussJacksonConfig {
+            initial_order: 4,
+            final_order: 10,
+            ndoubling_steps: 3,
+            ..Default::default()
+        };
+        let sm = StateMachine::configure(&config);
+        assert!((sm.cycle_scale() - 1.0 / 8.0).abs() < 1e-15);
+
+        // Run through FSM until operational, recording cycle_scale at
+        // each downsample.
+        let mut sm = StateMachine::configure(&config);
+        let mut scales = vec![sm.cycle_scale()];
+
+        for _ in 0..500 {
+            sm.perform_step();
+            if sm.at_downsample() {
+                scales.push(sm.cycle_scale());
+            }
+            if sm.fsm_state() == FsmState::Operational {
+                break;
+            }
+        }
+        assert_eq!(
+            sm.fsm_state(),
+            FsmState::Operational,
+            "FSM did not reach operational"
+        );
+
+        // Initial scale = 1/8, then doubles: 1/4, 1/2, 1.0
+        assert_eq!(scales.len(), 4, "Expected 3 doublings + initial");
+        let expected = [1.0 / 8.0, 1.0 / 4.0, 1.0 / 2.0, 1.0];
+        for (i, (&got, &exp)) in scales.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-15,
+                "cycle_scale[{i}]: expected {exp}, got {got}"
+            );
+        }
     }
 }

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -262,10 +262,12 @@ impl GaussJacksonState {
         }
 
         // ── Start of cycle (stage 1 for all non-operational states) ──
-        // start_cycle may trigger a downsample which changes cycle_scale,
-        // so we must recompute cycle_dyndt afterwards.
+        // start_cycle may trigger a downsample which changes cycle_scale.
+        // It takes sim_dt + time_scale_factor (not pre-computed cycle_dyndt)
+        // so it can derive cycle_dyndt from the post-downsample cycle_scale
+        // for delinv reinitialization.
         let cycle_dyndt = if stage == 1 {
-            self.start_cycle(cycle_dyndt, acc, state);
+            self.start_cycle(sim_dt, time_scale_factor, acc, state);
             // Recompute: cycle_scale may have changed via downsample.
             sim_dt * self.state_machine.cycle_scale() * time_scale_factor
         } else {
@@ -389,8 +391,20 @@ impl GaussJacksonState {
 
     /// Start an integration cycle.
     ///
-    /// JEOD: `GaussJacksonIntegratorBase::start_cycle(dt, acc, state)`.
-    fn start_cycle(&mut self, dt: f64, acc: DVec3, state: &TranslationalState) {
+    /// JEOD: `GaussJacksonIntegratorBase::start_cycle(dt, acc, state)` +
+    /// `GaussJacksonIntegrationControls::start_cycle(sim_dt)`.
+    ///
+    /// Takes `sim_dt` and `time_scale_factor` rather than pre-computed
+    /// `cycle_dyndt` because `perform_step()` may trigger a downsample that
+    /// changes `cycle_scale`. The post-downsample `cycle_dyndt` must be used
+    /// for `initialize_*_integration_constants()`.
+    fn start_cycle(
+        &mut self,
+        sim_dt: f64,
+        time_scale_factor: f64,
+        acc: DVec3,
+        state: &TranslationalState,
+    ) {
         if self.fsm_state == FsmState::Reset {
             // Save epoch data.
             // JEOD: `save_epoch_data(acc, state)`
@@ -410,6 +424,8 @@ impl GaussJacksonState {
         self.fsm_state = self.state_machine.fsm_state();
 
         // Downsample if indicated.
+        // JEOD: cycle_simdt and cycle_dyndt are recomputed here, BEFORE
+        // the reinitialize check (gauss_jackson_integration_controls.cc:298-301).
         if self.state_machine.at_downsample() {
             self.downsample_hist();
         }
@@ -424,12 +440,14 @@ impl GaussJacksonState {
         }
 
         // Reinitialize delinv if indicated.
+        // Compute cycle_dyndt from the (possibly updated) cycle_scale.
         if self.state_machine.at_reinitialize() {
+            let cycle_dyndt = sim_dt * self.state_machine.cycle_scale() * time_scale_factor;
             if self.fsm_state == FsmState::BootstrapEdit {
-                self.initialize_edit_integration_constants(dt);
+                self.initialize_edit_integration_constants(cycle_dyndt);
                 self.history_length = 1;
             } else {
-                self.initialize_predictor_integration_constants(dt);
+                self.initialize_predictor_integration_constants(cycle_dyndt);
             }
         }
     }
@@ -793,9 +811,10 @@ mod tests {
         let r0: f64 = 7_000_000.0;
         let v0 = (mu / r0).sqrt();
 
-        let dt: f64 = 10.0;
+        let target_dt: f64 = 10.0;
         let period = 2.0 * std::f64::consts::PI * (r0.powi(3) / mu).sqrt();
-        let steps = (period / dt).round() as usize;
+        let steps = (period / target_dt).round() as usize;
+        let dt = period / steps as f64;
 
         let mut state = TranslationalState {
             position: DVec3::new(r0, 0.0, 0.0),
@@ -951,9 +970,12 @@ mod tests {
         let r0: f64 = 7_000_000.0;
         let v0 = (mu / r0).sqrt();
 
-        let dt: f64 = 10.0;
+        // Choose dt so that steps * dt == period exactly, avoiding orbit
+        // closure error from rounding mismatch.
+        let target_dt: f64 = 10.0;
         let period = 2.0 * std::f64::consts::PI * (r0.powi(3) / mu).sqrt();
-        let steps = (period / dt).round() as usize;
+        let steps = (period / target_dt).round() as usize;
+        let dt = period / steps as f64;
 
         let mut state = TranslationalState {
             position: DVec3::new(r0, 0.0, 0.0),

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -60,6 +60,13 @@ impl IntegratorResult {
             passed: true,
         }
     }
+
+    fn more_stages_with(passed: bool) -> Self {
+        Self {
+            time_scale: 0.0,
+            passed,
+        }
+    }
 }
 
 /// Gauss-Jackson integrator state for second-order ODEs.
@@ -346,7 +353,7 @@ impl GaussJacksonState {
             if self.state_machine.at_end_of_tour() {
                 IntegratorResult::complete(passed)
             } else {
-                IntegratorResult::more_stages()
+                IntegratorResult::more_stages_with(passed)
             }
         }
     }
@@ -380,7 +387,7 @@ impl GaussJacksonState {
             if self.state_machine.at_end_of_tour() {
                 IntegratorResult::complete(passed)
             } else {
-                IntegratorResult::more_stages()
+                IntegratorResult::more_stages_with(passed)
             }
         }
     }

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -1028,4 +1028,157 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn gj_time_scale_factor_equivalence() {
+        // Validates that time_scale_factor actually multiplies into cycle_dyndt.
+        //
+        // Key insight: integrate(sim_dt=0.005, tsf=2.0) produces the same
+        // cycle_dyndt as integrate(sim_dt=0.01, tsf=1.0) at every stage.
+        // With the same number of integrate() calls, the state machine sees
+        // identical step counts and the physics sees identical cycle_dyndt,
+        // so the trajectories must be bitwise identical.
+        //
+        // This test would FAIL if time_scale_factor were ignored: run B
+        // would integrate at half the effective dt, producing a very
+        // different trajectory.
+        let config = GaussJacksonConfig::default(); // ndoubling=4
+        let n_steps: usize = 1000;
+
+        // Run A: sim_dt=0.01, time_scale_factor=1.0 (baseline)
+        // Dynamic time per step = 0.01 * 1.0 = 0.01
+        let mut state_a = TranslationalState {
+            position: DVec3::new(1.0, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        };
+        let mut gj_a = GaussJacksonState::new(config);
+        for _ in 0..n_steps {
+            loop {
+                let acc = -state_a.position;
+                let result = gj_a.integrate(0.01, 1.0, acc, &mut state_a);
+                if result.time_scale > 0.0 {
+                    break;
+                }
+            }
+        }
+
+        // Run B: sim_dt=0.005, time_scale_factor=2.0 (same effective dt)
+        // Dynamic time per step = 0.005 * 2.0 = 0.01
+        // Same number of calls → same total dynamic time (10.0s).
+        let mut state_b = TranslationalState {
+            position: DVec3::new(1.0, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        };
+        let mut gj_b = GaussJacksonState::new(config);
+        for _ in 0..n_steps {
+            loop {
+                let acc = -state_b.position;
+                let result = gj_b.integrate(0.005, 2.0, acc, &mut state_b);
+                if result.time_scale > 0.0 {
+                    break;
+                }
+            }
+        }
+
+        // Both should reach the same state (bitwise identical cycle_dyndt
+        // at every stage means identical floating-point trajectories).
+        let pos_diff = (state_a.position - state_b.position).length();
+        let vel_diff = (state_a.velocity - state_b.velocity).length();
+        println!("time_scale_factor equivalence: pos_diff={pos_diff:.2e}, vel_diff={vel_diff:.2e}");
+        assert!(
+            pos_diff < 1e-14,
+            "Position divergence {pos_diff:.2e} between tsf=1.0 and tsf=2.0 runs"
+        );
+        assert!(
+            vel_diff < 1e-14,
+            "Velocity divergence {vel_diff:.2e} between tsf=1.0 and tsf=2.0 runs"
+        );
+
+        // Sanity: both should also be accurate vs exact solution
+        let total_dyn_time: f64 = 10.0;
+        let exact_pos = total_dyn_time.cos();
+        let err_a = (state_a.position.x - exact_pos).abs();
+        let err_b = (state_b.position.x - exact_pos).abs();
+        assert!(
+            err_a < 1e-10,
+            "Run A position error {err_a:.2e} exceeds 1e-10"
+        );
+        assert!(
+            err_b < 1e-10,
+            "Run B position error {err_b:.2e} exceeds 1e-10"
+        );
+    }
+
+    #[test]
+    fn gj_time_scale_factor_affects_dynamics() {
+        // Validates that time_scale_factor != 1.0 actually changes the dynamics.
+        //
+        // With tsf=2.0 and sim_dt=0.01, the effective dt is 0.02 per sim step.
+        // After 500 sim steps, dynamic time = 500 * 0.02 = 10.0s.
+        // With tsf=1.0 and sim_dt=0.01, after 500 sim steps, dynamic time = 5.0s.
+        //
+        // The two trajectories MUST differ — if they don't, time_scale_factor
+        // is being ignored.
+        let config = GaussJacksonConfig::default();
+        let sim_steps = 500;
+
+        // Run A: tsf=1.0, 500 steps → 5.0s of dynamic time
+        let mut state_a = TranslationalState {
+            position: DVec3::new(1.0, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        };
+        let mut gj_a = GaussJacksonState::new(config);
+        for _ in 0..sim_steps {
+            loop {
+                let acc = -state_a.position;
+                let result = gj_a.integrate(0.01, 1.0, acc, &mut state_a);
+                if result.time_scale > 0.0 {
+                    break;
+                }
+            }
+        }
+
+        // Run B: tsf=2.0, 500 steps → 10.0s of dynamic time
+        let mut state_b = TranslationalState {
+            position: DVec3::new(1.0, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        };
+        let mut gj_b = GaussJacksonState::new(config);
+        for _ in 0..sim_steps {
+            loop {
+                let acc = -state_b.position;
+                let result = gj_b.integrate(0.01, 2.0, acc, &mut state_b);
+                if result.time_scale > 0.0 {
+                    break;
+                }
+            }
+        }
+
+        // Run A should be at cos(5.0), Run B at cos(10.0) — very different
+        let exact_a = 5.0_f64.cos();
+        let exact_b = 10.0_f64.cos();
+        let err_a = (state_a.position.x - exact_a).abs();
+        let err_b = (state_b.position.x - exact_b).abs();
+
+        println!(
+            "tsf=1.0: pos={:.10}, exact={exact_a:.10}, err={err_a:.2e}",
+            state_a.position.x
+        );
+        println!(
+            "tsf=2.0: pos={:.10}, exact={exact_b:.10}, err={err_b:.2e}",
+            state_b.position.x
+        );
+
+        assert!(err_a < 1e-10, "tsf=1.0 error {err_a:.2e} exceeds 1e-10");
+        // tsf=2.0 doubles the effective dt → larger truncation error
+        assert!(err_b < 1e-9, "tsf=2.0 error {err_b:.2e} exceeds 1e-9");
+
+        // The states must actually differ (proves tsf is not ignored)
+        let pos_diff = (state_a.position.x - state_b.position.x).abs();
+        assert!(
+            pos_diff > 0.1,
+            "Runs with different time_scale_factor produced nearly identical \
+             positions (diff={pos_diff:.2e}), suggesting time_scale_factor is ignored"
+        );
+    }
 }

--- a/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
@@ -131,9 +131,13 @@ impl StateMachine {
         self.at_order_change
     }
 
-    #[allow(dead_code)]
     pub fn at_end_of_tour(&self) -> bool {
         self.at_end_of_tour
+    }
+
+    /// JEOD: `GaussJacksonStateMachine::get_cycle_scale()`.
+    pub fn cycle_scale(&self) -> f64 {
+        self.cycle_scale
     }
 
     #[allow(dead_code)]

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -23,7 +23,11 @@ use jeod_dynamics::{
 /// - `gravity_fn`: computes gravitational acceleration from position (called per integrator stage)
 /// - `non_grav_force`: total non-gravity force in inertial frame (constant over step)
 /// - `torque`: total torque in body frame (constant over step)
-/// - `dt`: timestep in seconds
+/// - `dt`: simulation timestep in seconds (JEOD: `sim_dt`)
+/// - `time_scale_factor`: ratio of dynamic time to simulation time
+///   (JEOD: `TimeDyn::scale_factor`). Applied uniformly to all integrators:
+///   RK4/RKF45 use `integ_dyndt = dt * time_scale_factor`, Gauss-Jackson
+///   uses `cycle_dyndt = dt * cycle_scale * time_scale_factor`.
 /// - `integrator`: integration method to use
 ///
 /// # Panics
@@ -67,6 +71,10 @@ pub fn integrate_body(
         );
     };
 
+    // JEOD: integ_dyndt = sim_dt * time_scale_factor
+    // (single_cycle_integration_controls.cc:63-65, standard_integration_controls.cc:80-82)
+    let integ_dyndt = dt * time_scale_factor;
+
     // JEOD_INV: DB.08 — rotational_dynamics gates integration
     // 6-DOF path: rotational dynamics enabled AND components present
     if config.rotational_dynamics {
@@ -83,12 +91,20 @@ pub fn integrate_body(
             let accel = |s: &SixDofState| gravity_fn(s.trans.position) + non_grav_accel;
             let torque_fn = |_s: &SixDofState| constant_torque;
             let new_state = match integrator {
-                IntegratorType::Rk4 => {
-                    jeod_dynamics::rk4_sixdof_step(&six_state, accel, torque_fn, mass_props, dt)
-                }
-                IntegratorType::Rkf45 => {
-                    jeod_dynamics::rkf45_sixdof_step(&six_state, accel, torque_fn, mass_props, dt)
-                }
+                IntegratorType::Rk4 => jeod_dynamics::rk4_sixdof_step(
+                    &six_state,
+                    accel,
+                    torque_fn,
+                    mass_props,
+                    integ_dyndt,
+                ),
+                IntegratorType::Rkf45 => jeod_dynamics::rkf45_sixdof_step(
+                    &six_state,
+                    accel,
+                    torque_fn,
+                    mass_props,
+                    integ_dyndt,
+                ),
                 IntegratorType::GaussJackson(..) => {
                     panic!(
                         "GaussJackson 6-DOF integration not yet supported. \
@@ -112,10 +128,10 @@ pub fn integrate_body(
     let accel = |s: &TranslationalState| gravity_fn(s.position) + non_grav_accel;
     match integrator {
         IntegratorType::Rk4 => {
-            *trans = jeod_dynamics::rk4_translational_step(trans, accel, dt);
+            *trans = jeod_dynamics::rk4_translational_step(trans, accel, integ_dyndt);
         }
         IntegratorType::Rkf45 => {
-            *trans = jeod_dynamics::rkf45_translational_step(trans, accel, dt);
+            *trans = jeod_dynamics::rkf45_translational_step(trans, accel, integ_dyndt);
         }
         IntegratorType::GaussJackson(cfg) => {
             let gj = gj_state.expect(

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -43,6 +43,7 @@ pub fn integrate_body(
     non_grav_force: DVec3,
     torque: DVec3,
     dt: f64,
+    time_scale_factor: f64,
     integrator: IntegratorType,
     gj_state: Option<&mut jeod_dynamics::GaussJacksonState>,
 ) {
@@ -137,13 +138,14 @@ pub fn integrate_body(
             // (order * max_correction_iterations) + GJ predict/correct (2).
             let max_stages = {
                 let cfg = gj.config();
+                let tour_count = 1usize << cfg.ndoubling_steps;
                 let edits = cfg.final_order * (cfg.max_correction_iterations + 1);
-                (edits + 10).max(100) // generous headroom
+                ((edits + 10) * tour_count).max(100) // generous headroom
             };
             let mut completed = false;
             for _ in 0..max_stages {
                 let acc = gravity_fn(trans.position) + non_grav_accel;
-                let result = gj.integrate(dt, acc, trans);
+                let result = gj.integrate(dt, time_scale_factor, acc, trans);
                 if result.time_scale > 0.0 {
                     if !result.passed {
                         log::warn!(

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -154,9 +154,16 @@ pub fn integrate_body(
             // (order * max_correction_iterations) + GJ predict/correct (2).
             let max_stages = {
                 let cfg = gj.config();
-                let tour_count = 1usize << cfg.ndoubling_steps;
-                let edits = cfg.final_order * (cfg.max_correction_iterations + 1);
-                ((edits + 10) * tour_count).max(100) // generous headroom
+                // Cap ndoubling_steps to avoid huge tour_count (JEOD default: 4).
+                let capped_ndoubling = cfg.ndoubling_steps.min(10);
+                let tour_count = 1usize << capped_ndoubling;
+                let edits = cfg
+                    .final_order
+                    .saturating_mul(cfg.max_correction_iterations + 1);
+                edits
+                    .saturating_add(10)
+                    .saturating_mul(tour_count)
+                    .clamp(100, 10_000_000) // hard cap: prevent runaway loops
             };
             let mut completed = false;
             for _ in 0..max_stages {

--- a/crates/jeod_sim/src/simulation.rs
+++ b/crates/jeod_sim/src/simulation.rs
@@ -633,6 +633,7 @@ impl Simulation {
                 body.total_force.force,
                 body.total_force.torque,
                 dt,
+                self.time.time_scale_factor,
                 body.integrator,
                 body.gj_state.as_mut(),
             );

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run9.rs
@@ -129,6 +129,7 @@ fn tier3_simulation_run9a_torque() {
                 total.force,
                 total.torque + external_torque,
                 DT,
+                1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );
@@ -179,6 +180,7 @@ fn tier3_simulation_run9a_torque() {
                 total.force,
                 total.torque + external_torque,
                 remainder,
+                1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );
@@ -353,6 +355,7 @@ fn tier3_simulation_run9c_force_torque() {
                 total.force + external_force_inertial,
                 total.torque + external_torque,
                 DT,
+                1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );
@@ -505,6 +508,7 @@ fn tier3_simulation_run9d_force_torque_rate() {
                 total.force + external_force_inertial,
                 total.torque + external_torque,
                 DT,
+                1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );

--- a/crates/jeod_sim/tests/tier3_sim_gj.rs
+++ b/crates/jeod_sim/tests/tier3_sim_gj.rs
@@ -28,17 +28,20 @@ const MU_GJ_TEST: f64 = 5.76e14;
 
 /// Run a GJ cross-validation test with the given config and reference CSV.
 ///
-/// `time_scale` converts CSV sim-time to dynamic time via
-/// `dyn_time = sim_time * time_scale`. JEOD's SIM_GJ_test uses
-/// `dyn_time.scale_factor` to vary the effective dt: a scale of 10
-/// means each CSV sim-second corresponds to 10 dynamic seconds.
-/// For dt=1 runs, `time_scale = 1.0`. For dt=10 runs, `time_scale = 10.0`.
+/// JEOD's SIM_GJ_test uses `dyn_time.scale_factor` to vary the effective dt.
+/// We match this by setting `SimulationTime::time_scale_factor` and stepping
+/// the simulation at `sim_dt` (the sim clock rate), while the integrator
+/// internally computes `cycle_dyndt = sim_dt * cycle_scale * time_scale_factor`.
+///
+/// CSV times are in sim-seconds. For dt=1 runs, `time_scale_factor=1.0` and
+/// `sim_dt=1.0`. For dt=10 runs, `time_scale_factor=10.0` and `sim_dt=1.0`
+/// (each sim step advances 10s of dynamic time).
 fn run_gj_test(
     test_name: &str,
     csv_label: &str,
     config: GaussJacksonConfig,
-    dt: f64,
-    time_scale: f64,
+    sim_dt: f64,
+    time_scale_factor: f64,
     pos_tol: [f64; 3],
     vel_tol: [f64; 3],
 ) {
@@ -60,8 +63,9 @@ fn run_gj_test(
 
     let init = &trajectory[0];
 
-    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, dt);
+    let mut time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    time.time_scale_factor = time_scale_factor;
+    let mut sim = Simulation::new(time, sim_dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
@@ -88,20 +92,23 @@ fn run_gj_test(
 
     sim.validate().unwrap();
 
-    let final_dyn_time = trajectory.last().unwrap().time * time_scale;
+    // CSV times are in sim-seconds; step_until uses simtime.
+    let final_sim_time = trajectory.last().unwrap().time;
+    let effective_dt = sim_dt * time_scale_factor;
     println!(
-        "Tier 3 (Simulation): {test_name}, {} points over {:.0}s, dt={dt}s",
+        "Tier 3 (Simulation): {test_name}, {} points over {:.0}s sim ({:.0}s dyn), \
+         sim_dt={sim_dt}s, tsf={time_scale_factor}, effective_dt={effective_dt}s",
         trajectory.len(),
-        final_dyn_time
+        final_sim_time,
+        final_sim_time * time_scale_factor,
     );
 
     let mut our_states = Vec::with_capacity(trajectory.len() - 1);
     for record in &trajectory[1..] {
-        let dyn_time = record.time * time_scale;
-        sim.step_until(dyn_time);
+        sim.step_until(record.time);
         let body = sim.body(0);
         our_states.push(StateLog {
-            time: dyn_time,
+            time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
             ..Default::default()
@@ -111,7 +118,7 @@ fn run_gj_test(
     let ref_states: Vec<StateLog> = trajectory[1..]
         .iter()
         .map(|r| StateLog {
-            time: r.time * time_scale,
+            time: r.time,
             position: Some(r.position),
             velocity: Some(r.velocity),
             ..Default::default()
@@ -177,14 +184,17 @@ fn tier3_simulation_gj_order12() {
 
 #[test]
 fn tier3_simulation_gj_dt10() {
-    // GJ order 8, dt=10s. Coarser timestep → larger truncation error.
-    // JEOD SIM_GJ_test uses scale_factor=10 → CSV times are sim-seconds.
+    // GJ order 8, effective dt=10s. Coarser timestep → larger truncation error.
+    // Matches JEOD SIM_GJ_test: sim_dt=1.0, dyn_time.scale_factor=10.
+    // The integrator sees cycle_dyndt = 1.0 * cycle_scale * 10.0 = 10.0 * cycle_scale,
+    // producing the same physics as dt=10 with tsf=1.0.
+    // CSV times are in sim-seconds (log_cycle=30s, terminate=30000s).
     // Observed: pos [9.862e-1, 9.846e-1, 0] m, vel [8.751e-4, 8.755e-4, 0] m/s.
     run_gj_test(
         "tier3_simulation_gj_dt10",
         "integ_gj_dt10",
         GaussJacksonConfig::with_order(8),
-        10.0,
+        1.0,
         10.0,
         [1.036e0, 1.034e0, 1e-10],
         [9.189e-4, 9.193e-4, 1e-13],

--- a/crates/jeod_time/src/simulation_time.rs
+++ b/crates/jeod_time/src/simulation_time.rs
@@ -52,6 +52,12 @@ pub struct SimulationTime {
     /// [`set_ut1_tai_offset`](Self::set_ut1_tai_offset) with a value from
     /// IERS Bulletin A/B when sub-second accuracy in Earth orientation is needed.
     pub ut1_tai_offset: f64,
+    /// Ratio of dynamic time to simulation time.
+    /// JEOD: `TimeDyn::scale_factor`, read by integration controls via
+    /// `TimeInterface::get_time_scale_factor()`.
+    /// 1.0 = real-time, >1.0 = fast-forward, <0 = time reversal.
+    /// Default: 1.0.
+    pub time_scale_factor: f64,
 }
 
 impl SimulationTime {
@@ -81,6 +87,7 @@ impl SimulationTime {
             simtime: 0.0,
             leap_second_table: leap_table,
             ut1_tai_offset,
+            time_scale_factor: 1.0,
         };
         sim.recompute_derived();
         sim

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -160,6 +160,7 @@ pub fn integration_system(
         Option<&TidalConfigC>,
     )>,
     time: Res<Time<Fixed>>,
+    sim_time: Res<SimulationTimeR>,
 ) {
     let dt = time.delta_secs_f64();
     if dt == 0.0 {
@@ -221,6 +222,7 @@ pub fn integration_system(
             total_force.force,
             total_force.torque,
             dt,
+            sim_time.0.time_scale_factor,
             integrator_type,
             gj_state.as_mut().map(|g| &mut g.0),
         );

--- a/tests/bevy_parity_gj.rs
+++ b/tests/bevy_parity_gj.rs
@@ -1,0 +1,256 @@
+//! Bevy App vs jeod_sim::Simulation parity for Gauss-Jackson integrator.
+//!
+//! Mirrors each test in `crates/jeod_sim/tests/tier3_sim_gj.rs` with a
+//! Bevy-vs-Simulation bit-identical assertion, establishing:
+//!   Bevy ≡ Simulation ≈ JEOD
+//!
+//! Also covers bootstrap (ndoubling > 0) and time_scale_factor != 1.0 paths
+//! that the older cross_parity.rs GJ tests (Scenario I) do not exercise.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_jeod::{
+    DynamicsConfigC, GaussJacksonStateC, GravityAccelerationC, GravityControlsC, GravitySourceC,
+    IntegratorTypeC, JeodPlugin, SimulationTimeR, SourceInertialPositionC, TotalForceC,
+    TranslationalStateC,
+};
+use glam::DVec3;
+use jeod_sim::{
+    GaussJacksonConfig, GaussJacksonState, GravityControl, GravityControls, GravityModel,
+    GravitySource, GravitySourceEntry, IntegratorType, SimBody, Simulation, TranslationalState,
+};
+
+/// Non-standard μ matching SIM_GJ_test (same as tier3_sim_gj.rs).
+const MU_GJ_TEST: f64 = 5.76e14;
+
+/// GJ test initial state matching SIM_GJ_test: r₀=[9e6,0,0], v₀=[0,8000,0].
+fn gj_trans() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(9e6, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 8000.0, 0.0),
+    }
+}
+
+// ── Helpers ──
+
+fn step_bevy(app: &mut App, n: usize, dt: f64) {
+    for _ in 0..n {
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .advance_by(Duration::from_secs_f64(dt));
+        app.world_mut().run_schedule(FixedUpdate);
+    }
+}
+
+fn read_trans(world: &World, entity: Entity) -> TranslationalState {
+    world.get::<TranslationalStateC>(entity).unwrap().0
+}
+
+fn assert_bits_eq(label: &str, component: &str, a: f64, b: f64) {
+    assert!(
+        a.to_bits() == b.to_bits(),
+        "{label} {component} not bit-identical:\n  \
+         A: {a} (bits={:#018x})\n  \
+         B: {b} (bits={:#018x})",
+        a.to_bits(),
+        b.to_bits(),
+    );
+}
+
+fn assert_trans_eq(label: &str, a: &TranslationalState, b: &TranslationalState) {
+    for i in 0..3 {
+        assert_bits_eq(
+            label,
+            &format!("position[{i}]"),
+            a.position[i],
+            b.position[i],
+        );
+        assert_bits_eq(
+            label,
+            &format!("velocity[{i}]"),
+            a.velocity[i],
+            b.velocity[i],
+        );
+    }
+    println!("  {label}: bit-identical (all 6 components)");
+}
+
+/// Run a GJ Bevy-vs-Simulation parity test.
+///
+/// Builds identical Bevy App and Simulation with the given GJ config,
+/// sim_dt, time_scale_factor, and step count; asserts bit-identical
+/// translational state.
+fn run_gj_parity(
+    label: &str,
+    config: GaussJacksonConfig,
+    sim_dt: f64,
+    time_scale_factor: f64,
+    n_steps: usize,
+) {
+    let trans = gj_trans();
+
+    // ── Bevy ──
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(sim_dt));
+    app.add_plugins(JeodPlugin);
+
+    // Set time_scale_factor on the SimulationTimeR resource.
+    app.world_mut()
+        .resource_mut::<SimulationTimeR>()
+        .0
+        .time_scale_factor = time_scale_factor;
+
+    let planet = app
+        .world_mut()
+        .spawn((
+            Name::new("Planet"),
+            GravitySourceC(GravitySource {
+                mu: MU_GJ_TEST,
+                model: GravityModel::PointMass,
+            }),
+            SourceInertialPositionC::default(),
+            TranslationalStateC::default(),
+        ))
+        .id();
+
+    let vehicle = app
+        .world_mut()
+        .spawn((
+            DynamicsConfigC::default(),
+            TranslationalStateC(trans),
+            GravityControlsC(GravityControls {
+                controls: vec![GravityControl::new_spherical(planet, false)],
+            }),
+            GravityAccelerationC::default(),
+            TotalForceC::default(),
+            IntegratorTypeC(IntegratorType::GaussJackson(config)),
+            GaussJacksonStateC(GaussJacksonState::new(config)),
+        ))
+        .id();
+
+    step_bevy(&mut app, n_steps, sim_dt);
+    let bevy_trans = read_trans(app.world(), vehicle);
+
+    // ── Simulation ──
+    let mut time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    time.time_scale_factor = time_scale_factor;
+    let mut sim = Simulation::new(time, sim_dt);
+
+    let earth_idx = sim.add_source(GravitySourceEntry {
+        source: GravitySource {
+            mu: MU_GJ_TEST,
+            model: GravityModel::PointMass,
+        },
+        position: DVec3::ZERO,
+        t_inertial_pfix: None,
+        delta_c20: 0.0,
+        tidal_config: None,
+    });
+
+    sim.add_body(SimBody {
+        trans,
+        integrator: IntegratorType::GaussJackson(config),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth_idx, false)],
+        },
+        ..Default::default()
+    });
+    sim.validate().unwrap();
+    sim.step_n(n_steps);
+
+    let sim_trans = sim.body(0).trans;
+    assert_trans_eq(label, &bevy_trans, &sim_trans);
+}
+
+// ── Tests mirroring tier3_sim_gj.rs ──
+
+/// Mirrors `tier3_simulation_gj_order8`: GJ order 8, dt=1s, tsf=1.0.
+#[test]
+fn tier3_bevy_parity_gj_order8() {
+    run_gj_parity(
+        "GJ order 8, dt=1s",
+        GaussJacksonConfig::with_order(8),
+        1.0,
+        1.0,
+        1000,
+    );
+}
+
+/// Mirrors `tier3_simulation_gj_order4`: GJ order 4, dt=1s, tsf=1.0.
+#[test]
+fn tier3_bevy_parity_gj_order4() {
+    run_gj_parity(
+        "GJ order 4, dt=1s",
+        GaussJacksonConfig::with_order(4),
+        1.0,
+        1.0,
+        1000,
+    );
+}
+
+/// Mirrors `tier3_simulation_gj_order12`: GJ order 12, dt=1s, tsf=1.0.
+#[test]
+fn tier3_bevy_parity_gj_order12() {
+    run_gj_parity(
+        "GJ order 12, dt=1s",
+        GaussJacksonConfig::with_order(12),
+        1.0,
+        1.0,
+        1000,
+    );
+}
+
+/// Mirrors `tier3_simulation_gj_dt10`: GJ order 8, sim_dt=1s, tsf=10.
+/// Exercises time_scale_factor through both Bevy and Simulation pipelines.
+#[test]
+fn tier3_bevy_parity_gj_dt10() {
+    run_gj_parity(
+        "GJ order 8, sim_dt=1s, tsf=10",
+        GaussJacksonConfig::with_order(8),
+        1.0,
+        10.0,
+        1000,
+    );
+}
+
+// ── Bootstrap tests (ndoubling > 0) ──
+
+/// GJ with default config (initial=4, final=12, ndoubling=4).
+/// Exercises full bootstrap subcycling through both pipelines.
+#[test]
+fn tier3_bevy_parity_gj_bootstrap_default() {
+    run_gj_parity(
+        "GJ default (ndoubling=4), dt=1s",
+        GaussJacksonConfig::default(),
+        1.0,
+        1.0,
+        500,
+    );
+}
+
+/// GJ with standard config (initial=8, final=12, ndoubling=2).
+#[test]
+fn tier3_bevy_parity_gj_bootstrap_standard() {
+    run_gj_parity(
+        "GJ standard (ndoubling=2), dt=10s",
+        GaussJacksonConfig::standard(),
+        10.0,
+        1.0,
+        100,
+    );
+}
+
+/// Bootstrap + time_scale_factor: default config with tsf=2.0.
+/// Exercises both subcycling and time scaling through both pipelines.
+#[test]
+fn tier3_bevy_parity_gj_bootstrap_tsf() {
+    run_gj_parity(
+        "GJ default (ndoubling=4), dt=0.5s, tsf=2.0",
+        GaussJacksonConfig::default(),
+        0.5,
+        2.0,
+        1000,
+    );
+}

--- a/tests/cross_parity.rs
+++ b/tests/cross_parity.rs
@@ -767,6 +767,7 @@ fn tier3_bevy_external_torque_per_body() {
             total.force,
             total.torque + torque,
             step_dt,
+            1.0,
             jeod_sim::IntegratorType::Rk4,
             None,
         );
@@ -819,6 +820,7 @@ fn tier3_bevy_external_torque_per_body() {
             total.force,
             total.torque + torque,
             step_dt,
+            1.0,
             jeod_sim::IntegratorType::Rk4,
             None,
         );


### PR DESCRIPTION
## Summary

Closes #41.

- Wire `cycle_scale` from the GJ state machine into the effective dt, computing `cycle_dyndt = sim_dt * cycle_scale * time_scale_factor` matching JEOD's four-variable naming (`integ_simdt`, `integ_dyndt`, `cycle_simdt`, `cycle_dyndt`)
- Gate `complete()` returns on `at_end_of_tour` so subcycled bootstrap steps return `more_stages()` to request fresh derivatives from the caller
- Add `time_scale_factor` field to `SimulationTime` (default 1.0), preparing infrastructure for JEOD-faithful time scaling (fast-forward, reversal via `TimeDyn::scale_factor`)
- Apply `time_scale_factor` uniformly to all integrators (RK4/RKF45/GJ), matching JEOD's `IntegrationControls` base class
- Wire `time_scale_factor` into Tier 3 GJ dt=10 test: set `SimulationTime.time_scale_factor=10` with `sim_dt=1.0` (matching JEOD's SIM_GJ_test), removing external CSV time multiplication
- New tests:
  - `gj_harmonic_oscillator_bootstrap` — full bootstrap with ndoubling=4
  - `gj_kepler_orbit_standard` — bootstrap with ndoubling=2
  - `gj_cycle_scale_progression` — FSM cycle_scale doubling sequence
  - `gj_time_scale_factor_equivalence` — proves `(sim_dt=0.005, tsf=2.0)` == `(sim_dt=0.01, tsf=1.0)`
  - `gj_time_scale_factor_affects_dynamics` — proves tsf=2.0 advances dynamics 2x faster

## Test plan

- [x] All 9 GJ unit tests pass (4 existing + 5 new)
- [x] Full unit + tier 2 suite passes (325 tests)
- [x] `cargo fmt --check && cargo clippy --workspace --tests -- -D warnings` clean
- [x] Tier 3 GJ cross-validation (4 tests pass locally, including dt=10 with time_scale_factor=10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)