### PR TITLE
Address orphaned Phase 5 tasks: ODE scheduling fix, examples, MassTree wiring (#60)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -685,8 +685,8 @@ Only polar motion remains.
 
 | ID | Task | Description | JEOD Reference |
 |----|------|-------------|----------------|
-| 5.33 | Multi-integrable-object scheduling | Port JEOD's DynManager integration loop that drives multiple integrable objects (orbital state + thermal state) through RK4 stages in the correct order. Required to close the 27.6 m / 23-day SRP thermal coupling residual (simnaut/bevy_jeod#13). | `dynamics_integration_group.cc`, `er7_utils` integration loop |
-| 5.34 | Thermal ODE as integrable object | Move plate temperature integration into the Bevy dynamics pipeline so it's driven by the same integration loop as the orbital state, matching JEOD's `ThermalIntegrableObject` scheduling. | `thermal_integrable_object.cc` |
+| 5.33 | Multi-integrable-object scheduling | ~~Port JEOD's DynManager integration loop~~ Root-caused: JEOD's standard `radiation.sm` schedules `compute_temp_dot()` as a "scheduled" job (once per step, not per-stage), making thermal integration effectively Forward Euler. Matching this behavior dropped SRP residual from 3.07 m → 0.037 m (82× improvement). Coupled RK4 infrastructure (`integrate_body_coupled`) added for future derivative-class SRP. Closes simnaut/bevy_jeod#13. | `dynamics_integration_group.cc`, `er7_utils` integration loop |
+| 5.34 | Thermal ODE as integrable object | Standalone `integrate_temperatures` now matches JEOD's Forward Euler scheduling. Coupled path (`finalize_rk4_temperatures` + `integrate_body_coupled`) added for the `radiation_1st_order.sm` variant that uses derivative-class SRP. | `thermal_integrable_object.cc` |
 
 #### 5G. Cross-Validation Infrastructure
 
@@ -726,9 +726,9 @@ JEOD 5.4).
 
 | ID | Task | Description |
 |----|------|-------------|
-| 5.30 | `apollo.rs` | Apollo trans-lunar injection scenario. Multi-body (Earth + Moon), stage separation (attach/detach). |
-| 5.31 | `earth_moon.rs` | Long-duration Earth-Moon trajectory. |
-| 5.32 | `mars_orbit.rs` | Mars orbit insertion and propagation. |
+| 5.30 | `apollo.rs` | ✅ Apollo trans-lunar injection: Earth+Moon+Sun point-mass gravity, MassTree staging (CSM + S-IVB detach), impulsive TLI delta-V, 3-day coast. Uses DE421 ephemeris. |
+| 5.31 | `earth_moon.rs` | ✅ Clementine lunar orbit: Moon LP150Q 60×60 SH, Earth/Sun 3rd-body, cannonball SRP, DE421 ephemeris + BPC libration. |
+| 5.32 | `mars_orbit.rs` | ✅ Dawn at Mars: MRO110B2 110×110 SH, IAU rotation, Sun 3rd-body, DE421 ephemeris. |
 
 ### Exit Criteria
 
@@ -741,7 +741,7 @@ JEOD 5.4).
 - [x] **Earth rotation**: ITRS frame orientation matches JEOD/IERS to < 1 arcsecond at 5+ test epochs — `tier3_rnp_component_comparison`
 
 #### Tier 3 (trajectory cross-validation — required for each new physics)
-- [x] **All prior phase exit criteria** still pass (no regressions) — 300 tests pass
+- [x] **All prior phase exit criteria** still pass (no regressions) — 555 tests pass
 - [x] **Tier 3 LEO 24h (high-fidelity gravity)**: Position error vs. JEOD < 10 m — RUN_3A (4x4): 0.13 m, RUN_3B (8x8): 0.23 m
 - [x] **Tier 3 LEO with drag**: Position error vs. JEOD < 100 m over 24h — RUN_6B: 1.1 m over 8h
 - ~~**Tier 3 Earth-Moon multi-body**~~ — moved to Phase 6 exit criteria (requires Moon gravity model + lunar RNP)
@@ -750,8 +750,8 @@ JEOD 5.4).
 - [x] **Tier 3 RKF45 trajectory**: RKF45 on same scenario — `tier3_bevy_rkf45_matches_simulation_bit_identical` validates bit-identical Bevy/Simulation parity; JEOD's RKF45 is also fixed-step (see Tier 1 note)
 - [x] **Tier 3 polar motion**: Earth-fixed frame with polar motion — `tier3_simulation_run2p_polar_motion` matches JEOD
 - [x] **Tier 3 solid tides**: Trajectory with tidal ΔC20 — `tier3_simulation_tide_run01` validates trajectory + ΔC20
-- [x] **Tier 3 SRP trajectory**: SRP with ephemeris Sun — `tier3_simulation_srp_flat_plate` achieves 3.07 m over 23 days
-- [x] **Tier 3 SRP thermal parity**: SIM_3_ORBIT RUN_radiation (23 days, flat-plate + thermal) — `tier3_simulation_srp_flat_plate` achieves 3.07 m (< 5 m budget)
+- [x] **Tier 3 SRP trajectory**: SRP with ephemeris Sun — `tier3_simulation_srp_flat_plate` achieves 0.040 m over 23 days (improved from 3.07 m after ODE scheduling fix in tasks 5.33/5.34)
+- [x] **Tier 3 SRP thermal parity**: SIM_3_ORBIT RUN_radiation (23 days, flat-plate + thermal) — `tier3_simulation_srp_flat_plate` achieves 0.040 m (< 5 m budget; 82× improvement from matching JEOD's Forward Euler thermal scheduling)
 - [x] **Tier 3 3rd-body isolation**: SIM_dyncomp RUN_4 (spherical gravity + Sun/Moon) — `tier3_simulation_run4_3rd_body` achieves 0.002 m (< 5 m budget)
 - [x] **Tier 3 Sun/Moon 3rd-body resolved**: Sun/Moon added to `tier3_sim_torque_simple.rs` with real mu values (Sun: 1.327e20, Moon: 4.903e12) and registered as 3rd-body gravity controls. Position tolerances meet target (< 0.5 m). Quaternion and torque tolerances are scenario-inherent: gradient-free runs (RUN_01/04) have no torque reference so attitude diverges freely; SH-gradient runs (RUN_06) compound errors through rotational dynamics over 3h with DE421 ephemeris offset as the dominant error source (~10 arcsec Sun direction, see simnaut/bevy_jeod#27). The `mu: 0.0` values in `tier3_sim_srp.rs` and `tier3_sim_solar_beta.rs` correctly match the JEOD reference sims (SIM_3_ORBIT and RUN_2), which deliberately exclude Sun/Moon gravity — these are not workarounds. 3rd-body gravity is validated independently by RUN_4, RUN_7A-D, and torque_simple.
 

--- a/crates/jeod_dynamics/src/lib.rs
+++ b/crates/jeod_dynamics/src/lib.rs
@@ -25,5 +25,8 @@ pub use mass::{MassProperties, INERTIA_CONSISTENCY_TOL};
 pub use mass_body::{point_mass_inertia, MassBody, MassBodyId, MassPointState, MassTree};
 pub use propagation::{propagate_body_frames, propagate_forward, propagate_reverse};
 pub use rkf45::{rkf45_sixdof_step, rkf45_translational_step};
-pub use rotational::{RotationalState, SixDofState};
+pub use rotational::{
+    compute_left_quat_deriv, compute_rotational_acceleration, normalize_integ, RotationalState,
+    SixDofState,
+};
 pub use state::TranslationalState;

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -1,0 +1,268 @@
+//! Apollo trans-lunar injection: multi-body gravity, staging, impulsive maneuver.
+//!
+//! Demonstrates:
+//! - Earth + Moon multi-body point-mass gravity
+//! - Mass tree with two-body vehicle (CSM + S-IVB stage)
+//! - Impulsive TLI delta-V maneuver
+//! - Stage separation via mass tree detach
+//! - 3-day coast to lunar encounter
+//!
+//! Uses DE421 ephemeris for Moon position. No SRP or drag.
+//!
+//! Requires `test_data/de421.bsp` for ephemeris data.
+//!
+//! ```bash
+//! cargo run -p jeod_runner --example apollo
+//! ```
+
+use std::path::Path;
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, Simulation, VehicleConfig};
+use jeod_sim::{
+    GravityControl, GravityControls, GravityModel, GravitySource, MassProperties, SimulationTime,
+    TranslationalState,
+};
+
+// Gravitational parameters
+const MU_EARTH: f64 = 3.986_004_418e14; // m^3/s^2
+const MU_MOON: f64 = 4.902_800_066e12; // m^3/s^2
+const MU_SUN: f64 = 1.327_124_400_41e20; // m^3/s^2
+
+const R_EARTH: f64 = 6_371_000.0; // mean radius, m
+
+// Apollo-like parking orbit: 185 km circular, 28.5° inclination (KSC latitude)
+const PARKING_ALT: f64 = 185_000.0; // m
+const INCLINATION_DEG: f64 = 28.5;
+
+// Vehicle masses (approximate Apollo values)
+const MASS_CSM: f64 = 28_800.0; // Command/Service Module, kg
+const MASS_SIVB: f64 = 13_300.0; // S-IVB dry mass, kg (after TLI burn)
+
+// TLI delta-V: ~3.1 km/s (prograde) applied at the right point in parking orbit
+const TLI_DELTA_V: f64 = 3_130.0; // m/s
+
+// Timing
+const PARKING_ORBITS: f64 = 2.5; // coast in parking orbit before TLI
+const DT: f64 = 60.0; // 1-minute timesteps
+const TOTAL_DURATION: f64 = 3.0 * 86_400.0; // 3 days
+
+// J2000.0 epoch for simplicity
+const EPOCH_TAI_TJT: f64 = 0.000_428; // J2000 + 37s TAI-UTC offset
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_data");
+    let bsp_path = data_dir.join("de421.bsp");
+    assert!(
+        bsp_path.exists(),
+        "DE421 not found at {}",
+        bsp_path.display()
+    );
+
+    let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path)?;
+    let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
+    let epoch_tdb_jd = time.tdb_julian_date();
+
+    // Get Moon and Sun positions at epoch
+    let (moon_pos, _) = ephemeris.get_state(
+        jeod_sim::EphemerisBody::Moon,
+        jeod_sim::EphemerisBody::Earth,
+        epoch_tdb_jd,
+    )?;
+    let (sun_pos, _) = ephemeris.get_state(
+        jeod_sim::EphemerisBody::Sun,
+        jeod_sim::EphemerisBody::Earth,
+        epoch_tdb_jd,
+    )?;
+
+    let mut sim = Simulation::new(time, DT);
+
+    // Earth at origin
+    let earth = sim.add_source(GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
+    ));
+
+    // Moon with per-step ephemeris updates
+    let moon = sim.add_source(GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_MOON,
+            model: GravityModel::PointMass,
+        },
+        moon_pos,
+        None,
+    ));
+    sim.set_source_ephemeris(
+        moon,
+        jeod_sim::EphemerisBody::Moon,
+        jeod_sim::EphemerisBody::Earth,
+    );
+
+    // Sun as 3rd-body (weak perturbation for TLI, but included for completeness)
+    let sun = sim.add_source(GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_SUN,
+            model: GravityModel::PointMass,
+        },
+        sun_pos,
+        None,
+    ));
+    sim.set_source_ephemeris(
+        sun,
+        jeod_sim::EphemerisBody::Sun,
+        jeod_sim::EphemerisBody::Earth,
+    );
+
+    sim.ephemeris = Some(ephemeris);
+
+    // Compute parking orbit initial state
+    let r_park = R_EARTH + PARKING_ALT;
+    let v_circ = (MU_EARTH / r_park).sqrt();
+    let inc = INCLINATION_DEG.to_radians();
+
+    // Start at ascending node: position along x, velocity in xy-plane tilted by inclination
+    let init_pos = DVec3::new(r_park, 0.0, 0.0);
+    let init_vel = DVec3::new(0.0, v_circ * inc.cos(), v_circ * inc.sin());
+
+    // CSM core mass — S-IVB mass is added via the mass tree
+    let total_mass = MASS_CSM + MASS_SIVB;
+    let body_idx = sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: init_pos,
+            velocity: init_vel,
+        },
+        mass: Some(MassProperties::new(MASS_CSM)),
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_spherical(earth, false),
+                GravityControl::new_third_body(moon),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        ..Default::default()
+    });
+
+    // Register in mass tree: CSM (root) + S-IVB (child)
+    let csm_tree_id = sim.add_body_to_tree(body_idx, "CSM");
+    // S-IVB attached at origin with identity rotation (simplified — no structural offset)
+    let tree = sim.mass_tree.as_mut().unwrap();
+    let sivb_tree_id = tree.add_body("S-IVB".to_string(), MassProperties::new(MASS_SIVB));
+    tree.attach(sivb_tree_id, csm_tree_id, DVec3::ZERO, DMat3::IDENTITY);
+    // Update body mass from tree composite
+    let composite = tree.get(csm_tree_id).composite_properties;
+    sim.set_body_mass(body_idx, composite);
+
+    sim.validate().expect("validation failed");
+
+    // Compute TLI time: after N parking orbits
+    let parking_period = 2.0 * std::f64::consts::PI * (r_park.powi(3) / MU_EARTH).sqrt();
+    let tli_time = PARKING_ORBITS * parking_period;
+    let separation_time = tli_time + 600.0; // 10 minutes after TLI burn
+
+    println!("Apollo trans-lunar injection — 3-day trajectory");
+    println!(
+        "  Parking orbit: {:.0} km circular, {INCLINATION_DEG}° inclination",
+        PARKING_ALT / 1000.0
+    );
+    println!("  Vehicle: CSM ({MASS_CSM} kg) + S-IVB ({MASS_SIVB} kg)");
+    println!(
+        "  TLI delta-V: {TLI_DELTA_V} m/s prograde at t={:.1} h",
+        tli_time / 3600.0
+    );
+    println!("  Stage separation at t={:.1} h", separation_time / 3600.0);
+    println!("  Earth + Moon + Sun point-mass gravity | dt={DT} s");
+    println!();
+    println!(
+        "{:>10}  {:>12}  {:>12}  {:>12}  {:>10}  {:>8}",
+        "Time (h)", "Alt (km)", "Dist Moon", "Speed (m/s)", "Mass (kg)", "Phase"
+    );
+    println!("{}", "-".repeat(76));
+
+    let total_steps = (TOTAL_DURATION / DT).round() as usize;
+    let print_interval = 7200.0; // 2 hours
+    let steps_per_print = (print_interval / DT).round() as usize;
+
+    let mut tli_applied = false;
+    let mut separated = false;
+
+    for step in 1..=total_steps {
+        let t = (step as f64) * DT;
+
+        // Apply TLI burn (impulsive)
+        if !tli_applied && t >= tli_time {
+            let body = sim.body(body_idx);
+            let vel_hat = body.trans.velocity.normalize();
+            let new_vel = body.trans.velocity + vel_hat * TLI_DELTA_V;
+            sim.set_body_velocity(body_idx, new_vel);
+            tli_applied = true;
+            println!(
+                "{:10.1}  {:>12}  {:>12}  {:>12}  {:>10}  TLI BURN",
+                t / 3600.0,
+                "---",
+                "---",
+                "---",
+                "---"
+            );
+        }
+
+        // Stage separation
+        if !separated && t >= separation_time {
+            // Detach S-IVB: body keeps CSM mass only
+            let tree = sim.mass_tree.as_mut().unwrap();
+            tree.detach(sivb_tree_id);
+            let csm_mass = tree.get(csm_tree_id).composite_properties;
+            sim.set_body_mass(body_idx, csm_mass);
+            separated = true;
+            println!(
+                "{:10.1}  {:>12}  {:>12}  {:>12}  {:10.0}  SEPARATE",
+                t / 3600.0,
+                "---",
+                "---",
+                "---",
+                csm_mass.mass
+            );
+        }
+
+        sim.step();
+
+        if step % steps_per_print == 0 {
+            let body = sim.body(body_idx);
+            let pos = body.trans.position;
+            let vel = body.trans.velocity;
+            let moon_source_pos = sim.sources[moon].position;
+
+            let alt_km = (pos.length() - R_EARTH) / 1000.0;
+            let dist_moon_km = (pos - moon_source_pos).length() / 1000.0;
+            let speed = vel.length();
+            let mass = if separated { MASS_CSM } else { total_mass };
+            let hours = t / 3600.0;
+
+            let phase = if !tli_applied {
+                "PARK"
+            } else if dist_moon_km < 50_000.0 {
+                "LUNAR"
+            } else {
+                "COAST"
+            };
+
+            println!(
+                "{hours:10.1}  {alt_km:12.1}  {dist_moon_km:12.1}  {speed:12.1}  {mass:10.0}  {phase}"
+            );
+        }
+    }
+
+    let final_body = sim.body(body_idx);
+    let final_moon_dist = (final_body.trans.position - sim.sources[moon].position).length();
+    println!();
+    println!(
+        "Final distance to Moon: {:.0} km after {:.1} days",
+        final_moon_dist / 1000.0,
+        TOTAL_DURATION / 86400.0
+    );
+
+    Ok(())
+}

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -153,8 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sivb_tree_id = tree.add_body("S-IVB".to_string(), MassProperties::new(MASS_SIVB));
     tree.attach(sivb_tree_id, csm_tree_id, DVec3::ZERO, DMat3::IDENTITY);
     // Update body mass from tree composite
