### PR TITLE
Pass source velocity to relativistic correction in Bevy integration_system

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -64,6 +64,19 @@ pub struct GravitySourceC(pub GravitySource);
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
 pub struct SourceInertialPositionC(pub DVec3);
 
+/// Inertial-frame velocity of a gravity source (m/s).
+///
+/// For the central body (e.g., Earth in an Earth-centered sim), this is
+/// typically `DVec3::ZERO`. For third bodies (Sun, Moon), this value is
+/// maintained by the `ephemeris_update_system`.
+///
+/// Used by the integration system to provide source velocity to the
+/// relativistic correction computation. Stored separately from
+/// `TranslationalStateC` to avoid Bevy query conflicts (the body's
+/// `TranslationalStateC` is already mutably queried by the integration system).
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+pub struct SourceInertialVelocityC(pub DVec3);
+
 /// Aerodynamic force and torque in the **structural** frame (N, N*m).
 ///
 /// Written by `aero_drag_system`.

--- a/src/components.rs
+++ b/src/components.rs
@@ -66,12 +66,14 @@ pub struct SourceInertialPositionC(pub DVec3);
 
 /// Inertial-frame velocity of a gravity source (m/s).
 ///
-/// For the central body (e.g., Earth in an Earth-centered sim), this is
-/// typically `DVec3::ZERO`. For third bodies (Sun, Moon), this value is
-/// maintained by the `ephemeris_update_system`.
+/// Optional component. For the central body (e.g., Earth in an Earth-centered
+/// sim), this is typically `DVec3::ZERO`. For third bodies (Sun, Moon), attach
+/// this component alongside [`EphemerisBodyC`] and the `ephemeris_update_system`
+/// will populate it each step. When absent, relativistic corrections fall back
+/// to zero source velocity.
 ///
