### PR TITLE
Load test ICs from JEOD source files instead of hardcoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
         env:
           JEOD_HOME: ${{ github.workspace }}/../jeod
         run: cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'
+      - name: Generate cross-validation report
+        run: cargo run -p jeod_test_data --bin tier3_report
+      - name: Upload cross-validation report
+        uses: actions/upload-artifact@v4
+        with:
+          name: tier3-crossval-report
+          path: target/tier3_report.md
 
   test-tier3-full:
     name: Test (Tier 3 full + earth_moon)
@@ -133,8 +140,8 @@ jobs:
         run: cargo nextest run --workspace -E 'test(tier3_)'
       - name: Generate cross-validation report
         run: cargo run -p jeod_test_data --bin tier3_report
-      - name: Upload cross-validation report
+      - name: Upload cross-validation report (full)
         uses: actions/upload-artifact@v4
         with:
-          name: tier3-crossval-report
+          name: tier3-crossval-report-full
           path: target/tier3_report.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,7 @@ jobs:
             models/environment/gravity/verif/unit_tests/grav_geospherical/data \
             models/environment/time/data \
             models/dynamics/body_action/verif/SIM_orbinit/Modified_data \
-            models/dynamics/derived_state/verif/unit_tests \
-            models/dynamics/derived_state/verif/SIM_NED \
-            models/dynamics/derived_state/verif/SIM_LVLH \
-            models/dynamics/derived_state/verif/SIM_OrbElem \
-            models/dynamics/derived_state/verif/SIM_Euler \
-            models/dynamics/derived_state/verif/SIM_Planetary \
+            models/dynamics/derived_state/verif \
             models/interactions/radiation_pressure/verif/SIM_3_ORBIT \
             models/interactions/radiation_pressure/verif/SIM_3_ORBIT_1st_ORDER \
             models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
@@ -120,12 +115,7 @@ jobs:
             models/environment/gravity/verif/unit_tests/grav_geospherical/data \
             models/environment/time/data \
             models/dynamics/body_action/verif/SIM_orbinit/Modified_data \
-            models/dynamics/derived_state/verif/unit_tests \
-            models/dynamics/derived_state/verif/SIM_NED \
-            models/dynamics/derived_state/verif/SIM_LVLH \
-            models/dynamics/derived_state/verif/SIM_OrbElem \
-            models/dynamics/derived_state/verif/SIM_Euler \
-            models/dynamics/derived_state/verif/SIM_Planetary \
+            models/dynamics/derived_state/verif \
             models/interactions/radiation_pressure/verif/SIM_3_ORBIT \
             models/interactions/radiation_pressure/verif/SIM_3_ORBIT_1st_ORDER \
             models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,7 @@ jobs:
         run: cargo nextest run --workspace -E 'not test(tier3_)'
 
   test-tier3:
-    name: Test (Tier 3 trajectory)
-    if: github.ref == 'refs/heads/main'
-    needs: test
+    name: Test (Tier 3 fast)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +64,6 @@ jobs:
           git clone --no-checkout --depth 1 --branch "$JEOD_TAG" \
             https://github.com/nasa/jeod.git ../jeod
           cd ../jeod
-          # Verify immutable tag hasn't moved
           [ "$(git rev-parse HEAD)" = "$JEOD_SHA" ] || \
             { echo "FATAL: $JEOD_TAG resolved to $(git rev-parse HEAD), expected $JEOD_SHA"; exit 1; }
           git sparse-checkout set \
@@ -75,10 +72,62 @@ jobs:
             models/environment/time/data \
             models/dynamics/body_action/verif/SIM_orbinit/Modified_data \
             models/dynamics/derived_state/verif/unit_tests \
-            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data
+            models/dynamics/derived_state/verif/SIM_NED \
+            models/dynamics/derived_state/verif/SIM_LVLH \
+            models/dynamics/derived_state/verif/SIM_OrbElem \
+            models/dynamics/derived_state/verif/SIM_Euler \
+            models/dynamics/derived_state/verif/SIM_Planetary \
+            models/interactions/radiation_pressure/verif/SIM_3_ORBIT \
+            models/interactions/radiation_pressure/verif/SIM_3_ORBIT_1st_ORDER \
+            models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
+            models/environment/time/verif/SIM_7_time_reversal \
+            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
+            verif/SIM_dyncomp
           git checkout
       - uses: taiki-e/install-action@nextest
-      - name: Run Tier 3 trajectory tests
+      - name: Run Tier 3 tests (exclude earth_moon ~17 min)
+        env:
+          JEOD_HOME: ${{ github.workspace }}/../jeod
+        run: cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'
+
+  test-tier3-full:
+    name: Test (Tier 3 full + earth_moon)
+    if: github.ref == 'refs/heads/main'
+    needs: test-tier3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Sparse checkout JEOD reference data
+        run: |
+          JEOD_TAG=jeod_v5.4.0
+          JEOD_SHA=27893108bbde8bb162b3213a30d57af89acd1c76
+          git clone --no-checkout --depth 1 --branch "$JEOD_TAG" \
+            https://github.com/nasa/jeod.git ../jeod
+          cd ../jeod
+          [ "$(git rev-parse HEAD)" = "$JEOD_SHA" ] || \
+            { echo "FATAL: $JEOD_TAG resolved to $(git rev-parse HEAD), expected $JEOD_SHA"; exit 1; }
+          git sparse-checkout set \
+            models/environment/gravity/data \
+            models/environment/gravity/verif/unit_tests/grav_geospherical/data \
+            models/environment/time/data \
+            models/dynamics/body_action/verif/SIM_orbinit/Modified_data \
+            models/dynamics/derived_state/verif/unit_tests \
+            models/dynamics/derived_state/verif/SIM_NED \
+            models/dynamics/derived_state/verif/SIM_LVLH \
+            models/dynamics/derived_state/verif/SIM_OrbElem \
+            models/dynamics/derived_state/verif/SIM_Euler \
+            models/dynamics/derived_state/verif/SIM_Planetary \
+            models/interactions/radiation_pressure/verif/SIM_3_ORBIT \
+            models/interactions/radiation_pressure/verif/SIM_3_ORBIT_1st_ORDER \
+            models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
+            models/environment/time/verif/SIM_7_time_reversal \
+            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
+            verif/SIM_dyncomp
+          git checkout
+      - uses: taiki-e/install-action@nextest
+      - name: Run all Tier 3 tests (including earth_moon)
         env:
           JEOD_HOME: ${{ github.workspace }}/../jeod
         run: cargo nextest run --workspace -E 'test(tier3_)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,9 +218,10 @@ and update the literal values in the test source.
 All Tier 3 test functions use the `tier3_` prefix, enabling cargo's name-based
 filtering. CI (`.github/workflows/ci.yml`) uses this:
 
-- **PRs**: `check` (fmt + clippy) and `test` (unit + tier 2, `--skip tier3_`)
-  run in parallel for fast feedback.
-- **Main push**: same jobs, plus `test-tier3` which runs only `tier3_` tests.
+- **PRs**: `check` (fmt + clippy), `test` (unit + tier 2), and `test-tier3`
+  (tier 3 excluding `earth_moon`) run in parallel for fast feedback.
+- **Main push**: same jobs, plus `test-tier3-full` which includes the
+  `earth_moon` test (~17 min) and generates the cross-validation report.
 - **Push to non-main branches**: no CI (only PRs and main trigger workflows).
 
 When adding new Tier 3 tests, always prefix the function name with `tier3_` so

--- a/crates/jeod_gravity/src/coefficients.rs
+++ b/crates/jeod_gravity/src/coefficients.rs
@@ -13,6 +13,28 @@ pub enum CoeffLoadError {
     InvalidFormat(String),
 }
 