-    let composite = tree.get(csm_tree_id).composite_properties;
-    sim.set_body_mass(body_idx, composite);
+    sim.sync_body_mass_from_tree(body_idx);
 
     sim.validate().expect("validation failed");
 
@@ -214,8 +213,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Detach S-IVB: body keeps CSM mass only
             let tree = sim.mass_tree.as_mut().unwrap();
             tree.detach(sivb_tree_id);
-            let csm_mass = tree.get(csm_tree_id).composite_properties;
-            sim.set_body_mass(body_idx, csm_mass);
+            let csm_mass = tree.get(csm_tree_id).composite_properties.mass;
+            sim.sync_body_mass_from_tree(body_idx);
             separated = true;
             println!(
                 "{:10.1}  {:>12}  {:>12}  {:>12}  {:10.0}  SEPARATE",
@@ -223,7 +222,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "---",
                 "---",
                 "---",
-                csm_mass.mass
+                csm_mass
             );
         }
 

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -47,9 +47,6 @@ const PARKING_ORBITS: f64 = 2.5; // coast in parking orbit before TLI
 const DT: f64 = 60.0; // 1-minute timesteps
 const TOTAL_DURATION: f64 = 3.0 * 86_400.0; // 3 days
 
-// J2000.0 epoch for simplicity
-const EPOCH_TAI_TJT: f64 = 0.000_428; // J2000 + 37s TAI-UTC offset
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_data");
     let bsp_path = data_dir.join("de421.bsp");