-/// Used by the integration system to provide source velocity to the
-/// relativistic correction computation. Stored separately from
+/// Used by the gravity and integration systems to provide source velocity to
+/// the relativistic correction computation. Stored separately from
 /// `TranslationalStateC` to avoid Bevy query conflicts (the body's
 /// `TranslationalStateC` is already mutably queried by the integration system).
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -104,6 +104,7 @@ pub fn ephemeris_update_system(
     mut query: Query<(
         &EphemerisBodyC,
         &mut SourceInertialPositionC,
+        Option<&mut SourceInertialVelocityC>,
         Option<&mut TranslationalStateC>,
     )>,
 ) {
@@ -111,7 +112,7 @@ pub fn ephemeris_update_system(
         return;
     };
     let tdb_jd = sim_time.tdb_julian_date();
-    for (ephem_body, mut source_pos, trans_state) in &mut query {
+    for (ephem_body, mut source_pos, source_vel, trans_state) in &mut query {
         let (pos, vel) = eph
             .get_state(ephem_body.target, ephem_body.observer, tdb_jd)
             .unwrap_or_else(|e| {
@@ -121,6 +122,9 @@ pub fn ephemeris_update_system(
                 )
             });
         source_pos.0 = pos;
+        if let Some(mut sv) = source_vel {
+            sv.0 = vel;
+        }
         if let Some(mut ts) = trans_state {
             ts.0.position = pos;
             ts.0.velocity = vel;
@@ -264,6 +268,7 @@ pub fn integration_system(
         &GravitySourceC,
         Option<&PlanetFixedRotationC>,
         &SourceInertialPositionC,
+        Option<&SourceInertialVelocityC>,
         Option<&TidalDeltaC20C>,
         Option<&TidalConfigC>,
     )>,
@@ -306,13 +311,15 @@ pub fn integration_system(
                 let mut accel =
                     jeod_sim::accumulate_gravity(pos, &controls.0, DVec3::ZERO, |source_entity| {
                         match sources.get(source_entity) {
-                            Ok((s, r, p, tidal, tidal_config)) => Some(jeod_sim::ResolvedSource {
-                                source: &s.0,
-                                rotation: r.map(|r| &r.0),
-                                position: p.0,
-                                delta_c20: tidal.map_or(0.0, |t| t.0),
-                                has_delta_coeffs: tidal_config.is_some(),
-                            }),
+                            Ok((s, r, p, _, tidal, tidal_config)) => {
+                                Some(jeod_sim::ResolvedSource {
+                                    source: &s.0,
+                                    rotation: r.map(|r| &r.0),
+                                    position: p.0,
+                                    delta_c20: tidal.map_or(0.0, |t| t.0),
+                                    has_delta_coeffs: tidal_config.is_some(),
+                                })
+                            }
                             Err(_) => {
                                 panic!(
                                     "Entity {entity:?}: GravityControl references source \
@@ -325,17 +332,16 @@ pub fn integration_system(
                     .grav_accel;
 
                 // Relativistic correction at each integrator stage.
-                // TODO(#53): source velocity is DVec3::ZERO.
                 accel += jeod_sim::accumulate_relativistic_corrections(
                     pos,
                     vel,
                     &controls.0,
                     |source_entity| {
-                        sources.get(source_entity).ok().map(|(s, _, p, _, _)| {
+                        sources.get(source_entity).ok().map(|(s, _, p, v, _, _)| {
                             jeod_sim::ResolvedRelativisticSource {
                                 mu: s.mu,
                                 position: p.0,
-                                velocity: DVec3::ZERO,
+                                velocity: v.map_or(DVec3::ZERO, |v| v.0),
                             }
                         })
                     },

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -380,6 +380,7 @@ pub fn gravity_computation_system(
         &GravitySourceC,
         Option<&PlanetFixedRotationC>,
         &SourceInertialPositionC,
+        Option<&SourceInertialVelocityC>,
         Option<&TidalDeltaC20C>,
         Option<&TidalConfigC>,
     )>,
@@ -390,15 +391,17 @@ pub fn gravity_computation_system(
             &controls.0,
             DVec3::ZERO,
             |source_entity| match sources.get(source_entity) {
-                Ok((source, rot, pos, tidal, tidal_config)) => Some(jeod_sim::ResolvedSource {
-                    source: &source.0,
-                    rotation: rot.map(|r| &r.0),
-                    position: pos.0,
-                    delta_c20: tidal.map_or(0.0, |t| t.0),
-                    // JEOD gates on n_deltacoeffs > 0 (tidal config
-                    // present), not on whether ΔC20 component exists.
-                    has_delta_coeffs: tidal_config.is_some(),
-                }),
+                Ok((source, rot, pos, _, tidal, tidal_config)) => {
+                    Some(jeod_sim::ResolvedSource {
+                        source: &source.0,
+                        rotation: rot.map(|r| &r.0),
+                        position: pos.0,
+                        delta_c20: tidal.map_or(0.0, |t| t.0),
+                        // JEOD gates on n_deltacoeffs > 0 (tidal config
+                        // present), not on whether ΔC20 component exists.
+                        has_delta_coeffs: tidal_config.is_some(),
+                    })
+                }
                 Err(_) => {
                     panic!(
                         "Entity {entity:?}: GravityControl references source \
@@ -411,17 +414,16 @@ pub fn gravity_computation_system(
 
         // Apply relativistic (post-Newtonian PPN) corrections after Newtonian
         // gravity, matching Simulation::step() stage 4b ordering.
-        // TODO: Source velocity is DVec3::ZERO — see #53.
         accel.grav_accel += jeod_sim::accumulate_relativistic_corrections(
             state.position,
             state.velocity,
             &controls.0,
             |source_entity| {
-                sources.get(source_entity).ok().map(|(s, _, p, _, _)| {
+                sources.get(source_entity).ok().map(|(s, _, p, v, _, _)| {
                     jeod_sim::ResolvedRelativisticSource {
                         mu: s.mu,
                         position: p.0,
-                        velocity: DVec3::ZERO,
+                        velocity: v.map_or(DVec3::ZERO, |v| v.0),
                     }
                 })
             },

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -94,8 +94,9 @@ pub fn tidal_update_system(
 ///
 /// Queries entities with `EphemerisBodyC` + `SourceInertialPositionC` and
 /// looks up the current position/velocity from the `EphemerisR` resource.
-/// Also updates `TranslationalStateC` if present (for Sun/Moon entities
-/// used by SRP, solar beta, and earth lighting systems).
+/// Also updates `SourceInertialVelocityC` and `TranslationalStateC` when
+/// present (velocity for relativistic corrections; translational state for
+/// Sun/Moon entities used by SRP, solar beta, and earth lighting systems).
 ///
 /// Placed in `JeodSet::EphemerisUpdate`.
 pub fn ephemeris_update_system(

--- a/tests/cross_parity.rs
+++ b/tests/cross_parity.rs
@@ -31,8 +31,8 @@ use bevy_jeod::{
     GravitySourceC, GravityTorqueC, IntegratorTypeC, JeodPlugin, LvlhFrameC, MassPropertiesC,
     MoonMarker, OrbitalElementsC, OrbitalElementsConfigC, PlanetC, PlanetFixedRotationC,
     RadiationForceC, RotationModelC, RotationalStateC, ShadowBodyC, SolarBetaC,
-    SourceInertialPositionC, SunMarker, TidalConfigC, TidalDeltaC20C, TotalForceC,
-    TranslationalStateC,
+    SourceInertialPositionC, SourceInertialVelocityC, SunMarker, TidalConfigC, TidalDeltaC20C,
+    TotalForceC, TranslationalStateC,
 };
 use glam::{DMat3, DVec3};
 use jeod_sim::{
@@ -5526,6 +5526,102 @@ fn tier3_bevy_mercury_relativistic() {
         &sim.body(0).trans,
     );
     println!("  Mercury relativistic: bit-identical");
+}
+
+/// Relativistic parity with non-zero source velocity.
+///
+/// A satellite orbits a Sun that is itself moving at 30 km/s (as if the Sun
+/// were in a barycentric frame). Both Bevy and Simulation receive the same
+/// non-zero source velocity for the PPN correction. This exercises
+/// `SourceInertialVelocityC` and ensures it is wired through both the
+/// `gravity_computation_system` and `integration_system`.
+#[test]
+fn tier3_bevy_relativistic_moving_source() {
+    println!("Relativistic moving source: Sun with non-zero velocity");
+
+    let mu_sun = 1.327_124_400_18e20;
+    let r_perihelion = 4.6e10;
+    let v_perihelion = 5.898e4;
+    let mercury_trans = TranslationalState {
+        position: DVec3::new(r_perihelion, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v_perihelion, 0.0),
+    };
+
+    // Non-zero source velocity (Sun moving in barycentric frame)
+    let source_velocity = DVec3::new(0.0, 0.0, 3.0e4);
+
+    // ── Bevy ──
+    let mut app = new_bevy_app(DT);
+
+    let sun_entity = app
+        .world_mut()
+        .spawn((
+            Name::new("Sun"),
+            SunMarker,
+            GravitySourceC(GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            }),
+            SourceInertialPositionC::default(),
+            SourceInertialVelocityC(source_velocity),
+            TranslationalStateC::default(),
+        ))
+        .id();
+
+    let mut sun_ctrl = GravityControl::new_spherical(sun_entity, false);
+    sun_ctrl.relativistic = true;
+
+    let vehicle = app
+        .world_mut()
+        .spawn((
+            TranslationalStateC(mercury_trans),
+            DynamicsConfigC::default(),
+            GravityControlsC(GravityControls {
+                controls: vec![sun_ctrl],
+            }),
+            GravityAccelerationC::default(),
+            TotalForceC::default(),
+        ))
+        .id();
+
+    step_bevy(&mut app, NUM_STEPS);
+    let bevy_trans = read_trans(app.world(), vehicle);
+
+    // ── Simulation ──
+    let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let mut sim = Simulation::new(time, DT);
+    let sun_idx = sim.add_source(GravitySourceEntry {
+        source: GravitySource {
+            mu: mu_sun,
+            model: GravityModel::PointMass,
+        },
+        position: DVec3::ZERO,
+        velocity: source_velocity,
+        t_inertial_pfix: None,
+        delta_c20: 0.0,
+        rotation_model: RotationModel::default(),
+        tidal_config: None,
+    });
+
+    let mut sim_sun_ctrl = GravityControl::new_spherical(sun_idx, false);
+    sim_sun_ctrl.relativistic = true;
+
+    sim.add_body(SimBody {
+        trans: mercury_trans,
+        gravity_controls: GravityControls {
+            controls: vec![sim_sun_ctrl],
+        },
+        ..Default::default()
+    });
+    sim.validate().unwrap();
+    sim.step_n(NUM_STEPS);
+
+    assert_trans_eq(
+        "Bevy vs Sim (relativistic_moving_source)",
+        &bevy_trans,
+        &sim.body(0).trans,
+    );
+    println!("  Relativistic moving source: bit-identical");
 }
 
 #[test]

--- a/tests/cross_parity.rs
+++ b/tests/cross_parity.rs
@@ -5621,7 +5621,21 @@ fn tier3_bevy_relativistic_moving_source() {
         &bevy_trans,
         &sim.body(0).trans,
     );
-    println!("  Relativistic moving source: bit-identical");
+
+    // Also compare gravity acceleration to cover gravity_computation_system
+    // wiring of SourceInertialVelocityC (integration_system recomputes gravity
+    // internally, so trans parity alone doesn't prove the precomputed path).
+    let bevy_grav = app.world().get::<GravityAccelerationC>(vehicle).unwrap();
+    let sim_grav = &sim.body(0).gravity_accel;
+    for i in 0..3 {
+        assert_bits_eq(
+            "Bevy vs Sim (relativistic_moving_source)",
+            &format!("grav_accel[{i}]"),
+            bevy_grav.grav_accel[i],
+            sim_grav.grav_accel[i],
+        );
+    }
+    println!("  Relativistic moving source: bit-identical (trans + gravity)");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add `SourceInertialVelocityC(DVec3)` component for gravity source entities
- `ephemeris_update_system` populates it from ephemeris data each step
- Both `gravity_computation_system` and `integration_system` read actual source velocity instead of hardcoded `DVec3::ZERO`
- Component is optional — entities without it fall back to zero velocity (backward compatible)

Closes #53

## Test plan
- [x] All existing tests pass (no behavioral change for current sims where sources have zero velocity in integration frame)
- [x] `tier3_bevy_mercury_relativistic` parity test continues to pass
- [x] New `tier3_bevy_relativistic_moving_source` test: exercises non-zero source velocity (30 km/s) through both gravity and integration systems, asserts Bevy vs Simulation bit-identical
- [ ] Verify clippy/fmt clean in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)