+/// Load only the gravitational parameter (mu) from a JEOD C++ gravity data file.
+///
+/// Works with any JEOD gravity file including spherical-only files (like
+/// `sun_spherical.cc`, `moon_spherical.cc`) that lack `degree`/`order` fields.
+///
+/// Returns mu in m³/s².
+pub fn load_mu_from_jeod_cc(path: &std::path::Path) -> Result<f64, CoeffLoadError> {
+    let content = std::fs::read_to_string(path)?;
+    let path_str = path.display().to_string();
+
+    for line in content.lines() {
+        if let Some(val) = extract_assign_f64(line.trim(), "mu") {
+            return Ok(val);
+        }
+    }
+
+    Err(CoeffLoadError::MissingField {
+        field: "mu",
+        path: path_str,
+    })
+}
+
 /// Load spherical harmonics coefficients from a JEOD C++ data file.
 ///
 /// Parses files like `earth_GGM05C.cc` that contain lines of the form:

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -91,7 +91,10 @@ pub use jeod_interactions::{
 pub use jeod_frames::RefFrameState;
 
 // jeod_time: simulation time and leap seconds
-pub use jeod_time::{leap_second::default_leap_second_table, SimulationTime};
+pub use jeod_time::{
+    leap_second::{default_leap_second_table, LeapSecondTable},
+    SimulationTime,
+};
 
 // jeod_time: planet rotation (used by ephemeris stage)
 pub use jeod_frames::rotation_j2000::{

--- a/crates/jeod_sim/tests/sim_test_helpers/mod.rs
+++ b/crates/jeod_sim/tests/sim_test_helpers/mod.rs
@@ -12,9 +12,6 @@ use std::path::Path;
 #[allow(unused_imports)] // Not all test binaries use dyncomp CSV loading
 pub use jeod_test_data::dyncomp_csv::{load_dyncomp_csv, DyncompRecord};
 
-pub const MU_EARTH: f64 = 3.986_004_415e14;
-pub const DT: f64 = 0.03125; // 32 Hz, matches JEOD SIM_dyncomp
-
 /// Earth rotation rate (JEOD RNPJ2000 default).
 pub const OMEGA_EARTH: f64 = 7.292_115_146_706_388e-5;
 

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run10.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run10.rs
@@ -1,15 +1,21 @@
 //! Tier 3: SIM_dyncomp RUN_10A/10C/10D — Gravity gradient torque
+//!
+//! All simulation parameters (mu, step size, mass) are loaded from JEOD source
+//! files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
 
-use glam::{DMat3, DVec3};
+use glam::DVec3;
 use jeod_sim::{
     DynamicsConfig, GravityControl, GravityControls, GravityModel, GravitySource,
     GravitySourceEntry, JeodQuat, MassProperties, RotationModel, RotationalState, SimBody,
     Simulation, SimulationTime, TranslationalState,
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
+
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 // ── RUN_10A: Gravity gradient torque, cylinder mass, 6-DOF ──
 //
@@ -20,6 +26,13 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 #[test]
 fn tier3_simulation_run10a_gravity_torque() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run10a_state.csv");
     assert!(
         csv_path.exists(),
@@ -28,20 +41,58 @@ fn tier3_simulation_run10a_gravity_torque() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
+    // Load cylinder mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_cylinder"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    // Cylinder mass properties (from Modified_data/mass.py set_mass_cylinder)
-    let inertia = DMat3::from_diagonal(DVec3::new(500.0, 12250.0, 12250.0));
-    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::new(6.0, 0.0, 0.0));
+    // Cylinder mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
+    // Point-mass test: epoch doesn't matter, use J2000.
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -150,7 +201,7 @@ fn tier3_simulation_run10a_gravity_torque() {
 
 // ── RUN_10A Analytical Libration Validation ──
 //
-// The RUN_10A data exercises a cylinder (Ixx=500, Iyy=Izz=12250 kg·m²)
+// The RUN_10A data exercises a cylinder (Ixx=500, Iyy=Izz=12250 kg*m^2)
 // in a circular orbit with gravity gradient torque. Initial attitude is
 // 85 deg pitch + 1 deg yaw from LVLH. Analytical solution (Hughes, Spacecraft
 // Attitude Dynamics, pp. 232-353):
@@ -277,6 +328,13 @@ fn tier3_reference_run10a_libration_period() {
 
 #[test]
 fn tier3_simulation_run10c_gravity_torque_elliptical() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run10c_state.csv");
     assert!(
         csv_path.exists(),
@@ -285,19 +343,58 @@ fn tier3_simulation_run10c_gravity_torque_elliptical() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
+    // Load cylinder mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_cylinder"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    let inertia = DMat3::from_diagonal(DVec3::new(500.0, 12250.0, 12250.0));
-    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::new(6.0, 0.0, 0.0));
+    // Cylinder mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
+    // Point-mass test: epoch doesn't matter, use J2000.
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -391,6 +488,13 @@ fn tier3_simulation_run10c_gravity_torque_elliptical() {
 
 #[test]
 fn tier3_simulation_run10d_gravity_torque_elliptical_rate() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run10d_state.csv");
     assert!(
         csv_path.exists(),
@@ -399,19 +503,58 @@ fn tier3_simulation_run10d_gravity_torque_elliptical_rate() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
+    // Load cylinder mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_cylinder"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    let inertia = DMat3::from_diagonal(DVec3::new(500.0, 12250.0, 12250.0));
-    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::new(6.0, 0.0, 0.0));
+    // Cylinder mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
+    // Point-mass test: epoch doesn't matter, use J2000.
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run2.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run2.rs
@@ -1,9 +1,12 @@
 //! Tier 3: SIM_dyncomp RUN_2 — Point-mass gravity (3-DOF and 6-DOF)
+//!
+//! All simulation parameters (mu, step size, mass) are loaded from JEOD source
+//! files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
 
-use glam::{DMat3, DVec3};
+use glam::DVec3;
 use jeod_sim::{
     DynamicsConfig, GravityControl, GravityControls, GravityModel, GravitySource,
     GravitySourceEntry, JeodQuat, MassProperties, RotationModel, RotationalState, SimBody,
@@ -11,10 +14,20 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
+
 // ── Scenario 1: Point-mass 3-DOF (RUN_2) ──
 
 #[test]
 fn tier3_simulation_run2_3dof() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run2_state.csv");
     assert!(
         csv_path.exists(),
@@ -23,17 +36,29 @@ fn tier3_simulation_run2_3dof() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() > 100);
 
     let init = &trajectory[0];
 
+    // Point-mass test: epoch doesn't matter, use J2000.
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -107,6 +132,13 @@ fn tier3_simulation_run2_3dof() {
 
 #[test]
 fn tier3_simulation_run2_6dof() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run2_state.csv");
     assert!(
         csv_path.exists(),
@@ -114,24 +146,59 @@ fn tier3_simulation_run2_6dof() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
+    // Load ISS mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() > 100);
 
     let init = &trajectory[0];
 
-    let inertia = DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    // ISS mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
     );
-    let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
+    // Point-mass test: epoch doesn't matter, use J2000.
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run3.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run3.rs
@@ -1,4 +1,7 @@
 //! Tier 3: SIM_dyncomp RUN_3A/3B — Spherical harmonics gravity (4x4 / 8x8 + RNP)
+//!
+//! All simulation parameters (epoch, step size, gravity degree/order) are loaded
+//! from the JEOD source files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
@@ -10,15 +13,12 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
-/// JEOD SIM_dyncomp epoch constants (from the original SH test).
-const SH_TAI_UTC_S: f64 = 32.0;
-const SH_TAI_TO_UT1_S: f64 = -32.469;
-const SH_EPOCH_UTC_TJT: f64 = 14424.0;
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn run_sh_simulation_test(
     csv_name: &str,
-    degree: usize,
-    order: usize,
+    run_dir: &str,
     label: &str,
     test_name: &str,
     pos_tol: [f64; 3],
@@ -38,6 +38,32 @@ fn run_sh_simulation_test(
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load gravity control (degree/order) from grav_controls.py + RUN input chain.
+    // RUN_3B exec's RUN_3A, so we include both when needed. Files are processed in
+    // order; later assignments win.
+    let mut grav_files: Vec<std::path::PathBuf> =
+        vec![sim_dir.join("Modified_data/grav_controls.py")];
+    // RUN_3A is always in the chain (RUN_3B exec's it)
+    grav_files.push(sim_dir.join("SET_test/RUN_3A/input.py"));
+    if run_dir != "RUN_3A" {
+        grav_files.push(sim_dir.join(format!("SET_test/{run_dir}/input.py")));
+    }
+    let grav_file_refs: Vec<&std::path::Path> = grav_files.iter().map(|p| p.as_path()).collect();
+    let grav_cfg = jeod_test_data::gravity_control::load_gravity_control(&grav_file_refs);
+
     // Load GGM02C spherical harmonics coefficients
     let ggm02c_path = jeod_root.join("models/environment/gravity/data/src/earth_GGM02C.cc");
     let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C");
@@ -53,14 +79,12 @@ fn run_sh_simulation_test(
         model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
     };
 
-    // Initialize Simulation at the SIM_dyncomp epoch.
-    // TAI TJT = UTC TJT + TAI-UTC/86400
-    let epoch_tai_tjt = SH_EPOCH_UTC_TJT + SH_TAI_UTC_S / 86400.0;
+    // Initialize Simulation at the SIM_dyncomp epoch (parsed from time.py).
     let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
     // Set UT1-TAI offset so GMST computation matches JEOD's time.py configuration
-    time.set_ut1_tai_offset(SH_TAI_TO_UT1_S);
+    time.set_ut1_tai_offset(ut1_tai_offset);
 
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     // Earth source with planet-fixed rotation (Simulation updates it each step).
     // Initialize with identity — first step() will compute the real rotation.
@@ -81,7 +105,10 @@ fn run_sh_simulation_test(
         },
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_nonspherical(
-                earth, degree, order, false,
+                earth,
+                grav_cfg.degree,
+                grav_cfg.order,
+                grav_cfg.gradient,
             )],
         },
         ..Default::default()
@@ -150,8 +177,7 @@ fn run_sh_simulation_test(
 fn tier3_simulation_run3a_sh4x4() {
     run_sh_simulation_test(
         "dyncomp_run3a_state.csv",
-        4,
-        4,
+        "RUN_3A",
         "RUN_3A (4x4 SH + RNP)",
         "tier3_simulation_run3a_sh4x4",
         [5.3e-2, 1.344e-1, 1.026e-1],
@@ -163,8 +189,7 @@ fn tier3_simulation_run3a_sh4x4() {
 fn tier3_simulation_run3b_sh8x8() {
     run_sh_simulation_test(
         "dyncomp_run3b_state.csv",
-        8,
-        8,
+        "RUN_3B",
         "RUN_3B (8x8 SH + RNP)",
         "tier3_simulation_run3b_sh8x8",
         [1.325e-1, 2.3e-1, 1.646e-1],

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run4.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run4.rs
@@ -12,6 +12,9 @@
 //!
 //! Sun and Moon positions are queried from the DE421 ephemeris at each
 //! logged 60s sample.
+//!
+//! All simulation parameters (epoch, step size, mu values, mass) are loaded
+//! from the JEOD source files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
@@ -25,13 +28,8 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
-const MU_SUN: f64 = 1.327_124_40e20;
-const MU_MOON: f64 = 4902.79980693169e9;
-
-/// SIM_dyncomp epoch: 2007-11-20 midnight UTC, same as all other RUN_* tests.
-const DYNCOMP_UTC_TJT: f64 = 14424.0;
-const DYNCOMP_TAI_UTC_S: f64 = 32.0;
-const DYNCOMP_UT1_TAI_S: f64 = -32.469;
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 /// Compute Earth-centered position of a body from DE421 ephemeris.
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
@@ -43,6 +41,13 @@ fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemer
 
 #[test]
 fn tier3_simulation_run4_3rd_body() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run4_state.csv");
     assert!(
         csv_path.exists(),
@@ -60,22 +65,53 @@ fn tier3_simulation_run4_3rd_body() {
     );
     let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu values from JEOD gravity coefficient files.
+    // Sun/Moon use load_mu (spherical-only files lack degree/order fields).
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+    let mu_sun =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+            .expect("load Sun mu");
+    let mu_moon =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+            .expect("load Moon mu");
+
+    // Load ISS mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() > 100);
 
     let init = &trajectory[0];
 
-    // Initialize at the SIM_dyncomp epoch (2007-11-20 UTC) so DE421 Sun/Moon
+    // Initialize at the SIM_dyncomp epoch (parsed from time.py) so DE421 Sun/Moon
     // queries match the JEOD reference sim's absolute time.
-    let epoch_tai_tjt = DYNCOMP_UTC_TJT + DYNCOMP_TAI_UTC_S / 86400.0;
     let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(DYNCOMP_UT1_TAI_S);
-    let mut sim = Simulation::new(time, DT);
+    time.set_ut1_tai_offset(ut1_tai_offset);
+    let mut sim = Simulation::new(time, dt);
 
     // Earth: central body at origin (not differential)
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -91,7 +127,7 @@ fn tier3_simulation_run4_3rd_body() {
     let initial_sun = earth_centered_position(EphemerisBody::Sun, tdb_jd, &ephemeris);
     let sun = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         position: initial_sun,
@@ -106,7 +142,7 @@ fn tier3_simulation_run4_3rd_body() {
     let initial_moon = earth_centered_position(EphemerisBody::Moon, tdb_jd, &ephemeris);
     let moon = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_MOON,
+            mu: mu_moon,
             model: GravityModel::PointMass,
         },
         position: initial_moon,
@@ -117,13 +153,29 @@ fn tier3_simulation_run4_3rd_body() {
         tidal_config: None,
     });
 
-    // ISS mass properties (same as RUN_2 6-DOF test)
+    // ISS mass properties (parsed from Modified_data/mass.py)
     let inertia = glam::DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
     );
-    let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     sim.add_body(SimBody {
         trans: TranslationalState {

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run5.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run5.rs
@@ -8,11 +8,13 @@
 //!
 //! RUN_5B: JEOD config uses F10.7 = 128.8 (solar mean)
 //! RUN_5C: JEOD config uses F10.7 = 250.0 (solar max)
+//!
+//! Mass properties are loaded from the JEOD source files, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
 
-use glam::{DMat3, DVec3};
+use glam::DVec3;
 use jeod_sim::{
     DynamicsConfig, GravityControl, GravityControls, GravityModel, GravitySource,
     GravitySourceEntry, JeodQuat, MassProperties, RotationModel, RotationalState, SimBody,
@@ -70,24 +72,59 @@ fn run_atmosphere_test(
         csv_path.display()
     );
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    // ISS mass properties (from Modified_data/mass.py set_mass_iss)
-    let inertia = DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    // ISS mass properties (loaded from JEOD Modified_data/mass.py)
+    let sim_dir = jeod_root.join("verif/SIM_dyncomp");
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
     );
-    let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
+
+    // Load Earth mu and step size from JEOD source files
+    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu");
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
 
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run6.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run6.rs
@@ -1,4 +1,7 @@
 //! Tier 3: SIM_dyncomp RUN_6A/6B — Drag (constant density and MET atmosphere)
+//!
+//! All simulation parameters (epoch, step size, mu, mass) are loaded from JEOD
+//! source files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
@@ -12,17 +15,20 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
-/// Epoch for SIM_dyncomp: midnight 2007-11-20 UTC.
-/// MJD = 54424.0, TJT = MJD - 40000 = 14424.0.
-/// From JEOD time.py: TAI-UTC = 32s override, tai_to_ut1 = -32.469s.
-const DRAG_EPOCH_UTC_TJT: f64 = 14424.0;
-const DRAG_TAI_UTC_S: f64 = 32.0;
-const DRAG_TAI_TO_UT1_S: f64 = -32.469;
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 // ── RUN_6B: MET atmosphere + drag, 6-DOF ──
 
 #[test]
 fn tier3_simulation_run6b_drag() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run6b_state.csv");
     assert!(
         csv_path.exists(),
@@ -31,14 +37,59 @@ fn tier3_simulation_run6b_drag() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
+    // Load sphere mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_sphere"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
 
     let init = &trajectory[0];
 
-    // Unit sphere mass (from Modified_data/mass.py)
-    let inertia = DMat3::from_diagonal(DVec3::splat(0.4));
-    let mass_props = MassProperties::with_inertia(1.0, inertia, DVec3::ZERO);
+    // Sphere mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     // MET atmosphere: solar mean conditions (from Modified_data/solar_flux.py)
     let met_model = MetAtmosphere {
@@ -56,18 +107,17 @@ fn tier3_simulation_run6b_drag() {
     };
 
     // Initialize Simulation at the SIM_dyncomp epoch with correct time offsets.
-    let epoch_tai_tjt = DRAG_EPOCH_UTC_TJT + DRAG_TAI_UTC_S / 86400.0;
     let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(DRAG_TAI_TO_UT1_S);
+    time.set_ut1_tai_offset(ut1_tai_offset);
 
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     // Earth source with planet-fixed rotation — the Simulation's ephemeris stage
     // updates it each step via RNP, so the atmosphere system sees correct geodetic
     // coordinates. Without this, MET density is evaluated at wrong lat/lon.
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -188,6 +238,13 @@ fn tier3_simulation_run6b_drag() {
 
 #[test]
 fn tier3_simulation_run6a_const_density_drag() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run6a_state.csv");
     assert!(
         csv_path.exists(),
@@ -197,13 +254,58 @@ fn tier3_simulation_run6a_const_density_drag() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let earth_grav =
+        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth gravity");
+
+    // Load sphere mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_sphere"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    // Unit sphere mass (from Modified_data/mass.py)
-    let inertia = DMat3::from_diagonal(DVec3::splat(0.4));
-    let mass_props = MassProperties::with_inertia(1.0, inertia, DVec3::ZERO);
+    // Sphere mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     // MET atmosphere config — the Simulation still runs the atmosphere pipeline
     // for wind (co-rotation), but constant_density overrides the MET density.
@@ -222,15 +324,14 @@ fn tier3_simulation_run6a_const_density_drag() {
         constant_density: Some(1.4e-12),
     };
 
-    let epoch_tai_tjt = DRAG_EPOCH_UTC_TJT + DRAG_TAI_UTC_S / 86400.0;
     let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(DRAG_TAI_TO_UT1_S);
+    time.set_ut1_tai_offset(ut1_tai_offset);
 
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run7.rs
@@ -13,6 +13,9 @@
 //! and GGM02C gravity coefficients with RNP Earth rotation.
 //!
 //! Sun and Moon positions are queried from DE421 ephemeris at each logged 60s sample.
+//!
+//! Simulation parameters (epoch, step size, mu values) are loaded from the JEOD
+//! source files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
@@ -27,13 +30,8 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
-const MU_SUN: f64 = 1.327_124_40e20;
-const MU_MOON: f64 = 4902.79980693169e9;
-
-/// Epoch constants (same as other SIM_dyncomp tests: Nov 20 2007 00:00 UTC).
-const EPOCH_UTC_TJT: f64 = 14424.0;
-const TAI_UTC_S: f64 = 32.0;
-const TAI_TO_UT1_S: f64 = -32.469;
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
     let (pos, _) = ephemeris
@@ -42,11 +40,9 @@ fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemer
     pos
 }
 
-#[allow(clippy::too_many_arguments)]
 fn run_7_test(
     csv_name: &str,
-    degree: usize,
-    order: usize,
+    run_dir: &str,
     with_drag: bool,
     label: &str,
     test_name: &str,
@@ -77,20 +73,59 @@ fn run_7_test(
     );
     let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
 
-    // Load GGM02C spherical harmonics coefficients (same as RUN_3 tests)
-    let ggm02c_path = jeod_root.join("models/environment/gravity/data/src/earth_GGM02C.cc");
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load gravity control (degree/order) from the exec chain.
+    // All RUN_7* start from RUN_7A (which sets 4x4). RUN_7B/7D override to 8x8.
+    // RUN_7C exec's RUN_7A, RUN_7D exec's RUN_7B.
+    let mut grav_files: Vec<std::path::PathBuf> =
+        vec![sim_dir.join("Modified_data/grav_controls.py")];
+    // RUN_7A is always in the chain
+    grav_files.push(sim_dir.join("SET_test/RUN_7A/input.py"));
+    // For 8x8 variants (7B, 7D), RUN_7B adds the override
+    if run_dir == "RUN_7B" || run_dir == "RUN_7D" {
+        grav_files.push(sim_dir.join("SET_test/RUN_7B/input.py"));
+    }
+    // 7C and 7D have their own files too (mostly drag, no gravity changes)
+    if run_dir == "RUN_7C" || run_dir == "RUN_7D" {
+        grav_files.push(sim_dir.join(format!("SET_test/{run_dir}/input.py")));
+    }
+    let grav_file_refs: Vec<&std::path::Path> = grav_files.iter().map(|p| p.as_path()).collect();
+    let grav_cfg = jeod_test_data::gravity_control::load_gravity_control(&grav_file_refs);
+
+    // Load GGM02C spherical harmonics coefficients
+    let ggm02c_path = grav_data_dir.join("earth_GGM02C.cc");
     let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C");
+
+    // Load Sun/Moon mu (spherical-only files lack degree/order fields)
+    let mu_sun =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+            .expect("load Sun mu");
+    let mu_moon =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+            .expect("load Moon mu");
 
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() > 100);
     let init = &trajectory[0];
 
-    // Initialize Simulation at the SIM_dyncomp epoch
-    let epoch_tai_tjt = EPOCH_UTC_TJT + TAI_UTC_S / 86400.0;
+    // Initialize Simulation at the SIM_dyncomp epoch (parsed from time.py)
     let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(TAI_TO_UT1_S);
+    time.set_ut1_tai_offset(ut1_tai_offset);
 
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     // Earth source with SH gravity and planet-fixed rotation
     let sh_source = GravitySource {
@@ -107,11 +142,11 @@ fn run_7_test(
         tidal_config: None,
     });
 
-    // Sun and Moon: third-body differential acceleration
+    // Sun and Moon: third-body differential acceleration (mu from JEOD gravity files)
     let tdb_jd = sim.time.tdb_julian_date();
     let sun = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         position: earth_centered_position(EphemerisBody::Sun, tdb_jd, &ephemeris),
@@ -123,7 +158,7 @@ fn run_7_test(
     });
     let moon = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_MOON,
+            mu: mu_moon,
             model: GravityModel::PointMass,
         },
         position: earth_centered_position(EphemerisBody::Moon, tdb_jd, &ephemeris),
@@ -160,9 +195,33 @@ fn run_7_test(
         None
     };
 
-    // Sphere mass: 1 kg, inertia 0.4*I, CoM at origin (from Modified_data/mass.py)
-    let sphere_mass =
-        MassProperties::with_inertia(1.0, DMat3::from_diagonal(DVec3::splat(0.4)), DVec3::ZERO);
+    // Sphere mass (loaded from JEOD Modified_data/mass.py, function set_mass_sphere)
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_sphere"),
+    );
+    let sphere_inertia = DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    let sphere_mass = MassProperties::with_inertia(
+        mass_init.mass,
+        sphere_inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     // Drag requires RotationalState for inertial-to-body frame transform.
     // Even for a sphere (isotropic drag), the code path needs orientation.
@@ -192,7 +251,12 @@ fn run_7_test(
         config,
         gravity_controls: GravityControls {
             controls: vec![
-                GravityControl::new_nonspherical(earth, degree, order, false),
+                GravityControl::new_nonspherical(
+                    earth,
+                    grav_cfg.degree,
+                    grav_cfg.order,
+                    grav_cfg.gradient,
+                ),
                 GravityControl::new_third_body(sun),
                 GravityControl::new_third_body(moon),
             ],
@@ -265,14 +329,11 @@ fn run_7_test(
     report.assert_velocity(vel_tol);
 }
 
-// Provisional tolerances: set high initially, tighten after first run.
-
 #[test]
 fn tier3_simulation_run7a_sh4x4_3rd_body() {
     run_7_test(
         "dyncomp_run7a_state.csv",
-        4,
-        4,
+        "RUN_7A",
         false,
         "RUN_7A (4x4 SH + Sun/Moon, no drag)",
         "tier3_simulation_run7a",
@@ -285,8 +346,7 @@ fn tier3_simulation_run7a_sh4x4_3rd_body() {
 fn tier3_simulation_run7b_sh8x8_3rd_body() {
     run_7_test(
         "dyncomp_run7b_state.csv",
-        8,
-        8,
+        "RUN_7B",
         false,
         "RUN_7B (8x8 SH + Sun/Moon, no drag)",
         "tier3_simulation_run7b",
@@ -299,8 +359,7 @@ fn tier3_simulation_run7b_sh8x8_3rd_body() {
 fn tier3_simulation_run7c_sh4x4_3rd_body_drag() {
     run_7_test(
         "dyncomp_run7c_state.csv",
-        4,
-        4,
+        "RUN_7C",
         true,
         "RUN_7C (4x4 SH + Sun/Moon + drag)",
         "tier3_simulation_run7c",
@@ -313,8 +372,7 @@ fn tier3_simulation_run7c_sh4x4_3rd_body_drag() {
 fn tier3_simulation_run7d_sh8x8_3rd_body_drag() {
     run_7_test(
         "dyncomp_run7d_state.csv",
-        8,
-        8,
+        "RUN_7D",
         true,
         "RUN_7D (8x8 SH + Sun/Moon + drag)",
         "tier3_simulation_run7d",

--- a/crates/jeod_sim/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_sim/tests/tier3_sim_dyncomp_run9.rs
@@ -1,4 +1,7 @@
 //! Tier 3: SIM_dyncomp RUN_9A/9C/9D — External force/torque
+//!
+//! All simulation parameters (mu, step size, mass) are loaded from JEOD source
+//! files rather than hardcoded, per issue #44.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
@@ -9,6 +12,9 @@ use jeod_sim::{
     MassProperties, RotationalState, TranslationalState,
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
+
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 // ── RUN_9A: External torque, 6-DOF ──
 //
@@ -25,6 +31,13 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 #[test]
 fn tier3_simulation_run9a_torque() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run9a_state.csv");
     assert!(
         csv_path.exists(),
@@ -32,17 +45,50 @@ fn tier3_simulation_run9a_torque() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
+    // Load ISS mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    // ISS mass properties (from Modified_data/mass.py)
-    let inertia = DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    // ISS mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
     );
-    let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     // Use per-body functions directly for torque injection.
     // This still validates jeod_sim's integrate_body and accumulate_gravity.
@@ -66,7 +112,7 @@ fn tier3_simulation_run9a_torque() {
     };
 
     let earth_source = GravitySource {
-        mu: MU_EARTH,
+        mu: mu_earth,
         model: GravityModel::PointMass,
     };
 
@@ -79,7 +125,7 @@ fn tier3_simulation_run9a_torque() {
     let mut current_time = init.time;
 
     for record in &trajectory[1..] {
-        while current_time + DT <= record.time + 0.001 {
+        while current_time + dt <= record.time + 0.001 {
             // Gravity (per-body function)
             let grav = jeod_sim::accumulate_gravity(
                 trans.position,
@@ -118,7 +164,7 @@ fn tier3_simulation_run9a_torque() {
             // Gravity recomputed at each RK4 intermediate state via closure.
             let gravity_fn = |pos: DVec3, _vel: DVec3| {
                 let r = pos.length();
-                pos * (-MU_EARTH / (r * r * r))
+                pos * (-mu_earth / (r * r * r))
             };
             jeod_sim::integrate_body(
                 &config,
@@ -128,12 +174,12 @@ fn tier3_simulation_run9a_torque() {
                 gravity_fn,
                 total.force,
                 total.torque + external_torque,
-                DT,
+                dt,
                 1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );
-            current_time += DT;
+            current_time += dt;
         }
 
         // Handle fractional remainder
@@ -169,7 +215,7 @@ fn tier3_simulation_run9a_torque() {
             );
             let gravity_fn = |pos: DVec3, _vel: DVec3| {
                 let r = pos.length();
-                pos * (-MU_EARTH / (r * r * r))
+                pos * (-mu_earth / (r * r * r))
             };
             jeod_sim::integrate_body(
                 &config,
@@ -256,6 +302,13 @@ fn tier3_simulation_run9a_torque() {
 
 #[test]
 fn tier3_simulation_run9c_force_torque() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run9c_state.csv");
     assert!(
         csv_path.exists(),
@@ -264,16 +317,50 @@ fn tier3_simulation_run9c_force_torque() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
+    // Load ISS mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    let inertia = DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    // ISS mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
     );
-    let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     let mut trans = TranslationalState {
         position: init.composite_body.position,
@@ -295,7 +382,7 @@ fn tier3_simulation_run9c_force_torque() {
     };
 
     let earth_source = GravitySource {
-        mu: MU_EARTH,
+        mu: mu_earth,
         model: GravityModel::PointMass,
     };
 
@@ -303,7 +390,7 @@ fn tier3_simulation_run9c_force_torque() {
     let mut current_time = init.time;
 
     for record in &trajectory[1..] {
-        while current_time + DT <= record.time + 0.001 {
+        while current_time + dt <= record.time + 0.001 {
             let grav = jeod_sim::accumulate_gravity(
                 trans.position,
                 &gravity_controls,
@@ -344,7 +431,7 @@ fn tier3_simulation_run9c_force_torque() {
 
             let gravity_fn = |pos: DVec3, _vel: DVec3| {
                 let r = pos.length();
-                pos * (-MU_EARTH / (r * r * r))
+                pos * (-mu_earth / (r * r * r))
             };
             jeod_sim::integrate_body(
                 &config,
@@ -354,12 +441,12 @@ fn tier3_simulation_run9c_force_torque() {
                 gravity_fn,
                 total.force + external_force_inertial,
                 total.torque + external_torque,
-                DT,
+                dt,
                 1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );
-            current_time += DT;
+            current_time += dt;
         }
 
         our_states.push(StateLog {
@@ -412,6 +499,13 @@ fn tier3_simulation_run9c_force_torque() {
 
 #[test]
 fn tier3_simulation_run9d_force_torque_rate() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("dyncomp_run9d_state.csv");
     assert!(
         csv_path.exists(),
@@ -420,16 +514,50 @@ fn tier3_simulation_run9d_force_torque_rate() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load mu from JEOD gravity coefficient file
+    let mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
+    // Load ISS mass properties from SIM_dyncomp mass.py
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &sim_dir.join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
+    );
+
     let trajectory = load_dyncomp_csv(&csv_path);
     assert!(trajectory.len() >= 100);
     let init = &trajectory[0];
 
-    let inertia = DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    // ISS mass properties (parsed from Modified_data/mass.py)
+    let inertia = glam::DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
     );
-    let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
+    let mass_props = MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    );
 
     let mut trans = TranslationalState {
         position: init.composite_body.position,
@@ -451,7 +579,7 @@ fn tier3_simulation_run9d_force_torque_rate() {
     };
 
     let earth_source = GravitySource {
-        mu: MU_EARTH,
+        mu: mu_earth,
         model: GravityModel::PointMass,
     };
 
@@ -459,7 +587,7 @@ fn tier3_simulation_run9d_force_torque_rate() {
     let mut current_time = init.time;
 
     for record in &trajectory[1..] {
-        while current_time + DT <= record.time + 0.001 {
+        while current_time + dt <= record.time + 0.001 {
             let grav = jeod_sim::accumulate_gravity(
                 trans.position,
                 &gravity_controls,
@@ -497,7 +625,7 @@ fn tier3_simulation_run9d_force_torque_rate() {
 
             let gravity_fn = |pos: DVec3, _vel: DVec3| {
                 let r = pos.length();
-                pos * (-MU_EARTH / (r * r * r))
+                pos * (-mu_earth / (r * r * r))
             };
             jeod_sim::integrate_body(
                 &config,
@@ -507,12 +635,12 @@ fn tier3_simulation_run9d_force_torque_rate() {
                 gravity_fn,
                 total.force + external_force_inertial,
                 total.torque + external_torque,
-                DT,
+                dt,
                 1.0,
                 jeod_sim::IntegratorType::Rk4,
                 None,
             );
-            current_time += DT;
+            current_time += dt;
         }
 
         our_states.push(StateLog {

--- a/crates/jeod_sim/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_sim/tests/tier3_sim_earth_moon.rs
@@ -24,6 +24,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
@@ -32,6 +37,11 @@ fn load_mu_earth() -> f64 {
 
 fn load_mu_sun() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_sim/tests/tier3_sim_earth_moon.rs
@@ -22,7 +22,21 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
-const MU_EARTH: f64 = 3.986_004_415e14;
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
+fn load_mu_sun() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
+    )
+    .expect("load Sun mu from sun_spherical")
+}
 
 /// Load a state CSV with interleaved columns: time, pos[0], vel[0], pos[1], vel[1], pos[2], vel[2].
 fn load_interleaved_csv(path: &std::path::Path, sim_name: &str) -> Vec<StateLog> {
@@ -60,6 +74,8 @@ fn load_interleaved_csv(path: &std::path::Path, sim_name: &str) -> Vec<StateLog>
 /// + cannonball SRP, matching JEOD SIM_Earth_Moon RUN_clem.
 #[test]
 fn tier3_simulation_earth_moon_clem() {
+    let mu_earth = load_mu_earth();
+    let mu_sun = load_mu_sun();
     let csv_path = test_data_path("earth_moon_clem_earth_moon.csv");
     let ref_states = load_interleaved_csv(&csv_path, "SIM_Earth_Moon RUN_clem");
     assert!(
@@ -124,7 +140,7 @@ fn tier3_simulation_earth_moon_clem() {
 
     let earth = sim.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         earth_pos_from_moon,
@@ -138,7 +154,7 @@ fn tier3_simulation_earth_moon_clem() {
         .expect("Sun-Moon state from DE421");
     let sun = sim.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: 1.327_124_40e20,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         sun_pos_from_moon,

--- a/crates/jeod_sim/tests/tier3_sim_euler.rs
+++ b/crates/jeod_sim/tests/tier3_sim_euler.rs
@@ -16,6 +16,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_euler.rs
+++ b/crates/jeod_sim/tests/tier3_sim_euler.rs
@@ -14,8 +14,17 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 #[test]
 fn tier3_simulation_euler() {
+    let mu_earth = load_mu_earth();
     let csv_path = test_data_path("dyncomp_run2_state.csv");
     assert!(
         csv_path.exists(),
@@ -35,12 +44,21 @@ fn tier3_simulation_euler() {
     );
     let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt =
+        jeod_test_data::s_define::load_dynamics_dt(&jeod_root.join("verif/SIM_dyncomp/S_define"));
+
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_sim/tests/tier3_sim_euler_edge.rs
@@ -20,6 +20,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_sim/tests/tier3_sim_euler_edge.rs
@@ -4,7 +4,7 @@
 //!          exercises Euler angle computation at different angular velocities.
 //! RUN_equ: Equatorial orbit (i=0) — exercises gimbal-lock-adjacent sequences.
 //!
-//! Both use point-mass Earth gravity, RK4 at DT=0.03125s, 24h duration.
+//! Both use point-mass Earth gravity, RK4 at the SIM_Euler S_define step size, 24h duration.
 //! Euler angles are validated against JEOD's logged quaternion data.
 
 mod sim_test_helpers;
@@ -18,9 +18,18 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 /// Set up an Euler-style simulation from CSV initial conditions.
 /// SIM_Euler uses the same mass/config as SIM_dyncomp RUN_2.
 fn run_euler_test(csv_filename: &str, label: &str, test_name: &str, quat_tol: f64, euler_tol: f64) {
+    let mu_earth = load_mu_earth();
     let csv_path = test_data_path(csv_filename);
     assert!(
         csv_path.exists(),
@@ -42,12 +51,22 @@ fn run_euler_test(csv_filename: &str, label: &str, test_name: &str, quat_tol: f6
     );
     let mass_props = MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0));
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt = jeod_test_data::s_define::load_dynamics_dt(
+        &jeod_root.join("models/dynamics/derived_state/verif/SIM_Euler/S_define"),
+    );
+
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_lvlh.rs
+++ b/crates/jeod_sim/tests/tier3_sim_lvlh.rs
@@ -15,6 +15,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_lvlh.rs
+++ b/crates/jeod_sim/tests/tier3_sim_lvlh.rs
@@ -13,8 +13,17 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 #[test]
 fn tier3_simulation_lvlh() {
+    let mu_earth = load_mu_earth();
     let csv_path = test_data_path("lvlh_inc_lvlh.csv");
     assert!(
         csv_path.exists(),
@@ -27,12 +36,22 @@ fn tier3_simulation_lvlh() {
     assert!(records.len() > 100);
     let init = &records[0];
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt = jeod_test_data::s_define::load_dynamics_dt(
+        &jeod_root.join("models/dynamics/derived_state/verif/SIM_LVLH/S_define"),
+    );
+
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_lvlh_edge.rs
+++ b/crates/jeod_sim/tests/tier3_sim_lvlh_edge.rs
@@ -4,7 +4,7 @@
 //!          exercises LVLH frame computation at different velocities.
 //! RUN_equ: Equatorial orbit (i=0) — near-singular LVLH at zero inclination.
 //!
-//! Point-mass Earth gravity, RK4 at DT=0.03125s, 24h.
+//! Point-mass Earth gravity, RK4 at the SIM_LVLH S_define step size, 24h.
 
 mod sim_test_helpers;
 use sim_test_helpers::*;
@@ -15,6 +15,14 @@ use jeod_sim::{
     RotationModel, SimBody, Simulation, SimulationTime, TranslationalState,
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
+
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
 
 fn run_lvlh_test(
     csv_filename: &str,
@@ -37,12 +45,22 @@ fn run_lvlh_test(
     assert!(records.len() > 100);
     let init = &records[0];
 
+    let mu_earth = load_mu_earth();
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt = jeod_test_data::s_define::load_dynamics_dt(
+        &jeod_root.join("models/dynamics/derived_state/verif/SIM_LVLH/S_define"),
+    );
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_lvlh_edge.rs
+++ b/crates/jeod_sim/tests/tier3_sim_lvlh_edge.rs
@@ -18,6 +18,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_sim/tests/tier3_sim_mars_orbit.rs
@@ -16,6 +16,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_sun() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_sim/tests/tier3_sim_mars_orbit.rs
@@ -14,7 +14,13 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
-const MU_SUN: f64 = 1.327_124_40e20;
+fn load_mu_sun() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
+    )
+    .expect("load Sun mu from sun_spherical")
+}
 
 /// Load a state CSV with interleaved columns: time, pos[0], vel[0], pos[1], vel[1], pos[2], vel[2].
 /// This is the default DRAscii layout when position and velocity are logged per-component.
@@ -56,6 +62,7 @@ fn load_interleaved_csv(path: &std::path::Path, sim_name: &str) -> Vec<StateLog>
 /// tighten the tolerance significantly.
 #[test]
 fn tier3_simulation_mars_dawn() {
+    let mu_sun = load_mu_sun();
     let csv_path = test_data_path("mars_dawn_mars.csv");
     let ref_states = load_interleaved_csv(&csv_path, "SIM_Mars RUN_dawn");
     assert!(
@@ -117,7 +124,7 @@ fn tier3_simulation_mars_dawn() {
     // Sun as 3rd-body with per-step DE421 ephemeris updates
     let sun = sim.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         sun_pos_from_mars,

--- a/crates/jeod_sim/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_sim/tests/tier3_sim_mercury.rs
@@ -20,6 +20,11 @@ use jeod_sim::{
 
 fn load_mu_sun() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_sim/tests/tier3_sim_mercury.rs
@@ -18,7 +18,13 @@ use jeod_sim::{
     Simulation, SimulationTime, TranslationalState,
 };
 
-const MU_SUN: f64 = 1.327_124_400_18e20;
+fn load_mu_sun() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
+    )
+    .expect("load Sun mu from sun_spherical")
+}
 
 /// Mercury at perihelion (approximate J2000 elements).
 fn mercury_perihelion_state() -> (DVec3, DVec3) {
@@ -39,7 +45,11 @@ struct PeriapsisEvent {
 }
 
 /// Propagate Mercury for N orbits, collecting periapsis events.
-fn propagate_mercury_periapses(relativistic: bool, num_orbits: usize) -> Vec<PeriapsisEvent> {
+fn propagate_mercury_periapses(
+    relativistic: bool,
+    num_orbits: usize,
+    mu_sun: f64,
+) -> Vec<PeriapsisEvent> {
     let leap_table = jeod_sim::default_leap_second_table();
     let time = SimulationTime::at_j2000(leap_table);
     let dt = 100.0; // 100s timestep
@@ -49,7 +59,7 @@ fn propagate_mercury_periapses(relativistic: bool, num_orbits: usize) -> Vec<Per
 
     let sun = sim.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         DVec3::ZERO,
@@ -89,7 +99,7 @@ fn propagate_mercury_periapses(relativistic: bool, num_orbits: usize) -> Vec<Per
         let r_dot = r.dot(v) / r.length();
 
         if step > 0 && prev_rdot < 0.0 && r_dot >= 0.0 {
-            if let Ok(e) = jeod_sim::OrbitalElements::from_cartesian(MU_SUN, r, v) {
+            if let Ok(e) = jeod_sim::OrbitalElements::from_cartesian(mu_sun, r, v) {
                 events.push(PeriapsisEvent {
                     time: sim_time,
                     long_perihelion: e.arg_periapsis + e.long_asc_node,
@@ -219,6 +229,7 @@ fn detect_periapses_from_csv(path: &std::path::Path, mu: f64) -> Vec<PeriapsisEv
 /// the relativistic correction is functioning in the simulation pipeline.
 #[test]
 fn tier3_simulation_mercury_relativistic_effect() {
+    let mu_sun = load_mu_sun();
     let num_orbits = 10;
 
     // Propagate Newtonian
@@ -234,7 +245,7 @@ fn tier3_simulation_mercury_relativistic_effect() {
     let mut sim_n = Simulation::new(time_n, dt);
     let sun_n = sim_n.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         DVec3::ZERO,
@@ -260,7 +271,7 @@ fn tier3_simulation_mercury_relativistic_effect() {
     let mut sim_r = Simulation::new(time_r, dt);
     let sun_r = sim_r.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         DVec3::ZERO,
@@ -313,12 +324,13 @@ fn tier3_simulation_mercury_relativistic_effect() {
 /// runs use the same integrator, so systematic integration errors cancel.
 #[test]
 fn tier3_mercury_perihelion_advance_rate() {
+    let mu_sun = load_mu_sun();
     let num_orbits = 200;
 
     println!("  Propagating Newtonian ({num_orbits} orbits)...");
-    let newton_events = propagate_mercury_periapses(false, num_orbits);
+    let newton_events = propagate_mercury_periapses(false, num_orbits, mu_sun);
     println!("  Propagating relativistic ({num_orbits} orbits)...");
-    let gr_events = propagate_mercury_periapses(true, num_orbits);
+    let gr_events = propagate_mercury_periapses(true, num_orbits, mu_sun);
 
     println!(
         "  Detected {} Newtonian and {} GR periapsis passages",
@@ -361,7 +373,7 @@ fn tier3_mercury_jeod_advance_rate() {
     // JEOD SIM_mercury uses DE405 GMs. The Sun mu in DE405 AU^3/day^2 units,
     // converted to km^3/s^2 by the setup.py. For our orbital element computation
     // we need mu in m^3/s^2 — use the same value as our simulation.
-    let mu = MU_SUN;
+    let mu = load_mu_sun();
 
     let newton_csv = test_data_path("mercury_newtonian_mercury.csv");
     let gr_csv = test_data_path("mercury_relativistic_mercury.csv");

--- a/crates/jeod_sim/tests/tier3_sim_ned.rs
+++ b/crates/jeod_sim/tests/tier3_sim_ned.rs
@@ -22,17 +22,22 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 const GEO_R_EQ: f64 = 6_378_137.0;
 const GEO_R_POL: f64 = GEO_R_EQ * (1.0 - 1.0 / 298.257_223_563);
 
-/// SIM_NED epoch: 1991-01-01 00:00:00 UTC.
-/// MJD = 48257.0, TJT = MJD - 40000 = 8257.0.
-const NED_EPOCH_UTC_TJT: f64 = 8257.0;
-const NED_TAI_UTC_S: f64 = 26.0;
+/// SIM_NED directory relative to JEOD root.
+const SIM_NED: &str = "models/dynamics/derived_state/verif/SIM_NED";
+
 /// UT1-TAI from JEOD tai_to_ut1.cc at 1991-01-01 (index 10592).
+/// This comes from JEOD's internal UT1 data table, not a sim config file.
 const NED_UT1_TAI_S: f64 = -25.381_221_5;
-/// Integration step: 1.0s (matches JEOD SIM_NED DYNAMICS rate).
-const NED_DT: f64 = 1.0;
 
 #[test]
 fn tier3_simulation_geodetic() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("ned_ell_inc_ned.csv");
     assert!(
         csv_path.exists(),
@@ -41,21 +46,39 @@ fn tier3_simulation_geodetic() {
         csv_path.display()
     );
 
+    let sim_dir = jeod_root.join(SIM_NED);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch from JEOD time config. SIM_NED uses UTC initializer without
+    // leap_sec_override_val, so we look up TAI-UTC from our leap second table.
+    let time_cfg = jeod_test_data::time_config::load_time_config(
+        &sim_dir.join("Modified_data/date_and_time.py"),
+    );
+    let leap_table = jeod_sim::default_leap_second_table();
+    let tai_utc_s = leap_table.tai_utc_at_utc_tjt(time_cfg.utc_tjt());
+    let epoch_tai_tjt = time_cfg.tai_tjt_with_offset(tai_utc_s);
+
+    // Load integration step size from S_define
+    let ned_dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load Earth mu from JEOD gravity data
+    let mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
     let records = load_ned_csv(&csv_path);
     assert!(records.len() > 100);
     let init = &records[0];
 
-    // Initialize at 1991-01-01 00:00:00 UTC
-    let epoch_tai_tjt = NED_EPOCH_UTC_TJT + NED_TAI_UTC_S / 86400.0;
-    let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
+    let mut time = SimulationTime::new(epoch_tai_tjt, leap_table);
     time.set_ut1_tai_offset(NED_UT1_TAI_S);
 
-    let mut sim = Simulation::new(time, NED_DT);
+    let mut sim = Simulation::new(time, ned_dt);
 
     // Earth: point-mass gravity (JEOD SIM_NED uses spherical=1) with RNP rotation
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_ned.rs
+++ b/crates/jeod_sim/tests/tier3_sim_ned.rs
@@ -22,6 +22,8 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 const GEO_R_EQ: f64 = 6_378_137.0;
 const GEO_R_POL: f64 = GEO_R_EQ * (1.0 - 1.0 / 298.257_223_563);
 
+/// Derived-state verif directory (shared Modified_data/ lives here, not in SIM_NED/).
+const DERIVED_STATE_VERIF: &str = "models/dynamics/derived_state/verif";
 /// SIM_NED directory relative to JEOD root.
 const SIM_NED: &str = "models/dynamics/derived_state/verif/SIM_NED";
 
@@ -47,12 +49,15 @@ fn tier3_simulation_geodetic() {
     );
 
     let sim_dir = jeod_root.join(SIM_NED);
+    let verif_dir = jeod_root.join(DERIVED_STATE_VERIF);
     let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
 
-    // Load epoch from JEOD time config. SIM_NED uses UTC initializer without
-    // leap_sec_override_val, so we look up TAI-UTC from our leap second table.
+    // Load epoch from JEOD time config. The derived-state SIMs share
+    // Modified_data/ at the verif/ level (not inside each SIM directory).
+    // SIM_NED uses UTC initializer without leap_sec_override_val, so we
+    // look up TAI-UTC from our leap second table.
     let time_cfg = jeod_test_data::time_config::load_time_config(
-        &sim_dir.join("Modified_data/date_and_time.py"),
+        &verif_dir.join("Modified_data/date_and_time.py"),
     );
     let leap_table = jeod_sim::default_leap_second_table();
     let tai_utc_s = leap_table.tai_utc_at_utc_tjt(time_cfg.utc_tjt());

--- a/crates/jeod_sim/tests/tier3_sim_ned_edge.rs
+++ b/crates/jeod_sim/tests/tier3_sim_ned_edge.rs
@@ -25,6 +25,8 @@ const GEO_R_POL: f64 = GEO_R_EQ * (1.0 - 1.0 / 298.257_223_563);
 /// Spherical Earth radius (JEOD uses r_eq for spherical model).
 const GEO_R_SPH: f64 = GEO_R_EQ;
 
+/// Derived-state verif directory (shared Modified_data/ lives here, not in SIM_NED/).
+const DERIVED_STATE_VERIF: &str = "models/dynamics/derived_state/verif";
 /// SIM_NED directory relative to JEOD root.
 const SIM_NED: &str = "models/dynamics/derived_state/verif/SIM_NED";
 
@@ -199,12 +201,13 @@ fn load_ned_params() -> (f64, LeapSecondTable, f64, f64) {
     );
 
     let sim_dir = jeod_root.join(SIM_NED);
+    let verif_dir = jeod_root.join(DERIVED_STATE_VERIF);
     let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
 
-    // Load epoch from JEOD time config. SIM_NED uses UTC initializer without
-    // leap_sec_override_val, so we look up TAI-UTC from our leap second table.
+    // Load epoch from JEOD time config. The derived-state SIMs share
+    // Modified_data/ at the verif/ level (not inside each SIM directory).
     let time_cfg = jeod_test_data::time_config::load_time_config(
-        &sim_dir.join("Modified_data/date_and_time.py"),
+        &verif_dir.join("Modified_data/date_and_time.py"),
     );
     let leap_table = jeod_sim::default_leap_second_table();
     let tai_utc_s = leap_table.tai_utc_at_utc_tjt(time_cfg.utc_tjt());

--- a/crates/jeod_sim/tests/tier3_sim_ned_edge.rs
+++ b/crates/jeod_sim/tests/tier3_sim_ned_edge.rs
@@ -18,16 +18,19 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+use jeod_sim::LeapSecondTable;
+
 const GEO_R_EQ: f64 = 6_378_137.0;
 const GEO_R_POL: f64 = GEO_R_EQ * (1.0 - 1.0 / 298.257_223_563);
 /// Spherical Earth radius (JEOD uses r_eq for spherical model).
 const GEO_R_SPH: f64 = GEO_R_EQ;
 
-/// SIM_NED epoch: 1991-01-01 00:00:00 UTC.
-const NED_EPOCH_UTC_TJT: f64 = 8257.0;
-const NED_TAI_UTC_S: f64 = 26.0;
+/// SIM_NED directory relative to JEOD root.
+const SIM_NED: &str = "models/dynamics/derived_state/verif/SIM_NED";
+
+/// UT1-TAI from JEOD tai_to_ut1.cc at 1991-01-01 (index 10592).
+/// This comes from JEOD's internal UT1 data table, not a sim config file.
 const NED_UT1_TAI_S: f64 = -25.381_221_5;
-const NED_DT: f64 = 1.0;
 
 #[allow(clippy::too_many_arguments)]
 fn run_ned_test(
@@ -39,6 +42,10 @@ fn run_ned_test(
     tol_lat: f64,
     tol_lon: f64,
     test_name: &str,
+    epoch_tai_tjt: f64,
+    leap_table: LeapSecondTable,
+    ned_dt: f64,
+    mu_earth: f64,
 ) {
     let csv_path = test_data_path(csv_filename);
     assert!(
@@ -53,15 +60,14 @@ fn run_ned_test(
     assert!(records.len() > 100);
     let init = &records[0];
 
-    let epoch_tai_tjt = NED_EPOCH_UTC_TJT + NED_TAI_UTC_S / 86400.0;
-    let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
+    let mut time = SimulationTime::new(epoch_tai_tjt, leap_table);
     time.set_ut1_tai_offset(NED_UT1_TAI_S);
 
-    let mut sim = Simulation::new(time, NED_DT);
+    let mut sim = Simulation::new(time, ned_dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -183,8 +189,41 @@ fn run_ned_test(
     report.assert_position(pos_tol);
 }
 
+/// Load SIM_NED parameters from JEOD source files.
+fn load_ned_params() -> (f64, LeapSecondTable, f64, f64) {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
+    let sim_dir = jeod_root.join(SIM_NED);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch from JEOD time config. SIM_NED uses UTC initializer without
+    // leap_sec_override_val, so we look up TAI-UTC from our leap second table.
+    let time_cfg = jeod_test_data::time_config::load_time_config(
+        &sim_dir.join("Modified_data/date_and_time.py"),
+    );
+    let leap_table = jeod_sim::default_leap_second_table();
+    let tai_utc_s = leap_table.tai_utc_at_utc_tjt(time_cfg.utc_tjt());
+    let epoch_tai_tjt = time_cfg.tai_tjt_with_offset(tai_utc_s);
+
+    // Load integration step size from S_define
+    let ned_dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load Earth mu from JEOD gravity data
+    let mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
+    (epoch_tai_tjt, leap_table, ned_dt, mu_earth)
+}
+
 #[test]
 fn tier3_simulation_ned_polar() {
+    let (epoch_tai_tjt, leap_table, ned_dt, mu_earth) = load_ned_params();
     // Polar orbit on ellipsoidal Earth. Position drift ~20 um over 24h causes:
     //   altitude: 2e-4 m (comparable to existing ell_inc's 8.5e-4 m)
     //   latitude: 1e-8 rad (well-behaved even at poles)
@@ -199,11 +238,16 @@ fn tier3_simulation_ned_polar() {
         1.089e-8,
         3.349e-5,
         "tier3_simulation_ned_polar",
+        epoch_tai_tjt,
+        leap_table,
+        ned_dt,
+        mu_earth,
     );
 }
 
 #[test]
 fn tier3_simulation_ned_sph_inc() {
+    let (epoch_tai_tjt, leap_table, ned_dt, mu_earth) = load_ned_params();
     // Inclined orbit on spherical Earth. All errors < 1e-6, same regime as ell_inc.
     run_ned_test(
         "ned_sph_inc_ned.csv",
@@ -214,11 +258,16 @@ fn tier3_simulation_ned_sph_inc() {
         4.181e-8,
         6.493e-8,
         "tier3_simulation_ned_sph_inc",
+        epoch_tai_tjt,
+        leap_table,
+        ned_dt,
+        mu_earth,
     );
 }
 
 #[test]
 fn tier3_simulation_ned_sph_polar() {
+    let (epoch_tai_tjt, leap_table, ned_dt, mu_earth) = load_ned_params();
     // Polar orbit on spherical Earth. Same pole singularity as ell_polar.
     run_ned_test(
         "ned_sph_polar_ned.csv",
@@ -229,5 +278,9 @@ fn tier3_simulation_ned_sph_polar() {
         1.083e-8,
         3.349e-5,
         "tier3_simulation_ned_sph_polar",
+        epoch_tai_tjt,
+        leap_table,
+        ned_dt,
+        mu_earth,
     );
 }

--- a/crates/jeod_sim/tests/tier3_sim_orbelem.rs
+++ b/crates/jeod_sim/tests/tier3_sim_orbelem.rs
@@ -13,8 +13,17 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 #[test]
 fn tier3_simulation_orbelem() {
+    let mu_earth = load_mu_earth();
     let csv_path = test_data_path("orbelem_ecc_orbelem.csv");
     assert!(
         csv_path.exists(),
@@ -27,12 +36,22 @@ fn tier3_simulation_orbelem() {
     assert!(records.len() > 100);
     let init = &records[0];
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt = jeod_test_data::s_define::load_dynamics_dt(
+        &jeod_root.join("models/dynamics/derived_state/verif/SIM_OrbElem/S_define"),
+    );
+
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_orbelem.rs
+++ b/crates/jeod_sim/tests/tier3_sim_orbelem.rs
@@ -15,6 +15,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/jeod_sim/tests/tier3_sim_orbelem_comprehensive.rs
@@ -19,6 +19,14 @@ use sim_test_helpers::*;
 use glam::DVec3;
 use jeod_sim::OrbitalElements;
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 /// Full record parsed from the verification CSV (all 21 columns).
 struct VerifRecord {
     semi_major_axis: f64,
@@ -129,9 +137,10 @@ fn assert_angle_close(name: &str, computed: f64, reference: f64, abs_tol: f64) {
 /// orb_ang_momentum=0). Our code computes valid values for these, but JEOD
 /// intentionally zeros them out for parabolic-regime orbits.
 fn verify_orbit_family(csv_name: &str, label: &str, skip_degenerate_scalars: bool) {
+    let mu_earth = load_mu_earth();
     let rec = load_verif_record(csv_name);
 
-    let oe = OrbitalElements::from_cartesian(MU_EARTH, rec.position, rec.velocity)
+    let oe = OrbitalElements::from_cartesian(mu_earth, rec.position, rec.velocity)
         .unwrap_or_else(|e| panic!("{label}: from_cartesian failed: {e:?}"));
 
     println!("Tier 3 (Static): {label}");

--- a/crates/jeod_sim/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/jeod_sim/tests/tier3_sim_orbelem_comprehensive.rs
@@ -21,6 +21,11 @@ use jeod_sim::OrbitalElements;
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_planetary.rs
+++ b/crates/jeod_sim/tests/tier3_sim_planetary.rs
@@ -21,6 +21,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_planetary.rs
+++ b/crates/jeod_sim/tests/tier3_sim_planetary.rs
@@ -19,6 +19,14 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 /// Load a planetary state CSV (7 columns: time, pos[3], vel[3]).
 fn load_planetary_csv(path: &std::path::Path) -> Vec<StateLog> {
     let content = std::fs::read_to_string(path).unwrap_or_else(|e| {
@@ -53,6 +61,7 @@ fn load_planetary_csv(path: &std::path::Path) -> Vec<StateLog> {
 
 /// Run a SIM_Planetary scenario: point-mass gravity, compare trajectory.
 fn run_planetary_scenario(label: &str, csv_name: &str) {
+    let mu_earth = load_mu_earth();
     let csv_path = test_data_path(csv_name);
     let ref_states = load_planetary_csv(&csv_path);
     assert!(!ref_states.is_empty(), "{label}: no reference data");
@@ -62,13 +71,23 @@ fn run_planetary_scenario(label: &str, csv_name: &str) {
     let init_pos = init.position.unwrap();
     let init_vel = init.velocity.unwrap();
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt = jeod_test_data::s_define::load_dynamics_dt(
+        &jeod_root.join("models/dynamics/derived_state/verif/SIM_Planetary/S_define"),
+    );
+
     let leap_table = jeod_sim::default_leap_second_table();
     let time = SimulationTime::at_j2000(leap_table);
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_polar_motion.rs
+++ b/crates/jeod_sim/tests/tier3_sim_polar_motion.rs
@@ -25,6 +25,11 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_polar_motion.rs
+++ b/crates/jeod_sim/tests/tier3_sim_polar_motion.rs
@@ -23,6 +23,14 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 /// Arcseconds to radians conversion factor (from JEOD polar_motion data).
 const ARCSEC_TO_RAD: f64 = 4.848_136_811_095_36e-6;
 
@@ -61,8 +69,17 @@ fn tier3_simulation_run2p_polar_motion() {
     assert!(trajectory.len() > 100);
     let init = &trajectory[0];
 
+    let mu_earth = load_mu_earth();
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt =
+        jeod_test_data::s_define::load_dynamics_dt(&jeod_root.join("verif/SIM_dyncomp/S_define"));
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     // Enable polar motion
     let xp = XP_ARCSEC * ARCSEC_TO_RAD;
@@ -71,7 +88,7 @@ fn tier3_simulation_run2p_polar_motion() {
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_shadow_2a.rs
+++ b/crates/jeod_sim/tests/tier3_sim_shadow_2a.rs
@@ -16,14 +16,22 @@ use jeod_sim::{Ephemeris, EphemerisBody};
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
+/// SIM_2A_SHADOW_CALC directory relative to JEOD root.
+const SIM_2A: &str = "models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC";
+
 /// Sun radius (m).
 const R_SUN: f64 = 6.96e8;
 /// Earth equatorial radius (m).
 const R_EARTH: f64 = 6_378_137.0;
-/// SIM_2A epoch: 1998-12-01 00:00:31 TAI.
-const EPOCH_TJT: f64 = 11148.0 + 31.0 / 86400.0;
 
 fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_tol: f64) {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path(csv_filename);
     assert!(
         csv_path.exists(),
@@ -41,6 +49,13 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
     );
     let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
 
+    // Load epoch from JEOD time config. SIM_2A uses TAI initializer.
+    let sim_dir = jeod_root.join(SIM_2A);
+    let time_cfg = jeod_test_data::time_config::load_time_config(
+        &sim_dir.join("Modified_data/date_and_time.py"),
+    );
+    let epoch_tjt = time_cfg.tai_tjt();
+
     let records = load_shadow_calc_csv(&csv_path);
     assert!(
         records.len() >= 2,
@@ -53,7 +68,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
         records.len()
     );
 
-    let base_jd = EPOCH_TJT + 40000.0 + 2_400_000.5;
+    let base_jd = epoch_tjt + 40000.0 + 2_400_000.5;
 
     let mut max_frac_err = 0.0_f64;
     let mut shadow_state_mismatches = 0;

--- a/crates/jeod_sim/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_sim/tests/tier3_sim_solar_beta.rs
@@ -21,6 +21,11 @@ use std::path::Path;
 
 fn load_mu_earth() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_sim/tests/tier3_sim_solar_beta.rs
@@ -19,8 +19,17 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
 #[test]
 fn tier3_simulation_solar_beta() {
+    let mu_earth = load_mu_earth();
     let csv_path = test_data_path("dyncomp_run2_state.csv");
     assert!(
         csv_path.exists(),
@@ -40,13 +49,22 @@ fn tier3_simulation_solar_beta() {
     assert!(trajectory.len() > 100);
     let init = &trajectory[0];
 
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt =
+        jeod_test_data::s_define::load_dynamics_dt(&jeod_root.join("verif/SIM_dyncomp/S_define"));
+
     // J2000.0 epoch (TJT = 0.0 for J2000)
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_EARTH,
+            mu: mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_srp.rs
+++ b/crates/jeod_sim/tests/tier3_sim_srp.rs
@@ -14,11 +14,11 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
-const SRP_MU_EARTH: f64 = 3.986_004_415e14;
+/// SIM_3_ORBIT directory relative to JEOD root.
+const SIM_3_ORBIT: &str = "models/interactions/radiation_pressure/verif/SIM_3_ORBIT";
+
 const SRP_R_EARTH: f64 = 6_378_137.0;
 const SRP_MASS: f64 = 300.0;
-const SRP_DT: f64 = 1.0;
-const SRP_EPOCH_TJT: f64 = 11148.0; // 1998-12-01 UTC
 
 fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
     let params = FlatPlateParams {
@@ -147,6 +147,13 @@ impl SunTable {
 
 #[test]
 fn tier3_simulation_srp_flat_plate() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("srp_orbit_radiation_srp_orbit.csv");
     assert!(
         csv_path.exists(),
@@ -162,6 +169,24 @@ fn tier3_simulation_srp_flat_plate() {
     );
     let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
 
+    let sim_dir = jeod_root.join(SIM_3_ORBIT);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch from JEOD time config. SIM_3_ORBIT uses TAI initializer,
+    // so tai_tjt() returns the TAI TJT directly from the calendar date.
+    let time_cfg = jeod_test_data::time_config::load_time_config(
+        &sim_dir.join("Modified_data/date_and_time.py"),
+    );
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+
+    // Load integration step size from S_define
+    let srp_dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load Earth mu from JEOD gravity data
+    let srp_mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
     let trajectory = load_srp_trajectory(&csv_path);
     assert!(trajectory.len() > 100);
     let init = &trajectory[0];
@@ -170,16 +195,14 @@ fn tier3_simulation_srp_flat_plate() {
     let num_plates = plates.len();
     let init_temp = 270.0_f64;
 
-    // Epoch: 1998-12-01 UTC. TAI-UTC=31s at this date.
-    let epoch_tai_tjt = SRP_EPOCH_TJT + 31.0 / 86400.0;
     let time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
     let epoch_tdb_jd = time.tdb_julian_date();
-    let mut sim = Simulation::new(time, SRP_DT);
+    let mut sim = Simulation::new(time, srp_dt);
 
     // Earth at origin (gravity source + shadow body)
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: SRP_MU_EARTH,
+            mu: srp_mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -251,10 +274,10 @@ fn tier3_simulation_srp_flat_plate() {
     let mut ref_states = Vec::with_capacity(trajectory.len() - 1);
 
     let mut next_record = 1;
-    let total_steps = (total_time / SRP_DT).round() as usize;
+    let total_steps = (total_time / srp_dt).round() as usize;
 
     for step_i in 1..=total_steps {
-        let t = (step_i as f64) * SRP_DT;
+        let t = (step_i as f64) * srp_dt;
 
         // Update Sun position every step (matching JEOD's per-step ephemeris update)
         sim.sources[sun].position = sun_table.at(t);
@@ -264,7 +287,7 @@ fn tier3_simulation_srp_flat_plate() {
         // Collect comparison data at record times
         if next_record < trajectory.len() {
             let record = &trajectory[next_record];
-            if (sim.time.simtime - record.time).abs() < SRP_DT * 0.5 {
+            if (sim.time.simtime - record.time).abs() < srp_dt * 0.5 {
                 let body = sim.body(0);
 
                 our_states.push(StateLog {

--- a/crates/jeod_sim/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_sim/tests/tier3_sim_srp_1st_order.rs
@@ -21,11 +21,11 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
-const SRP_MU_EARTH: f64 = 3.986_004_415e14;
+/// SIM_3_ORBIT_1st_ORDER directory relative to JEOD root.
+const SIM_3_ORBIT_1ST: &str = "models/interactions/radiation_pressure/verif/SIM_3_ORBIT_1st_ORDER";
+
 const SRP_R_EARTH: f64 = 6_378_137.0;
 const SRP_MASS: f64 = 300.0;
-const SRP_DT: f64 = 1.0;
-const SRP_EPOCH_TJT: f64 = 11148.0; // 1998-12-01 UTC
 
 fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
     let params = FlatPlateParams {
@@ -94,9 +94,9 @@ fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
     ]
 }
 
-fn srp_sun_position(sim_time: f64, ephemeris: &Ephemeris) -> DVec3 {
+fn srp_sun_position(sim_time: f64, epoch_tai_tjt: f64, ephemeris: &Ephemeris) -> DVec3 {
     let sim_days = sim_time / 86400.0;
-    let tdb_jd = (SRP_EPOCH_TJT + sim_days) + 40000.0 + 2_400_000.5;
+    let tdb_jd = (epoch_tai_tjt + sim_days) + 40000.0 + 2_400_000.5;
     let (sun_pos, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position query failed");
@@ -105,6 +105,13 @@ fn srp_sun_position(sim_time: f64, ephemeris: &Ephemeris) -> DVec3 {
 
 #[test]
 fn tier3_srp_1st_order_trajectory() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("srp_1st_order_radiation_srp_orbit.csv");
     assert!(
         csv_path.exists(),
@@ -122,6 +129,23 @@ fn tier3_srp_1st_order_trajectory() {
     );
     let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
 
+    let sim_dir = jeod_root.join(SIM_3_ORBIT_1ST);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch from JEOD time config. SIM_3_ORBIT_1st_ORDER uses TAI initializer.
+    let time_cfg = jeod_test_data::time_config::load_time_config(
+        &sim_dir.join("Modified_data/date_and_time.py"),
+    );
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+
+    // Load integration step size from S_define
+    let srp_dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load Earth mu from JEOD gravity data
+    let srp_mu_earth =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+            .expect("load Earth mu");
+
     let trajectory = load_srp_trajectory(&csv_path);
     assert!(trajectory.len() > 100);
     let init = &trajectory[0];
@@ -130,14 +154,12 @@ fn tier3_srp_1st_order_trajectory() {
     let num_plates = plates.len();
     let init_temp = 270.0_f64;
 
-    // Epoch: 1998-12-01 UTC. TAI-UTC=31s at this date.
-    let epoch_tai_tjt = SRP_EPOCH_TJT + 31.0 / 86400.0;
     let time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    let mut sim = Simulation::new(time, SRP_DT);
+    let mut sim = Simulation::new(time, srp_dt);
 
     let earth = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: SRP_MU_EARTH,
+            mu: srp_mu_earth,
             model: GravityModel::PointMass,
         },
         position: DVec3::ZERO,
@@ -150,7 +172,7 @@ fn tier3_srp_1st_order_trajectory() {
 
     // Sun: mu=0 because the JEOD SIM_3_ORBIT_1st_ORDER reference sim uses Sun
     // only for SRP direction, not gravitational perturbation.
-    let initial_sun = srp_sun_position(0.0, &ephemeris);
+    let initial_sun = srp_sun_position(0.0, epoch_tai_tjt, &ephemeris);
     let sun = sim.add_source(GravitySourceEntry {
         source: GravitySource {
             mu: 0.0,
@@ -199,7 +221,7 @@ fn tier3_srp_1st_order_trajectory() {
     let mut ref_states = Vec::with_capacity(trajectory.len() - 1);
 
     for record in &trajectory[1..] {
-        sim.sources[sun].position = srp_sun_position(record.time, &ephemeris);
+        sim.sources[sun].position = srp_sun_position(record.time, epoch_tai_tjt, &ephemeris);
         sim.step_until(record.time);
 
         let body = sim.body(0);

--- a/crates/jeod_sim/tests/tier3_sim_tide_verif.rs
+++ b/crates/jeod_sim/tests/tier3_sim_tide_verif.rs
@@ -22,13 +22,8 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
-const MU_SUN: f64 = 1.327_124_40e20;
-const MU_MOON: f64 = 4902.79980693169e9;
-
-/// Epoch: Nov 20, 2007 00:00 UTC (same as SIM_dyncomp)
-const EPOCH_UTC_TJT: f64 = 14424.0;
-const TAI_UTC_S: f64 = 32.0;
-const TAI_TO_UT1_S: f64 = -32.469;
+/// SIM_dyncomp directory relative to JEOD root.
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
     let (pos, _) = ephemeris
@@ -60,6 +55,13 @@ fn load_tide_csv(path: &std::path::Path) -> Vec<(f64, DVec3, DVec3, f64)> {
 
 #[test]
 fn tier3_simulation_tide_run01() {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
     let csv_path = test_data_path("tide_run01_tide.csv");
     assert!(
         csv_path.exists(),
@@ -75,23 +77,42 @@ fn tier3_simulation_tide_run01() {
     );
     let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
 
-    let jeod_root = jeod_test_data::jeod_path();
-    let ggm05c_path = jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc");
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
+
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    // Load gravity parameters from JEOD coefficient files
+    let ggm05c_path = grav_data_dir.join("earth_GGM05C.cc");
     let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&ggm05c_path).expect("load GGM05C");
     let earth_mu = sh_data.mu;
     let earth_radius = sh_data.radius;
+    let mu_sun =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+            .expect("load Sun mu");
+    let mu_moon =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+            .expect("load Moon mu");
 
     let records = load_tide_csv(&csv_path);
     assert!(records.len() > 100);
 
     let (_, init_pos, init_vel, _) = &records[0];
 
-    // Initialize at same epoch as SIM_dyncomp/SIM_tide_verif
-    let epoch_tai_tjt = EPOCH_UTC_TJT + TAI_UTC_S / 86400.0;
+    // Initialize at the SIM_dyncomp epoch (parsed from time.py)
     let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(TAI_TO_UT1_S);
+    time.set_ut1_tai_offset(ut1_tai_offset);
 
-    let mut sim = Simulation::new(time, DT);
+    let mut sim = Simulation::new(time, dt);
 
     // Earth source with SH gravity, RNP rotation, and tidal configuration
     let tdb_jd = sim.time.tdb_julian_date();
@@ -104,11 +125,11 @@ fn tier3_simulation_tide_run01() {
         radius_primary: earth_radius,
         tidal_bodies: vec![
             TidalBody {
-                mu: MU_MOON,
+                mu: mu_moon,
                 position_inertial: initial_moon,
             },
             TidalBody {
-                mu: MU_SUN,
+                mu: mu_sun,
                 position_inertial: initial_sun,
             },
         ],
@@ -130,7 +151,7 @@ fn tier3_simulation_tide_run01() {
     // Sun: 3rd-body differential
     let sun = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         position: initial_sun,
@@ -144,7 +165,7 @@ fn tier3_simulation_tide_run01() {
     // Moon: 3rd-body differential
     let moon = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_MOON,
+            mu: mu_moon,
             model: GravityModel::PointMass,
         },
         position: initial_moon,

--- a/crates/jeod_sim/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_sim/tests/tier3_sim_time_reversal.rs
@@ -18,6 +18,11 @@ use jeod_sim::{
 
 fn load_mu_earth_gemt1() -> f64 {
     let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
     jeod_sim::coefficients::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GEMT1.cc"),
     )

--- a/crates/jeod_sim/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_sim/tests/tier3_sim_time_reversal.rs
@@ -16,8 +16,13 @@ use jeod_sim::{
     TranslationalState,
 };
 
-// GEM-T1 mu (used by JEOD SIM_7_time_reversal), NOT GGM05C
-const MU_EARTH_GEMT1: f64 = 3.986_004_36e14;
+fn load_mu_earth_gemt1() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GEMT1.cc"),
+    )
+    .expect("load Earth mu from GEMT1")
+}
 
 #[allow(dead_code)] // position/velocity used by run1, not by time-only run3a/run8b
 struct ReversalRecord {
@@ -64,6 +69,7 @@ fn load_reversal_csv(path: &std::path::Path) -> Vec<ReversalRecord> {
 /// Validates both time and trajectory against JEOD reference.
 #[test]
 fn tier3_sim_time_reversal_run1() {
+    let mu_earth_gemt1 = load_mu_earth_gemt1();
     let csv_path = test_data_path("reversal_run1_reversal.csv");
     let records = load_reversal_csv(&csv_path);
     assert!(records.len() > 1, "no reference data");
@@ -71,13 +77,23 @@ fn tier3_sim_time_reversal_run1() {
     let init = &records[0];
 
     // Epoch: 2007-11-20 00:00:00 UTC. TAI TJT from CSV.
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    let dt = jeod_test_data::s_define::load_dynamics_dt(
+        &jeod_root.join("models/environment/time/verif/SIM_7_time_reversal/S_define"),
+    );
+
     let leap_table = jeod_sim::default_leap_second_table();
     let time = SimulationTime::new(init.tai_tjt, leap_table);
-    let mut sim = Simulation::new(time, DT); // 0.03125 s
+    let mut sim = Simulation::new(time, dt);
 
     let earth = sim.add_source(GravitySourceEntry::new(
         GravitySource {
-            mu: MU_EARTH_GEMT1,
+            mu: mu_earth_gemt1,
             model: GravityModel::PointMass,
         },
         DVec3::ZERO,

--- a/crates/jeod_sim/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_sim/tests/tier3_sim_torque_simple.rs
@@ -33,27 +33,39 @@ use jeod_sim::{
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
 
-const MU_SUN: f64 = 1.327_124_40e20;
-const MU_MOON: f64 = 4902.79980693169e9;
+/// SIM_dyncomp root directory (relative to JEOD_HOME).
+const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
-// -- ISS mass properties from JEOD Modified_data/mass/iss.py --
-
+/// Load ISS mass properties from JEOD SIM_dyncomp Modified_data/mass.py.
 fn iss_mass_props() -> MassProperties {
-    let inertia = DMat3::from_cols(
-        DVec3::new(1.02e8, -6.96e6, -5.48e6),
-        DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-        DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    let jeod_root = jeod_test_data::jeod_path();
+    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
+        &jeod_root.join(SIM_DYNCOMP).join("Modified_data/mass.py"),
+        Some("set_mass_iss"),
     );
-    MassProperties::with_inertia(400_000.0, inertia, DVec3::new(-3.0, -1.5, 4.0))
+    let inertia = DMat3::from_cols(
+        DVec3::new(
+            mass_init.inertia[0][0],
+            mass_init.inertia[1][0],
+            mass_init.inertia[2][0],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][1],
+            mass_init.inertia[1][1],
+            mass_init.inertia[2][1],
+        ),
+        DVec3::new(
+            mass_init.inertia[0][2],
+            mass_init.inertia[1][2],
+            mass_init.inertia[2][2],
+        ),
+    );
+    MassProperties::with_inertia(
+        mass_init.mass,
+        inertia,
+        DVec3::from_slice(&mass_init.position),
+    )
 }
-
-// -- Epoch constants --
-// Nov 20, 2007 00:00:00 UTC
-// JEOD overrides: leap_sec_override_val = 32, tai_to_ut1_override_val = -32.469
-
-const EPOCH_UTC_TJT: f64 = 14424.0;
-const TAI_UTC_S: f64 = 32.0;
-const TAI_TO_UT1_S: f64 = -32.469;
 
 /// Load GGM05C spherical harmonics data from JEOD source.
 fn load_ggm05c() -> GravitySource {
@@ -118,18 +130,36 @@ fn build_simulation(
     init: &TorqueSimpleRecord,
     ephemeris: &Ephemeris,
 ) -> SimSetup {
-    let epoch_tai_tjt = EPOCH_UTC_TJT + TAI_UTC_S / 86400.0;
-    let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(TAI_TO_UT1_S);
+    let jeod_root = jeod_test_data::jeod_path();
+    let sim_dir = jeod_root.join(SIM_DYNCOMP);
+    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
 
-    let mut sim = Simulation::new(time, DT);
+    // Load epoch and time offsets from JEOD time config
+    let time_cfg =
+        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
+    let epoch_tai_tjt = time_cfg.tai_tjt();
+    let ut1_tai_offset = time_cfg
+        .ut1_tai_offset()
+        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
+
+    // Load integration step size from S_define
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+
+    let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
+    time.set_ut1_tai_offset(ut1_tai_offset);
+
+    let mut sim = Simulation::new(time, dt);
 
     // Earth source — with planet-fixed rotation for SH gravity and SH gradient
     let earth_source = if config.earth_nonspherical || config.gradient_degree > 0 {
         load_ggm05c()
     } else {
+        // Load Earth mu from gravity coefficient file even for point-mass
+        let earth_grav =
+            jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+                .expect("load Earth gravity");
         GravitySource {
-            mu: MU_EARTH,
+            mu: earth_grav.mu,
             model: GravityModel::PointMass,
         }
     };
@@ -151,12 +181,20 @@ fn build_simulation(
         tidal_config: None,
     });
 
+    // Sun/Moon mu (spherical-only files lack degree/order fields)
+    let mu_sun =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+            .expect("load Sun mu");
+    let mu_moon =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+            .expect("load Moon mu");
+
     // Sun: third-body differential acceleration (matches JEOD: spherical, gradient=false)
     let epoch_tdb_jd = sim.time.tdb_julian_date();
     let initial_sun = earth_centered_position(EphemerisBody::Sun, epoch_tdb_jd, ephemeris);
     let sun_idx = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_SUN,
+            mu: mu_sun,
             model: GravityModel::PointMass,
         },
         position: initial_sun,
@@ -171,7 +209,7 @@ fn build_simulation(
     let initial_moon = earth_centered_position(EphemerisBody::Moon, epoch_tdb_jd, ephemeris);
     let moon_idx = sim.add_source(GravitySourceEntry {
         source: GravitySource {
-            mu: MU_MOON,
+            mu: mu_moon,
             model: GravityModel::PointMass,
         },
         position: initial_moon,

--- a/crates/jeod_test_data/src/gravity_control.rs
+++ b/crates/jeod_test_data/src/gravity_control.rs
@@ -1,0 +1,133 @@
+use regex::Regex;
+use std::path::Path;
+
+/// Gravity control configuration parsed from a JEOD Trick input file.
+///
+/// Parses assignments like:
+/// - `earth_grav_control.spherical = False`
+/// - `earth_grav_control.degree = 4`
+/// - `earth_grav_control.order = 4`
+/// - `earth_grav_control.gradient = False`
+#[derive(Debug, Clone)]
+pub struct GravityControlConfig {
+    pub spherical: bool,
+    pub degree: usize,
+    pub order: usize,
+    pub gradient: bool,
+}
+
+impl Default for GravityControlConfig {
+    /// Default matches JEOD's default: spherical (point mass), degree/order 0, no gradient.
+    fn default() -> Self {
+        Self {
+            spherical: true,
+            degree: 0,
+            order: 0,
+            gradient: false,
+        }
+    }
+}
+
+/// Parse gravity control configuration from a JEOD Trick input file.
+///
+/// Scans all files for `earth_grav_control.*` assignments. Accepts multiple
+/// file paths to handle the common pattern where `common_input.py` exec's
+/// `grav_controls.py`, then the RUN input.py overrides specific fields.
+///
+/// Files are processed in order; later assignments override earlier ones.
+///
+/// # Panics
+/// Panics if any file cannot be read.
+pub fn load_gravity_control(py_paths: &[&Path]) -> GravityControlConfig {
+    let mut cfg = GravityControlConfig::default();
+
+    let spherical_re = Regex::new(r"earth_grav_control\.spherical\s*=\s*(\w+)").unwrap();
+    let degree_re = Regex::new(r"earth_grav_control\.degree\s*=\s*(\d+)").unwrap();
+    let order_re = Regex::new(r"earth_grav_control\.order\s*=\s*(\d+)").unwrap();
+    let gradient_re = Regex::new(r"earth_grav_control\.gradient\s*=\s*(\w+)").unwrap();
+
+    for py_path in py_paths {
+        let content = std::fs::read_to_string(py_path)
+            .unwrap_or_else(|e| panic!("Cannot read {}: {}", py_path.display(), e));
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') {
+                continue;
+            }
+
+            if let Some(cap) = spherical_re.captures(trimmed) {
+                cfg.spherical = parse_python_bool(&cap[1]);
+            }
+            if let Some(cap) = degree_re.captures(trimmed) {
+                cfg.degree = cap[1].parse().unwrap();
+            }
+            if let Some(cap) = order_re.captures(trimmed) {
+                cfg.order = cap[1].parse().unwrap();
+            }
+            if let Some(cap) = gradient_re.captures(trimmed) {
+                cfg.gradient = parse_python_bool(&cap[1]);
+            }
+        }
+    }
+
+    cfg
+}
+
+fn parse_python_bool(s: &str) -> bool {
+    match s {
+        "True" | "true" | "1" => true,
+        "False" | "false" | "0" => false,
+        _ => panic!("Cannot parse '{}' as boolean", s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_gravity_control() {
+        let grav_controls = r#"
+vehicle.earth_grav_control.source_name = "Earth"
+vehicle.earth_grav_control.spherical = True
+vehicle.earth_grav_control.degree = 20
+vehicle.earth_grav_control.order = 20
+vehicle.earth_grav_control.gradient = True
+"#;
+        let run_input = r#"
+# Reconfigure gravity to 4x4
+vehicle.earth_grav_control.spherical = False
+vehicle.earth_grav_control.degree = 4
+vehicle.earth_grav_control.order  = 4
+
+# Turn off grav gradient
+vehicle.earth_grav_control.gradient  = False
+"#;
+        let tmpdir = std::env::temp_dir().join("jeod_test_grav_ctrl");
+        std::fs::create_dir_all(&tmpdir).unwrap();
+        let grav_path = tmpdir.join("grav_controls.py");
+        let run_path = tmpdir.join("input.py");
+        std::fs::write(&grav_path, grav_controls).unwrap();
+        std::fs::write(&run_path, run_input).unwrap();
+
+        let cfg = load_gravity_control(&[grav_path.as_path(), run_path.as_path()]);
+        assert!(!cfg.spherical);
+        assert_eq!(cfg.degree, 4);
+        assert_eq!(cfg.order, 4);
+        assert!(!cfg.gradient);
+
+        std::fs::remove_file(&grav_path).ok();
+        std::fs::remove_file(&run_path).ok();
+        std::fs::remove_dir(&tmpdir).ok();
+    }
+
+    #[test]
+    fn test_default_is_spherical() {
+        let cfg = GravityControlConfig::default();
+        assert!(cfg.spherical);
+        assert_eq!(cfg.degree, 0);
+        assert_eq!(cfg.order, 0);
+        assert!(!cfg.gradient);
+    }
+}

--- a/crates/jeod_test_data/src/gravity_control.rs
+++ b/crates/jeod_test_data/src/gravity_control.rs
@@ -104,7 +104,11 @@ vehicle.earth_grav_control.order  = 4
 # Turn off grav gradient
 vehicle.earth_grav_control.gradient  = False
 "#;
-        let tmpdir = std::env::temp_dir().join("jeod_test_grav_ctrl");
+        let tmpdir = std::env::temp_dir().join(format!(
+            "jeod_test_grav_ctrl_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
         std::fs::create_dir_all(&tmpdir).unwrap();
         let grav_path = tmpdir.join("grav_controls.py");
         let run_path = tmpdir.join("input.py");
@@ -117,9 +121,7 @@ vehicle.earth_grav_control.gradient  = False
         assert_eq!(cfg.order, 4);
         assert!(!cfg.gradient);
 
-        std::fs::remove_file(&grav_path).ok();
-        std::fs::remove_file(&run_path).ok();
-        std::fs::remove_dir(&tmpdir).ok();
+        let _ = std::fs::remove_dir_all(&tmpdir);
     }
 
     #[test]

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -1,12 +1,15 @@
 pub mod crossval;
 pub mod dyncomp_csv;
 pub mod euler_test;
+pub mod gravity_control;
 pub mod gravity_verif;
 pub mod leap_second;
 pub mod mass_data;
 pub mod orbital_data;
 pub mod orbital_init;
 pub mod reference_state;
+pub mod s_define;
+pub mod time_config;
 
 /// Get the JEOD root path from environment variables.
 ///

--- a/crates/jeod_test_data/src/mass_data.rs
+++ b/crates/jeod_test_data/src/mass_data.rs
@@ -250,7 +250,11 @@ def set_mass_cylinder() :
   vehicle.mass_init.properties.inertia[1]  = [   0.0, 12250.0,     0.0]
   vehicle.mass_init.properties.inertia[2]  = [   0.0,     0.0, 12250.0]
 "#;
-        let tmpdir = std::env::temp_dir().join("jeod_test_mass");
+        let tmpdir = std::env::temp_dir().join(format!(
+            "jeod_test_mass_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
         std::fs::create_dir_all(&tmpdir).unwrap();
         let path = tmpdir.join("mass.py");
         std::fs::write(&path, content).unwrap();
@@ -267,7 +271,6 @@ def set_mass_cylinder() :
         assert_eq!(cyl.position, [6.0, 0.0, 0.0]);
         assert_eq!(cyl.inertia[0][0], 500.0);
 
-        std::fs::remove_file(&path).ok();
-        std::fs::remove_dir(&tmpdir).ok();
+        let _ = std::fs::remove_dir_all(&tmpdir);
     }
 }

--- a/crates/jeod_test_data/src/mass_data.rs
+++ b/crates/jeod_test_data/src/mass_data.rs
@@ -88,6 +88,127 @@ pub fn load_mass_data(jeod_root: &std::path::Path, vehicle: &str) -> MassInitDat
     }
 }
 
+/// Load mass initialization data from an arbitrary JEOD mass `.py` file.
+///
+/// If `function_name` is `Some("set_mass_iss")`, only lines within that
+/// function definition are parsed (up to the next `def ` or end of file).
+/// If `None`, the entire file is parsed (first match wins for each field).
+///
+/// # Panics
+/// Panics if the file cannot be read or required fields (mass, position,
+/// 3 inertia rows) are missing.
+pub fn load_mass_from_file(path: &std::path::Path, function_name: Option<&str>) -> MassInitData {
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("Cannot read {}: {}", path.display(), e));
+
+    let section = match function_name {
+        Some(fname) => extract_function_body(&content, fname, path),
+        None => content.clone(),
+    };
+
+    parse_mass_content(&section, path)
+}
+
+/// Extract lines belonging to a Python function definition.
+///
+/// Returns all lines from `def <name>(...):` until the next `def ` or EOF.
+fn extract_function_body(content: &str, function_name: &str, source: &std::path::Path) -> String {
+    let mut lines = Vec::new();
+    let mut in_function = false;
+    let def_pattern = format!("def {}(", function_name);
+    // Also match `def name() :`  with flexible whitespace
+    let def_pattern_alt = format!("def {}", function_name);
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with(&def_pattern) || trimmed.starts_with(&def_pattern_alt) {
+            in_function = true;
+            continue;
+        }
+        if in_function {
+            // Next function definition ends our block
+            if trimmed.starts_with("def ") {
+                break;
+            }
+            lines.push(line);
+        }
+    }
+
+    assert!(
+        !lines.is_empty(),
+        "Function '{}' not found in {}",
+        function_name,
+        source.display()
+    );
+    lines.join("\n")
+}
+
+/// Parse mass fields from string content.
+fn parse_mass_content(content: &str, source: &std::path::Path) -> MassInitData {
+    let mass_re = Regex::new(r"\.properties\.mass\s*=\s*([-\d.eE+]+)").unwrap();
+    let pos_re =
+        Regex::new(r"\.properties\.position\s*=\s*\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]")
+            .unwrap();
+    let inertia_re =
+        Regex::new(r"\.properties\.inertia\[(\d+)\]\s*=\s*\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]")
+            .unwrap();
+
+    let mut mass: Option<f64> = None;
+    let mut position = [0.0; 3];
+    let mut inertia = [[0.0; 3]; 3];
+    let mut has_position = false;
+    let mut inertia_rows_seen = [false; 3];
+
+    for line in content.lines() {
+        if let Some(cap) = mass_re.captures(line) {
+            if mass.is_none() {
+                mass = Some(cap[1].parse().unwrap());
+            }
+            continue;
+        }
+        if let Some(cap) = pos_re.captures(line) {
+            if !has_position {
+                position = [
+                    cap[1].parse().unwrap(),
+                    cap[2].parse().unwrap(),
+                    cap[3].parse().unwrap(),
+                ];
+                has_position = true;
+            }
+            continue;
+        }
+        if let Some(cap) = inertia_re.captures(line) {
+            let row: usize = cap[1].parse().unwrap();
+            assert!(
+                row < 3,
+                "Inertia row index {} out of bounds in {}",
+                row,
+                source.display()
+            );
+            if !inertia_rows_seen[row] {
+                inertia[row] = [
+                    cap[2].parse().unwrap(),
+                    cap[3].parse().unwrap(),
+                    cap[4].parse().unwrap(),
+                ];
+                inertia_rows_seen[row] = true;
+            }
+        }
+    }
+
+    assert!(mass.is_some(), "Missing mass in {}", source.display());
+    assert!(has_position, "Missing position in {}", source.display());
+    for (i, seen) in inertia_rows_seen.iter().enumerate() {
+        assert!(seen, "Missing inertia row {} in {}", i, source.display());
+    }
+
+    MassInitData {
+        mass: mass.unwrap(),
+        position,
+        inertia,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +231,43 @@ mod tests {
         assert_eq!(data.inertia[0][0], 7e12, "ISS Ixx");
         assert_eq!(data.inertia[1][1], 12e12, "ISS Iyy");
         assert_eq!(data.inertia[2][2], 10e12, "ISS Izz");
+    }
+
+    #[test]
+    fn test_load_mass_from_file_with_function() {
+        let content = r#"
+def set_mass_iss() :
+  vehicle.mass_init.properties.mass        = 400000.0
+  vehicle.mass_init.properties.position    = [ -3.0, -1.5, 4.0]
+  vehicle.mass_init.properties.inertia[0]  = [  1.02e+8,-6.96e+6,-5.48e+6]
+  vehicle.mass_init.properties.inertia[1]  = [ -6.96e+6, 0.91e+8, 5.90e+5]
+  vehicle.mass_init.properties.inertia[2]  = [ -5.48e+6, 5.90e+5, 1.64e+8]
+
+def set_mass_cylinder() :
+  vehicle.mass_init.properties.mass        = 1000.0
+  vehicle.mass_init.properties.position    = [ 6.0, 0.0, 0.0]
+  vehicle.mass_init.properties.inertia[0]  = [ 500.0,     0.0,     0.0]
+  vehicle.mass_init.properties.inertia[1]  = [   0.0, 12250.0,     0.0]
+  vehicle.mass_init.properties.inertia[2]  = [   0.0,     0.0, 12250.0]
+"#;
+        let tmpdir = std::env::temp_dir().join("jeod_test_mass");
+        std::fs::create_dir_all(&tmpdir).unwrap();
+        let path = tmpdir.join("mass.py");
+        std::fs::write(&path, content).unwrap();
+
+        // Load ISS mass
+        let iss = load_mass_from_file(&path, Some("set_mass_iss"));
+        assert_eq!(iss.mass, 400000.0);
+        assert_eq!(iss.position, [-3.0, -1.5, 4.0]);
+        assert_eq!(iss.inertia[0][0], 1.02e8);
+
+        // Load cylinder mass
+        let cyl = load_mass_from_file(&path, Some("set_mass_cylinder"));
+        assert_eq!(cyl.mass, 1000.0);
+        assert_eq!(cyl.position, [6.0, 0.0, 0.0]);
+        assert_eq!(cyl.inertia[0][0], 500.0);
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_dir(&tmpdir).ok();
     }
 }

--- a/crates/jeod_test_data/src/mass_data.rs
+++ b/crates/jeod_test_data/src/mass_data.rs
@@ -115,13 +115,13 @@ pub fn load_mass_from_file(path: &std::path::Path, function_name: Option<&str>) 
 fn extract_function_body(content: &str, function_name: &str, source: &std::path::Path) -> String {
     let mut lines = Vec::new();
     let mut in_function = false;
-    let def_pattern = format!("def {}(", function_name);
-    // Also match `def name() :`  with flexible whitespace
-    let def_pattern_alt = format!("def {}", function_name);
+    // Match `def name(` exactly — the char after the name must be `(` or whitespace
+    // to avoid prefix matches (e.g., `set_mass_iss` matching `set_mass_iss2`).
+    let re = Regex::new(&format!(r"^def\s+{}\s*\(", regex::escape(function_name))).unwrap();
 
     for line in content.lines() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with(&def_pattern) || trimmed.starts_with(&def_pattern_alt) {
+        if re.is_match(trimmed) {
             in_function = true;
             continue;
         }

--- a/crates/jeod_test_data/src/s_define.rs
+++ b/crates/jeod_test_data/src/s_define.rs
@@ -45,7 +45,11 @@ mod tests {
 
 #include "sim_objects/default_trick_sys.sm"
 "#;
-        let tmpdir = std::env::temp_dir().join("jeod_test_s_define");
+        let tmpdir = std::env::temp_dir().join(format!(
+            "jeod_test_s_define_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
         std::fs::create_dir_all(&tmpdir).unwrap();
         let path = tmpdir.join("S_define");
         std::fs::write(&path, content).unwrap();
@@ -53,14 +57,17 @@ mod tests {
         let dt = load_dynamics_dt(&path);
         assert!((dt - 0.03125).abs() < 1e-15, "Expected 0.03125, got {}", dt);
 
-        std::fs::remove_file(&path).ok();
-        std::fs::remove_dir(&tmpdir).ok();
+        let _ = std::fs::remove_dir_all(&tmpdir);
     }
 
     #[test]
     fn test_parse_dynamics_dt_integer() {
         let content = "#define DYNAMICS 1.0\n";
-        let tmpdir = std::env::temp_dir().join("jeod_test_s_define2");
+        let tmpdir = std::env::temp_dir().join(format!(
+            "jeod_test_s_define_int_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
         std::fs::create_dir_all(&tmpdir).unwrap();
         let path = tmpdir.join("S_define");
         std::fs::write(&path, content).unwrap();
@@ -68,7 +75,6 @@ mod tests {
         let dt = load_dynamics_dt(&path);
         assert!((dt - 1.0).abs() < 1e-15, "Expected 1.0, got {}", dt);
 
-        std::fs::remove_file(&path).ok();
-        std::fs::remove_dir(&tmpdir).ok();
+        let _ = std::fs::remove_dir_all(&tmpdir);
     }
 }

--- a/crates/jeod_test_data/src/s_define.rs
+++ b/crates/jeod_test_data/src/s_define.rs
@@ -1,0 +1,74 @@
+use regex::Regex;
+use std::path::Path;
+
+/// Parse the dynamics integration step size from a JEOD S_define file.
+///
+/// Looks for `#define DYNAMICS <float>` and returns the value in seconds.
+///
+/// # Panics
+/// Panics if the file cannot be read or does not contain a `#define DYNAMICS` line.
+pub fn load_dynamics_dt(s_define_path: &Path) -> f64 {
+    let content = std::fs::read_to_string(s_define_path)
+        .unwrap_or_else(|e| panic!("Cannot read {}: {}", s_define_path.display(), e));
+
+    let re = Regex::new(r"#define\s+DYNAMICS\s+([\d.eE+-]+)").unwrap();
+
+    for line in content.lines() {
+        if let Some(cap) = re.captures(line) {
+            return cap[1].parse::<f64>().unwrap_or_else(|e| {
+                panic!(
+                    "Cannot parse DYNAMICS value '{}' in {}: {}",
+                    &cap[1],
+                    s_define_path.display(),
+                    e
+                )
+            });
+        }
+    }
+
+    panic!("No #define DYNAMICS found in {}", s_define_path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_dynamics_dt() {
+        let content = r#"
+//=============================================================================
+// S_define for SIM_dyncomp
+//=============================================================================
+
+#define DYNAMICS 0.03125   // Vehicle and planetary dynamics interval (32Hz)
+#define LOW_RATE_ENV 5400.00 // Ephemeris update
+
+#include "sim_objects/default_trick_sys.sm"
+"#;
+        let tmpdir = std::env::temp_dir().join("jeod_test_s_define");
+        std::fs::create_dir_all(&tmpdir).unwrap();
+        let path = tmpdir.join("S_define");
+        std::fs::write(&path, content).unwrap();
+
+        let dt = load_dynamics_dt(&path);
+        assert!((dt - 0.03125).abs() < 1e-15, "Expected 0.03125, got {}", dt);
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_dir(&tmpdir).ok();
+    }
+
+    #[test]
+    fn test_parse_dynamics_dt_integer() {
+        let content = "#define DYNAMICS 1.0\n";
+        let tmpdir = std::env::temp_dir().join("jeod_test_s_define2");
+        std::fs::create_dir_all(&tmpdir).unwrap();
+        let path = tmpdir.join("S_define");
+        std::fs::write(&path, content).unwrap();
+
+        let dt = load_dynamics_dt(&path);
+        assert!((dt - 1.0).abs() < 1e-15, "Expected 1.0, got {}", dt);
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_dir(&tmpdir).ok();
+    }
+}

--- a/crates/jeod_test_data/src/time_config.rs
+++ b/crates/jeod_test_data/src/time_config.rs
@@ -164,10 +164,13 @@ fn parse_time_config_str(content: &str, source: &Path) -> TimeConfig {
         }
     }
 
+    // All date fields are captured by a single regex — if year is missing, none are set.
+    if utc_year.is_none() {
+        panic!("No set_date_and_time() found in {}", source.display());
+    }
     TimeConfig {
         initializer: initializer.unwrap_or(TimeInitializer::Utc),
-        utc_year: utc_year
-            .unwrap_or_else(|| panic!("No set_date_and_time() found in {}", source.display())),
+        utc_year: utc_year.unwrap(),
         utc_month: utc_month.unwrap(),
         utc_day: utc_day.unwrap(),
         utc_hour: utc_hour.unwrap(),

--- a/crates/jeod_test_data/src/time_config.rs
+++ b/crates/jeod_test_data/src/time_config.rs
@@ -1,0 +1,435 @@
+use regex::Regex;
+use std::path::Path;
+
+/// Which time scale the `set_date_and_time` call specifies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeInitializer {
+    /// Date is UTC (most common: `time_utc.set_date_and_time(...)`)
+    Utc,
+    /// Date is TAI (e.g., `time_tai.set_date_and_time(...)`)
+    Tai,
+}
+
+/// Time configuration parsed from a JEOD Trick time input file.
+///
+/// Parses files like `Modified_data/time.py` or `Modified_data/date_and_time.py`
+/// containing:
+/// - `initializer = "UTC"` or `initializer = "TAI"`
+/// - `set_date_and_time(year, month, day, hour, minute, second)`
+/// - `leap_sec_override_val = <float>` (TAI - UTC override)
+/// - `tai_to_ut1_override_val = <float>` (UT1 - TAI override)
+#[derive(Debug, Clone)]
+pub struct TimeConfig {
+    /// Which time scale the parsed date refers to.
+    pub initializer: TimeInitializer,
+    pub utc_year: i32,
+    pub utc_month: u32,
+    pub utc_day: u32,
+    pub utc_hour: u32,
+    pub utc_minute: u32,
+    pub utc_second: f64,
+    pub tai_utc_override: Option<f64>,
+    pub tai_to_ut1_override: Option<f64>,
+}
+
+impl TimeConfig {
+    /// Compute UTC truncated Julian time (TJT = MJD - 40000) from the parsed date.
+    pub fn utc_tjt(&self) -> f64 {
+        let mjd = calendar_to_mjd(
+            self.utc_year,
+            self.utc_month,
+            self.utc_day,
+            self.utc_hour,
+            self.utc_minute,
+            self.utc_second,
+        );
+        mjd - 40_000.0
+    }
+
+    /// Compute TAI TJT from UTC TJT + TAI-UTC offset.
+    ///
+    /// Panics if `tai_utc_override` is None (caller must ensure the time file
+    /// contains a leap second override, or use the leap second table directly).
+    pub fn tai_tjt(&self) -> f64 {
+        match self.initializer {
+            TimeInitializer::Tai => {
+                // The date IS TAI — the TJT from the calendar date is TAI TJT directly.
+                self.utc_tjt() // Misleadingly named, but calendar_to_mjd just does date math
+            }
+            TimeInitializer::Utc => {
+                let tai_utc = self
+                    .tai_utc_override
+                    .expect("tai_utc_override not set in time config; cannot compute TAI TJT");
+                self.utc_tjt() + tai_utc / 86_400.0
+            }
+        }
+    }
+
+    /// Compute TAI TJT using an external TAI-UTC offset (from a leap second table).
+    ///
+    /// Use this when the time file does not contain a `leap_sec_override_val`
+    /// but the epoch date is UTC and the caller can supply the TAI-UTC offset.
+    pub fn tai_tjt_with_offset(&self, tai_utc_s: f64) -> f64 {
+        assert_eq!(
+            self.initializer,
+            TimeInitializer::Utc,
+            "tai_tjt_with_offset only valid for UTC-initialized epochs"
+        );
+        self.utc_tjt() + tai_utc_s / 86_400.0
+    }
+
+    /// Return the UT1-TAI offset in seconds, if overridden in the time file.
+    pub fn ut1_tai_offset(&self) -> Option<f64> {
+        self.tai_to_ut1_override
+    }
+}
+
+/// Parse time configuration from a JEOD Trick Python file.
+///
+/// Scans the file for:
+/// - `set_date_and_time(year, month, day, hour, minute, second)`
+/// - `leap_sec_override_val = <float>`
+/// - `tai_to_ut1_override_val = <float>` or expressions like `0.0115221 - 4.2`
+///
+/// # Panics
+/// Panics if the file cannot be read or does not contain a `set_date_and_time` call.
+pub fn load_time_config(py_path: &Path) -> TimeConfig {
+    let content = std::fs::read_to_string(py_path)
+        .unwrap_or_else(|e| panic!("Cannot read {}: {}", py_path.display(), e));
+
+    parse_time_config_str(&content, py_path)
+}
+
+/// Parse time config from string content (for testing).
+fn parse_time_config_str(content: &str, source: &Path) -> TimeConfig {
+    // Match: set_date_and_time(year, month, day, hour, minute, second)
+    let date_re = Regex::new(
+        r"set_date_and_time\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)",
+    )
+    .unwrap();
+
+    // Match: leap_sec_override_val = <float>
+    let leap_re = Regex::new(r"leap_sec_override_val\s*=\s*([-\d.eE+]+)").unwrap();
+
+    // Match: tai_to_ut1_override_val = <expression>
+    // Handles both simple values and expressions like "0.0115221 - 4.2"
+    let ut1_re = Regex::new(r"tai_to_ut1_override_val\s*=\s*(.+)").unwrap();
+
+    // Match: initializer = "UTC" or "TAI"
+    let init_re = Regex::new(r#"initializer\s*=\s*"(UTC|TAI)""#).unwrap();
+
+    let mut initializer = None;
+    let mut utc_year = None;
+    let mut utc_month = None;
+    let mut utc_day = None;
+    let mut utc_hour = None;
+    let mut utc_minute = None;
+    let mut utc_second = None;
+    let mut tai_utc_override = None;
+    let mut tai_to_ut1_override = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+
+        if let Some(cap) = init_re.captures(trimmed) {
+            initializer = Some(match &cap[1] {
+                "TAI" => TimeInitializer::Tai,
+                "UTC" => TimeInitializer::Utc,
+                other => panic!(
+                    "Unknown time initializer '{}' in {}",
+                    other,
+                    source.display()
+                ),
+            });
+        }
+
+        if let Some(cap) = date_re.captures(trimmed) {
+            utc_year = Some(cap[1].parse::<i32>().unwrap());
+            utc_month = Some(cap[2].parse::<u32>().unwrap());
+            utc_day = Some(cap[3].parse::<u32>().unwrap());
+            utc_hour = Some(cap[4].parse::<u32>().unwrap());
+            utc_minute = Some(cap[5].parse::<u32>().unwrap());
+            utc_second = Some(cap[6].parse::<f64>().unwrap());
+        }
+
+        if let Some(cap) = leap_re.captures(trimmed) {
+            tai_utc_override = Some(cap[1].parse::<f64>().unwrap());
+        }
+
+        if let Some(cap) = ut1_re.captures(trimmed) {
+            tai_to_ut1_override = Some(eval_simple_sum(cap[1].trim()));
+        }
+    }
+
+    TimeConfig {
+        initializer: initializer.unwrap_or(TimeInitializer::Utc),
+        utc_year: utc_year
+            .unwrap_or_else(|| panic!("No set_date_and_time() found in {}", source.display())),
+        utc_month: utc_month.unwrap(),
+        utc_day: utc_day.unwrap(),
+        utc_hour: utc_hour.unwrap(),
+        utc_minute: utc_minute.unwrap(),
+        utc_second: utc_second.unwrap(),
+        tai_utc_override,
+        tai_to_ut1_override,
+    }
+}
+
+/// Evaluate a simple arithmetic expression with addition and subtraction only.
+///
+/// Handles patterns like: `32`, `-32.469`, `0.0115221 - 4.2`
+fn eval_simple_sum(expr: &str) -> f64 {
+    let trimmed = expr.trim();
+
+    // Try direct parse first (handles simple values and negative numbers)
+    if let Ok(val) = trimmed.parse::<f64>() {
+        return val;
+    }
+
+    // Tokenize: split into signed numeric tokens.
+    // Walk characters, splitting on +/- that are NOT part of scientific notation.
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+
+    for ch in trimmed.chars() {
+        if (ch == '+' || ch == '-') && !current.trim().is_empty() {
+            // Check if this sign is part of scientific notation (e.g., 1e-5)
+            let trimmed_current = current.trim_end();
+            if trimmed_current.ends_with('e') || trimmed_current.ends_with('E') {
+                current.push(ch);
+                continue;
+            }
+            tokens.push(current.trim().to_string());
+            current.clear();
+            if ch == '-' {
+                current.push('-');
+            }
+        } else {
+            current.push(ch);
+        }
+    }
+    if !current.trim().is_empty() {
+        tokens.push(current.trim().to_string());
+    }
+
+    tokens
+        .iter()
+        .map(|t| {
+            // Remove internal whitespace (e.g., "- 4.2" → "-4.2")
+            let cleaned: String = t.chars().filter(|c| !c.is_whitespace()).collect();
+            cleaned
+                .parse::<f64>()
+                .unwrap_or_else(|e| panic!("Cannot parse '{}' as f64: {}", cleaned, e))
+        })
+        .sum()
+}
+
+/// Convert a Gregorian calendar date to Modified Julian Date (MJD).
+///
+/// Uses the standard algorithm valid for dates after 1582-10-15 (Gregorian calendar).
+fn calendar_to_mjd(year: i32, month: u32, day: u32, hour: u32, minute: u32, second: f64) -> f64 {
+    // Algorithm: Meeus, Astronomical Algorithms, Ch. 7
+    let (y, m) = if month <= 2 {
+        (year - 1, month + 12)
+    } else {
+        (year, month)
+    };
+
+    let a = y / 100;
+    let b = 2 - a + a / 4;
+
+    let jd = (365.25 * (y + 4716) as f64).floor()
+        + (30.6001 * (m + 1) as f64).floor()
+        + day as f64
+        + b as f64
+        - 1524.5;
+
+    let day_fraction = (hour as f64 + minute as f64 / 60.0 + second / 3600.0) / 24.0;
+
+    // MJD = JD - 2400000.5
+    jd + day_fraction - 2_400_000.5
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_calendar_to_mjd_j2000() {
+        // J2000.0 = 2000-01-01 12:00:00 TT → MJD 51544.5
+        let mjd = calendar_to_mjd(2000, 1, 1, 12, 0, 0.0);
+        assert!(
+            (mjd - 51544.5).abs() < 1e-10,
+            "J2000 MJD: expected 51544.5, got {}",
+            mjd
+        );
+    }
+
+    #[test]
+    fn test_calendar_to_mjd_2007_nov_20() {
+        // 2007-11-20 00:00:00 UTC → MJD 54424.0 → TJT 14424.0
+        let mjd = calendar_to_mjd(2007, 11, 20, 0, 0, 0.0);
+        let tjt = mjd - 40_000.0;
+        assert!(
+            (tjt - 14424.0).abs() < 1e-10,
+            "SIM_dyncomp epoch TJT: expected 14424.0, got {}",
+            tjt
+        );
+    }
+
+    #[test]
+    fn test_calendar_to_mjd_1991_jan_01() {
+        // 1991-01-01 00:00:00 → MJD 48257.0 → TJT 8257.0
+        let mjd = calendar_to_mjd(1991, 1, 1, 0, 0, 0.0);
+        let tjt = mjd - 40_000.0;
+        assert!(
+            (tjt - 8257.0).abs() < 1e-10,
+            "1991-01-01 TJT: expected 8257.0, got {}",
+            tjt
+        );
+    }
+
+    #[test]
+    fn test_eval_simple_sum() {
+        assert!((eval_simple_sum("32") - 32.0).abs() < 1e-15);
+        assert!((eval_simple_sum("-32.469") - (-32.469)).abs() < 1e-15);
+        assert!((eval_simple_sum("0.0115221 - 4.2") - (0.0115221 - 4.2)).abs() < 1e-15);
+        assert!((eval_simple_sum("1.5 + 2.3") - 3.8).abs() < 1e-15);
+        assert!((eval_simple_sum("1e2 + 3") - 103.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_parse_dyncomp_time() {
+        let content = r#"
+jeod_time.time_manager_init.initializer = "UTC"
+jeod_time.time_manager_init.sim_start_format = trick.TimeEnum.calendar
+jeod_time.time_utc.set_date_and_time(2007, 11, 20, 0, 0, 0.0)
+
+jeod_time.time_tai.initialize_from_name = "UTC"
+jeod_time.time_ut1.initialize_from_name = "TAI"
+
+jeod_time.time_converter_tai_utc.override_data_table = True
+jeod_time.time_converter_tai_utc.leap_sec_override_val = 32
+
+jeod_time.time_converter_tai_ut1.override_data_table = True
+jeod_time.time_converter_tai_ut1.tai_to_ut1_override_val = -32.469
+"#;
+        let cfg = parse_time_config_str(content, &PathBuf::from("test"));
+
+        assert_eq!(cfg.initializer, TimeInitializer::Utc);
+        assert_eq!(cfg.utc_year, 2007);
+        assert_eq!(cfg.utc_month, 11);
+        assert_eq!(cfg.utc_day, 20);
+        assert_eq!(cfg.utc_hour, 0);
+        assert_eq!(cfg.utc_minute, 0);
+        assert!((cfg.utc_second - 0.0).abs() < 1e-15);
+        assert!((cfg.tai_utc_override.unwrap() - 32.0).abs() < 1e-15);
+        assert!((cfg.tai_to_ut1_override.unwrap() - (-32.469)).abs() < 1e-15);
+
+        // TJT should be 14424.0
+        assert!(
+            (cfg.utc_tjt() - 14424.0).abs() < 1e-10,
+            "UTC TJT: {}",
+            cfg.utc_tjt()
+        );
+
+        // TAI TJT = 14424.0 + 32/86400
+        let expected_tai_tjt = 14424.0 + 32.0 / 86400.0;
+        assert!(
+            (cfg.tai_tjt() - expected_tai_tjt).abs() < 1e-12,
+            "TAI TJT: {}",
+            cfg.tai_tjt()
+        );
+    }
+
+    #[test]
+    fn test_parse_apollo_time_with_expression() {
+        let content = r#"
+jeod_time.time_utc.set_date_and_time(1969, 7, 16, 13, 44, 0.0)
+jeod_time.time_converter_tai_utc.override_data_table = True
+jeod_time.time_converter_tai_utc.leap_sec_override_val = 4.2
+jeod_time.time_converter_tai_ut1.override_data_table = True
+jeod_time.time_converter_tai_ut1.tai_to_ut1_override_val = 0.0115221 - 4.2
+"#;
+        let cfg = parse_time_config_str(content, &PathBuf::from("test"));
+
+        assert_eq!(cfg.utc_year, 1969);
+        assert_eq!(cfg.utc_month, 7);
+        assert!((cfg.tai_utc_override.unwrap() - 4.2).abs() < 1e-15);
+        assert!(
+            (cfg.tai_to_ut1_override.unwrap() - (0.0115221 - 4.2)).abs() < 1e-15,
+            "UT1-TAI: {}",
+            cfg.tai_to_ut1_override.unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_tai_initialized_time() {
+        // SRP SIM date_and_time.py: TAI initializer, date is TAI not UTC.
+        let content = r#"
+jeod_time.time_manager_init.initializer = "TAI"
+jeod_time.time_manager_init.sim_start_format = trick.TimeEnum.calendar
+jeod_time.time_tai.set_date_and_time(1998, 12, 1, 0, 0, 31.0)
+jeod_time.time_tai.update_from_name = "Dyn"
+jeod_time.time_tt.initialize_from_name = "TAI"
+jeod_time.time_tt.update_from_name = "TAI"
+"#;
+        let cfg = parse_time_config_str(content, &PathBuf::from("test"));
+
+        assert_eq!(cfg.initializer, TimeInitializer::Tai);
+        assert_eq!(cfg.utc_year, 1998);
+        assert_eq!(cfg.utc_month, 12);
+        assert_eq!(cfg.utc_day, 1);
+        assert!((cfg.utc_second - 31.0).abs() < 1e-15);
+        assert!(cfg.tai_utc_override.is_none());
+
+        // TAI TJT: 1998-12-01 00:00:31 TAI → MJD 51148.0 + 31/86400 → TJT 11148.0 + 31/86400
+        // Note: calendar_to_mjd converts seconds via hour/minute/second path, so the
+        // result differs from the exact 31.0/86400.0 by ~8e-14 due to floating-point
+        // rounding in the intermediate 31/3600/24 computation.
+        let expected_tai_tjt = 11148.0 + 31.0 / 86400.0;
+        assert!(
+            (cfg.tai_tjt() - expected_tai_tjt).abs() < 1e-10,
+            "TAI TJT: expected {}, got {}",
+            expected_tai_tjt,
+            cfg.tai_tjt()
+        );
+    }
+
+    #[test]
+    fn test_parse_utc_no_overrides() {
+        // NED SIM date_and_time.py: UTC initializer, no leap sec override.
+        let content = r#"
+jeod_time.time_manager_init.initializer = "UTC"
+jeod_time.time_manager_init.sim_start_format = trick.TimeEnum.calendar
+jeod_time.time_utc.set_date_and_time(1991, 1, 1, 0, 0, 0.0)
+jeod_time.time_tai.initialize_from_name = "UTC"
+jeod_time.time_ut1.initialize_from_name = "TAI"
+"#;
+        let cfg = parse_time_config_str(content, &PathBuf::from("test"));
+
+        assert_eq!(cfg.initializer, TimeInitializer::Utc);
+        assert_eq!(cfg.utc_year, 1991);
+        assert!(cfg.tai_utc_override.is_none());
+        assert!(cfg.tai_to_ut1_override.is_none());
+
+        // UTC TJT: 1991-01-01 → MJD 48257.0 → TJT 8257.0
+        assert!(
+            (cfg.utc_tjt() - 8257.0).abs() < 1e-10,
+            "UTC TJT: {}",
+            cfg.utc_tjt()
+        );
+
+        // tai_tjt_with_offset with external TAI-UTC=26s
+        let expected_tai_tjt = 8257.0 + 26.0 / 86400.0;
+        assert!(
+            (cfg.tai_tjt_with_offset(26.0) - expected_tai_tjt).abs() < 1e-12,
+            "TAI TJT with offset: {}",
+            cfg.tai_tjt_with_offset(26.0)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #44.

- Add parsers for JEOD time config (`time_config.rs`), S_define step size (`s_define.rs`), and gravity control degree/order (`gravity_control.rs`) in `jeod_test_data`
- Generalize mass parser to accept arbitrary `.py` paths with optional function-name selector (e.g., `set_mass_iss`, `set_mass_cylinder`)
- Add `load_mu_from_jeod_cc()` for extracting mu from spherical-only gravity files (Sun, Moon) that lack degree/order fields
- Migrate all ~30 Tier 3 test files to load epoch, mu, dt, mass properties, and gravity degree/order from JEOD source files
- Remove hardcoded `MU_EARTH` and `DT` constants from `sim_test_helpers`
- Run Tier 3 tests (excluding `earth_moon`) in PR CI; full suite including `earth_moon` on main merge only
- Expand JEOD sparse checkout to include SIM directories needed by the new parsers

## Test plan

- [x] `cargo fmt --check && cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 359 unit/tier-2 tests pass
- [x] `cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'` — 153 tier-3 tests pass
- [x] `cargo nextest run --workspace -E 'test(earth_moon)'` — 2 passed (18 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)