@@ -60,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path)?;
-    let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let epoch_tdb_jd = time.tdb_julian_date();
 
     // Get Moon and Sun positions at epoch

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -1,0 +1,209 @@
+//! Clementine lunar orbit: multi-body gravity with Earth, Moon, and Sun.
+//!
+//! Demonstrates:
+//! - Moon LP150Q 60x60 spherical harmonics gravity
+//! - Earth and Sun as 3rd-body point-mass perturbations
+//! - DE421 ephemeris for per-step source position updates
+//! - Moon libration rotation from DE421 BPC data
+//! - Cannonball solar radiation pressure with Earth shadow
+//!
+//! Requires JEOD source checkout (JEOD_HOME or JEOD_PATH) for gravity
+//! coefficients and `test_data/de421.bsp` + `test_data/moon_pa_de421_1900-2050.bpc`
+//! for ephemeris data.
+//!
+//! ```bash
+//! cargo run -p jeod_runner --example earth_moon
+//! ```
+
+use std::path::Path;
+
+use glam::DVec3;
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, SrpModel, VehicleConfig};
+use jeod_sim::{
+    Ephemeris, EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource,
+    MassProperties, SimulationTime, TranslationalState,
+};
+
+// Clementine orbital parameters at epoch (1994-03-01 00:00 UTC).
+// Initial state from JEOD SIM_Earth_Moon RUN_clem reference trajectory (t=0).
+// Moon-centered inertial frame.
+const INIT_POS: DVec3 = DVec3::new(1_296_944.012, -1_060_824.45, 2_522_289.146);
+const INIT_VEL: DVec3 = DVec3::new(-930.578, -439.312, 862.075);
+
+// Clementine spacecraft parameters
+const MASS_KG: f64 = 424.0;
+const SRP_CX_AREA: f64 = 2.1432; // m^2
+const SRP_ALBEDO: f64 = 1.0;
+const SRP_DIFFUSE: f64 = 0.27;
+
+// Epoch: 1994-03-01 00:00:00 UTC
+// TAI-UTC = 28 s; TAI TJT = MJD - 40000 + 28/86400
+const EPOCH_TAI_TJT: f64 = 9412.0 + 28.0 / 86400.0;
+
+// Propagation: 1 day at 1 s. (The Tier 3 test uses dt=0.03125 s for
+// cross-validation accuracy; examples use a larger step for speed.)
+const DT: f64 = 1.0;
+const DURATION: f64 = 86_400.0; // 1 day
+
+// Moon equatorial radius for altitude computation
+const R_MOON: f64 = 1_737_400.0; // m
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
+    let grav_dir = jeod_root.join("models/environment/gravity/data/src");
+    let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_data");
+    let bsp_path = data_dir.join("de421.bsp");
+    let bpc_path = data_dir.join("moon_pa_de421_1900-2050.bpc");
+
+    assert!(
+        bsp_path.exists(),
+        "DE421 not found at {}",
+        bsp_path.display()
+    );
+    assert!(
+        bpc_path.exists(),
+        "Moon BPC not found at {}",
+        bpc_path.display()
+    );
+
+    // Load gravity coefficients
+    let lp150q = jeod_sim::coefficients::load_from_jeod_cc(&grav_dir.join("moon_LP150Q.cc"))?;
+    let moon_mu = lp150q.mu;
+    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_dir.join("earth_GGM05C.cc"))?;
+    let mu_sun = jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_dir.join("sun_spherical.cc"))?;
+
+    // Load ephemeris
+    let mut ephemeris = Ephemeris::from_bsp(&bsp_path)?;
+    ephemeris.load_bpc(&bpc_path)?;
+
+    let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
+    let epoch_tdb_jd = time.tdb_julian_date();
+
+    let mut sim = Simulation::new(time, DT);
+
+    // Moon: central body with LP150Q 60x60 SH gravity + DE421 BPC libration
+    let moon_rotation = ephemeris.get_body_rotation(EphemerisBody::Moon, epoch_tdb_jd)?;
+
+    let moon = sim.add_source(GravitySourceEntry {
+        source: GravitySource {
+            mu: moon_mu,
+            model: GravityModel::SphericalHarmonics(Box::new(lp150q)),
+        },
+        position: DVec3::ZERO,
+        velocity: DVec3::ZERO,
+        t_inertial_pfix: Some(moon_rotation),
+        rotation_model: RotationModel::MoonDE421,
+        delta_c20: 0.0,
+        tidal_config: None,
+    });
+
+    // Earth: 3rd-body perturbation with per-step ephemeris
+    let (earth_pos, _) =
+        ephemeris.get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)?;
+    let earth = sim.add_source(GravitySourceEntry::new(
+        GravitySource {
+            mu: mu_earth,
+            model: GravityModel::PointMass,
+        },
+        earth_pos,
+        None,
+    ));
+    sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
+
+    // Sun: 3rd-body + SRP source with per-step ephemeris
+    let (sun_pos, _) =
+        ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)?;
+    let sun = sim.add_source(GravitySourceEntry::new(
+        GravitySource {
+            mu: mu_sun,
+            model: GravityModel::PointMass,
+        },
+        sun_pos,
+        None,
+    ));
+    sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Moon);
+    sim.sun_source = Some(sun);
+    sim.ephemeris = Some(ephemeris);
+
+    // Clementine spacecraft
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: INIT_POS,
+            velocity: INIT_VEL,
+        },
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_nonspherical(moon, 60, 60, false),
+                GravityControl::new_third_body(earth),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        mass: Some(MassProperties::new(MASS_KG)),
+        srp: Some(SrpModel::Cannonball {
+            cx_area: SRP_CX_AREA,
+            albedo: SRP_ALBEDO,
+            diffuse: SRP_DIFFUSE,
+        }),
+        ..Default::default()
+    });
+
+    sim.validate().expect("validation failed");
+
+    println!(
+        "Clementine lunar orbit — {:.0}-day propagation",
+        DURATION / 86400.0
+    );
+    println!("  Moon: LP150Q 60x60 SH | Earth + Sun 3rd-body | Cannonball SRP");
+    println!("  Integrator: RK4 at dt={DT} s | Mass: {MASS_KG} kg");
+    println!();
+    println!(
+        "{:>10}  {:>12}  {:>12}  {:>10}  {:>10}",
+        "Time (h)", "Alt (km)", "Speed (m/s)", "Period (h)", "Ecc"
+    );
+    println!("{}", "-".repeat(62));
+
+    let print_interval = 7200.0; // 2 hours
+    let total_steps = (DURATION / DT).round() as usize;
+    let steps_per_print = (print_interval / DT).round() as usize;
+
+    for step in 1..=total_steps {
+        sim.step();
+
+        if step % steps_per_print == 0 {
+            let body = sim.body(0);
+            let pos = body.trans.position;
+            let vel = body.trans.velocity;
+
+            let r = pos.length();
+            let v = vel.length();
+            let altitude_km = (r - R_MOON) / 1000.0;
+            let hours = (step as f64) * DT / 3600.0;
+
+            // Vis-viva for orbital period and eccentricity
+            let energy = 0.5 * v * v - moon_mu / r;
+            let sma = -moon_mu / (2.0 * energy);
+            let period_h = 2.0 * std::f64::consts::PI * (sma.powi(3) / moon_mu).sqrt() / 3600.0;
+            let h_vec = pos.cross(vel);
+            let ecc_vec = vel.cross(h_vec) / moon_mu - pos / r;
+            let ecc = ecc_vec.length();
+
+            println!("{hours:10.1}  {altitude_km:12.1}  {v:12.1}  {period_h:10.2}  {ecc:10.6}");
+        }
+    }
+
+    println!();
+    let final_body = sim.body(0);
+    let final_alt = (final_body.trans.position.length() - R_MOON) / 1000.0;
+    println!(
+        "Final altitude: {final_alt:.1} km after {:.1} days",
+        DURATION / 86400.0
+    );
+
+    Ok(())
+}

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -1,0 +1,174 @@
+//! Dawn spacecraft at Mars: high-fidelity spherical harmonics gravity.
+//!
+//! Demonstrates:
+//! - Mars MRO110B2 110x110 spherical harmonics gravity
+//! - Mars IAU rotation model
+//! - Sun as 3rd-body perturbation with DE421 ephemeris
+//!
+//! Shows how Mars's lumpy gravity field perturbs the orbit over 3 hours.
+//!
+//! Requires JEOD source checkout (JEOD_HOME or JEOD_PATH) for gravity
+//! coefficients and `test_data/de421.bsp` for ephemeris data.
+//!
+//! ```bash
+//! cargo run -p jeod_runner --example mars_orbit
+//! ```
+
+use std::path::Path;
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::{
+    GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime,
+    TranslationalState,
+};
+
+// Dawn spacecraft initial state at Mars (from JEOD SIM_Mars RUN_dawn, t=0).
+// Mars-centered inertial frame.
+const INIT_POS: DVec3 = DVec3::new(11_563_355.6802, -14_356_668.8977, 6_293_704.6169);
+const INIT_VEL: DVec3 = DVec3::new(-2273.1078, 2380.1324, -22.911);
+
+// Epoch: 2009-02-17 23:00:00 UTC (TAI-UTC = 34 s)
+const EPOCH_TAI_TJT: f64 = 14_879.958_727;
+
+// Propagation: 3 hours at 10 s (error insensitive to dt)
+const DT: f64 = 10.0;
+const DURATION: f64 = 10_800.0; // 3 hours
+
+// Mars equatorial radius for altitude computation
+const R_MARS_EQ: f64 = 3_396_190.0; // m
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+
+    let grav_dir = jeod_root.join("models/environment/gravity/data/src");
+    let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_data");
+    let bsp_path = data_dir.join("de421.bsp");
+
+    assert!(
+        bsp_path.exists(),
+        "DE421 not found at {}",
+        bsp_path.display()
+    );
+
+    // Load Mars MRO110B2 110x110 spherical harmonics
+    let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&grav_dir.join("mars_MRO110B2.cc"))?;
+    let mars_mu = sh_data.mu;
+
+    // Load Sun mu
+    let mu_sun = jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_dir.join("sun_spherical.cc"))?;
+
+    // Ephemeris for Sun position relative to Mars
+    let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path)?;
+    let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
+    let epoch_tdb_jd = time.tdb_julian_date();
+
+    let (sun_pos, _) = ephemeris.get_state(
+        jeod_sim::EphemerisBody::Sun,
+        jeod_sim::EphemerisBody::Mars,
+        epoch_tdb_jd,
+    )?;
+
+    let mut sim = Simulation::new(time, DT);
+
+    // Mars: central body with MRO110B2 SH gravity + IAU rotation
+    let mars = sim.add_source(GravitySourceEntry {
+        source: GravitySource {
+            mu: mars_mu,
+            model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+        },
+        position: DVec3::ZERO,
+        velocity: DVec3::ZERO,
+        t_inertial_pfix: Some(DMat3::IDENTITY),
+        rotation_model: RotationModel::MarsIAU,
+        delta_c20: 0.0,
+        tidal_config: None,
+    });
+
+    // Sun: 3rd-body with per-step DE421 ephemeris
+    let sun = sim.add_source(GravitySourceEntry::new(
+        GravitySource {
+            mu: mu_sun,
+            model: GravityModel::PointMass,
+        },
+        sun_pos,
+        None,
+    ));
+    sim.set_source_ephemeris(
+        sun,
+        jeod_sim::EphemerisBody::Sun,
+        jeod_sim::EphemerisBody::Mars,
+    );
+    sim.ephemeris = Some(ephemeris);
+
+    // Dawn spacecraft (no SRP, no drag — gravity-only propagation)
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: INIT_POS,
+            velocity: INIT_VEL,
+        },
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_nonspherical(mars, 110, 110, false),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        ..Default::default()
+    });
+
+    sim.validate().expect("validation failed");
+
+    println!("Dawn spacecraft at Mars — 3-hour propagation");
+    println!("  Mars: MRO110B2 110x110 SH | IAU rotation | Sun 3rd-body");
+    println!("  Integrator: RK4 at dt={DT} s");
+    println!();
+    println!(
+        "{:>10}  {:>12}  {:>12}  {:>12}  {:>10}",
+        "Time (min)", "Alt (km)", "Speed (m/s)", "SMA (km)", "Ecc"
+    );
+    println!("{}", "-".repeat(62));
+
+    let print_interval = 900.0; // 15 minutes
+    let total_steps = (DURATION / DT).round() as usize;
+    let steps_per_print = (print_interval / DT).round() as usize;
+
+    for step in 1..=total_steps {
+        sim.step();
+
+        if step % steps_per_print == 0 {
+            let body = sim.body(0);
+            let pos = body.trans.position;
+            let vel = body.trans.velocity;
+
+            let r = pos.length();
+            let v = vel.length();
+            let altitude_km = (r - R_MARS_EQ) / 1000.0;
+            let minutes = (step as f64) * DT / 60.0;
+
+            // Vis-viva
+            let energy = 0.5 * v * v - mars_mu / r;
+            let sma = -mars_mu / (2.0 * energy);
+            let sma_km = sma / 1000.0;
+            let h_vec = pos.cross(vel);
+            let ecc_vec = vel.cross(h_vec) / mars_mu - pos / r;
+            let ecc = ecc_vec.length();
+
+            println!("{minutes:10.1}  {altitude_km:12.1}  {v:12.1}  {sma_km:12.1}  {ecc:10.6}");
+        }
+    }
+
+    println!();
+    let final_body = sim.body(0);
+    let final_alt = (final_body.trans.position.length() - R_MARS_EQ) / 1000.0;
+    println!(
+        "Final altitude: {final_alt:.1} km after {:.0} minutes",
+        DURATION / 60.0
+    );
+
+    Ok(())
+}

--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -400,7 +400,14 @@ impl SimulationBuilder {
     ///
     /// Must be called after [`add_body`](Self::add_body). Bodies registered in
     /// the tree can be connected via [`attach_bodies`](Self::attach_bodies).
+    ///
+    /// # Panics
+    /// Panics if the body does not define mass properties.
     pub fn register_in_mass_tree(&mut self, body_idx: usize, name: impl Into<String>) -> &mut Self {
+        assert!(
+            self.bodies[body_idx].mass.is_some(),
+            "register_in_mass_tree: body {body_idx} has no mass properties"
+        );
         self.mass_tree_names[body_idx] = Some(name.into());
         self
     }

--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -270,6 +270,18 @@ impl VehicleBuilder {
 /// builder.add_body(VehicleConfig::builder(trans).gravity(ctrl).build());
 /// let mut sim = builder.build()?;
 /// ```
+/// A pending mass-tree attachment, resolved during [`SimulationBuilder::build`].
+struct MassTreeAttachment {
+    /// Body index of the child.
+    child_idx: usize,
+    /// Body index of the parent.
+    parent_idx: usize,
+    /// Child structural origin in parent's structural frame (m).
+    offset: DVec3,
+    /// Rotation from parent structural frame to child structural frame.
+    t_parent_child: DMat3,
+}
+
 pub struct SimulationBuilder {
     time: SimulationTime,
     dt: f64,
@@ -282,6 +294,10 @@ pub struct SimulationBuilder {
     sources: Vec<GravitySourceEntry>,
     source_ephem_bodies: Vec<Option<(jeod_sim::EphemerisBody, jeod_sim::EphemerisBody)>>,
     bodies: Vec<VehicleConfig>,
+    /// Body names for mass tree registration (index matches `bodies`).
+    mass_tree_names: Vec<Option<String>>,
+    /// Pending attachments, resolved during `build()`.
+    mass_tree_attachments: Vec<MassTreeAttachment>,
 }
 
 impl Simulation {
@@ -299,6 +315,8 @@ impl Simulation {
             sources: Vec::new(),
             source_ephem_bodies: Vec::new(),
             bodies: Vec::new(),
+            mass_tree_names: Vec::new(),
+            mass_tree_attachments: Vec::new(),
         }
     }
 }
@@ -374,7 +392,37 @@ impl SimulationBuilder {
     pub fn add_body(&mut self, config: VehicleConfig) -> usize {
         let idx = self.bodies.len();
         self.bodies.push(config);
+        self.mass_tree_names.push(None);
         idx
+    }
+
+    /// Register a body in the mass tree with the given name.
+    ///
+    /// Must be called after [`add_body`](Self::add_body). Bodies registered in
+    /// the tree can be connected via [`attach_bodies`](Self::attach_bodies).
+    pub fn register_in_mass_tree(&mut self, body_idx: usize, name: impl Into<String>) -> &mut Self {
+        self.mass_tree_names[body_idx] = Some(name.into());
+        self
+    }
+
+    /// Declare a mass-tree attachment between two bodies.
+    ///
+    /// Both bodies must be registered via [`register_in_mass_tree`](Self::register_in_mass_tree).
+    /// The attachment is resolved during [`build`](Self::build).
+    pub fn attach_bodies(
+        &mut self,
+        child_idx: usize,
+        parent_idx: usize,
+        offset: DVec3,
+        t_parent_child: DMat3,
+    ) -> &mut Self {
+        self.mass_tree_attachments.push(MassTreeAttachment {
+            child_idx,
+            parent_idx,
+            offset,
+            t_parent_child,
+        });
+        self
     }
 
     // ── Build ──
@@ -409,6 +457,24 @@ impl SimulationBuilder {
 
         for body in self.bodies {
             sim.add_body(body);
+        }
+
+        // Wire up mass tree if any bodies were registered.
+        let has_tree = self.mass_tree_names.iter().any(|n| n.is_some());
+        if has_tree {
+            for (idx, name) in self.mass_tree_names.into_iter().enumerate() {
+                if let Some(name) = name {
+                    sim.add_body_to_tree(idx, name);
+                }
+            }
+            for att in self.mass_tree_attachments {
+                sim.attach(
+                    att.child_idx,
+                    att.parent_idx,
+                    att.offset,
+                    att.t_parent_child,
+                );
+            }
         }
 
         sim

--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -409,6 +409,9 @@ impl SimulationBuilder {
     ///
     /// Both bodies must be registered via [`register_in_mass_tree`](Self::register_in_mass_tree).
     /// The attachment is resolved during [`build`](Self::build).
+    ///
+    /// # Panics
+    /// Panics if either body has not been registered in the mass tree.
     pub fn attach_bodies(
         &mut self,
         child_idx: usize,
@@ -416,6 +419,14 @@ impl SimulationBuilder {
         offset: DVec3,
         t_parent_child: DMat3,
     ) -> &mut Self {
+        assert!(
+            self.mass_tree_names[child_idx].is_some(),
+            "attach_bodies: child body {child_idx} not registered in mass tree"
+        );
+        assert!(
+            self.mass_tree_names[parent_idx].is_some(),
+            "attach_bodies: parent body {parent_idx} not registered in mass tree"
+        );
         self.mass_tree_attachments.push(MassTreeAttachment {
             child_idx,
             parent_idx,

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1347,6 +1347,7 @@ impl Simulation {
     /// [`sync_body_mass_from_tree`](Self::sync_body_mass_from_tree) instead
     /// when the mass tree has been modified via `attach`/`detach`.
     pub fn set_body_mass(&mut self, idx: usize, mut mass: MassProperties) {
+        mass.dirty = true;
         mass.recompute_derived();
         self.bodies[idx].mass = Some(mass);
     }
@@ -1367,6 +1368,7 @@ impl Simulation {
             .as_ref()
             .expect("sync_body_mass_from_tree requires a mass tree");
         let mut composite = tree.get(id).composite_properties;
+        composite.dirty = true;
         composite.recompute_derived();
         self.bodies[idx].mass = Some(composite);
     }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -348,6 +348,8 @@ struct SimBody {
     trans: TranslationalState,
     rot: Option<RotationalState>,
     mass: Option<MassProperties>,
+    /// If this body participates in a mass tree, its node ID.
+    mass_body_id: Option<jeod_dynamics::MassBodyId>,
     config: DynamicsConfig,
     gravity_controls: GravityControls<usize>,
     integrator: jeod_dynamics::IntegratorType,
@@ -422,6 +424,7 @@ impl SimBody {
             trans: config.trans,
             rot: config.rot,
             mass: config.mass,
+            mass_body_id: None,
             config: dynamics_config,
             gravity_controls: config.gravity_controls,
             integrator: config.integrator,
@@ -531,6 +534,9 @@ pub struct Simulation {
     pub ephemeris: Option<jeod_sim::Ephemeris>,
     /// Per-source ephemeris body mapping. Index matches `sources` vector.
     pub source_ephem_bodies: Vec<Option<(jeod_sim::EphemerisBody, jeod_sim::EphemerisBody)>>,
+    /// Optional mass tree for multi-body vehicles (attach/detach/staging).
+    /// Bodies participating in the tree have `SimBody::mass_body_id` set.
+    pub mass_tree: Option<jeod_dynamics::MassTree>,
 }
 
 impl Simulation {
@@ -548,6 +554,7 @@ impl Simulation {
             dt,
             ephemeris: None,
             source_ephem_bodies: Vec::new(),
+            mass_tree: None,
         }
     }
 
@@ -1321,6 +1328,100 @@ impl Simulation {
     /// at each timestep (e.g., SIM_2A_SHADOW_CALC).
     pub fn set_body_position(&mut self, idx: usize, position: DVec3) {
         self.bodies[idx].trans.position = position;
+    }
+
+    /// Set a body's translational velocity (inertial frame, m/s).
+    ///
+    /// Used for impulsive maneuvers (e.g., Apollo TLI delta-V).
+    pub fn set_body_velocity(&mut self, idx: usize, velocity: DVec3) {
+        self.bodies[idx].trans.velocity = velocity;
+    }
+
+    /// Replace a body's mass properties.
+    ///
+    /// Used for discrete mass changes (e.g., post-burn fuel consumption,
+    /// stage separation). Recomputes `inverse_mass` and `inverse_inertia`.
+    pub fn set_body_mass(&mut self, idx: usize, mut mass: MassProperties) {
+        mass.recompute_derived();
+        self.bodies[idx].mass = Some(mass);
+    }
+
+    /// Register a body in the simulation's mass tree.
+    ///
+    /// Creates (or reuses) a `MassTree` and adds the body's mass as a node.
+    /// Returns the `MassBodyId` for use with [`attach`](Self::attach) and
+    /// [`detach`](Self::detach). The body's `mass` field must be `Some`.
+    ///
+    /// # Panics
+    /// Panics if the body has no mass properties.
+    pub fn add_body_to_tree(
+        &mut self,
+        body_idx: usize,
+        name: impl Into<String>,
+    ) -> jeod_dynamics::MassBodyId {
+        let mass = self.bodies[body_idx]
+            .mass
+            .expect("add_body_to_tree requires mass properties");
+        let tree = self
+            .mass_tree
+            .get_or_insert_with(jeod_dynamics::MassTree::new);
+        let id = tree.add_body(name.into(), mass);
+        self.bodies[body_idx].mass_body_id = Some(id);
+        id
+    }
+
+    /// Attach a child body to a parent body in the mass tree.
+    ///
+    /// Both bodies must have been registered via [`add_body_to_tree`](Self::add_body_to_tree).
+    /// After attachment, the parent's composite mass properties are updated
+    /// automatically. The parent body's `mass` is synced from the tree.
+    ///
+    /// # Panics
+    /// Panics if either body is not in the tree, or if the child already has a parent.
+    pub fn attach(
+        &mut self,
+        child_idx: usize,
+        parent_idx: usize,
+        offset: DVec3,
+        t_parent_child: DMat3,
+    ) {
+        let child_id = self.bodies[child_idx]
+            .mass_body_id
+            .expect("child not in mass tree");
+        let parent_id = self.bodies[parent_idx]
+            .mass_body_id
+            .expect("parent not in mass tree");
+        let tree = self.mass_tree.as_mut().expect("no mass tree");
+        tree.attach(child_id, parent_id, offset, t_parent_child);
+        // Sync parent's composite mass from tree
+        self.bodies[parent_idx].mass = Some(tree.get(parent_id).composite_properties);
+    }
+
+    /// Detach a child body from its parent in the mass tree.
+    ///
+    /// After detachment, both the former parent's and the child's mass
+    /// properties are updated from the tree's recomputed composites.
+    ///
+    /// # Panics
+    /// Panics if the body is not in the tree or has no parent.
+    pub fn detach(&mut self, child_idx: usize) {
+        let child_id = self.bodies[child_idx]
+            .mass_body_id
+            .expect("child not in mass tree");
+        let tree = self.mass_tree.as_mut().expect("no mass tree");
+        let parent_id = tree
+            .parent(child_id)
+            .expect("detach called on body with no parent in tree");
+        tree.detach(child_id);
+        // Sync both bodies' mass from tree
+        self.bodies[child_idx].mass = Some(tree.get(child_id).composite_properties);
+        // Find parent body index and sync
+        for body in &mut self.bodies {
+            if body.mass_body_id == Some(parent_id) {
+                body.mass = Some(tree.get(parent_id).composite_properties);
+                break;
+            }
+        }
     }
 
     /// Number of bodies in the simulation.

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1341,9 +1341,34 @@ impl Simulation {
     ///
     /// Used for discrete mass changes (e.g., post-burn fuel consumption,
     /// stage separation). Recomputes `inverse_mass` and `inverse_inertia`.
+    ///
+    /// **Warning:** If the body is registered in the mass tree, calling this
+    /// method will desynchronize the body's mass from the tree's copy. Use
+    /// [`sync_body_mass_from_tree`](Self::sync_body_mass_from_tree) instead
+    /// when the mass tree has been modified via `attach`/`detach`.
     pub fn set_body_mass(&mut self, idx: usize, mut mass: MassProperties) {
         mass.recompute_derived();
         self.bodies[idx].mass = Some(mass);
+    }
+
+    /// Sync a body's mass properties from the mass tree's composite.
+    ///
+    /// After modifying the mass tree via `attach`/`detach`, call this to
+    /// update the body's mass from the tree's composite properties.
+    ///
+    /// # Panics
+    /// Panics if the body is not registered in the mass tree.
+    pub fn sync_body_mass_from_tree(&mut self, idx: usize) {
+        let id = self.bodies[idx]
+            .mass_body_id
+            .expect("sync_body_mass_from_tree requires body registered in mass tree");
+        let tree = self
+            .mass_tree
+            .as_ref()
+            .expect("sync_body_mass_from_tree requires a mass tree");
+        let mut composite = tree.get(id).composite_properties;
+        composite.recompute_derived();
+        self.bodies[idx].mass = Some(composite);
     }
 
     /// Register a body in the simulation's mass tree.

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -330,5 +330,8 @@ fn tier3_simulation_srp_flat_plate() {
     let max_pos_error = report.max_position_component();
     println!("  Max position error: {:.6e} m", max_pos_error);
 
-    report.assert_position([3.074, 2.799, 1.216]);
+    // Thermal integration matches JEOD's scheduled-class temp_dot (constant
+    // across RK4 stages, effective Forward Euler). Previous tolerance was ~3 m
+    // when using RK4 thermal with per-stage derivative recomputation.
+    report.assert_position([0.034, 0.040, 0.016]);
 }

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -299,6 +299,11 @@ pub fn integrate_body_coupled(
 
     // Stage 1: evaluate at current state
     let eval1 = stage_fn(trans, None, thermal);
+    debug_assert_eq!(
+        eval1.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 1"
+    );
     let k1_accel = compute_total_accel(&eval1, mass);
     let k1_v = vel0;
     let k1_tdots = &eval1.temp_dots;
@@ -311,6 +316,11 @@ pub fn integrate_body_coupled(
     };
     advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, k1_tdots, half_dt);
     let eval2 = stage_fn(&s2_trans, None, thermal);
+    debug_assert_eq!(
+        eval2.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 2"
+    );
     let k2_accel = compute_total_accel(&eval2, mass);
     let k2_v = s2_trans.velocity;
     let k2_tdots = eval2.temp_dots.clone();
@@ -322,6 +332,11 @@ pub fn integrate_body_coupled(
     };
     advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k2_tdots, half_dt);
     let eval3 = stage_fn(&s3_trans, None, thermal);
+    debug_assert_eq!(
+        eval3.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 3"
+    );
     let k3_accel = compute_total_accel(&eval3, mass);
     let k3_v = s3_trans.velocity;
     let k3_tdots = eval3.temp_dots.clone();
@@ -333,6 +348,11 @@ pub fn integrate_body_coupled(
     };
     advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k3_tdots, integ_dyndt);
     let eval4 = stage_fn(&s4_trans, None, thermal);
+    debug_assert_eq!(
+        eval4.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 4"
+    );
     let k4_accel = compute_total_accel(&eval4, mass);
     let k4_v = s4_trans.velocity;
 
@@ -407,6 +427,11 @@ fn integrate_coupled_sixdof(
 
     // Stage 1
     let eval1 = stage_fn(trans, Some(rot), thermal);
+    debug_assert_eq!(
+        eval1.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 1"
+    );
     let (k1_accel, k1_qdot, k1_alpha) = eval_rot_derivs(&eval1, rot);
     let k1_v = vel0;
     let k1_tdots = &eval1.temp_dots;
@@ -420,6 +445,11 @@ fn integrate_coupled_sixdof(
     let s2_rot = make_rot(step_q(q0, k1_qdot, half_dt), omega0 + k1_alpha * half_dt);
     advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, k1_tdots, half_dt);
     let eval2 = stage_fn(&s2_trans, Some(&s2_rot), thermal);
+    debug_assert_eq!(
+        eval2.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 2"
+    );
     let (k2_accel, k2_qdot, k2_alpha) = eval_rot_derivs(&eval2, &s2_rot);
     let k2_v = s2_trans.velocity;
     let k2_tdots = eval2.temp_dots.clone();
@@ -432,6 +462,11 @@ fn integrate_coupled_sixdof(
     let s3_rot = make_rot(step_q(q0, k2_qdot, half_dt), omega0 + k2_alpha * half_dt);
     advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k2_tdots, half_dt);
     let eval3 = stage_fn(&s3_trans, Some(&s3_rot), thermal);
+    debug_assert_eq!(
+        eval3.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 3"
+    );
     let (k3_accel, k3_qdot, k3_alpha) = eval_rot_derivs(&eval3, &s3_rot);
     let k3_v = s3_trans.velocity;
     let k3_tdots = eval3.temp_dots.clone();
@@ -447,6 +482,11 @@ fn integrate_coupled_sixdof(
     );
     advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k3_tdots, integ_dyndt);
     let eval4 = stage_fn(&s4_trans, Some(&s4_rot), thermal);
+    debug_assert_eq!(
+        eval4.temp_dots.len(),
+        n_plates,
+        "stage_fn returned wrong temp_dots length at stage 4"
+    );
     let (k4_accel, k4_qdot, k4_alpha) = eval_rot_derivs(&eval4, &s4_rot);
     let k4_v = s4_trans.velocity;
 

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -3,6 +3,9 @@ use jeod_dynamics::{
     DynamicsConfig, IntegratorType, MassProperties, RotationalState, SixDofState,
     TranslationalState,
 };
+use jeod_math::JeodQuat;
+
+use crate::interactions::FlatPlateState;
 
 /// Integrate a single body's state forward by one timestep.
 ///
@@ -187,5 +190,411 @@ pub fn integrate_body(
                  The FSM may be stuck. Reset the integrator or check configuration."
             );
         }
+    }
+}
+
+/// Evaluation results at one RK4 stage, returned by the stage closure
+/// passed to [`integrate_body_coupled`].
+///
+/// The closure recomputes gravity, SRP force/torque, and thermal derivatives
+/// at each intermediate state, coupling the thermal and orbital ODEs.
+#[derive(Debug, Clone)]
+pub struct CoupledStageEval {
+    /// Gravitational acceleration (m/s²) at the intermediate position.
+    pub gravity_accel: DVec3,
+    /// Total non-gravity force (N) in inertial frame, including SRP with
+    /// thermal emission computed from the intermediate temperature state.
+    pub non_grav_force: DVec3,
+    /// Total torque (N·m) in body frame.
+    pub torque: DVec3,
+    /// Per-plate temperature derivatives (K/s) at the intermediate state.
+    /// Same length as `FlatPlateState::temperatures`.
+    pub temp_dots: Vec<f64>,
+}
+
+/// Integrate orbital + thermal state through a coupled RK4 step.
+///
+/// Port of JEOD's `DynamicsIntegrationGroup::integrate_bodies()` which drives
+/// both `DynBody` (orbital) and `ThermalIntegrableObject` (thermal) through the
+/// same RK4 stage loop. At each stage the `stage_fn` closure is called with the
+/// intermediate orbital and thermal state, returning derivatives for both.
+///
+/// This ensures that:
+/// - Temperature derivatives use the intermediate orbital position (solar flux
+///   direction changes across stages)
+/// - SRP force uses the intermediate temperatures (thermal emission coupling)
+/// - Both ODEs see the same RK4 stage structure
+///
+/// JEOD's `DynamicsIntegrationGroup` is integrator-agnostic (RK4, RKF45, GJ,
+/// LSODE). This implementation covers RK4 only — the only integrator for which
+/// JEOD verification sims exercise thermal coupling.
+///
+/// # Arguments
+/// - `config`: dynamics flags (translational/rotational)
+/// - `trans`: translational state (mutated in place)
+/// - `rot`: optional rotational state (mutated in place if 6-DOF)
+/// - `mass`: mass properties (required for non-zero forces and 6-DOF)
+/// - `stage_fn`: closure that evaluates derivatives at an intermediate state.
+///   Called 4 times (once per RK4 stage). Must recompute gravity, SRP
+///   force/torque, and thermal derivatives at the given intermediate state.
+/// - `thermal`: flat-plate thermal state (temperatures mutated in place)
+/// - `dt`: simulation timestep in seconds
+/// - `time_scale_factor`: ratio of dynamic time to simulation time
+///
+/// # Panics
+/// - Non-zero force without mass properties (JEOD_INV: MA.01)
+/// - `rotational_dynamics=true` without `RotationalState` or `MassProperties` (JEOD_INV: DB.04)
+// JEOD_INV: DB.07 — translational_dynamics gates integration
+// JEOD_INV: DB.08 — rotational_dynamics gates integration
+#[allow(clippy::too_many_arguments)]
+pub fn integrate_body_coupled(
+    config: &DynamicsConfig,
+    trans: &mut TranslationalState,
+    rot: Option<&mut RotationalState>,
+    mass: Option<&MassProperties>,
+    mut stage_fn: impl FnMut(
+        &TranslationalState,
+        Option<&RotationalState>,
+        &FlatPlateState,
+    ) -> CoupledStageEval,
+    thermal: &mut FlatPlateState,
+    dt: f64,
+    time_scale_factor: f64,
+) {
+    // JEOD_INV: DB.07 — translational_dynamics gates integration
+    if !config.translational_dynamics {
+        return;
+    }
+
+    let integ_dyndt = dt * time_scale_factor;
+    let n_plates = thermal.temperatures.len();
+
+    // Dispatch to 6-DOF or 3-DOF coupled path.
+    if config.rotational_dynamics {
+        if let (Some(rot_state), Some(mass_props)) = (rot, mass) {
+            integrate_coupled_sixdof(
+                trans,
+                rot_state,
+                mass_props,
+                &mut stage_fn,
+                thermal,
+                integ_dyndt,
+                n_plates,
+            );
+            return;
+        }
+        // JEOD_INV: DB.04
+        panic!(
+            "rotational_dynamics=true but RotationalState and/or MassProperties \
+             missing. Provide these or set rotational_dynamics=false."
+        );
+    }
+
+    // ── 3-DOF coupled RK4 (translational + thermal) ──
+
+    let pos0 = trans.position;
+    let vel0 = trans.velocity;
+    let temps0: Vec<f64> = thermal.temperatures.clone();
+    let t_pow4_0: Vec<f64> = thermal.t_pow4_cached.clone();
+
+    // Stage 1: evaluate at current state
+    let eval1 = stage_fn(trans, None, thermal);
+    let k1_accel = compute_total_accel(&eval1, mass);
+    let k1_v = vel0;
+    let k1_tdots = &eval1.temp_dots;
+
+    // Stage 2: evaluate at t + dt/2 using k1
+    let half_dt = integ_dyndt * 0.5;
+    let s2_trans = TranslationalState {
+        position: pos0 + k1_v * half_dt,
+        velocity: vel0 + k1_accel * half_dt,
+    };
+    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, k1_tdots, half_dt);
+    let eval2 = stage_fn(&s2_trans, None, thermal);
+    let k2_accel = compute_total_accel(&eval2, mass);
+    let k2_v = s2_trans.velocity;
+    let k2_tdots = eval2.temp_dots.clone();
+
+    // Stage 3: evaluate at t + dt/2 using k2
+    let s3_trans = TranslationalState {
+        position: pos0 + k2_v * half_dt,
+        velocity: vel0 + k2_accel * half_dt,
+    };
+    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k2_tdots, half_dt);
+    let eval3 = stage_fn(&s3_trans, None, thermal);
+    let k3_accel = compute_total_accel(&eval3, mass);
+    let k3_v = s3_trans.velocity;
+    let k3_tdots = eval3.temp_dots.clone();
+
+    // Stage 4: evaluate at t + dt using k3
+    let s4_trans = TranslationalState {
+        position: pos0 + k3_v * integ_dyndt,
+        velocity: vel0 + k3_accel * integ_dyndt,
+    };
+    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k3_tdots, integ_dyndt);
+    let eval4 = stage_fn(&s4_trans, None, thermal);
+    let k4_accel = compute_total_accel(&eval4, mass);
+    let k4_v = s4_trans.velocity;
+
+    // Combine orbital state
+    let sixth_dt = integ_dyndt / 6.0;
+    trans.position = pos0 + (k1_v + k2_v * 2.0 + k3_v * 2.0 + k4_v) * sixth_dt;
+    trans.velocity = vel0 + (k1_accel + k2_accel * 2.0 + k3_accel * 2.0 + k4_accel) * sixth_dt;
+
+    // Combine thermal state with overshoot clamping
+    thermal.finalize_rk4_temperatures(
+        &temps0,
+        &t_pow4_0,
+        k1_tdots,
+        &k2_tdots,
+        &k3_tdots,
+        &eval4.temp_dots,
+        integ_dyndt,
+        n_plates,
+    );
+}
+
+/// 6-DOF coupled RK4: translational + rotational + thermal.
+#[allow(clippy::too_many_arguments)]
+fn integrate_coupled_sixdof(
+    trans: &mut TranslationalState,
+    rot: &mut RotationalState,
+    mass_props: &MassProperties,
+    stage_fn: &mut impl FnMut(
+        &TranslationalState,
+        Option<&RotationalState>,
+        &FlatPlateState,
+    ) -> CoupledStageEval,
+    thermal: &mut FlatPlateState,
+    integ_dyndt: f64,
+    n_plates: usize,
+) {
+    let pos0 = trans.position;
+    let vel0 = trans.velocity;
+    let q0 = rot.quaternion.data;
+    let omega0 = rot.ang_vel_body;
+    let temps0: Vec<f64> = thermal.temperatures.clone();
+    let t_pow4_0: Vec<f64> = thermal.t_pow4_cached.clone();
+
+    let make_rot = |q: [f64; 4], omega: DVec3| RotationalState {
+        quaternion: JeodQuat::new(q[0], q[1], q[2], q[3]),
+        ang_vel_body: omega,
+    };
+
+    let step_q = |q_base: [f64; 4], k_qdot: [f64; 4], h: f64| -> [f64; 4] {
+        [
+            q_base[0] + k_qdot[0] * h,
+            q_base[1] + k_qdot[1] * h,
+            q_base[2] + k_qdot[2] * h,
+            q_base[3] + k_qdot[3] * h,
+        ]
+    };
+
+    // Helper: compute orbital + rotational derivatives from eval
+    let eval_rot_derivs = |eval: &CoupledStageEval,
+                           rot_s: &RotationalState|
+     -> (DVec3, [f64; 4], DVec3) {
+        let accel = compute_total_accel(eval, Some(mass_props));
+        let k_qdot = jeod_dynamics::compute_left_quat_deriv(&rot_s.quaternion, rot_s.ang_vel_body);
+        let k_alpha = jeod_dynamics::compute_rotational_acceleration(
+            &mass_props.inertia,
+            &mass_props.inverse_inertia,
+            rot_s.ang_vel_body,
+            eval.torque,
+        );
+        (accel, k_qdot, k_alpha)
+    };
+
+    // Stage 1
+    let eval1 = stage_fn(trans, Some(rot), thermal);
+    let (k1_accel, k1_qdot, k1_alpha) = eval_rot_derivs(&eval1, rot);
+    let k1_v = vel0;
+    let k1_tdots = &eval1.temp_dots;
+
+    // Stage 2
+    let half_dt = integ_dyndt * 0.5;
+    let s2_trans = TranslationalState {
+        position: pos0 + k1_v * half_dt,
+        velocity: vel0 + k1_accel * half_dt,
+    };
+    let s2_rot = make_rot(step_q(q0, k1_qdot, half_dt), omega0 + k1_alpha * half_dt);
+    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, k1_tdots, half_dt);
+    let eval2 = stage_fn(&s2_trans, Some(&s2_rot), thermal);
+    let (k2_accel, k2_qdot, k2_alpha) = eval_rot_derivs(&eval2, &s2_rot);
+    let k2_v = s2_trans.velocity;
+    let k2_tdots = eval2.temp_dots.clone();
+
+    // Stage 3
+    let s3_trans = TranslationalState {
+        position: pos0 + k2_v * half_dt,
+        velocity: vel0 + k2_accel * half_dt,
+    };
+    let s3_rot = make_rot(step_q(q0, k2_qdot, half_dt), omega0 + k2_alpha * half_dt);
+    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k2_tdots, half_dt);
+    let eval3 = stage_fn(&s3_trans, Some(&s3_rot), thermal);
+    let (k3_accel, k3_qdot, k3_alpha) = eval_rot_derivs(&eval3, &s3_rot);
+    let k3_v = s3_trans.velocity;
+    let k3_tdots = eval3.temp_dots.clone();
+
+    // Stage 4
+    let s4_trans = TranslationalState {
+        position: pos0 + k3_v * integ_dyndt,
+        velocity: vel0 + k3_accel * integ_dyndt,
+    };
+    let s4_rot = make_rot(
+        step_q(q0, k3_qdot, integ_dyndt),
+        omega0 + k3_alpha * integ_dyndt,
+    );
+    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k3_tdots, integ_dyndt);
+    let eval4 = stage_fn(&s4_trans, Some(&s4_rot), thermal);
+    let (k4_accel, k4_qdot, k4_alpha) = eval_rot_derivs(&eval4, &s4_rot);
+    let k4_v = s4_trans.velocity;
+
+    // Combine orbital state
+    let sixth_dt = integ_dyndt / 6.0;
+    trans.position = pos0 + (k1_v + k2_v * 2.0 + k3_v * 2.0 + k4_v) * sixth_dt;
+    trans.velocity = vel0 + (k1_accel + k2_accel * 2.0 + k3_accel * 2.0 + k4_accel) * sixth_dt;
+
+    // Combine rotational state
+    rot.ang_vel_body = omega0 + (k1_alpha + k2_alpha * 2.0 + k3_alpha * 2.0 + k4_alpha) * sixth_dt;
+    let final_q = [
+        q0[0] + (k1_qdot[0] + 2.0 * k2_qdot[0] + 2.0 * k3_qdot[0] + k4_qdot[0]) * sixth_dt,
+        q0[1] + (k1_qdot[1] + 2.0 * k2_qdot[1] + 2.0 * k3_qdot[1] + k4_qdot[1]) * sixth_dt,
+        q0[2] + (k1_qdot[2] + 2.0 * k2_qdot[2] + 2.0 * k3_qdot[2] + k4_qdot[2]) * sixth_dt,
+        q0[3] + (k1_qdot[3] + 2.0 * k2_qdot[3] + 2.0 * k3_qdot[3] + k4_qdot[3]) * sixth_dt,
+    ];
+    // JEOD_INV: DB.09 — quaternion normalized after every integration step
+    rot.quaternion = JeodQuat::new(final_q[0], final_q[1], final_q[2], final_q[3]);
+    jeod_dynamics::normalize_integ(&mut rot.quaternion);
+
+    // Combine thermal state with overshoot clamping
+    thermal.finalize_rk4_temperatures(
+        &temps0,
+        &t_pow4_0,
+        k1_tdots,
+        &k2_tdots,
+        &k3_tdots,
+        &eval4.temp_dots,
+        integ_dyndt,
+        n_plates,
+    );
+}
+
+/// Compute total translational acceleration from a stage evaluation.
+fn compute_total_accel(eval: &CoupledStageEval, mass: Option<&MassProperties>) -> DVec3 {
+    let non_grav_accel = if eval.non_grav_force == DVec3::ZERO {
+        DVec3::ZERO
+    } else if let Some(m) = mass {
+        // JEOD_INV: DB.18 — force to acceleration via inverse mass
+        jeod_dynamics::compute_translational_acceleration(eval.non_grav_force, m.inverse_mass)
+    } else {
+        panic!(
+            "Non-zero force ({:?}) but no MassProperties. \
+             Provide MassProperties for any body with interaction forces.",
+            eval.non_grav_force
+        );
+    };
+    eval.gravity_accel + non_grav_accel
+}
+
+/// Advance thermal state to an intermediate RK4 position.
+///
+/// Sets temperatures to `temps0 + k_tdots * h` and updates cached T^4.
+/// Used between RK4 stages so the next `stage_fn` call sees intermediate
+/// temperatures for thermal emission force coupling.
+fn advance_thermal_intermediate(
+    thermal: &mut FlatPlateState,
+    temps0: &[f64],
+    _t_pow4_0: &[f64],
+    k_tdots: &[f64],
+    h: f64,
+) {
+    for i in 0..thermal.temperatures.len() {
+        let t = (temps0[i] + k_tdots[i] * h).max(0.0);
+        thermal.temperatures[i] = t;
+        thermal.t_pow4_cached[i] = t * t * t * t;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interactions::FlatPlateState;
+
+    /// Verify coupled path produces identical results to standard path
+    /// when forces are held constant (no thermal coupling).
+    #[test]
+    fn coupled_matches_standard_constant_force() {
+        let config = DynamicsConfig {
+            translational_dynamics: true,
+            rotational_dynamics: false,
+            three_dof: true,
+        };
+        let mass = jeod_dynamics::MassProperties::new(500.0);
+        let dt = 1.0;
+        let tsf = 1.0;
+        let mu = 3.986004418e14;
+
+        let pos0 = DVec3::new(6.778e6, 0.0, 0.0);
+        let vel0 = DVec3::new(0.0, 7672.0, 0.0);
+        let srp_force = DVec3::new(1e-4, 2e-4, 3e-4);
+
+        // Standard path
+        let mut trans1 = TranslationalState {
+            position: pos0,
+            velocity: vel0,
+        };
+        integrate_body(
+            &config,
+            &mut trans1,
+            None,
+            Some(&mass),
+            |pos, _vel| -mu / pos.length().powi(3) * pos,
+            srp_force,
+            DVec3::ZERO,
+            dt,
+            tsf,
+            jeod_dynamics::IntegratorType::Rk4,
+            None,
+        );
+
+        // Coupled path with constant forces (no thermal state)
+        let mut trans2 = TranslationalState {
+            position: pos0,
+            velocity: vel0,
+        };
+        let mut thermal = FlatPlateState {
+            plates: vec![],
+            temperatures: vec![],
+            t_pow4_cached: vec![],
+        };
+        integrate_body_coupled(
+            &config,
+            &mut trans2,
+            None,
+            Some(&mass),
+            |inter_trans, _inter_rot, _inter_thermal| CoupledStageEval {
+                gravity_accel: {
+                    let pos = inter_trans.position;
+                    -mu / pos.length().powi(3) * pos
+                },
+                non_grav_force: srp_force,
+                torque: DVec3::ZERO,
+                temp_dots: vec![],
+            },
+            &mut thermal,
+            dt,
+            tsf,
+        );
+
+        let pos_diff = (trans1.position - trans2.position).length();
+        let vel_diff = (trans1.velocity - trans2.velocity).length();
+        eprintln!("Standard pos: {:?}", trans1.position);
+        eprintln!("Coupled  pos: {:?}", trans2.position);
+        eprintln!("Position diff: {:.6e} m", pos_diff);
+        eprintln!("Velocity diff: {:.6e} m/s", vel_diff);
+
+        assert!(pos_diff < 1e-10, "Position mismatch: {pos_diff:.6e} m");
+        assert!(vel_diff < 1e-10, "Velocity mismatch: {vel_diff:.6e} m/s");
     }
 }

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -21,19 +21,25 @@ pub struct FlatPlateState {
 }
 
 impl FlatPlateState {
-    /// Integrate plate temperatures via RK4 with overshoot clamping.
+    /// Integrate plate temperatures via Forward Euler with overshoot clamping.
     ///
     /// Port of JEOD `ThermalIntegrableObject::integrate()` (thermal_integrable_object.cc:98-124).
-    /// Uses RK4 (matching the orbital state integrator order) with overshoot
-    /// detection: if the integrated temperature crosses the radiative equilibrium
-    /// value, it is clamped to equilibrium.
+    /// JEOD's standard `radiation.sm` schedules `compute_temp_dot()` as a
+    /// "scheduled" job (once per step, not per integrator stage), so the
+    /// derivative is constant across all RK4 stages. This produces
+    /// `new_temp = old_temp + temp_dot * dt` — effectively Forward Euler.
+    /// We match this behavior for parity with JEOD's standard SIM_3_ORBIT.
+    ///
+    /// Overshoot detection: if the integrated temperature crosses the radiative
+    /// equilibrium value, it is clamped to equilibrium.
     ///
     /// `temp_dots_k1` is the per-plate temperature derivative from the current
-    /// step's `compute_flat_plate_srp_thermal` call. The absorbed power is
-    /// recovered from k1 and held constant over the RK4 sub-steps (solar flux
-    /// changes negligibly over one timestep).
+    /// step's `compute_flat_plate_srp_thermal` call.
     ///
     /// Called after `compute_flat_plate_srp_thermal` returns `temp_dots`.
+    /// For true RK4 thermal integration (derivative-class SRP), use
+    /// [`finalize_rk4_temperatures`](Self::finalize_rk4_temperatures) via
+    /// [`crate::integration::integrate_body_coupled`] instead.
     pub fn integrate_temperatures(&mut self, temp_dots_k1: &[f64], dt: f64) {
         for (i, (plate, _params, thermal)) in self.plates.iter().enumerate() {
             let old_temp = self.temperatures[i];

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -50,19 +50,17 @@ impl FlatPlateState {
             // power_absorb = temp_dot * heat_capacity + rad_constant * T^4
             let power_absorb = temp_dots_k1[i] * heat_cap + rad_constant * old_t_pow4;
 
-            // Temperature derivative at a given temperature (power_absorb is constant).
-            let tdot = |temp: f64| -> f64 {
-                let t4 = temp * temp * temp * temp;
-                (power_absorb - rad_constant * t4) / heat_cap
-            };
-
-            // RK4 stages
+            // JEOD's standard radiation.sm schedules compute_temp_dot() as a
+            // "scheduled" job (once per step), not a "derivative" job (per stage).
+            // This means temp_dot is constant across all RK4 stages, so the
+            // er7_utils integrator sees k1=k2=k3=k4=temp_dot, producing:
+            //   new_temp = old_temp + temp_dot * dt  (Forward Euler equivalent)
+            //
+            // We match this behavior for parity with JEOD's standard SIM_3_ORBIT
+            // reference trajectory. The 1st-order variant (radiation_1st_order.sm)
+            // uses derivative-class SRP, which WOULD recompute temp_dot per stage.
             let k1 = temp_dots_k1[i];
-            let k2 = tdot(old_temp + k1 * dt * 0.5);
-            let k3 = tdot(old_temp + k2 * dt * 0.5);
-            let k4 = tdot(old_temp + k3 * dt);
-
-            let mut new_temp = old_temp + (k1 + 2.0 * k2 + 2.0 * k3 + k4) * (dt / 6.0);
+            let mut new_temp = old_temp + k1 * dt;
             new_temp = new_temp.max(0.0);
 
             let new_t_pow4 = new_temp * new_temp * new_temp * new_temp;
@@ -76,6 +74,59 @@ impl FlatPlateState {
                     self.t_pow4_cached[i] = t_eq_pow4.max(0.0);
                     self.temperatures[i] = self.t_pow4_cached[i].sqrt().sqrt();
                     continue;
+                }
+            }
+
+            self.temperatures[i] = new_temp;
+            self.t_pow4_cached[i] = new_t_pow4;
+        }
+    }
+
+    /// Finalize RK4 thermal integration from four stage derivatives.
+    ///
+    /// Combines k1–k4 temperature derivatives via the standard RK4 formula
+    /// and applies JEOD overshoot clamping (thermal_integrable_object.cc:106-121).
+    /// Called by [`crate::integration::integrate_body_coupled`] after all four
+    /// stages have been evaluated.
+    ///
+    /// This is the coupled-integration counterpart of [`Self::integrate_temperatures`]:
+    /// instead of deriving k2–k4 internally from k1's `power_absorb`, the four
+    /// derivatives were computed at intermediate orbital positions by the stage
+    /// closure.
+    #[allow(clippy::too_many_arguments)]
+    pub fn finalize_rk4_temperatures(
+        &mut self,
+        temps0: &[f64],
+        t_pow4_0: &[f64],
+        k1_tdots: &[f64],
+        k2_tdots: &[f64],
+        k3_tdots: &[f64],
+        k4_tdots: &[f64],
+        dt: f64,
+        n_plates: usize,
+    ) {
+        let sixth_dt = dt / 6.0;
+        for i in 0..n_plates {
+            let combined_tdot = k1_tdots[i] + 2.0 * k2_tdots[i] + 2.0 * k3_tdots[i] + k4_tdots[i];
+            let mut new_temp = (temps0[i] + combined_tdot * sixth_dt).max(0.0);
+            let mut new_t_pow4 = new_temp * new_temp * new_temp * new_temp;
+
+            // JEOD overshoot clamping (thermal_integrable_object.cc:106-121).
+            // If integrated temperature crossed the radiative equilibrium asymptote,
+            // clamp to equilibrium. Use k1's derivative and recover power_absorb from
+            // the initial state, matching the standalone path.
+            let (_, _, thermal) = &self.plates[i];
+            let plate = &self.plates[i].0;
+            let rad_constant = plate.area * thermal.emissivity * STEFAN_BOLTZMANN;
+            if rad_constant > 0.0 {
+                let heat_cap = thermal.heat_capacity_per_area * plate.area;
+                if heat_cap > 0.0 {
+                    let power_absorb = k1_tdots[i] * heat_cap + rad_constant * t_pow4_0[i];
+                    let t_eq_pow4 = power_absorb / rad_constant;
+                    if k1_tdots[i] * (t_eq_pow4 - new_t_pow4) < 0.0 {
+                        new_t_pow4 = t_eq_pow4.max(0.0);
+                        new_temp = new_t_pow4.sqrt().sqrt();
+                    }
                 }
             }
 

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -57,7 +57,7 @@ pub use gravity::{
     accumulate_gravity, accumulate_relativistic_corrections, ResolvedRelativisticSource,
     ResolvedSource,
 };
-pub use integration::integrate_body;
+pub use integration::{integrate_body, integrate_body_coupled, CoupledStageEval};
 pub use interactions::{
     compute_cannonball_srp, compute_drag, compute_gravity_torque, FlatPlateState,
 };
@@ -74,8 +74,8 @@ pub use validation::{validate_body, ValidationError};
 // jeod_dynamics: state types, force types, mass, config, frame utilities
 pub use jeod_dynamics::{
     compute_t_inertial_struct, DynamicsConfig, ForceContributions, FrameDerivatives,
-    GravityAcceleration, MassProperties, RotationalState, SixDofState, TotalForce,
-    TranslationalState, INERTIA_CONSISTENCY_TOL,
+    GravityAcceleration, MassBodyId, MassProperties, MassTree, RotationalState, SixDofState,
+    TotalForce, TranslationalState, INERTIA_CONSISTENCY_TOL,
 };
 
 // jeod_gravity: source definitions, controls, and tides

--- a/src/components.rs
+++ b/src/components.rs
@@ -364,3 +364,39 @@ pub struct ExternalForceC(pub DVec3);
 /// Mutate between steps to implement time-scheduled torque injection.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
 pub struct ExternalTorqueC(pub DVec3);
+
+// ── Mass Tree (Staging) ──
+
+/// Maps this entity to a node in the shared [`MassTreeR`](crate::MassTreeR) resource.
+///
+/// Entities with this component participate in the mass tree. After
+/// attach/detach events are processed, the entity's [`MassPropertiesC`]
+/// is synced from the tree's composite properties.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct MassBodyIdC(pub jeod_sim::MassBodyId);
+
+/// Message: attach a child body to a parent in the mass tree.
+///
+/// Both entities must have [`MassBodyIdC`]. Processed by `staging_system`
+/// before integration each step.
+#[derive(Message, Debug, Clone)]
+pub struct AttachEvent {
+    /// Entity of the child body.
+    pub child: Entity,
+    /// Entity of the parent body.
+    pub parent: Entity,
+    /// Child structural origin in parent's structural frame (m).
+    pub offset: DVec3,
+    /// Rotation from parent structural frame to child structural frame.
+    pub t_parent_child: glam::DMat3,
+}
+
+/// Message: detach a child body from its parent in the mass tree.
+///
+/// The entity must have [`MassBodyIdC`] and be attached to a parent.
+/// Processed by `staging_system` before integration each step.
+#[derive(Message, Debug, Clone)]
+pub struct DetachEvent {
+    /// Entity to detach from its parent.
+    pub child: Entity,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,12 @@ pub struct EphemerisR(pub jeod_sim::Ephemeris);
 /// The `staging_system` processes [`AttachEvent`](components::AttachEvent) and
 /// [`DetachEvent`](components::DetachEvent) to modify the tree and sync
 /// composite mass properties back to affected entities.
+///
+/// This resource is not inserted automatically by [`JeodPlugin`]. Applications
+/// that use staging must insert `MassTreeR` before sending
+/// [`AttachEvent`](components::AttachEvent) or
+/// [`DetachEvent`](components::DetachEvent). If the resource is absent, staging
+/// events are silently drained.
 #[derive(Resource, Deref, DerefMut)]
 pub struct MassTreeR(pub jeod_sim::MassTree);
 
@@ -133,13 +139,13 @@ impl Plugin for JeodPlugin {
         app.add_systems(
             FixedUpdate,
             (
+                // Mass tree staging (attach/detach) — runs before force collection
+                // so mass changes affect the current step's forces and integration.
+                systems::staging_system
+                    .after(JeodSet::Interaction)
+                    .before(JeodSet::ForceCollection),
                 // Force collection and integration
                 systems::force_collection_system.in_set(JeodSet::ForceCollection),
-                // Mass tree staging (attach/detach) — runs before integration
-                // so mass changes affect the current step.
-                systems::staging_system
-                    .in_set(JeodSet::Integration)
-                    .before(systems::integration_system),
                 systems::integration_system.in_set(JeodSet::Integration),
                 // Derived states
                 systems::orbital_elements_system.in_set(JeodSet::DerivedState),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,11 @@ impl Plugin for JeodPlugin {
                 // Atmosphere evaluation
                 systems::atmosphere_update_system.in_set(JeodSet::Environment),
                 // Interactions
+                // Mass tree staging (attach/detach) — runs before interactions
+                // so mass changes affect the current step's forces and integration.
+                systems::staging_system
+                    .after(JeodSet::Environment)
+                    .before(JeodSet::Interaction),
                 systems::aero_drag_system.in_set(JeodSet::Interaction),
                 systems::gravity_torque_system.in_set(JeodSet::Interaction),
                 systems::flat_plate_srp_system.in_set(JeodSet::Interaction),
@@ -139,11 +144,6 @@ impl Plugin for JeodPlugin {
         app.add_systems(
             FixedUpdate,
             (
-                // Mass tree staging (attach/detach) — runs before force collection
-                // so mass changes affect the current step's forces and integration.
-                systems::staging_system
-                    .after(JeodSet::Interaction)
-                    .before(JeodSet::ForceCollection),
                 // Force collection and integration
                 systems::force_collection_system.in_set(JeodSet::ForceCollection),
                 systems::integration_system.in_set(JeodSet::Integration),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,15 @@ pub struct AtmosphereModelR {
 #[derive(Resource, Deref, DerefMut)]
 pub struct EphemerisR(pub jeod_sim::Ephemeris);
 
+/// Bevy resource wrapping `MassTree` for multi-body vehicles.
+///
+/// Shared by all entities that have [`MassBodyIdC`](components::MassBodyIdC).
+/// The `staging_system` processes [`AttachEvent`](components::AttachEvent) and
+/// [`DetachEvent`](components::DetachEvent) to modify the tree and sync
+/// composite mass properties back to affected entities.
+#[derive(Resource, Deref, DerefMut)]
+pub struct MassTreeR(pub jeod_sim::MassTree);
+
 /// Unified JEOD plugin — registers all pipeline systems and schedule sets.
 pub struct JeodPlugin;
 
@@ -85,13 +94,16 @@ impl Plugin for JeodPlugin {
         // ── Resources ──
         app.init_resource::<SimulationTimeR>();
 
+        // ── Events ──
+        app.add_message::<AttachEvent>();
+        app.add_message::<DetachEvent>();
+
         // ── Systems ──
+        // Split into two add_systems calls to stay within Bevy's tuple size limit.
         app.add_systems(
             FixedUpdate,
             (
                 // Validation runs first — matches JEOD's initialize_simulation()
-                // which validates all bodies before the first integration step.
-                // Uses Local<bool> to run only once.
                 validation::validate_jeod_invariants.before(JeodSet::TimeUpdate),
                 // Time advance
                 systems::time_advance_system.in_set(JeodSet::TimeUpdate),
@@ -116,8 +128,18 @@ impl Plugin for JeodPlugin {
                 systems::gravity_torque_system.in_set(JeodSet::Interaction),
                 systems::flat_plate_srp_system.in_set(JeodSet::Interaction),
                 systems::cannonball_srp_system.in_set(JeodSet::Interaction),
+            ),
+        );
+        app.add_systems(
+            FixedUpdate,
+            (
                 // Force collection and integration
                 systems::force_collection_system.in_set(JeodSet::ForceCollection),
+                // Mass tree staging (attach/detach) — runs before integration
+                // so mass changes affect the current step.
+                systems::staging_system
+                    .in_set(JeodSet::Integration)
+                    .before(systems::integration_system),
                 systems::integration_system.in_set(JeodSet::Integration),
                 // Derived states
                 systems::orbital_elements_system.in_set(JeodSet::DerivedState),

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -854,3 +854,80 @@ pub fn cannonball_srp_system(
         srp_force.torque = DVec3::ZERO;
     }
 }
+
+/// Process mass-tree attach/detach events and sync composite properties.
+///
+/// Runs before integration so that mass changes from staging are reflected
+/// in the current step's force collection and integration.
+///
+/// # Example
+/// ```ignore
+/// // In user code (e.g., an observer or system):
+/// commands.send_event(DetachEvent { child: booster_entity });
+/// ```
+pub fn staging_system(
+    tree: Option<ResMut<crate::MassTreeR>>,
+    mut attach_events: bevy::ecs::message::MessageReader<crate::AttachEvent>,
+    mut detach_events: bevy::ecs::message::MessageReader<crate::DetachEvent>,
+    mut bodies: Query<(&crate::MassBodyIdC, &mut MassPropertiesC)>,
+) {
+    // No mass tree resource → drain events and return.
+    let Some(mut tree) = tree else {
+        attach_events.clear();
+        detach_events.clear();
+        return;
+    };
+
+    let mut changed_ids: Vec<jeod_sim::MassBodyId> = Vec::new();
+
+    for evt in attach_events.read() {
+        let child_id = bodies
+            .get(evt.child)
+            .expect("AttachEvent child has no MassBodyIdC")
+            .0
+             .0;
+        let parent_id = bodies
+            .get(evt.parent)
+            .expect("AttachEvent parent has no MassBodyIdC")
+            .0
+             .0;
+        tree.attach(child_id, parent_id, evt.offset, evt.t_parent_child);
+        changed_ids.push(child_id);
+        changed_ids.push(parent_id);
+    }
+
+    for evt in detach_events.read() {
+        let child_id = bodies
+            .get(evt.child)
+            .expect("DetachEvent child has no MassBodyIdC")
+            .0
+             .0;
+        if let Some(parent_id) = tree.parent(child_id) {
+            changed_ids.push(parent_id);
+        }
+        tree.detach(child_id);
+        changed_ids.push(child_id);
+    }
+
+    // Sync composite mass properties for all affected nodes.
+    // Walk up from each changed node to the root to capture cascading updates.
+    if !changed_ids.is_empty() {
+        let mut sync_ids: Vec<jeod_sim::MassBodyId> = Vec::new();
+        for &id in &changed_ids {
+            let mut current = id;
+            sync_ids.push(current);
+            while let Some(parent) = tree.parent(current) {
+                sync_ids.push(parent);
+                current = parent;
+            }
+        }
+        sync_ids.sort_unstable();
+        sync_ids.dedup();
+
+        for (body_id, mut mass) in &mut bodies {
+            if sync_ids.contains(&body_id.0) {
+                *mass = MassPropertiesC(tree.get(body_id.0).composite_properties);
+            }
+        }
+    }
+}

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -857,8 +857,9 @@ pub fn cannonball_srp_system(
 
 /// Process mass-tree attach/detach messages and sync composite properties.
 ///
-/// Runs before force collection so that mass changes from staging are
-/// reflected in the current step's forces and integration.
+/// Runs before interactions so that mass changes from staging are
+/// reflected in the current step's interaction forces, force collection,
+/// and integration.
 ///
 /// Note: [`crate::MassTreeR`] must be present as a resource for attach/detach
 /// messages to have any effect.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -855,15 +855,22 @@ pub fn cannonball_srp_system(
     }
 }
 
-/// Process mass-tree attach/detach events and sync composite properties.
+/// Process mass-tree attach/detach messages and sync composite properties.
 ///
-/// Runs before integration so that mass changes from staging are reflected
-/// in the current step's force collection and integration.
+/// Runs before force collection so that mass changes from staging are
+/// reflected in the current step's forces and integration.
+///
+/// Note: [`crate::MassTreeR`] must be present as a resource for attach/detach
+/// messages to have any effect.
 ///
 /// # Example
 /// ```ignore
-/// // In user code (e.g., an observer or system):
-/// commands.send_event(DetachEvent { child: booster_entity });
+/// fn detach_booster(
+///     mut detach_messages: bevy::ecs::message::MessageWriter<crate::DetachEvent>,
+///     booster_entity: Entity,
+/// ) {
+///     detach_messages.write(crate::DetachEvent { child: booster_entity });
+/// }
 /// ```
 pub fn staging_system(
     tree: Option<ResMut<crate::MassTreeR>>,
@@ -883,12 +890,12 @@ pub fn staging_system(
     for evt in attach_events.read() {
         let child_id = bodies
             .get(evt.child)
-            .expect("AttachEvent child has no MassBodyIdC")
+            .expect("AttachEvent child entity missing MassBodyIdC or MassPropertiesC")
             .0
              .0;
         let parent_id = bodies
             .get(evt.parent)
-            .expect("AttachEvent parent has no MassBodyIdC")
+            .expect("AttachEvent parent entity missing MassBodyIdC or MassPropertiesC")
             .0
              .0;
         tree.attach(child_id, parent_id, evt.offset, evt.t_parent_child);
@@ -899,7 +906,7 @@ pub fn staging_system(
     for evt in detach_events.read() {
         let child_id = bodies
             .get(evt.child)
-            .expect("DetachEvent child has no MassBodyIdC")
+            .expect("DetachEvent child entity missing MassBodyIdC or MassPropertiesC")
             .0
              .0;
         if let Some(parent_id) = tree.parent(child_id) {
@@ -925,7 +932,7 @@ pub fn staging_system(
         sync_ids.dedup();
 
         for (body_id, mut mass) in &mut bodies {
-            if sync_ids.contains(&body_id.0) {
+            if sync_ids.binary_search(&body_id.0).is_ok() {
                 *mass = MassPropertiesC(tree.get(body_id.0).composite_properties);
             }
         }


### PR DESCRIPTION
## Summary

Addresses all 5 orphaned Phase 5 tasks from #60:

- **5.33/5.34 (ODE scheduling):** Root-caused the 3.07 m SRP thermal residual over 23 days (#13). JEOD's standard `radiation.sm` schedules `compute_temp_dot()` as a "scheduled" job (once per step), making thermal integration effectively Forward Euler. Our code was doing proper RK4, causing divergence. Switching to match JEOD drops the error from **3.07 m → 0.037 m** (82× improvement). Tolerance tightened from ~3 m to ~0.04 m.
- **5.30 (`apollo.rs`):** Runner example — Apollo TLI with Earth+Moon+Sun gravity, MassTree staging (CSM + S-IVB detach), impulsive delta-V, 3-day coast.
- **5.31 (`earth_moon.rs`):** Runner example — Clementine lunar orbit with Moon LP150Q 60×60 SH, Earth/Sun 3rd-body, cannonball SRP, DE421 ephemeris + BPC libration.
- **5.32 (`mars_orbit.rs`):** Runner example — Dawn at Mars with MRO110B2 110×110 SH, IAU rotation, Sun 3rd-body, DE421 ephemeris.

### Supporting infrastructure

- **MassTree wiring (runner):** `Simulation::add_body_to_tree()`, `attach()`, `detach()` + `SimulationBuilder` support via `register_in_mass_tree()` and `attach_bodies()`
- **Body mutation:** `set_body_velocity()`, `set_body_mass()` on `Simulation` for impulsive maneuvers
- **Bevy mass tree:** `MassTreeR` resource, `MassBodyIdC` component, `AttachEvent`/`DetachEvent` messages, `staging_system`
- **Coupled integration infrastructure:** `integrate_body_coupled()` and `CoupledStageEval` in `jeod_sim` — ready for future 1st-order variant (`radiation_1st_order.sm` which uses derivative-class SRP)

## Test plan

- [x] All 554 tests pass (`cargo nextest run --workspace -E 'not test(earth_moon)'`)
- [x] SRP flat-plate tolerance tightened: `[3.074, 2.799, 1.216]` → `[0.034, 0.040, 0.016]`
- [x] `cargo run -p jeod_runner --example earth_moon` — prints Clementine orbital evolution
- [x] `cargo run -p jeod_runner --example mars_orbit` — prints Dawn flyby trajectory
- [x] `cargo run -p jeod_runner --example apollo` — prints TLI + staging + coast trajectory
- [x] `cargo fmt --check && cargo clippy --workspace --tests -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)