### PR TITLE
Port JEOD RefFrame tree for translational state propagation

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"62c9b50b-ed82-4b2d-85ba-9a5de08fd809","pid":16189,"acquiredAt":1776152163822}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"62c9b50b-ed82-4b2d-85ba-9a5de08fd809","pid":16189,"acquiredAt":1776152163822}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test_data/*.trk
 # Mercury CSVs are ~774 MB each (600-year sim at 1-hour intervals)
 test_data/mercury_newtonian_mercury.csv
 test_data/mercury_relativistic_mercury.csv
+.claude/scheduled_tasks.lock

--- a/crates/jeod_frames/src/frame_tree.rs
+++ b/crates/jeod_frames/src/frame_tree.rs
@@ -215,6 +215,11 @@ impl FrameTree {
             id
         );
 
+        // No-op if already parented to `new_parent`.
+        if self.parent[id] == Some(new_parent) {
+            return;
+        }
+
         assert!(
             !self.is_descendant_of(new_parent, id),
             "reparent: new_parent {} is a descendant of {} — would create a cycle",

--- a/crates/jeod_frames/src/frame_tree.rs
+++ b/crates/jeod_frames/src/frame_tree.rs
@@ -206,6 +206,7 @@ impl FrameTree {
     /// # Panics
     /// - `new_parent` is a descendant of `id` (would create a cycle).
     /// - `id` is a root frame with no parent.
+    /// - `id` and `new_parent` do not share a common root.
     pub fn reparent(&mut self, id: FrameId, new_parent: FrameId) {
         // Check root first — root has no parent to detach from.
         assert!(
@@ -220,6 +221,25 @@ impl FrameTree {
             new_parent,
             id
         );
+
+        // Verify frames share a common root before computing relative state.
+        // find_common_ancestor panics with a generic message; catch it here
+        // with a reparent-specific message for easier debugging.
+        {
+            let mut cur = new_parent;
+            while let Some(p) = self.parent[cur] {
+                cur = p;
+            }
+            let new_parent_root = cur;
+            cur = id;
+            while let Some(p) = self.parent[cur] {
+                cur = p;
+            }
+            assert!(
+                cur == new_parent_root,
+                "reparent: frame {id} and new_parent {new_parent} do not share a common root"
+            );
+        }
 
         // Compute state of `id` relative to `new_parent` (preserves absolute state).
         let new_state = self.compute_relative_state(new_parent, id);

--- a/crates/jeod_frames/src/frame_tree.rs
+++ b/crates/jeod_frames/src/frame_tree.rs
@@ -173,6 +173,71 @@ impl FrameTree {
         from_negated.incr_right(&state_to)
     }
 
+    // -- lookup --------------------------------------------------------------
+
+    /// Find a frame by name. Returns the first match, or `None`.
+    pub fn find_by_name(&self, name: &str) -> Option<FrameId> {
+        self.nodes.iter().position(|n| n.name == name)
+    }
+
+    // -- tree mutation -------------------------------------------------------
+
+    /// Test whether `id` is a descendant of `ancestor` (or equal to it).
+    pub fn is_descendant_of(&self, id: FrameId, ancestor: FrameId) -> bool {
+        if id == ancestor {
+            return true;
+        }
+        let mut current = id;
+        while let Some(p) = self.parent[current] {
+            if p == ancestor {
+                return true;
+            }
+            current = p;
+        }
+        false
+    }
+
+    /// Move a frame to a new parent, preserving its absolute state.
+    ///
+    /// Port of JEOD's `RefFrame::transplant_node()`: the frame's position in
+    /// the tree changes, but its state relative to the root is preserved by
+    /// recomputing the relative state with respect to the new parent.
+    ///
+    /// # Panics
+    /// - `new_parent` is a descendant of `id` (would create a cycle).
+    /// - `id` is a root frame with no parent.
+    pub fn reparent(&mut self, id: FrameId, new_parent: FrameId) {
+        // Check root first — root has no parent to detach from.
+        assert!(
+            self.parent[id].is_some(),
+            "reparent: frame {} has no parent (is a root) — cannot reparent root frames",
+            id
+        );
+
+        assert!(
+            !self.is_descendant_of(new_parent, id),
+            "reparent: new_parent {} is a descendant of {} — would create a cycle",
+            new_parent,
+            id
+        );
+
+        // Compute state of `id` relative to `new_parent` (preserves absolute state).
+        let new_state = self.compute_relative_state(new_parent, id);
+
+        // Remove from old parent's children list.
+        let old_parent = self.parent[id].unwrap();
+        self.children[old_parent].retain(|&c| c != id);
+
+        // Attach to new parent.
+        self.parent[id] = Some(new_parent);
+        self.children[new_parent].push(id);
+
+        // Store recomputed relative state.
+        self.nodes[id].state = new_state;
+    }
+
+    // -- tree traversal (internal) ------------------------------------------
+
     /// Compose states from `id` up to `ancestor`, returning the state of
     /// `id` relative to `ancestor`.
     ///
@@ -719,5 +784,174 @@ mod tests {
             "  4-level frame tree: all 4 frame pairs match direct composition within tolerances \
              (rot {tol_rot:.0e}, pos/vel {tol_pos:.0e})"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // 9. find_by_name
+    // -----------------------------------------------------------------------
+    #[test]
+    fn find_by_name() {
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("Earth.inertial".into(), RefFrameKind::Inertial);
+        let moon = tree.add_child(
+            root,
+            "Moon.inertial".into(),
+            RefFrameKind::Inertial,
+            RefFrameState::default(),
+        );
+
+        assert_eq!(tree.find_by_name("Earth.inertial"), Some(root));
+        assert_eq!(tree.find_by_name("Moon.inertial"), Some(moon));
+        assert_eq!(tree.find_by_name("Mars.inertial"), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // 10. is_descendant_of
+    // -----------------------------------------------------------------------
+    #[test]
+    fn is_descendant_of() {
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+        let a = tree.add_child(
+            root,
+            "A".into(),
+            RefFrameKind::Body,
+            RefFrameState::default(),
+        );
+        let b = tree.add_child(a, "B".into(), RefFrameKind::Body, RefFrameState::default());
+        let c = tree.add_child(
+            root,
+            "C".into(),
+            RefFrameKind::Body,
+            RefFrameState::default(),
+        );
+
+        assert!(tree.is_descendant_of(b, root));
+        assert!(tree.is_descendant_of(b, a));
+        assert!(tree.is_descendant_of(a, root));
+        assert!(tree.is_descendant_of(root, root)); // self
+        assert!(!tree.is_descendant_of(root, a));
+        assert!(!tree.is_descendant_of(c, a)); // sibling, not descendant
+        assert!(!tree.is_descendant_of(b, c)); // cross-branch
+    }
+
+    // -----------------------------------------------------------------------
+    // 11. reparent: move a child to a different parent, verify state preserved
+    // -----------------------------------------------------------------------
+    #[test]
+    fn reparent_preserves_absolute_state() {
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+
+        // Two children of root with distinct states.
+        let state_a = make_state(
+            0.3,
+            DVec3::new(1000.0, 0.0, 0.0),
+            DVec3::new(10.0, 0.0, 0.0),
+            DVec3::new(0.0, 0.0, 0.01),
+        );
+        let a = tree.add_child(root, "A".into(), RefFrameKind::Body, state_a);
+
+        let state_b = make_state(
+            -0.5,
+            DVec3::new(0.0, 2000.0, 0.0),
+            DVec3::new(0.0, 20.0, 0.0),
+            DVec3::new(0.0, 0.0, 0.02),
+        );
+        let b = tree.add_child(root, "B".into(), RefFrameKind::Body, state_b);
+
+        // Child of B.
+        let state_c = make_state(
+            0.1,
+            DVec3::new(100.0, 100.0, 0.0),
+            DVec3::new(1.0, 1.0, 0.0),
+            DVec3::new(0.001, 0.0, 0.0),
+        );
+        let c = tree.add_child(b, "C".into(), RefFrameKind::Body, state_c);
+
+        // Record absolute state of C before reparent (root -> C).
+        let abs_before = tree.compute_relative_state(root, c);
+
+        // Reparent C from B to A.
+        tree.reparent(c, a);
+
+        // Verify tree structure changed.
+        assert_eq!(tree.parent(c), Some(a));
+        assert!(tree.children(a).contains(&c));
+        assert!(!tree.children(b).contains(&c));
+
+        // Verify absolute state is preserved.
+        let abs_after = tree.compute_relative_state(root, c);
+
+        let tol_pos = 1e-10;
+        let tol_rot = 1e-13;
+        assert!(
+            approx_eq_vec3(abs_after.trans.position, abs_before.trans.position, tol_pos),
+            "reparent position drift: expected {:?}, got {:?}, diff = {:.4e}",
+            abs_before.trans.position,
+            abs_after.trans.position,
+            (abs_after.trans.position - abs_before.trans.position).length()
+        );
+        assert!(
+            approx_eq_vec3(abs_after.trans.velocity, abs_before.trans.velocity, tol_pos),
+            "reparent velocity drift: expected {:?}, got {:?}",
+            abs_before.trans.velocity,
+            abs_after.trans.velocity
+        );
+        assert!(
+            approx_eq_mat3(
+                &abs_after.rot.t_parent_this,
+                &abs_before.rot.t_parent_this,
+                tol_rot
+            ),
+            "reparent rotation drift"
+        );
+        assert!(
+            approx_eq_vec3(
+                abs_after.rot.ang_vel_this,
+                abs_before.rot.ang_vel_this,
+                tol_rot
+            ),
+            "reparent ang_vel drift"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 12. reparent panics on cycle
+    // -----------------------------------------------------------------------
+    #[test]
+    #[should_panic(expected = "would create a cycle")]
+    fn reparent_cycle_panics() {
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+        let a = tree.add_child(
+            root,
+            "A".into(),
+            RefFrameKind::Body,
+            RefFrameState::default(),
+        );
+        let b = tree.add_child(a, "B".into(), RefFrameKind::Body, RefFrameState::default());
+
+        // Try to reparent A under its own descendant B — should panic.
+        tree.reparent(a, b);
+    }
+
+    // -----------------------------------------------------------------------
+    // 13. reparent panics on root
+    // -----------------------------------------------------------------------
+    #[test]
+    #[should_panic(expected = "cannot reparent root frames")]
+    fn reparent_root_panics() {
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+        let a = tree.add_child(
+            root,
+            "A".into(),
+            RefFrameKind::Body,
+            RefFrameState::default(),
+        );
+
+        // Try to reparent the root — should panic.
+        tree.reparent(root, a);
     }
 }

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -75,17 +75,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sim = Simulation::new(time, DT);
 
     // Earth at origin
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
 
     // Moon with per-step ephemeris updates
     let moon = sim.add_source(

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -75,24 +75,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sim = Simulation::new(time, DT);
 
     // Earth at origin
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     // Moon with per-step ephemeris updates
-    let moon = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_MOON,
-            model: GravityModel::PointMass,
-        },
-        moon_pos,
-        None,
-    ));
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_MOON,
+                model: GravityModel::PointMass,
+            },
+            moon_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(
         moon,
         jeod_sim::EphemerisBody::Moon,
@@ -100,14 +106,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Sun as 3rd-body (weak perturbation for TLI, but included for completeness)
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_SUN,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(
         sun,
         jeod_sim::EphemerisBody::Sun,
@@ -229,7 +238,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let body = sim.body(body_idx);
             let pos = body.trans.position;
             let vel = body.trans.velocity;
-            let moon_source_pos = sim.sources[moon].position;
+            let moon_source_pos = sim.source_position(moon);
 
             let alt_km = (pos.length() - R_EARTH) / 1000.0;
             let dist_moon_km = (pos - moon_source_pos).length() / 1000.0;
@@ -252,7 +261,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let final_body = sim.body(body_idx);
-    let final_moon_dist = (final_body.trans.position - sim.sources[moon].position).length();
+    let final_moon_dist = (final_body.trans.position - sim.source_position(moon)).length();
     println!();
     println!(
         "Final distance to Moon: {:.0} km after {:.1} days",

--- a/crates/jeod_runner/examples/batch_propagation.rs
+++ b/crates/jeod_runner/examples/batch_propagation.rs
@@ -52,6 +52,7 @@ fn main() {
             delta_c20: 0.0,
             rotation_model: jeod_sim::RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/examples/batch_propagation.rs
+++ b/crates/jeod_runner/examples/batch_propagation.rs
@@ -39,18 +39,22 @@ fn main() {
 
     let time = SimulationTime::at_j2000(default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: jeod_sim::RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: jeod_sim::RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     let body_idx = sim.add_body(VehicleConfig {
         trans: state0,
         gravity_controls: GravityControls {

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -103,6 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             rotation_model: RotationModel::MoonDE421,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -90,43 +90,53 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Moon: central body with LP150Q 60x60 SH gravity + DE421 BPC libration
     let moon_rotation = ephemeris.get_body_rotation(EphemerisBody::Moon, epoch_tdb_jd)?;
 
-    let moon = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: moon_mu,
-            model: GravityModel::SphericalHarmonics(Box::new(lp150q)),
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: moon_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(lp150q)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(moon_rotation),
+            rotation_model: RotationModel::MoonDE421,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(moon_rotation),
-        rotation_model: RotationModel::MoonDE421,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
     // Earth: 3rd-body perturbation with per-step ephemeris
     let (earth_pos, _) =
         ephemeris.get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)?;
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
-        },
-        earth_pos,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            earth_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
 
     // Sun: 3rd-body + SRP source with per-step ephemeris
     let (sun_pos, _) =
         ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)?;
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Moon);
     sim.sun_source = Some(sun);
     sim.ephemeris = Some(ephemeris);

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -62,19 +62,23 @@ fn main() {
 
     let time = SimulationTime::at_j2000(default_leap_second_table());
     let mut sim = Simulation::new(time, 60.0);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            // Set to Some so Simulation updates this with GMST each step.
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        // Set to Some so Simulation updates this with GMST each step.
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),
         r_eq: R_EARTH_EQ,

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -74,7 +74,7 @@ fn main() {
             // Set to Some so Simulation updates this with GMST each step.
             t_inertial_pfix: Some(DMat3::IDENTITY),
             delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
+            rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
             central: true,
         },

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -76,6 +76,7 @@ fn main() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -90,6 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             rotation_model: RotationModel::MarsIAU,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -77,28 +77,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sim = Simulation::new(time, DT);
 
     // Mars: central body with MRO110B2 SH gravity + IAU rotation
-    let mars = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mars_mu,
-            model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+    let mars = sim.add_source(
+        "Mars",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mars_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            rotation_model: RotationModel::MarsIAU,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        rotation_model: RotationModel::MarsIAU,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
     // Sun: 3rd-body with per-step DE421 ephemeris
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(
         sun,
         jeod_sim::EphemerisBody::Sun,

--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -235,7 +235,7 @@ impl VehicleBuilder {
 
     // ── Frame switching ──
 
-    /// Set the initial integration source (default: root frame / Earth).
+    /// Set the initial integration source (default: simulation root / central body).
     /// `source_idx` is the index returned by `SimulationBuilder::add_source()`.
     pub fn integ_source(mut self, source_idx: usize) -> Self {
         self.integ_source = Some(source_idx);

--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -16,7 +16,7 @@ use jeod_sim::{
 
 use crate::{
     DerivedStateConfig, EarthLightingConfig, FrameSwitchConfig, GeodeticConfig, GravitySourceEntry,
-    IntegrationFrame, ShadowBody, Simulation, SrpModel, VehicleConfig,
+    ShadowBody, Simulation, SrpModel, VehicleConfig,
 };
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -52,7 +52,7 @@ pub struct VehicleBuilder {
     derived: DerivedStateConfig,
     external_force: DVec3,
     external_torque: DVec3,
-    integ_frame: IntegrationFrame,
+    integ_source: Option<usize>,
     frame_switches: Vec<FrameSwitchConfig>,
 }
 
@@ -73,7 +73,7 @@ impl VehicleConfig {
             derived: DerivedStateConfig::default(),
             external_force: DVec3::ZERO,
             external_torque: DVec3::ZERO,
-            integ_frame: IntegrationFrame::default(),
+            integ_source: None,
             frame_switches: Vec::new(),
         }
     }
@@ -235,9 +235,10 @@ impl VehicleBuilder {
 
     // ── Frame switching ──
 
-    /// Set the initial integration frame (default: [`IntegrationFrame::EarthInertial`]).
-    pub fn integ_frame(mut self, frame: IntegrationFrame) -> Self {
-        self.integ_frame = frame;
+    /// Set the initial integration source (default: root frame / Earth).
+    /// `source_idx` is the index returned by `SimulationBuilder::add_source()`.
+    pub fn integ_source(mut self, source_idx: usize) -> Self {
+        self.integ_source = Some(source_idx);
         self
     }
 
@@ -268,7 +269,7 @@ impl VehicleBuilder {
             derived: self.derived,
             external_force: self.external_force,
             external_torque: self.external_torque,
-            integ_frame: self.integ_frame,
+            integ_source: self.integ_source,
             frame_switches: self.frame_switches,
         }
     }
@@ -286,7 +287,7 @@ impl VehicleBuilder {
 /// use jeod_sim::{SimulationTime, EARTH, AtmosphereModel};
 ///
 /// let mut builder = Simulation::builder(time, 10.0);
-/// let earth = builder.add_source(GravitySourceEntry::central_body(&EARTH));
+/// let earth = builder.add_source("Earth", GravitySourceEntry::central_body(&EARTH));
 /// builder.add_body(VehicleConfig::builder(trans).gravity(ctrl).build());
 /// let mut sim = builder.build()?;
 /// ```
@@ -311,7 +312,7 @@ pub struct SimulationBuilder {
     polar_motion: Option<(f64, f64)>,
     sun_source: Option<usize>,
     moon_source: Option<usize>,
-    sources: Vec<GravitySourceEntry>,
+    sources: Vec<(String, GravitySourceEntry)>,
     source_ephem_bodies: Vec<Option<(jeod_sim::EphemerisBody, jeod_sim::EphemerisBody)>>,
     bodies: Vec<VehicleConfig>,
     /// Body names for mass tree registration (index matches `bodies`).
@@ -389,10 +390,10 @@ impl SimulationBuilder {
 
     // ── Sources and bodies (&mut self for index returns) ──
 
-    /// Add a gravity source. Returns its index.
-    pub fn add_source(&mut self, entry: GravitySourceEntry) -> usize {
+    /// Add a gravity source with a name for the frame tree. Returns its index.
+    pub fn add_source(&mut self, name: impl Into<String>, entry: GravitySourceEntry) -> usize {
         let idx = self.sources.len();
-        self.sources.push(entry);
+        self.sources.push((name.into(), entry));
         self.source_ephem_bodies.push(None);
         idx
     }
@@ -486,8 +487,8 @@ impl SimulationBuilder {
         sim.sun_source = self.sun_source;
         sim.moon_source = self.moon_source;
 
-        for (i, source) in self.sources.into_iter().enumerate() {
-            sim.add_source(source);
+        for (i, (name, source)) in self.sources.into_iter().enumerate() {
+            sim.add_source(name, source);
             if let Some(Some((target, observer))) = self.source_ephem_bodies.get(i) {
                 sim.set_source_ephemeris(i, *target, *observer);
             }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -796,6 +796,12 @@ impl Simulation {
             "set_source_ephemeris: source_idx {source_idx} out of bounds (len = {})",
             self.source_ephem_bodies.len()
         );
+        assert!(
+            self.source_frame_ids[source_idx].inertial != self.root_frame_id,
+            "set_source_ephemeris: source {source_idx} ({target:?} wrt {observer:?}) \
+             is mapped to the root frame. The root frame must remain at the origin; \
+             ephemeris position updates would be silently ignored."
+        );
         self.source_ephem_bodies[source_idx] = Some((target, observer));
     }
 
@@ -1141,6 +1147,13 @@ impl Simulation {
                     index: idx,
                     num_sources,
                 });
+            }
+        }
+
+        // Ephemeris mapping on root-frame sources — would silently discard position.
+        for (i, ephem) in self.source_ephem_bodies.iter().enumerate() {
+            if ephem.is_some() && self.source_frame_ids[i].inertial == self.root_frame_id {
+                all_errors.push(ValidationError::EphemerisOnRootSource { source_idx: i });
             }
         }
 
@@ -1793,7 +1806,18 @@ impl Simulation {
                 if !sw.active {
                     continue;
                 }
-                let target_fid = self.source_frame_ids[sw.target_source].inertial;
+                let target_fid = self
+                    .source_frame_ids
+                    .get(sw.target_source)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "frame switch evaluation: target_source {} out of range; \
+                             {} source(s) configured. Run validate() before step().",
+                            sw.target_source,
+                            self.source_frame_ids.len()
+                        )
+                    })
+                    .inertial;
                 let (target_origin, _) = self.frame_origin(target_fid);
                 let (current_origin, _) = self.frame_origin(self.bodies[body_idx].integ_frame_id);
                 let body_pos_eci = self.bodies[body_idx].trans.position + current_origin;
@@ -1819,7 +1843,7 @@ impl Simulation {
                 let target_source = self.bodies[body_idx].frame_switches[idx].target_source;
                 self.bodies[body_idx].frame_switches[idx].active = false;
 
-                let new_integ_fid = self.source_frame_ids[target_source].inertial;
+                let new_integ_fid = self.source_frame_ids[target_source].inertial; // bounds already checked above
                 let body_fid = self.bodies[body_idx].body_frame_id;
 
                 // Reparent body frame in tree (preserves absolute state).

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -870,7 +870,8 @@ impl Simulation {
             .inertial
     }
 
-    /// Get the current position of a gravity source in the inertial frame.
+    /// Get the current position of a gravity source relative to the root
+    /// inertial frame. Returns `DVec3::ZERO` for the root-mapped central source.
     pub fn source_position(&self, source_idx: usize) -> DVec3 {
         let fid = self.source_frame(source_idx);
         if fid == self.root_frame_id {
@@ -880,7 +881,7 @@ impl Simulation {
         }
     }
 
-    /// Set the position of a gravity source in the inertial frame.
+    /// Set the position of a gravity source relative to the root inertial frame.
     pub fn set_source_position(&mut self, source_idx: usize, position: DVec3) {
         assert!(
             source_idx < self.source_frame_ids.len(),
@@ -896,7 +897,7 @@ impl Simulation {
         self.frame_tree.get_mut(fid).state.trans.position = position;
     }
 
-    /// Set the position and velocity of a gravity source in the inertial frame.
+    /// Set the position and velocity of a gravity source relative to the root inertial frame.
     ///
     /// Prefer this over [`set_source_position`](Simulation::set_source_position)
     /// when velocity is also available, to keep position and velocity consistent.
@@ -1080,22 +1081,22 @@ impl Simulation {
             // Only validate active switches — JEOD only evaluates active switches.
             for sw in &body.frame_switches {
                 if sw.active {
-                    let central = sw.target_source;
-                    if central >= num_sources {
-                        all_errors.push(ValidationError::FrameSwitchCentralSourceOutOfRange {
+                    let target = sw.target_source;
+                    if target >= num_sources {
+                        all_errors.push(ValidationError::FrameSwitchTargetSourceOutOfRange {
                             body_idx,
-                            central_source: central,
+                            target_source: target,
                             num_sources,
                         });
                     } else if !body
                         .gravity_controls
                         .controls
                         .iter()
-                        .any(|c| c.source_name == central)
+                        .any(|c| c.source_name == target)
                     {
-                        all_errors.push(ValidationError::FrameSwitchCentralSourceNotInControls {
+                        all_errors.push(ValidationError::FrameSwitchTargetSourceNotInControls {
                             body_idx,
-                            central_source: central,
+                            target_source: target,
                         });
                     }
                 }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1104,16 +1104,16 @@ impl Simulation {
             // derived states in the central-body inertial frame; they will
             // produce incorrect results in other frames.
             {
-                let non_eci_integ = body.integ_frame_id != self.root_frame_id;
-                let non_eci_switch = body.frame_switches.iter().any(|sw| {
+                let non_root_integ = body.integ_frame_id != self.root_frame_id;
+                let non_root_switch = body.frame_switches.iter().any(|sw| {
                     sw.active
                         && self
                             .source_frame_ids
                             .get(sw.target_source)
                             .is_some_and(|frame| frame.inertial != self.root_frame_id)
                 });
-                if non_eci_integ || non_eci_switch {
-                    let has_eci_feature = body.drag.is_some()
+                if non_root_integ || non_root_switch {
+                    let has_root_dependent_feature = body.drag.is_some()
                         || body.flat_plate_state.is_some()
                         || body.cannonball_srp.is_some()
                         || body.orbital_elements_source.is_some()
@@ -1122,8 +1122,8 @@ impl Simulation {
                         || body.geodetic_planet.is_some()
                         || body.compute_solar_beta
                         || body.earth_lighting_config.is_some();
-                    if has_eci_feature {
-                        all_errors.push(ValidationError::NonEciFrameWithEciDependentFeatures {
+                    if has_root_dependent_feature {
+                        all_errors.push(ValidationError::NonRootFrameWithRootDependentFeatures {
                             body_idx,
                         });
                     }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -730,30 +730,40 @@ impl Simulation {
             )
         };
 
-        // Create planet-fixed child if source has a rotation model.
-        let pfix_id = if entry.rotation_model != RotationModel::None {
-            let pfix_name = format!("{name}.pfix");
-            let rot = if let Some(t) = entry.t_inertial_pfix {
-                RefFrameRot {
-                    q_parent_this: JeodQuat::left_quat_from_transformation(&t),
-                    t_parent_this: t,
-                    ang_vel_this: DVec3::ZERO,
-                }
+        // Create a planet-fixed child when the source has a rotation model or
+        // an explicit inertial-to-pfix transform. This ensures a fixed initial
+        // orientation is not silently ignored when rotation_model is None.
+        let pfix_id =
+            if entry.rotation_model != RotationModel::None || entry.t_inertial_pfix.is_some() {
+                let pfix_name = format!("{name}.pfix");
+                let rot = if let Some(t) = entry.t_inertial_pfix {
+                    RefFrameRot {
+                        q_parent_this: JeodQuat::left_quat_from_transformation(&t),
+                        t_parent_this: t,
+                        ang_vel_this: DVec3::ZERO,
+                    }
+                } else {
+                    RefFrameRot::default()
+                };
+                Some(self.frame_tree.add_child(
+                    inertial_id,
+                    pfix_name,
+                    RefFrameKind::PlanetFixed,
+                    RefFrameState {
+                        trans: RefFrameTrans::default(),
+                        rot,
+                    },
+                ))
             } else {
-                RefFrameRot::default()
+                None
             };
-            Some(self.frame_tree.add_child(
-                inertial_id,
-                pfix_name,
-                RefFrameKind::PlanetFixed,
-                RefFrameState {
-                    trans: RefFrameTrans::default(),
-                    rot,
-                },
-            ))
-        } else {
-            None
-        };
+
+        // Tidal ΔC20 requires a planet-fixed frame for the rotation matrix.
+        assert!(
+            entry.tidal_config.is_none() || pfix_id.is_some(),
+            "add_source: tidal_config requires a planet-fixed frame \
+             (set rotation_model or t_inertial_pfix on the source)."
+        );
 
         self.source_frame_ids.push(SourceFrameIds {
             inertial: inertial_id,

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -855,12 +855,21 @@ impl Simulation {
 
     /// Get the inertial frame ID for a gravity source.
     pub fn source_frame(&self, source_idx: usize) -> FrameId {
-        self.source_frame_ids[source_idx].inertial
+        self.source_frame_ids
+            .get(source_idx)
+            .unwrap_or_else(|| {
+                panic!(
+                    "source_frame: source index {source_idx} is out of range; \
+                     {} source frame(s) configured",
+                    self.num_sources()
+                )
+            })
+            .inertial
     }
 
     /// Get the current position of a gravity source in the inertial frame.
     pub fn source_position(&self, source_idx: usize) -> DVec3 {
-        let fid = self.source_frame_ids[source_idx].inertial;
+        let fid = self.source_frame(source_idx);
         if fid == self.root_frame_id {
             DVec3::ZERO
         } else {
@@ -870,6 +879,12 @@ impl Simulation {
 
     /// Set the position of a gravity source in the inertial frame.
     pub fn set_source_position(&mut self, source_idx: usize, position: DVec3) {
+        assert!(
+            source_idx < self.source_frame_ids.len(),
+            "set_source_position: source index {source_idx} out of range; \
+             {} source(s) configured",
+            self.source_frame_ids.len()
+        );
         let fid = self.source_frame_ids[source_idx].inertial;
         assert_ne!(
             fid, self.root_frame_id,

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -896,7 +896,15 @@ impl Simulation {
     /// Get the planet-fixed rotation matrix for a gravity source. Returns `None`
     /// if the source has no rotation model (no pfix frame).
     pub fn source_pfix_rotation(&self, source_idx: usize) -> Option<DMat3> {
-        self.source_frame_ids[source_idx]
+        self.source_frame_ids
+            .get(source_idx)
+            .unwrap_or_else(|| {
+                panic!(
+                    "source_pfix_rotation: source index {source_idx} out of range; \
+                     {} source(s) configured",
+                    self.source_frame_ids.len()
+                )
+            })
             .pfix
             .map(|pfix_id| self.frame_tree.get(pfix_id).state.rot.t_parent_this)
     }
@@ -906,11 +914,27 @@ impl Simulation {
         &mut self,
         source_idx: usize,
     ) -> Option<&mut jeod_gravity::tides::TidalConfig> {
-        self.gravity_data[source_idx].tidal_config.as_mut()
+        let len = self.gravity_data.len();
+        self.gravity_data
+            .get_mut(source_idx)
+            .unwrap_or_else(|| {
+                panic!(
+                    "source_tidal_config_mut: source index {source_idx} out of range; \
+                     {len} source(s) configured",
+                )
+            })
+            .tidal_config
+            .as_mut()
     }
 
     /// Get the current ΔC20 tidal correction for a gravity source.
     pub fn source_delta_c20(&self, source_idx: usize) -> f64 {
+        assert!(
+            source_idx < self.gravity_data.len(),
+            "source_delta_c20: source index {source_idx} out of range; \
+             {} source(s) configured",
+            self.gravity_data.len()
+        );
         self.gravity_data[source_idx].delta_c20
     }
 

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1665,12 +1665,15 @@ impl Simulation {
                 body.rot.as_mut(),
                 body.mass.as_ref(),
                 |pos, vel, time_frac| {
-                    // Sub-stage interpolation: linearly interpolate source positions
-                    // at the sub-stage time fraction, matching JEOD's continuous
-                    // frame tree updates at each derivative evaluation.
+                    // Sub-stage interpolation for the integration frame origin.
                     let origin = integ_origin + integ_vel * (time_frac * dt);
-                    // Only interpolate for non-ECI frames; ECI with
-                    // deriv_ephem_update=false freezes positions per step.
+                    // Source position interpolation: JEOD's `deriv_ephem_update`
+                    // defaults to false, meaning ephemerides are NOT updated at
+                    // each derivative evaluation — source positions are frozen
+                    // within a step. We match this for ECI integration
+                    // (integ_vel == ZERO). For non-ECI frames the frame origin
+                    // moves within the step, so we must also interpolate source
+                    // positions to keep gravity evaluation consistent.
                     let sub_dt = if integ_vel != DVec3::ZERO {
                         time_frac * dt
                     } else {

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -915,6 +915,8 @@ impl Simulation {
         let node = self.frame_tree.get_mut(fid);
         node.state.trans.position = position;
         node.state.trans.velocity = velocity;
+        // Keep gravity_data velocity in sync for relativistic corrections (PPN).
+        self.gravity_data[source_idx].velocity = velocity;
     }
 
     /// Get the planet-fixed rotation matrix for a gravity source. Returns `None`

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -118,6 +118,10 @@ struct GravityData {
     tidal_config: Option<jeod_gravity::tides::TidalConfig>,
     /// Rotation model for updating planet-fixed frame each step.
     rotation_model: RotationModel,
+    /// Sidereal angular velocity (rad/s) for the planet-fixed frame's
+    /// `ang_vel_this`. Sourced from `PlanetConfig::omega` at setup time.
+    /// JEOD sets this as `[0, 0, planet_omega]` in `planet_rnp.cc`.
+    planet_omega: f64,
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -147,6 +151,10 @@ pub struct GravitySourceEntry {
     pub delta_c20: f64,
     /// Tidal configuration. When `Some`, the simulation computes ΔC20 each step.
     pub tidal_config: Option<jeod_gravity::tides::TidalConfig>,
+    /// Sidereal angular velocity (rad/s) for the planet-fixed frame's
+    /// `ang_vel_this`. Sourced from [`PlanetConfig::omega`]. Set to 0.0
+    /// for sources without a rotation model.
+    pub planet_omega: f64,
     /// Whether this is the central body (uses the root frame in the tree).
     /// Set automatically by [`central_body`](Self::central_body) and
     /// [`central_body_sh`](Self::central_body_sh).
@@ -165,6 +173,7 @@ impl GravitySourceEntry {
             velocity: DVec3::ZERO,
             t_inertial_pfix,
             rotation_model: RotationModel::None,
+            planet_omega: 0.0,
             delta_c20: 0.0,
             tidal_config: None,
             central: false,
@@ -190,6 +199,7 @@ impl GravitySourceEntry {
                 None
             },
             rotation_model: planet.rotation_model,
+            planet_omega: planet.omega,
             delta_c20: 0.0,
             tidal_config: None,
             central: true,
@@ -218,6 +228,7 @@ impl GravitySourceEntry {
                 None
             },
             rotation_model: planet.rotation_model,
+            planet_omega: planet.omega,
             delta_c20: 0.0,
             tidal_config: None,
             central: true,
@@ -238,6 +249,7 @@ impl GravitySourceEntry {
             velocity: DVec3::ZERO,
             t_inertial_pfix: None,
             rotation_model: RotationModel::None,
+            planet_omega: 0.0,
             delta_c20: 0.0,
             tidal_config: None,
             central: false,
@@ -775,6 +787,7 @@ impl Simulation {
             delta_c20: entry.delta_c20,
             tidal_config: entry.tidal_config,
             rotation_model: entry.rotation_model,
+            planet_omega: entry.planet_omega,
         });
         self.source_ephem_bodies.push(None);
         idx
@@ -1255,24 +1268,21 @@ impl Simulation {
     /// Sync a planet-fixed frame node's rotation state from a computed matrix.
     ///
     /// Sets `t_parent_this`, derives `q_parent_this` from it, and sets
-    /// `ang_vel_this = [0, 0, planet_omega]` for models with a constant spin
-    /// rate (matching JEOD's `planet_rnp.cc`). Moon models have
-    /// time-varying angular velocity due to libration; `ang_vel_this` is left
-    /// at zero for those (a known limitation).
+    /// `ang_vel_this = [0, 0, planet_omega]` matching JEOD's `planet_rnp.cc`.
+    /// The `planet_omega` value comes from [`PlanetConfig::omega`] via
+    /// [`GravityData::planet_omega`].
     fn sync_pfix_rotation(
         frame_tree: &mut jeod_frames::FrameTree,
         pfix_id: jeod_frames::FrameId,
         rotation: DMat3,
-        model: RotationModel,
+        planet_omega: f64,
     ) {
         let node = frame_tree.get_mut(pfix_id);
         node.state.rot.t_parent_this = rotation;
         node.state.rot.q_parent_this = JeodQuat::left_quat_from_transformation(&rotation);
         // JEOD sets ang_vel_this = [0, 0, planet_omega] in planet_rnp.cc.
         // This is used by compute_relative_state velocity composition.
-        if let Some(omega) = model.planet_omega() {
-            node.state.rot.ang_vel_this = DVec3::new(0.0, 0.0, omega);
-        }
+        node.state.rot.ang_vel_this = DVec3::new(0.0, 0.0, planet_omega);
     }
 
     /// Internal step with explicit dt (avoids temporary mutation of `self.dt`
@@ -1303,7 +1313,7 @@ impl Simulation {
                             &mut self.frame_tree,
                             pfix_id,
                             rotation,
-                            grav.rotation_model,
+                            grav.planet_omega,
                         );
                     }
                 }
@@ -1318,7 +1328,7 @@ impl Simulation {
                             &mut self.frame_tree,
                             pfix_id,
                             rotation,
-                            grav.rotation_model,
+                            grav.planet_omega,
                         );
                     }
                 }
@@ -1333,7 +1343,7 @@ impl Simulation {
                             &mut self.frame_tree,
                             pfix_id,
                             rotation,
-                            grav.rotation_model,
+                            grav.planet_omega,
                         );
                     }
                 }
@@ -1351,7 +1361,7 @@ impl Simulation {
                             &mut self.frame_tree,
                             pfix_id,
                             rotation,
-                            grav.rotation_model,
+                            grav.planet_omega,
                         );
                     }
                 }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1294,7 +1294,7 @@ impl Simulation {
             if let Some(ref config) = grav.tidal_config {
                 let pfix_id = self.source_frame_ids[i]
                     .pfix
-                    .expect("tidal_config requires a planet-fixed frame (rotation_model != None).");
+                    .expect("tidal_config requires a planet-fixed frame (set rotation_model or t_inertial_pfix).");
                 let rotation = self.frame_tree.get(pfix_id).state.rot.t_parent_this;
                 grav.delta_c20 = jeod_gravity::tides::compute_delta_c20(config, &rotation);
             } else {

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1445,21 +1445,25 @@ impl Simulation {
 
         // ── 6. Interactions — drag, SRP, gravity torque ──
         // sun_pos is also used in stage 9 (solar beta, earth lighting); compute once here.
-        let sun_pos = self.sun_source.map(|idx| {
-            let fid = self.source_frame_ids[idx].inertial;
-            if fid == self.root_frame_id {
-                DVec3::ZERO
-            } else {
-                self.frame_tree.get(fid).state.trans.position
-            }
+        let sun_pos = self.sun_source.and_then(|idx| {
+            self.source_frame_ids.get(idx).map(|sfids| {
+                let fid = sfids.inertial;
+                if fid == self.root_frame_id {
+                    DVec3::ZERO
+                } else {
+                    self.frame_tree.get(fid).state.trans.position
+                }
+            })
         });
-        let moon_pos = self.moon_source.map(|idx| {
-            let fid = self.source_frame_ids[idx].inertial;
-            if fid == self.root_frame_id {
-                DVec3::ZERO
-            } else {
-                self.frame_tree.get(fid).state.trans.position
-            }
+        let moon_pos = self.moon_source.and_then(|idx| {
+            self.source_frame_ids.get(idx).map(|sfids| {
+                let fid = sfids.inertial;
+                if fid == self.root_frame_id {
+                    DVec3::ZERO
+                } else {
+                    self.frame_tree.get(fid).state.trans.position
+                }
+            })
         });
         let source_frame_ids = &self.source_frame_ids;
         let frame_tree = &self.frame_tree;

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1988,6 +1988,8 @@ impl Simulation {
     /// at each timestep (e.g., SIM_2A_SHADOW_CALC).
     pub fn set_body_position(&mut self, idx: usize, position: DVec3) {
         self.bodies[idx].trans.position = position;
+        let fid = self.bodies[idx].body_frame_id;
+        self.frame_tree.get_mut(fid).state.trans.position = position;
     }
 
     /// Set a body's translational velocity (inertial frame, m/s).
@@ -1995,6 +1997,8 @@ impl Simulation {
     /// Used for impulsive maneuvers (e.g., Apollo TLI delta-V).
     pub fn set_body_velocity(&mut self, idx: usize, velocity: DVec3) {
         self.bodies[idx].trans.velocity = velocity;
+        let fid = self.bodies[idx].body_frame_id;
+        self.frame_tree.get_mut(fid).state.trans.velocity = velocity;
     }
 
     /// Replace a body's mass properties.

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1033,7 +1033,10 @@ impl Simulation {
                 let non_eci_integ = body.integ_frame_id != self.root_frame_id;
                 let non_eci_switch = body.frame_switches.iter().any(|sw| {
                     sw.active
-                        && self.source_frame_ids[sw.target_source].inertial != self.root_frame_id
+                        && self
+                            .source_frame_ids
+                            .get(sw.target_source)
+                            .is_some_and(|frame| frame.inertial != self.root_frame_id)
                 });
                 if non_eci_integ || non_eci_switch {
                     let has_eci_feature = body.drag.is_some()

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -667,8 +667,9 @@ pub struct Simulation {
 impl Simulation {
     /// Create a new simulation with the given initial time and timestep.
     ///
-    /// Creates a frame tree with a root "Earth.inertial" frame (all positions
-    /// are relative to this).
+    /// Creates a frame tree whose root is initially named "Earth.inertial"
+    /// and may be renamed when a central source is added via [`add_source`].
+    /// All positions are relative to this root frame regardless of its name.
     pub fn new(time: SimulationTime, dt: f64) -> Self {
         let mut frame_tree = FrameTree::new();
         let root_frame_id = frame_tree.add_root("Earth.inertial".into(), RefFrameKind::Inertial);

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -617,7 +617,9 @@ pub struct Simulation {
     bodies: Vec<SimBody>,
     /// Reference frame tree — single source of truth for celestial body positions,
     /// velocities, and rotations. Updated each step from ephemeris data.
-    pub frame_tree: FrameTree,
+    /// Private to protect invariants; use [`frame_tree()`](Self::frame_tree) for
+    /// read-only access.
+    frame_tree: FrameTree,
     /// Root inertial frame ID for this simulation. This is the integration-origin
     /// frame to which all positions are relative, and it is not necessarily
     /// `Earth.inertial` (for example, it may be renamed to match the configured
@@ -703,7 +705,14 @@ impl Simulation {
                 "add_source: a central source already maps to root_frame_id. \
                  Only one central source is allowed per simulation."
             );
+            assert!(
+                entry.position == DVec3::ZERO,
+                "add_source: central sources must have zero position because they map \
+                 directly to root_frame_id."
+            );
             // Central body: use the root frame directly. Rename to match.
+            // `entry.velocity` is stored in `gravity_data` for relativistic
+            // corrections, but is not applied as root-frame kinematics.
             self.frame_tree.get_mut(self.root_frame_id).name = inertial_name;
             self.root_frame_id
         } else {
@@ -822,6 +831,11 @@ impl Simulation {
         self.bodies
             .push(SimBody::from_config(config, integ_frame_id, body_frame_id));
         idx
+    }
+
+    /// Read-only access to the reference frame tree.
+    pub fn frame_tree(&self) -> &FrameTree {
+        &self.frame_tree
     }
 
     /// Number of gravity sources.
@@ -1250,18 +1264,23 @@ impl Simulation {
                                  ({target:?} wrt {observer:?}) at TDB JD {tdb_jd}: {e}"
                                 )
                             });
-                    // Update frame tree node with ephemeris position/velocity.
-                    // Skip the root frame — its state must remain identity
-                    // (JEOD invariant: root frame is the inertial reference).
+                    // Root-mapped sources cannot consume ephemeris position updates:
+                    // the root frame must remain identity, so accepting such a
+                    // mapping would silently ignore `pos` and yield an incorrect
+                    // source position.
                     let fid = self.source_frame_ids[i].inertial;
-                    if fid != self.root_frame_id {
-                        let node = self.frame_tree.get_mut(fid);
-                        node.state.trans.position = pos;
-                        node.state.trans.velocity = vel;
-                    }
-                    // Always update gravity_data velocity for relativistic corrections
-                    // (central bodies at root have zero tree velocity but may need
-                    // physical velocity for PPN).
+                    assert!(
+                        fid != self.root_frame_id,
+                        "Invalid ephemeris mapping for source {i} \
+                         ({target:?} wrt {observer:?}): source inertial frame is the root frame, \
+                         whose state must remain identity. Root-mapped sources cannot use \
+                         ephemeris position updates."
+                    );
+                    // Update frame tree node with ephemeris position/velocity.
+                    let node = self.frame_tree.get_mut(fid);
+                    node.state.trans.position = pos;
+                    node.state.trans.velocity = vel;
+                    // Also update gravity_data velocity for relativistic corrections.
                     self.gravity_data[i].velocity = vel;
                 }
             }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1252,6 +1252,29 @@ impl Simulation {
         (state.trans.position, state.trans.velocity)
     }
 
+    /// Sync a planet-fixed frame node's rotation state from a computed matrix.
+    ///
+    /// Sets `t_parent_this`, derives `q_parent_this` from it, and sets
+    /// `ang_vel_this = [0, 0, planet_omega]` for models with a constant spin
+    /// rate (matching JEOD's `planet_rnp.cc`). Moon models have
+    /// time-varying angular velocity due to libration; `ang_vel_this` is left
+    /// at zero for those (a known limitation).
+    fn sync_pfix_rotation(
+        frame_tree: &mut jeod_frames::FrameTree,
+        pfix_id: jeod_frames::FrameId,
+        rotation: DMat3,
+        model: RotationModel,
+    ) {
+        let node = frame_tree.get_mut(pfix_id);
+        node.state.rot.t_parent_this = rotation;
+        node.state.rot.q_parent_this = JeodQuat::left_quat_from_transformation(&rotation);
+        // JEOD sets ang_vel_this = [0, 0, planet_omega] in planet_rnp.cc.
+        // This is used by compute_relative_state velocity composition.
+        if let Some(omega) = model.planet_omega() {
+            node.state.rot.ang_vel_this = DVec3::new(0.0, 0.0, omega);
+        }
+    }
+
     /// Internal step with explicit dt (avoids temporary mutation of `self.dt`
     /// in `step_until`).
     fn step_internal(&mut self, dt: f64) {
@@ -1276,10 +1299,12 @@ impl Simulation {
                     });
                     // Sync to frame tree pfix node.
                     if let Some(pfix_id) = self.source_frame_ids[i].pfix {
-                        let node = self.frame_tree.get_mut(pfix_id);
-                        node.state.rot.t_parent_this = rotation;
-                        node.state.rot.q_parent_this =
-                            JeodQuat::left_quat_from_transformation(&rotation);
+                        Self::sync_pfix_rotation(
+                            &mut self.frame_tree,
+                            pfix_id,
+                            rotation,
+                            grav.rotation_model,
+                        );
                     }
                 }
                 RotationModel::MarsIAU => {
@@ -1289,10 +1314,12 @@ impl Simulation {
                     let rotation =
                         jeod_frames::rotation_mars::compute_mars_rotation(tt_s_since_j2000);
                     if let Some(pfix_id) = self.source_frame_ids[i].pfix {
-                        let node = self.frame_tree.get_mut(pfix_id);
-                        node.state.rot.t_parent_this = rotation;
-                        node.state.rot.q_parent_this =
-                            JeodQuat::left_quat_from_transformation(&rotation);
+                        Self::sync_pfix_rotation(
+                            &mut self.frame_tree,
+                            pfix_id,
+                            rotation,
+                            grav.rotation_model,
+                        );
                     }
                 }
                 RotationModel::MoonIAU => {
@@ -1302,10 +1329,12 @@ impl Simulation {
                     let rotation =
                         jeod_frames::rotation_moon::compute_moon_rotation(tdb_s_since_j2000);
                     if let Some(pfix_id) = self.source_frame_ids[i].pfix {
-                        let node = self.frame_tree.get_mut(pfix_id);
-                        node.state.rot.t_parent_this = rotation;
-                        node.state.rot.q_parent_this =
-                            JeodQuat::left_quat_from_transformation(&rotation);
+                        Self::sync_pfix_rotation(
+                            &mut self.frame_tree,
+                            pfix_id,
+                            rotation,
+                            grav.rotation_model,
+                        );
                     }
                 }
                 RotationModel::MoonDE421 => {
@@ -1318,10 +1347,12 @@ impl Simulation {
                         .get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd)
                         .expect("Moon DE421 BPC rotation query failed");
                     if let Some(pfix_id) = self.source_frame_ids[i].pfix {
-                        let node = self.frame_tree.get_mut(pfix_id);
-                        node.state.rot.t_parent_this = rotation;
-                        node.state.rot.q_parent_this =
-                            JeodQuat::left_quat_from_transformation(&rotation);
+                        Self::sync_pfix_rotation(
+                            &mut self.frame_tree,
+                            pfix_id,
+                            rotation,
+                            grav.rotation_model,
+                        );
                     }
                 }
             }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -796,12 +796,9 @@ impl Simulation {
             "set_source_ephemeris: source_idx {source_idx} out of bounds (len = {})",
             self.source_ephem_bodies.len()
         );
-        assert!(
-            self.source_frame_ids[source_idx].inertial != self.root_frame_id,
-            "set_source_ephemeris: source {source_idx} ({target:?} wrt {observer:?}) \
-             is mapped to the root frame. The root frame must remain at the origin; \
-             ephemeris position updates would be silently ignored."
-        );
+        // Root-frame conflict is caught by validate() → EphemerisOnRootSource.
+        // We don't panic here so that all misconfiguration errors are reported
+        // together in a single validate() pass rather than aborting on the first.
         self.source_ephem_bodies[source_idx] = Some((target, observer));
     }
 
@@ -897,6 +894,27 @@ impl Simulation {
             "Cannot set position of the root (central body) source"
         );
         self.frame_tree.get_mut(fid).state.trans.position = position;
+    }
+
+    /// Set the position and velocity of a gravity source in the inertial frame.
+    ///
+    /// Prefer this over [`set_source_position`](Simulation::set_source_position)
+    /// when velocity is also available, to keep position and velocity consistent.
+    pub fn set_source_state(&mut self, source_idx: usize, position: DVec3, velocity: DVec3) {
+        assert!(
+            source_idx < self.source_frame_ids.len(),
+            "set_source_state: source index {source_idx} out of range; \
+             {} source(s) configured",
+            self.source_frame_ids.len()
+        );
+        let fid = self.source_frame_ids[source_idx].inertial;
+        assert_ne!(
+            fid, self.root_frame_id,
+            "Cannot set state of the root (central body) source"
+        );
+        let node = self.frame_tree.get_mut(fid);
+        node.state.trans.position = position;
+        node.state.trans.velocity = velocity;
     }
 
     /// Get the planet-fixed rotation matrix for a gravity source. Returns `None`
@@ -1458,26 +1476,8 @@ impl Simulation {
 
         // ── 6. Interactions — drag, SRP, gravity torque ──
         // sun_pos is also used in stage 9 (solar beta, earth lighting); compute once here.
-        let sun_pos = self.sun_source.and_then(|idx| {
-            self.source_frame_ids.get(idx).map(|sfids| {
-                let fid = sfids.inertial;
-                if fid == self.root_frame_id {
-                    DVec3::ZERO
-                } else {
-                    self.frame_tree.get(fid).state.trans.position
-                }
-            })
-        });
-        let moon_pos = self.moon_source.and_then(|idx| {
-            self.source_frame_ids.get(idx).map(|sfids| {
-                let fid = sfids.inertial;
-                if fid == self.root_frame_id {
-                    DVec3::ZERO
-                } else {
-                    self.frame_tree.get(fid).state.trans.position
-                }
-            })
-        });
+        let sun_pos = self.sun_source.map(|idx| self.source_position(idx));
+        let moon_pos = self.moon_source.map(|idx| self.source_position(idx));
         let source_frame_ids = &self.source_frame_ids;
         let frame_tree = &self.frame_tree;
         let root_fid = self.root_frame_id;

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -618,7 +618,10 @@ pub struct Simulation {
     /// Reference frame tree — single source of truth for celestial body positions,
     /// velocities, and rotations. Updated each step from ephemeris data.
     pub frame_tree: FrameTree,
-    /// Root frame ID (Earth.inertial). All positions are relative to this.
+    /// Root inertial frame ID for this simulation. This is the integration-origin
+    /// frame to which all positions are relative, and it is not necessarily
+    /// `Earth.inertial` (for example, it may be renamed to match the configured
+    /// central body, such as `Mars.inertial`).
     pub root_frame_id: FrameId,
     /// Per-source frame tree node IDs (parallel to `gravity_data`).
     source_frame_ids: Vec<SourceFrameIds>,
@@ -676,8 +679,11 @@ impl Simulation {
 
     /// Add a gravity source. Returns its index for use in `GravityControls`.
     ///
-    /// Sources at the origin (position=ZERO, velocity=ZERO) are treated as the
-    /// central body and mapped to the root frame. Third bodies get child frames.
+    /// Sources with `central: true` (set by [`GravitySourceEntry::central_body`]
+    /// and [`GravitySourceEntry::central_body_sh`]) are mapped to the root frame.
+    /// Non-central sources get child inertial frames under the root.
+    ///
+    /// Only one central source may be added; a second will panic.
     ///
     /// If the source has a rotation model, a planet-fixed child frame is also
     /// created under the source's inertial frame.
@@ -685,13 +691,19 @@ impl Simulation {
         let idx = self.gravity_data.len();
         let name = name.into();
 
-        // Every source gets its own frame node. Central bodies at the origin
-        // get a node with zero position (identical to root), but the node
-        // stores the source's velocity for relativistic corrections.
+        // Central bodies map to the root frame; third bodies get child frames.
+        // Only one central source is allowed (the root can't be shared).
         let inertial_name = format!("{name}.inertial");
         let inertial_id = if entry.central {
-            // Central body: use the root frame directly. Its position is ZERO
-            // by definition. Rename the root to match the source name.
+            assert!(
+                !self
+                    .source_frame_ids
+                    .iter()
+                    .any(|sf| sf.inertial == self.root_frame_id),
+                "add_source: a central source already maps to root_frame_id. \
+                 Only one central source is allowed per simulation."
+            );
+            // Central body: use the root frame directly. Rename to match.
             self.frame_tree.get_mut(self.root_frame_id).name = inertial_name;
             self.root_frame_id
         } else {
@@ -779,7 +791,18 @@ impl Simulation {
         // Resolve integration frame from source index.
         let integ_frame_id = config
             .integ_source
-            .map(|src| self.source_frame_ids[src].inertial)
+            .map(|src| {
+                self.source_frame_ids
+                    .get(src)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "VehicleConfig::integ_source index {src} is out of range; \
+                             {} source frame(s) configured",
+                            self.source_frame_ids.len()
+                        )
+                    })
+                    .inertial
+            })
             .unwrap_or(self.root_frame_id);
 
         // Create body frame in tree under the integration frame.
@@ -1228,11 +1251,17 @@ impl Simulation {
                                 )
                             });
                     // Update frame tree node with ephemeris position/velocity.
+                    // Skip the root frame — its state must remain identity
+                    // (JEOD invariant: root frame is the inertial reference).
                     let fid = self.source_frame_ids[i].inertial;
-                    let node = self.frame_tree.get_mut(fid);
-                    node.state.trans.position = pos;
-                    node.state.trans.velocity = vel;
-                    // Also update gravity_data velocity for relativistic corrections.
+                    if fid != self.root_frame_id {
+                        let node = self.frame_tree.get_mut(fid);
+                        node.state.trans.position = pos;
+                        node.state.trans.velocity = vel;
+                    }
+                    // Always update gravity_data velocity for relativistic corrections
+                    // (central bodies at root have zero tree velocity but may need
+                    // physical velocity for PPN).
                     self.gravity_data[i].velocity = vel;
                 }
             }
@@ -1529,12 +1558,12 @@ impl Simulation {
         // DynamicsIntegrationGroup where the derivative function calls gravity
         // at every stage with the current intermediate position and velocity.
         //
-        // Frame tree sub-stage updates: source positions are linearly
-        // interpolated at each RK4 sub-stage via velocity * (time_frac * dt),
-        // matching JEOD's behavior of updating the reference frame tree at
-        // each derivative evaluation.
+        // For RK4 sub-stage evaluations, source positions are derived from a
+        // linear interpolation of their base inertial position using
+        // velocity * (time_frac * dt), matching JEOD's behavior of evaluating
+        // gravity using the current sub-stage source state.
         //
-        // Snapshot base positions for sub-stage interpolation (restored after integration).
+        // Snapshot base source positions and velocities for sub-stage interpolation.
         let base_positions: Vec<DVec3> = self
             .source_frame_ids
             .iter()

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1099,9 +1099,10 @@ impl Simulation {
                 }
             }
 
-            // Warn when non-ECI frame is used with ECI-dependent features.
-            // JEOD evaluates these derived states in Earth-centered inertial; they
-            // will produce incorrect results in other frames.
+            // Warn when body uses a non-root integration frame with features
+            // that assume root-inertial coordinates. JEOD evaluates these
+            // derived states in the central-body inertial frame; they will
+            // produce incorrect results in other frames.
             {
                 let non_eci_integ = body.integ_frame_id != self.root_frame_id;
                 let non_eci_switch = body.frame_switches.iter().any(|sw| {
@@ -1237,7 +1238,7 @@ impl Simulation {
         self.step_internal(self.dt);
     }
 
-    /// Get the position and velocity of a frame relative to the root (ECI).
+    /// Get the position and velocity of a frame relative to the root inertial frame.
     pub fn frame_origin(&self, frame_id: FrameId) -> (DVec3, DVec3) {
         if frame_id == self.root_frame_id {
             return (DVec3::ZERO, DVec3::ZERO);
@@ -1734,12 +1735,14 @@ impl Simulation {
                     // Sub-stage interpolation for the integration frame origin.
                     let origin = integ_origin + integ_vel * (time_frac * dt);
                     // Source position interpolation: JEOD's `deriv_ephem_update`
-                    // defaults to false, meaning ephemerides are NOT updated at
-                    // each derivative evaluation — source positions are frozen
-                    // within a step. We match this for ECI integration
-                    // (integ_vel == ZERO). For non-ECI frames the frame origin
-                    // moves within the step, so we must also interpolate source
-                    // positions to keep gravity evaluation consistent.
+                    // (DynamicsIntegrationGroup, default false) controls whether
+                    // ephemerides are updated at each derivative evaluation.
+                    // With default=false, source positions are frozen within a
+                    // step — we match this for root-frame integration where
+                    // integ_vel == ZERO. For non-root frames the frame origin
+                    // moves within the step, so we must interpolate source
+                    // positions to keep gravity evaluation consistent with the
+                    // interpolated integration-frame origin.
                     let sub_dt = if integ_vel != DVec3::ZERO {
                         time_frac * dt
                     } else {

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -28,6 +28,7 @@
 
 use glam::{DMat3, DVec3};
 
+use jeod_frames::{FrameTree, RefFrameKind, RefFrameRot, RefFrameState, RefFrameTrans};
 use jeod_sim::atmosphere::{evaluate_atmosphere, AtmosphereConfig};
 use jeod_sim::forces::collect_and_resolve_forces;
 use jeod_sim::gravity::accumulate_gravity;
@@ -35,9 +36,9 @@ use jeod_sim::integration::integrate_body;
 use jeod_sim::validation::ValidationError;
 use jeod_sim::{
     AerodynamicForce, AtmosphereState, DragConfig, DynamicsConfig, EulerSequence, FrameDerivatives,
-    GeodeticState, GravityAcceleration, GravityControls, GravitySource, LvlhFrame, MassProperties,
-    OrbitalElements, PlanetConfig, RadiationForce, RotationalState, SimulationTime, TotalForce,
-    TranslationalState,
+    GeodeticState, GravityAcceleration, GravityControls, GravitySource, JeodQuat, LvlhFrame,
+    MassProperties, OrbitalElements, PlanetConfig, RadiationForce, RotationalState, SimulationTime,
+    TotalForce, TranslationalState,
 };
 
 pub mod builder;
@@ -49,25 +50,12 @@ pub use jeod_sim::RotationModel;
 // Re-export builder types for ergonomic use.
 pub use builder::{SimulationBuilder, VehicleBuilder};
 
+// Re-export FrameId for downstream API.
+pub use jeod_frames::FrameId;
+
 // ══════════════════════════════════════════════════════════════════════════════
 // Integration frame switching
 // ══════════════════════════════════════════════════════════════════════════════
-
-/// Which celestial body's inertial frame is used for integration.
-///
-/// Body position/velocity are stored relative to this frame's origin.
-/// The frame's origin position in canonical (Earth-centered) coordinates
-/// is derived from ephemeris at each timestep.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum IntegrationFrame {
-    /// Earth-centered inertial (J2000 ICRF). Origin at (0,0,0).
-    #[default]
-    EarthInertial,
-    /// Moon-centered inertial. Origin = Moon ephemeris position.
-    MoonInertial,
-    /// Sun-centered inertial. Origin = Sun ephemeris position.
-    SunInertial,
-}
 
 /// Trigger condition for a frame switch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,21 +68,56 @@ pub enum SwitchSense {
 
 /// Configuration for a distance-based integration frame switch.
 ///
-/// Port of JEOD's `DynBodyFrameSwitch` body action.
+/// Port of JEOD's `DynBodyFrameSwitch` body action. When triggered, the
+/// body's integration frame is reparented to the target source's inertial
+/// frame in the frame tree, and gravity controls are flipped to make the
+/// target source non-differential (central body).
 #[derive(Debug, Clone)]
 pub struct FrameSwitchConfig {
-    /// Target integration frame to switch to.
-    pub target_frame: IntegrationFrame,
+    /// Index of the gravity source whose inertial frame to switch to.
+    /// On switch, this source becomes non-differential and all others become
+    /// differential, matching JEOD's `GravityInteraction::set_integ_frame()`.
+    pub target_source: usize,
     /// Whether to switch on approach or departure.
     pub switch_sense: SwitchSense,
     /// Distance threshold (meters).
     pub switch_distance: f64,
     /// Whether this switch is active.
     pub active: bool,
-    /// Index of the gravity source that is the central body in the target frame.
-    /// On switch, this source becomes non-differential and all others become
-    /// differential, matching JEOD's `GravityInteraction::set_integ_frame()`.
-    pub central_source: Option<usize>,
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Frame tree source registry
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Maps a gravity source to its frame tree nodes.
+struct SourceFrameIds {
+    /// Inertial frame for this source (e.g., "Earth.inertial").
+    inertial: FrameId,
+    /// Planet-fixed frame (e.g., "Earth.pfix"), if the source has a rotation model.
+    pfix: Option<FrameId>,
+}
+
+/// Gravity-specific data associated with a source (decoupled from frame tree).
+///
+/// The frame tree stores position/velocity/rotation state; this struct stores
+/// the physical gravity model data that lives alongside it. The `velocity`
+/// field stores source velocity for relativistic corrections — for central
+/// bodies at the root frame, the tree node has zero velocity but the source
+/// may still have physical velocity (e.g., Sun orbiting the barycenter).
+struct GravityData {
+    /// Physical gravity source (mu, model: PointMass or SphericalHarmonics).
+    source: GravitySource,
+    /// Source velocity in the inertial frame (m/s). Used for relativistic
+    /// corrections. Stored here rather than in the tree because the root
+    /// frame's velocity must be zero (it's the reference origin).
+    velocity: DVec3,
+    /// Tidal ΔC20 to add to the base C20 coefficient. Updated each step.
+    delta_c20: f64,
+    /// Tidal configuration. When `Some`, the simulation computes ΔC20 each step.
+    tidal_config: Option<jeod_gravity::tides::TidalConfig>,
+    /// Rotation model for updating planet-fixed frame each step.
+    rotation_model: RotationModel,
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -124,6 +147,10 @@ pub struct GravitySourceEntry {
     pub delta_c20: f64,
     /// Tidal configuration. When `Some`, the simulation computes ΔC20 each step.
     pub tidal_config: Option<jeod_gravity::tides::TidalConfig>,
+    /// Whether this is the central body (uses the root frame in the tree).
+    /// Set automatically by [`central_body`](Self::central_body) and
+    /// [`central_body_sh`](Self::central_body_sh).
+    pub central: bool,
 }
 
 impl GravitySourceEntry {
@@ -140,6 +167,7 @@ impl GravitySourceEntry {
             rotation_model: RotationModel::None,
             delta_c20: 0.0,
             tidal_config: None,
+            central: false,
         }
     }
 
@@ -164,6 +192,7 @@ impl GravitySourceEntry {
             rotation_model: planet.rotation_model,
             delta_c20: 0.0,
             tidal_config: None,
+            central: true,
         }
     }
 
@@ -191,6 +220,7 @@ impl GravitySourceEntry {
             rotation_model: planet.rotation_model,
             delta_c20: 0.0,
             tidal_config: None,
+            central: true,
         }
     }
 
@@ -210,6 +240,7 @@ impl GravitySourceEntry {
             rotation_model: RotationModel::None,
             delta_c20: 0.0,
             tidal_config: None,
+            central: false,
         }
     }
 
@@ -336,8 +367,10 @@ pub struct VehicleConfig {
     pub external_torque: DVec3,
 
     // ── Frame switching ──
-    /// Initial integration frame. Defaults to [`IntegrationFrame::EarthInertial`].
-    pub integ_frame: IntegrationFrame,
+    /// Gravity source whose inertial frame is used for integration.
+    /// `None` means the root frame (Earth.inertial). `Some(idx)` means
+    /// the inertial frame of the source at that index.
+    pub integ_source: Option<usize>,
     /// Distance-based frame switch triggers.
     pub frame_switches: Vec<FrameSwitchConfig>,
 }
@@ -358,7 +391,7 @@ impl Default for VehicleConfig {
             derived: DerivedStateConfig::default(),
             external_force: DVec3::ZERO,
             external_torque: DVec3::ZERO,
-            integ_frame: IntegrationFrame::default(),
+            integ_source: None,
             frame_switches: Vec::new(),
         }
     }
@@ -376,8 +409,8 @@ impl Default for VehicleConfig {
 pub struct VehicleOutput {
     /// Current translational state (position, velocity) in the integration frame.
     pub trans: TranslationalState,
-    /// Current integration frame (for converting to inertial if needed).
-    pub integ_frame: IntegrationFrame,
+    /// Frame ID of the current integration frame in the simulation's frame tree.
+    pub integ_frame_id: FrameId,
     /// Current rotational state (quaternion, angular velocity). `None` for 3-DOF.
     pub rot: Option<RotationalState>,
     /// Orbital elements from the latest step.
@@ -422,7 +455,8 @@ struct SimBody {
     external_torque: DVec3,
 
     // ── Frame switching ──
-    integ_frame: IntegrationFrame,
+    integ_frame_id: FrameId,
+    body_frame_id: FrameId,
     frame_switches: Vec<FrameSwitchConfig>,
 
     // ── Bookkeeping (written each step, not user-visible) ──
@@ -455,7 +489,7 @@ struct SimBody {
 
 impl SimBody {
     /// Convert a user-facing VehicleConfig into an internal SimBody.
-    fn from_config(config: VehicleConfig) -> Self {
+    fn from_config(config: VehicleConfig, integ_frame_id: FrameId, body_frame_id: FrameId) -> Self {
         let has_rot = config.rot.is_some();
         let dynamics_config = DynamicsConfig {
             translational_dynamics: true,
@@ -500,7 +534,8 @@ impl SimBody {
             external_force: config.external_force,
             external_torque: config.external_torque,
 
-            integ_frame: config.integ_frame,
+            integ_frame_id,
+            body_frame_id,
             frame_switches: config.frame_switches,
 
             gravity_accel: GravityAcceleration::default(),
@@ -538,7 +573,7 @@ impl SimBody {
     fn output(&self) -> VehicleOutput {
         VehicleOutput {
             trans: self.trans,
-            integ_frame: self.integ_frame,
+            integ_frame_id: self.integ_frame_id,
             rot: self.rot,
             orbital_elements: self.orbital_elements.clone(),
             euler_angles: self.euler_angles,
@@ -564,7 +599,7 @@ impl SimBody {
 /// # Example
 /// ```ignore
 /// let mut sim = Simulation::new(time, 10.0);
-/// let earth = sim.add_source(GravitySourceEntry::central_body(&EARTH));
+/// let earth = sim.add_source("Earth", GravitySourceEntry::central_body(&EARTH));
 /// let vehicle = sim.add_body(VehicleConfig {
 ///     trans: initial_state,
 ///     gravity_controls: controls,
@@ -580,15 +615,24 @@ pub struct Simulation {
     /// Dynamic bodies (internal, private).
     // JEOD_INV: DS.01 — private to prevent runtime mutation of derived-state config
     bodies: Vec<SimBody>,
-    /// Gravity sources.
-    pub sources: Vec<GravitySourceEntry>,
+    /// Reference frame tree — single source of truth for celestial body positions,
+    /// velocities, and rotations. Updated each step from ephemeris data.
+    pub frame_tree: FrameTree,
+    /// Root frame ID (Earth.inertial). All positions are relative to this.
+    pub root_frame_id: FrameId,
+    /// Per-source frame tree node IDs (parallel to `gravity_data`).
+    source_frame_ids: Vec<SourceFrameIds>,
+    /// Per-source gravity model data (parallel to `source_frame_ids`).
+    gravity_data: Vec<GravityData>,
+    /// Per-source ephemeris body mapping (parallel to `source_frame_ids`).
+    source_ephem_bodies: Vec<Option<(jeod_sim::EphemerisBody, jeod_sim::EphemerisBody)>>,
     /// Atmosphere configuration. `None` disables atmosphere for all bodies.
     pub atmosphere: Option<AtmosphereConfig>,
-    /// Index into `sources` for the planet whose rotation is used for atmosphere.
+    /// Source index for the planet whose rotation is used for atmosphere.
     pub atmosphere_planet_source: Option<usize>,
-    /// Index into `sources` for the Sun (used by SRP and earth lighting).
+    /// Source index for the Sun (used by SRP and earth lighting).
     pub sun_source: Option<usize>,
-    /// Index into `sources` for the Moon (used by earth lighting).
+    /// Source index for the Moon (used by earth lighting).
     pub moon_source: Option<usize>,
     /// Polar motion parameters (xp, yp) in radians. When `Some`, the RNP
     /// composition includes polar motion: W(xp,yp) × R(GAST) × N × P.
@@ -598,8 +642,6 @@ pub struct Simulation {
     pub dt: f64,
     /// Optional ephemeris for per-step source position updates.
     pub ephemeris: Option<jeod_sim::Ephemeris>,
-    /// Per-source ephemeris body mapping. Index matches `sources` vector.
-    pub source_ephem_bodies: Vec<Option<(jeod_sim::EphemerisBody, jeod_sim::EphemerisBody)>>,
     /// Optional mass tree for multi-body vehicles (attach/detach/staging).
     /// Bodies participating in the tree have `SimBody::mass_body_id` set.
     pub mass_tree: Option<jeod_dynamics::MassTree>,
@@ -607,11 +649,20 @@ pub struct Simulation {
 
 impl Simulation {
     /// Create a new simulation with the given initial time and timestep.
+    ///
+    /// Creates a frame tree with a root "Earth.inertial" frame (all positions
+    /// are relative to this).
     pub fn new(time: SimulationTime, dt: f64) -> Self {
+        let mut frame_tree = FrameTree::new();
+        let root_frame_id = frame_tree.add_root("Earth.inertial".into(), RefFrameKind::Inertial);
         Self {
             time,
             bodies: Vec::new(),
-            sources: Vec::new(),
+            frame_tree,
+            root_frame_id,
+            source_frame_ids: Vec::new(),
+            gravity_data: Vec::new(),
+            source_ephem_bodies: Vec::new(),
             atmosphere: None,
             atmosphere_planet_source: None,
             sun_source: None,
@@ -619,15 +670,81 @@ impl Simulation {
             polar_motion: None,
             dt,
             ephemeris: None,
-            source_ephem_bodies: Vec::new(),
             mass_tree: None,
         }
     }
 
     /// Add a gravity source. Returns its index for use in `GravityControls`.
-    pub fn add_source(&mut self, entry: GravitySourceEntry) -> usize {
-        let idx = self.sources.len();
-        self.sources.push(entry);
+    ///
+    /// Sources at the origin (position=ZERO, velocity=ZERO) are treated as the
+    /// central body and mapped to the root frame. Third bodies get child frames.
+    ///
+    /// If the source has a rotation model, a planet-fixed child frame is also
+    /// created under the source's inertial frame.
+    pub fn add_source(&mut self, name: impl Into<String>, entry: GravitySourceEntry) -> usize {
+        let idx = self.gravity_data.len();
+        let name = name.into();
+
+        // Every source gets its own frame node. Central bodies at the origin
+        // get a node with zero position (identical to root), but the node
+        // stores the source's velocity for relativistic corrections.
+        let inertial_name = format!("{name}.inertial");
+        let inertial_id = if entry.central {
+            // Central body: use the root frame directly. Its position is ZERO
+            // by definition. Rename the root to match the source name.
+            self.frame_tree.get_mut(self.root_frame_id).name = inertial_name;
+            self.root_frame_id
+        } else {
+            self.frame_tree.add_child(
+                self.root_frame_id,
+                inertial_name,
+                RefFrameKind::Inertial,
+                RefFrameState {
+                    trans: RefFrameTrans {
+                        position: entry.position,
+                        velocity: entry.velocity,
+                    },
+                    rot: RefFrameRot::default(),
+                },
+            )
+        };
+
+        // Create planet-fixed child if source has a rotation model.
+        let pfix_id = if entry.rotation_model != RotationModel::None {
+            let pfix_name = format!("{name}.pfix");
+            let rot = if let Some(t) = entry.t_inertial_pfix {
+                RefFrameRot {
+                    q_parent_this: JeodQuat::left_quat_from_transformation(&t),
+                    t_parent_this: t,
+                    ang_vel_this: DVec3::ZERO,
+                }
+            } else {
+                RefFrameRot::default()
+            };
+            Some(self.frame_tree.add_child(
+                inertial_id,
+                pfix_name,
+                RefFrameKind::PlanetFixed,
+                RefFrameState {
+                    trans: RefFrameTrans::default(),
+                    rot,
+                },
+            ))
+        } else {
+            None
+        };
+
+        self.source_frame_ids.push(SourceFrameIds {
+            inertial: inertial_id,
+            pfix: pfix_id,
+        });
+        self.gravity_data.push(GravityData {
+            source: entry.source,
+            velocity: entry.velocity,
+            delta_c20: entry.delta_c20,
+            tidal_config: entry.tidal_config,
+            rotation_model: entry.rotation_model,
+        });
         self.source_ephem_bodies.push(None);
         idx
     }
@@ -653,12 +770,86 @@ impl Simulation {
 
     /// Add a dynamic body from a [`VehicleConfig`]. Returns its index.
     ///
-    /// The config is consumed and converted into internal state. Use
+    /// The config is consumed and converted into internal state. Creates a
+    /// body frame in the frame tree under the integration frame. Use
     /// [`body`](Simulation::body) to access results after stepping.
     pub fn add_body(&mut self, config: VehicleConfig) -> usize {
         let idx = self.bodies.len();
-        self.bodies.push(SimBody::from_config(config));
+
+        // Resolve integration frame from source index.
+        let integ_frame_id = config
+            .integ_source
+            .map(|src| self.source_frame_ids[src].inertial)
+            .unwrap_or(self.root_frame_id);
+
+        // Create body frame in tree under the integration frame.
+        let body_frame_id = self.frame_tree.add_child(
+            integ_frame_id,
+            format!("body_{idx}.integ"),
+            RefFrameKind::Body,
+            RefFrameState {
+                trans: RefFrameTrans {
+                    position: config.trans.position,
+                    velocity: config.trans.velocity,
+                },
+                rot: RefFrameRot::default(),
+            },
+        );
+
+        self.bodies
+            .push(SimBody::from_config(config, integ_frame_id, body_frame_id));
         idx
+    }
+
+    /// Number of gravity sources.
+    pub fn num_sources(&self) -> usize {
+        self.gravity_data.len()
+    }
+
+    /// Get the inertial frame ID for a gravity source.
+    pub fn source_frame(&self, source_idx: usize) -> FrameId {
+        self.source_frame_ids[source_idx].inertial
+    }
+
+    /// Get the current position of a gravity source in the inertial frame.
+    pub fn source_position(&self, source_idx: usize) -> DVec3 {
+        let fid = self.source_frame_ids[source_idx].inertial;
+        if fid == self.root_frame_id {
+            DVec3::ZERO
+        } else {
+            self.frame_tree.get(fid).state.trans.position
+        }
+    }
+
+    /// Set the position of a gravity source in the inertial frame.
+    pub fn set_source_position(&mut self, source_idx: usize, position: DVec3) {
+        let fid = self.source_frame_ids[source_idx].inertial;
+        assert_ne!(
+            fid, self.root_frame_id,
+            "Cannot set position of the root (central body) source"
+        );
+        self.frame_tree.get_mut(fid).state.trans.position = position;
+    }
+
+    /// Get the planet-fixed rotation matrix for a gravity source. Returns `None`
+    /// if the source has no rotation model (no pfix frame).
+    pub fn source_pfix_rotation(&self, source_idx: usize) -> Option<DMat3> {
+        self.source_frame_ids[source_idx]
+            .pfix
+            .map(|pfix_id| self.frame_tree.get(pfix_id).state.rot.t_parent_this)
+    }
+
+    /// Get mutable access to a source's tidal configuration.
+    pub fn source_tidal_config_mut(
+        &mut self,
+        source_idx: usize,
+    ) -> Option<&mut jeod_gravity::tides::TidalConfig> {
+        self.gravity_data[source_idx].tidal_config.as_mut()
+    }
+
+    /// Get the current ΔC20 tidal correction for a gravity source.
+    pub fn source_delta_c20(&self, source_idx: usize) -> f64 {
+        self.gravity_data[source_idx].delta_c20
     }
 
     /// Validate all bodies against JEOD invariants and apply auto-corrections.
@@ -671,6 +862,7 @@ impl Simulation {
     /// and the Bevy adapter's startup validation).
     // JEOD_INV: GV.03 — check_validity() called at startup (auto-corrections applied in-place)
     pub fn validate(&mut self) -> Result<(), Vec<ValidationError>> {
+        let num_sources = self.gravity_data.len();
         let mut all_errors = Vec::new();
         for (body_idx, body) in self.bodies.iter_mut().enumerate() {
             let plate_counts = body.flat_plate_state.as_ref().map(|fps| {
@@ -687,37 +879,37 @@ impl Simulation {
                 body.mass.as_ref(),
                 body.rot.is_some(),
                 Some(&body.trans),
-                |source_id: usize| self.sources.get(source_id).map(|s| &s.source),
+                |source_id: usize| self.gravity_data.get(source_id).map(|g| &g.source),
                 plate_counts,
             );
             all_errors.extend(errors);
 
             // Validate shadow_body index
             if let Some((idx, _radius)) = body.shadow_body {
-                if idx >= self.sources.len() {
+                if idx >= num_sources {
                     all_errors.push(ValidationError::ShadowBodyOutOfRange {
                         index: idx,
-                        num_sources: self.sources.len(),
+                        num_sources,
                     });
                 }
             }
 
             // Validate geodetic_planet index
             if let Some((idx, _, _)) = body.geodetic_planet {
-                if idx >= self.sources.len() {
+                if idx >= num_sources {
                     all_errors.push(ValidationError::GeodeticPlanetOutOfRange {
                         index: idx,
-                        num_sources: self.sources.len(),
+                        num_sources,
                     });
                 }
             }
 
             // Validate orbital_elements_source index
             if let Some(idx) = body.orbital_elements_source {
-                if idx >= self.sources.len() {
+                if idx >= num_sources {
                     all_errors.push(ValidationError::OrbitalElementsSourceOutOfRange {
                         index: idx,
-                        num_sources: self.sources.len(),
+                        num_sources,
                     });
                 }
             }
@@ -770,32 +962,29 @@ impl Simulation {
                 all_errors.push(ValidationError::GravityTorqueWithoutMassOrRot { body_idx });
             }
 
-            // Frame switch central_source must be a valid source index AND
+            // Frame switch target_source must be a valid source index AND
             // present in the body's gravity controls (so the post-switch
             // differential flip actually takes effect).
             // Only validate active switches — JEOD only evaluates active switches.
             for sw in &body.frame_switches {
                 if sw.active {
-                    if let Some(central) = sw.central_source {
-                        if central >= self.sources.len() {
-                            all_errors.push(ValidationError::FrameSwitchCentralSourceOutOfRange {
-                                body_idx,
-                                central_source: central,
-                                num_sources: self.sources.len(),
-                            });
-                        } else if !body
-                            .gravity_controls
-                            .controls
-                            .iter()
-                            .any(|c| c.source_name == central)
-                        {
-                            all_errors.push(
-                                ValidationError::FrameSwitchCentralSourceNotInControls {
-                                    body_idx,
-                                    central_source: central,
-                                },
-                            );
-                        }
+                    let central = sw.target_source;
+                    if central >= num_sources {
+                        all_errors.push(ValidationError::FrameSwitchCentralSourceOutOfRange {
+                            body_idx,
+                            central_source: central,
+                            num_sources,
+                        });
+                    } else if !body
+                        .gravity_controls
+                        .controls
+                        .iter()
+                        .any(|c| c.source_name == central)
+                    {
+                        all_errors.push(ValidationError::FrameSwitchCentralSourceNotInControls {
+                            body_idx,
+                            central_source: central,
+                        });
                     }
                 }
             }
@@ -804,11 +993,11 @@ impl Simulation {
             // JEOD evaluates these derived states in Earth-centered inertial; they
             // will produce incorrect results in other frames.
             {
-                let non_eci_integ = body.integ_frame != IntegrationFrame::EarthInertial;
-                let non_eci_switch = body
-                    .frame_switches
-                    .iter()
-                    .any(|sw| sw.active && sw.target_frame != IntegrationFrame::EarthInertial);
+                let non_eci_integ = body.integ_frame_id != self.root_frame_id;
+                let non_eci_switch = body.frame_switches.iter().any(|sw| {
+                    sw.active
+                        && self.source_frame_ids[sw.target_source].inertial != self.root_frame_id
+                });
                 if non_eci_integ || non_eci_switch {
                     let has_eci_feature = body.drag.is_some()
                         || body.flat_plate_state.is_some()
@@ -830,38 +1019,38 @@ impl Simulation {
             // Apply gravity control auto-corrections (degree/order clamping).
             // JEOD_INV: GV.03 — check_validity() auto-corrects out-of-range settings
             for ctrl in &mut body.gravity_controls.controls {
-                if let Some(source_entry) = self.sources.get(ctrl.source_name) {
-                    ctrl.check_validity(&source_entry.source);
+                if let Some(grav) = self.gravity_data.get(ctrl.source_name) {
+                    ctrl.check_validity(&grav.source);
                 }
             }
         }
 
         // Validate sun_source index (simulation-level, outside body loop)
         if let Some(idx) = self.sun_source {
-            if idx >= self.sources.len() {
+            if idx >= num_sources {
                 all_errors.push(ValidationError::SunSourceOutOfRange {
                     index: idx,
-                    num_sources: self.sources.len(),
+                    num_sources,
                 });
             }
         }
 
         // Validate moon_source index
         if let Some(idx) = self.moon_source {
-            if idx >= self.sources.len() {
+            if idx >= num_sources {
                 all_errors.push(ValidationError::MoonSourceOutOfRange {
                     index: idx,
-                    num_sources: self.sources.len(),
+                    num_sources,
                 });
             }
         }
 
         // Validate atmosphere_planet_source index
         if let Some(idx) = self.atmosphere_planet_source {
-            if idx >= self.sources.len() {
+            if idx >= num_sources {
                 all_errors.push(ValidationError::AtmospherePlanetOutOfRange {
                     index: idx,
-                    num_sources: self.sources.len(),
+                    num_sources,
                 });
             }
         }
@@ -916,50 +1105,27 @@ impl Simulation {
     ///
     /// Runs the full JEOD pipeline in order:
     /// 1. Time update
-    /// 2. Ephemeris update (planet-fixed rotations)
+    /// 2. Ephemeris update (planet-fixed rotations + frame tree sync)
     /// 3. Mass update (recompute derived quantities)
     /// 4. Gravity computation
     /// 5. Atmosphere evaluation
     /// 6. Interaction computation (drag, SRP, gravity torque)
     /// 7. Force collection and frame derivative computation
-    /// 8. State integration (RK4)
+    /// 8. State integration (RK4, with sub-stage tree updates)
     /// 9. Derived state computation
     pub fn step(&mut self) {
         self.step_internal(self.dt);
     }
 
-    /// Resolve the origin position and velocity of an integration frame
-    /// in canonical (Earth-centered inertial) coordinates.
-    pub fn resolve_frame_origin(&self, frame: IntegrationFrame) -> (DVec3, DVec3) {
-        match frame {
-            IntegrationFrame::EarthInertial => (DVec3::ZERO, DVec3::ZERO),
-            IntegrationFrame::MoonInertial => {
-                if let Some(ref eph) = self.ephemeris {
-                    let tdb_jd = self.time.tdb_julian_date();
-                    eph.get_state(
-                        jeod_sim::EphemerisBody::Moon,
-                        jeod_sim::EphemerisBody::Earth,
-                        tdb_jd,
-                    )
-                    .expect("Moon ephemeris lookup failed for frame switch")
-                } else {
-                    panic!("MoonInertial frame requires ephemeris");
-                }
-            }
-            IntegrationFrame::SunInertial => {
-                if let Some(ref eph) = self.ephemeris {
-                    let tdb_jd = self.time.tdb_julian_date();
-                    eph.get_state(
-                        jeod_sim::EphemerisBody::Sun,
-                        jeod_sim::EphemerisBody::Earth,
-                        tdb_jd,
-                    )
-                    .expect("Sun ephemeris lookup failed for frame switch")
-                } else {
-                    panic!("SunInertial frame requires ephemeris");
-                }
-            }
+    /// Get the position and velocity of a frame relative to the root (ECI).
+    pub fn frame_origin(&self, frame_id: FrameId) -> (DVec3, DVec3) {
+        if frame_id == self.root_frame_id {
+            return (DVec3::ZERO, DVec3::ZERO);
         }
+        let state = self
+            .frame_tree
+            .compute_relative_state(self.root_frame_id, frame_id);
+        (state.trans.position, state.trans.velocity)
     }
 
     /// Internal step with explicit dt (avoids temporary mutation of `self.dt`
@@ -968,13 +1134,13 @@ impl Simulation {
         // ── 1. Time update ──
         self.time.advance(dt);
 
-        // ── 2. Ephemeris update — planet-fixed rotations ──
+        // ── 2. Ephemeris update — planet-fixed rotations + frame tree sync ──
         // JEOD_INV: DM.13 — ephemeris updated before gravity
         // Per-source rotation dispatch: each source has its own rotation model.
         // Lazy-compute Earth RNP only if needed (most common case).
         let mut earth_rotation: Option<DMat3> = Option::None;
-        for source in &mut self.sources {
-            match source.rotation_model {
+        for (i, grav) in self.gravity_data.iter_mut().enumerate() {
+            match grav.rotation_model {
                 RotationModel::None => {}
                 RotationModel::EarthRNP => {
                     let rotation = *earth_rotation.get_or_insert_with(|| {
@@ -984,7 +1150,13 @@ impl Simulation {
                             self.polar_motion,
                         )
                     });
-                    source.t_inertial_pfix = Some(rotation);
+                    // Sync to frame tree pfix node.
+                    if let Some(pfix_id) = self.source_frame_ids[i].pfix {
+                        let node = self.frame_tree.get_mut(pfix_id);
+                        node.state.rot.t_parent_this = rotation;
+                        node.state.rot.q_parent_this =
+                            JeodQuat::left_quat_from_transformation(&rotation);
+                    }
                 }
                 RotationModel::MarsIAU => {
                     // JEOD's RNPMars receives TT seconds since J2000 (time_tt.seconds).
@@ -992,7 +1164,12 @@ impl Simulation {
                         * jeod_time::epoch::SECONDS_PER_DAY;
                     let rotation =
                         jeod_frames::rotation_mars::compute_mars_rotation(tt_s_since_j2000);
-                    source.t_inertial_pfix = Some(rotation);
+                    if let Some(pfix_id) = self.source_frame_ids[i].pfix {
+                        let node = self.frame_tree.get_mut(pfix_id);
+                        node.state.rot.t_parent_this = rotation;
+                        node.state.rot.q_parent_this =
+                            JeodQuat::left_quat_from_transformation(&rotation);
+                    }
                 }
                 RotationModel::MoonIAU => {
                     let tdb_jd = self.time.tdb_julian_date();
@@ -1000,7 +1177,12 @@ impl Simulation {
                         * jeod_time::epoch::SECONDS_PER_DAY;
                     let rotation =
                         jeod_frames::rotation_moon::compute_moon_rotation(tdb_s_since_j2000);
-                    source.t_inertial_pfix = Some(rotation);
+                    if let Some(pfix_id) = self.source_frame_ids[i].pfix {
+                        let node = self.frame_tree.get_mut(pfix_id);
+                        node.state.rot.t_parent_this = rotation;
+                        node.state.rot.q_parent_this =
+                            JeodQuat::left_quat_from_transformation(&rotation);
+                    }
                 }
                 RotationModel::MoonDE421 => {
                     let eph = self.ephemeris.as_ref().expect(
@@ -1011,27 +1193,31 @@ impl Simulation {
                     let rotation = eph
                         .get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd)
                         .expect("Moon DE421 BPC rotation query failed");
-                    source.t_inertial_pfix = Some(rotation);
+                    if let Some(pfix_id) = self.source_frame_ids[i].pfix {
+                        let node = self.frame_tree.get_mut(pfix_id);
+                        node.state.rot.t_parent_this = rotation;
+                        node.state.rot.q_parent_this =
+                            JeodQuat::left_quat_from_transformation(&rotation);
+                    }
                 }
             }
             // Compute tidal ΔC20 if configured; otherwise clear any stale value.
-            // Uses whatever rotation is current (Earth RNP for Earth sources).
-            if let Some(ref config) = source.tidal_config {
-                let rotation = source.t_inertial_pfix.expect(
-                    "tidal_config requires t_inertial_pfix (planet-fixed rotation). \
-                     Set a rotation_model or provide an initial t_inertial_pfix.",
-                );
-                source.delta_c20 = jeod_gravity::tides::compute_delta_c20(config, &rotation);
+            if let Some(ref config) = grav.tidal_config {
+                let pfix_id = self.source_frame_ids[i]
+                    .pfix
+                    .expect("tidal_config requires a planet-fixed frame (rotation_model != None).");
+                let rotation = self.frame_tree.get(pfix_id).state.rot.t_parent_this;
+                grav.delta_c20 = jeod_gravity::tides::compute_delta_c20(config, &rotation);
             } else {
-                source.delta_c20 = 0.0;
+                grav.delta_c20 = 0.0;
             }
         }
 
         // ── 2b. Ephemeris update — source positions from DE4xx ──
-        // Update source positions from ephemeris each step (for 3rd-body accuracy).
+        // Update source positions from ephemeris each step and sync to frame tree.
         if let Some(ref eph) = self.ephemeris {
             let tdb_jd = self.time.tdb_julian_date();
-            for (i, source) in self.sources.iter_mut().enumerate() {
+            for i in 0..self.source_ephem_bodies.len() {
                 if let Some(Some((target, observer))) = self.source_ephem_bodies.get(i) {
                     let (pos, vel) =
                         eph.get_state(*target, *observer, tdb_jd)
@@ -1041,8 +1227,13 @@ impl Simulation {
                                  ({target:?} wrt {observer:?}) at TDB JD {tdb_jd}: {e}"
                                 )
                             });
-                    source.position = pos;
-                    source.velocity = vel;
+                    // Update frame tree node with ephemeris position/velocity.
+                    let fid = self.source_frame_ids[i].inertial;
+                    let node = self.frame_tree.get_mut(fid);
+                    node.state.trans.position = pos;
+                    node.state.trans.velocity = vel;
+                    // Also update gravity_data velocity for relativistic corrections.
+                    self.gravity_data[i].velocity = vel;
                 }
             }
         }
@@ -1054,73 +1245,47 @@ impl Simulation {
             }
         }
 
-        // Precompute frame origins only for frames actually in use.
-        // Avoids unnecessary ephemeris lookups and panics early if ephemeris
-        // is absent but a non-Earth frame is needed.
-        let (needs_moon, needs_sun) =
-            self.bodies
-                .iter()
-                .fold((false, false), |(moon, sun), body| {
-                    let (m, s) = match body.integ_frame {
-                        IntegrationFrame::MoonInertial => (true, sun),
-                        IntegrationFrame::SunInertial => (moon, true),
-                        IntegrationFrame::EarthInertial => (moon, sun),
-                    };
-                    body.frame_switches
-                        .iter()
-                        .filter(|sw| sw.active)
-                        .fold((m, s), |(m, s), sw| match sw.target_frame {
-                            IntegrationFrame::MoonInertial => (true, s),
-                            IntegrationFrame::SunInertial => (m, true),
-                            IntegrationFrame::EarthInertial => (m, s),
-                        })
-                });
-
-        let earth_origin = (DVec3::ZERO, DVec3::ZERO);
-        let moon_origin = if needs_moon {
-            if self.ephemeris.is_some() {
-                self.resolve_frame_origin(IntegrationFrame::MoonInertial)
-            } else {
-                panic!("MoonInertial frame requires ephemeris. Set sim.ephemeris = Some(...).")
-            }
-        } else {
-            (DVec3::ZERO, DVec3::ZERO)
-        };
-        let sun_origin = if needs_sun {
-            if self.ephemeris.is_some() {
-                self.resolve_frame_origin(IntegrationFrame::SunInertial)
-            } else {
-                panic!("SunInertial frame requires ephemeris. Set sim.ephemeris = Some(...).")
-            }
-        } else {
-            (DVec3::ZERO, DVec3::ZERO)
-        };
-        let resolve = |frame: IntegrationFrame| -> (DVec3, DVec3) {
-            match frame {
-                IntegrationFrame::EarthInertial => earth_origin,
-                IntegrationFrame::MoonInertial => moon_origin,
-                IntegrationFrame::SunInertial => sun_origin,
-            }
-        };
+        // Precompute frame origins from the tree for all body integration frames.
+        let body_integ_origins: Vec<(DVec3, DVec3)> = self
+            .bodies
+            .iter()
+            .map(|b| self.frame_origin(b.integ_frame_id))
+            .collect();
 
         // ── 4. Environment — gravity ──
-        // Split borrows: sources (immutable) vs bodies (mutable)
-        let sources = &self.sources;
-        for body in &mut self.bodies {
-            let integ_origin = resolve(body.integ_frame).0;
+        // Helper: resolve source to gravity data via frame tree.
+        let gravity_data = &self.gravity_data;
+        let source_frame_ids = &self.source_frame_ids;
+        let frame_tree = &self.frame_tree;
+        let root_fid = self.root_frame_id;
+        let resolve_source = |source_id: usize| -> Option<jeod_sim::ResolvedSource<'_>> {
+            let grav = gravity_data.get(source_id)?;
+            let sfids = &source_frame_ids[source_id];
+            let src_node = frame_tree.get(sfids.inertial);
+            let position = if sfids.inertial == root_fid {
+                DVec3::ZERO
+            } else {
+                src_node.state.trans.position
+            };
+            let rotation = sfids
+                .pfix
+                .map(|pfix_id| &frame_tree.get(pfix_id).state.rot.t_parent_this);
+            Some(jeod_sim::ResolvedSource {
+                source: &grav.source,
+                rotation,
+                position,
+                delta_c20: grav.delta_c20,
+                has_delta_coeffs: grav.tidal_config.is_some(),
+            })
+        };
+
+        for (body_idx, body) in self.bodies.iter_mut().enumerate() {
+            let integ_origin = body_integ_origins[body_idx].0;
             body.gravity_accel = accumulate_gravity(
                 body.trans.position + integ_origin,
                 &body.gravity_controls,
                 integ_origin,
-                |source_id: usize| {
-                    sources.get(source_id).map(|s| jeod_sim::ResolvedSource {
-                        source: &s.source,
-                        rotation: s.t_inertial_pfix.as_ref(),
-                        position: s.position,
-                        delta_c20: s.delta_c20,
-                        has_delta_coeffs: s.tidal_config.is_some(),
-                    })
-                },
+                resolve_source,
             );
         }
 
@@ -1128,21 +1293,32 @@ impl Simulation {
         // After Newtonian gravity, apply post-Newtonian PPN correction for
         // any source with `relativistic: true`. Folkner eq 27 (β=γ=1).
         // PPN uses inertial coordinates — convert from integration frame.
-        for body in &mut self.bodies {
-            let (origin, origin_vel) = resolve(body.integ_frame);
+        let resolve_rel_source =
+            |source_id: usize| -> Option<jeod_sim::ResolvedRelativisticSource> {
+                let grav = gravity_data.get(source_id)?;
+                let sfids = &source_frame_ids[source_id];
+                let position = if sfids.inertial == root_fid {
+                    DVec3::ZERO
+                } else {
+                    frame_tree.get(sfids.inertial).state.trans.position
+                };
+                Some(jeod_sim::ResolvedRelativisticSource {
+                    mu: grav.source.mu,
+                    position,
+                    // Use velocity from gravity_data, not the tree node, because
+                    // central bodies at the root frame have zero tree velocity
+                    // but may have physical velocity for relativistic corrections.
+                    velocity: grav.velocity,
+                })
+            };
+
+        for (body_idx, body) in self.bodies.iter_mut().enumerate() {
+            let (origin, origin_vel) = body_integ_origins[body_idx];
             body.gravity_accel.grav_accel += jeod_sim::accumulate_relativistic_corrections(
                 body.trans.position + origin,
                 body.trans.velocity + origin_vel,
                 &body.gravity_controls,
-                |source_id: usize| {
-                    sources
-                        .get(source_id)
-                        .map(|s| jeod_sim::ResolvedRelativisticSource {
-                            mu: s.source.mu,
-                            position: s.position,
-                            velocity: s.velocity,
-                        })
-                },
+                resolve_rel_source,
             );
         }
 
@@ -1150,8 +1326,9 @@ impl Simulation {
         if let Some(ref atmos_config) = self.atmosphere {
             let t_pfix = self
                 .atmosphere_planet_source
-                .and_then(|idx| self.sources.get(idx))
-                .and_then(|s| s.t_inertial_pfix.as_ref());
+                .and_then(|idx| self.source_frame_ids.get(idx))
+                .and_then(|sfids| sfids.pfix)
+                .map(|pfix_id| &self.frame_tree.get(pfix_id).state.rot.t_parent_this);
             let tai_tjt = Some(self.time.tai_tjt);
 
             for body in &mut self.bodies {
@@ -1168,13 +1345,25 @@ impl Simulation {
 
         // ── 6. Interactions — drag, SRP, gravity torque ──
         // sun_pos is also used in stage 9 (solar beta, earth lighting); compute once here.
-        let sun_pos = self
-            .sun_source
-            .and_then(|idx| self.sources.get(idx).map(|s| s.position));
-        let moon_pos = self
-            .moon_source
-            .and_then(|idx| self.sources.get(idx).map(|s| s.position));
-        let sources = &self.sources;
+        let sun_pos = self.sun_source.map(|idx| {
+            let fid = self.source_frame_ids[idx].inertial;
+            if fid == self.root_frame_id {
+                DVec3::ZERO
+            } else {
+                self.frame_tree.get(fid).state.trans.position
+            }
+        });
+        let moon_pos = self.moon_source.map(|idx| {
+            let fid = self.source_frame_ids[idx].inertial;
+            if fid == self.root_frame_id {
+                DVec3::ZERO
+            } else {
+                self.frame_tree.get(fid).state.trans.position
+            }
+        });
+        let source_frame_ids = &self.source_frame_ids;
+        let frame_tree = &self.frame_tree;
+        let root_fid = self.root_frame_id;
 
         for body in &mut self.bodies {
             // Compute structural transform once (shared by drag and flat-plate SRP)
@@ -1216,7 +1405,14 @@ impl Simulation {
                                 jeod_sim::compute_shadow_fraction(
                                     body.trans.position,
                                     sun_position,
-                                    sources[idx].position,
+                                    {
+                                        let fid = source_frame_ids[idx].inertial;
+                                        if fid == root_fid {
+                                            DVec3::ZERO
+                                        } else {
+                                            frame_tree.get(fid).state.trans.position
+                                        }
+                                    },
                                     radius,
                                     jeod_sim::SOLAR_RADIUS,
                                 )
@@ -1253,7 +1449,14 @@ impl Simulation {
                             jeod_sim::compute_shadow_fraction(
                                 body.trans.position,
                                 sun_position,
-                                sources[idx].position,
+                                {
+                                    let fid = source_frame_ids[idx].inertial;
+                                    if fid == root_fid {
+                                        DVec3::ZERO
+                                    } else {
+                                        frame_tree.get(fid).state.trans.position
+                                    }
+                                },
                                 radius,
                                 jeod_sim::SOLAR_RADIUS,
                             )
@@ -1326,16 +1529,42 @@ impl Simulation {
         // DynamicsIntegrationGroup where the derivative function calls gravity
         // at every stage with the current intermediate position and velocity.
         //
-        // Precompute per-body integration frame origins and velocities.
-        // For non-ECI bodies, the origin velocity is used to linearly
-        // interpolate the frame origin at each RK4 sub-stage, matching
-        // JEOD's behavior of updating the reference frame tree at each
-        // derivative evaluation (even with deriv_ephem_update=false).
-        let body_integ_data: Vec<(DVec3, DVec3)> =
-            self.bodies.iter().map(|b| resolve(b.integ_frame)).collect();
-        let sources = &self.sources;
+        // Frame tree sub-stage updates: source positions are linearly
+        // interpolated at each RK4 sub-stage via velocity * (time_frac * dt),
+        // matching JEOD's behavior of updating the reference frame tree at
+        // each derivative evaluation.
+        //
+        // Snapshot base positions for sub-stage interpolation (restored after integration).
+        let base_positions: Vec<DVec3> = self
+            .source_frame_ids
+            .iter()
+            .map(|sfids| {
+                if sfids.inertial == self.root_frame_id {
+                    DVec3::ZERO
+                } else {
+                    self.frame_tree.get(sfids.inertial).state.trans.position
+                }
+            })
+            .collect();
+        let base_velocities: Vec<DVec3> = self
+            .source_frame_ids
+            .iter()
+            .map(|sfids| {
+                if sfids.inertial == self.root_frame_id {
+                    DVec3::ZERO
+                } else {
+                    self.frame_tree.get(sfids.inertial).state.trans.velocity
+                }
+            })
+            .collect();
+
+        let gravity_data = &self.gravity_data;
+        let source_frame_ids = &self.source_frame_ids;
+        let frame_tree = &self.frame_tree;
+        let root_fid = self.root_frame_id;
+
         for (body_idx, body) in self.bodies.iter_mut().enumerate() {
-            let (integ_origin, integ_vel) = body_integ_data[body_idx];
+            let (integ_origin, integ_vel) = body_integ_origins[body_idx];
             let controls = &body.gravity_controls;
 
             // Precompute relativistic "other source" lists outside the closure
@@ -1349,21 +1578,33 @@ impl Simulation {
                 .iter()
                 .filter(|c| c.relativistic)
                 .filter_map(|ctrl| {
-                    let src = sources.get(ctrl.source_name)?;
+                    let grav = gravity_data.get(ctrl.source_name)?;
+                    let sfids = &source_frame_ids[ctrl.source_name];
+                    let src_pos = if sfids.inertial == root_fid {
+                        DVec3::ZERO
+                    } else {
+                        frame_tree.get(sfids.inertial).state.trans.position
+                    };
+                    let src_vel = grav.velocity;
                     let other: Vec<_> = controls
                         .controls
                         .iter()
                         .filter(|c| c.source_name != ctrl.source_name)
                         .filter_map(|c| {
-                            sources.get(c.source_name).map(|s| {
-                                jeod_gravity::relativistic::RelativisticSource {
-                                    mu: s.source.mu,
-                                    position: s.position,
-                                }
+                            let g = gravity_data.get(c.source_name)?;
+                            let sf = &source_frame_ids[c.source_name];
+                            let pos = if sf.inertial == root_fid {
+                                DVec3::ZERO
+                            } else {
+                                frame_tree.get(sf.inertial).state.trans.position
+                            };
+                            Some(jeod_gravity::relativistic::RelativisticSource {
+                                mu: g.source.mu,
+                                position: pos,
                             })
                         })
                         .collect();
-                    Some((src.source.mu, src.position, src.velocity, other))
+                    Some((grav.source.mu, src_pos, src_vel, other))
                 })
                 .collect();
 
@@ -1373,28 +1614,32 @@ impl Simulation {
                 body.rot.as_mut(),
                 body.mass.as_ref(),
                 |pos, vel, time_frac| {
-                    // For non-ECI frames, linearly interpolate the frame origin
-                    // at the current integrator sub-stage time. This matches JEOD's
-                    // behavior of updating its reference frame tree at each
-                    // derivative evaluation.
+                    // Sub-stage interpolation: linearly interpolate source positions
+                    // at the sub-stage time fraction, matching JEOD's continuous
+                    // frame tree updates at each derivative evaluation.
                     let origin = integ_origin + integ_vel * (time_frac * dt);
-                    // Interpolate source positions at the sub-stage time,
-                    // matching JEOD's continuous frame tree updates.
-                    // Only for non-ECI frames; ECI with deriv_ephem_update=false
-                    // freezes source positions per step (matching JEOD).
+                    // Only interpolate for non-ECI frames; ECI with
+                    // deriv_ephem_update=false freezes positions per step.
                     let sub_dt = if integ_vel != DVec3::ZERO {
                         time_frac * dt
                     } else {
                         0.0
                     };
                     let mut accel =
-                        accumulate_gravity(pos + origin, controls, origin, |source_id| {
-                            sources.get(source_id).map(|s| jeod_sim::ResolvedSource {
-                                source: &s.source,
-                                rotation: s.t_inertial_pfix.as_ref(),
-                                position: s.position + s.velocity * sub_dt,
-                                delta_c20: s.delta_c20,
-                                has_delta_coeffs: s.tidal_config.is_some(),
+                        accumulate_gravity(pos + origin, controls, origin, |source_id: usize| {
+                            let grav = gravity_data.get(source_id)?;
+                            let sfids = &source_frame_ids[source_id];
+                            let position =
+                                base_positions[source_id] + base_velocities[source_id] * sub_dt;
+                            let rotation = sfids
+                                .pfix
+                                .map(|pfix_id| &frame_tree.get(pfix_id).state.rot.t_parent_this);
+                            Some(jeod_sim::ResolvedSource {
+                                source: &grav.source,
+                                rotation,
+                                position,
+                                delta_c20: grav.delta_c20,
+                                has_delta_coeffs: grav.tidal_config.is_some(),
                             })
                         })
                         .grav_accel;
@@ -1418,23 +1663,33 @@ impl Simulation {
             );
         }
 
+        // Sync body positions back to frame tree after integration.
+        for body in &self.bodies {
+            let node = self.frame_tree.get_mut(body.body_frame_id);
+            node.state.trans.position = body.trans.position;
+            node.state.trans.velocity = body.trans.velocity;
+        }
+
         // ── 8b. Frame switch (body actions) ──
         // Applied AFTER integration, matching JEOD's pipeline where
         // DynBodyFrameSwitch is a body action evaluated post-integration.
         // The body has already been integrated in its current frame for this
         // step; the switch transforms to the new frame for the NEXT step.
-        for body in &mut self.bodies {
-            if body.frame_switches.is_empty() {
+        // Uses frame tree reparenting for structural correctness.
+        // Use index-based loop to avoid borrow conflict with self.frame_tree.
+        for body_idx in 0..self.bodies.len() {
+            if self.bodies[body_idx].frame_switches.is_empty() {
                 continue;
             }
             let mut switch_idx = None;
-            for (idx, sw) in body.frame_switches.iter().enumerate() {
+            for (idx, sw) in self.bodies[body_idx].frame_switches.iter().enumerate() {
                 if !sw.active {
                     continue;
                 }
-                let (target_origin, _) = resolve(sw.target_frame);
-                let (current_origin, _) = resolve(body.integ_frame);
-                let body_pos_eci = body.trans.position + current_origin;
+                let target_fid = self.source_frame_ids[sw.target_source].inertial;
+                let (target_origin, _) = self.frame_origin(target_fid);
+                let (current_origin, _) = self.frame_origin(self.bodies[body_idx].integ_frame_id);
+                let body_pos_eci = self.bodies[body_idx].trans.position + current_origin;
                 let threshold_sq = sw.switch_distance * sw.switch_distance;
 
                 // JEOD dyn_body_frame_switch.cc:173-182:
@@ -1444,7 +1699,9 @@ impl Simulation {
                     SwitchSense::OnApproach => {
                         (body_pos_eci - target_origin).length_squared() < threshold_sq
                     }
-                    SwitchSense::OnDeparture => body.trans.position.length_squared() > threshold_sq,
+                    SwitchSense::OnDeparture => {
+                        self.bodies[body_idx].trans.position.length_squared() > threshold_sq
+                    }
                 };
                 if triggered {
                     switch_idx = Some(idx);
@@ -1452,38 +1709,34 @@ impl Simulation {
                 }
             }
             if let Some(idx) = switch_idx {
-                let target_frame = body.frame_switches[idx].target_frame;
-                let central_source = body.frame_switches[idx].central_source;
-                body.frame_switches[idx].active = false;
+                let target_source = self.bodies[body_idx].frame_switches[idx].target_source;
+                self.bodies[body_idx].frame_switches[idx].active = false;
 
-                let (old_origin, old_vel) = resolve(body.integ_frame);
-                let (new_origin, new_vel) = resolve(target_frame);
-                body.trans.position = body.trans.position + old_origin - new_origin;
-                body.trans.velocity = body.trans.velocity + old_vel - new_vel;
-                body.integ_frame = target_frame;
+                let new_integ_fid = self.source_frame_ids[target_source].inertial;
+                let body_fid = self.bodies[body_idx].body_frame_id;
 
-                if let Some(central) = central_source {
-                    for ctrl in &mut body.gravity_controls.controls {
-                        ctrl.differential = ctrl.source_name != central;
-                    }
+                // Reparent body frame in tree (preserves absolute state).
+                self.frame_tree.reparent(body_fid, new_integ_fid);
+                let new_state = self.frame_tree.get(body_fid).state;
+                self.bodies[body_idx].trans.position = new_state.trans.position;
+                self.bodies[body_idx].trans.velocity = new_state.trans.velocity;
+                self.bodies[body_idx].integ_frame_id = new_integ_fid;
+
+                // Flip gravity controls: target source becomes non-differential
+                // (central body), all others become differential.
+                for ctrl in &mut self.bodies[body_idx].gravity_controls.controls {
+                    ctrl.differential = ctrl.source_name != target_source;
                 }
             }
         }
 
         // ── 9. Derived states ──
-        // NOTE: Derived states, atmosphere evaluation, SRP/shadow geometry, solar
-        // beta, and earth lighting all assume body.trans.position is in ECI.
-        // When integ_frame != EarthInertial, these results will be incorrect.
-        // Currently frame switching is only supported for gravity + integration;
-        // non-Earth frames disable these other pipeline stages in practice
-        // (no existing test configures both frame switching and interactions).
-        // A proper fix requires converting to ECI at each call site (#67).
-        let sources = &self.sources;
+        let gravity_data = &self.gravity_data;
 
         for body in &mut self.bodies {
             // Orbital elements
             if let Some(src_idx) = body.orbital_elements_source {
-                if let Some(mu) = sources.get(src_idx).map(|s| s.source.mu) {
+                if let Some(mu) = gravity_data.get(src_idx).map(|g| g.source.mu) {
                     body.orbital_elements = jeod_sim::compute_orbital_elements(
                         mu,
                         body.trans.position,
@@ -1514,17 +1767,18 @@ impl Simulation {
 
             // Geodetic state
             if let Some((src_idx, r_eq, r_pol)) = body.geodetic_planet {
-                if let Some(src) = sources.get(src_idx) {
-                    if let Some(t_pfix) = src.t_inertial_pfix.as_ref() {
-                        body.geodetic_state = Some(jeod_sim::compute_body_geodetic(
-                            body.trans.position,
-                            t_pfix,
-                            r_eq,
-                            r_pol,
-                        ));
-                    } else {
-                        body.geodetic_state = None;
-                    }
+                let pfix_rot = self
+                    .source_frame_ids
+                    .get(src_idx)
+                    .and_then(|sfids| sfids.pfix)
+                    .map(|pfix_id| self.frame_tree.get(pfix_id).state.rot.t_parent_this);
+                if let Some(t_pfix) = pfix_rot {
+                    body.geodetic_state = Some(jeod_sim::compute_body_geodetic(
+                        body.trans.position,
+                        &t_pfix,
+                        r_eq,
+                        r_pol,
+                    ));
                 } else {
                     body.geodetic_state = None;
                 }

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -58,6 +58,7 @@ fn pipeline_earth_lighting_smoke() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -80,6 +81,7 @@ fn pipeline_earth_lighting_smoke() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );
@@ -103,6 +105,7 @@ fn pipeline_earth_lighting_smoke() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -45,36 +45,44 @@ fn pipeline_earth_lighting_smoke() {
     let mut sim = Simulation::new(time, 60.0);
 
     // Earth
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Sun from DE421
     let j2000_jd = 2_451_545.0;
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, j2000_jd)
         .expect("Sun position at J2000");
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun);
 
@@ -82,18 +90,22 @@ fn pipeline_earth_lighting_smoke() {
     let (initial_moon, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Moon, j2000_jd)
         .expect("Moon position at J2000");
-    let moon = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_moon,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_moon,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.set_source_ephemeris(moon, EphemerisBody::Moon, EphemerisBody::Earth);
     sim.moon_source = Some(moon);
     sim.ephemeris = Some(ephemeris);

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -100,17 +100,16 @@ fn build_apollo8_sim(frame_switches: Vec<FrameSwitchConfig>) -> (Simulation, usi
         jeod_sim::EphemerisBody::Earth,
     );
 
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
 
     let moon = sim.add_source(
         "Moon",

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -14,9 +14,7 @@
 
 use glam::{DMat3, DQuat, DVec3};
 use jeod_math::JeodQuat;
-use jeod_runner::{
-    FrameSwitchConfig, GravitySourceEntry, IntegrationFrame, Simulation, SwitchSense, VehicleConfig,
-};
+use jeod_runner::{FrameSwitchConfig, GravitySourceEntry, Simulation, SwitchSense, VehicleConfig};
 use jeod_sim::{
     GravityControl, GravityControls, GravityModel, GravitySource, MassProperties, RotationalState,
     SimulationTime,
@@ -85,37 +83,46 @@ fn build_apollo8_sim(frame_switches: Vec<FrameSwitchConfig>) -> (Simulation, usi
     sim.ephemeris = Some(ephemeris);
 
     // Gravity sources: Sun, Earth, Moon (all spherical, matching JEOD config)
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_SUN,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(
         sun,
         jeod_sim::EphemerisBody::Sun,
         jeod_sim::EphemerisBody::Earth,
     );
 
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
-    let moon = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_MOON,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_MOON,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(
         moon,
         jeod_sim::EphemerisBody::Moon,
@@ -153,7 +160,7 @@ fn build_apollo8_sim(frame_switches: Vec<FrameSwitchConfig>) -> (Simulation, usi
                 GravityControl::new_third_body(moon),
             ],
         },
-        integ_frame: IntegrationFrame::EarthInertial,
+        integ_source: None,
         frame_switches,
         ..Default::default()
     });
@@ -291,11 +298,10 @@ fn tier3_apollo8_eci_integ() {
 #[test]
 fn tier3_apollo8_frame_switch() {
     let (mut sim, body_idx) = build_apollo8_sim(vec![FrameSwitchConfig {
-        target_frame: IntegrationFrame::MoonInertial,
+        target_source: 2, // moon source index
         switch_sense: SwitchSense::OnApproach,
         switch_distance: SWITCH_DISTANCE,
         active: true,
-        central_source: Some(2),
     }]);
 
     let ref_positions = load_reference_positions("apollo8_frame_switch_V_1_State.csv");
@@ -312,7 +318,7 @@ fn tier3_apollo8_frame_switch() {
         }
         let our_pos = sim.body(body_idx).trans.position;
         let err = (our_pos - ref_positions[ref_idx]).length();
-        if sim.body(body_idx).integ_frame == IntegrationFrame::EarthInertial {
+        if sim.body(body_idx).integ_frame_id == sim.root_frame_id {
             max_err_eci = max_err_eci.max(err);
         } else {
             max_err_moon = max_err_moon.max(err);

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -58,8 +58,11 @@ fn test_data_dir() -> std::path::PathBuf {
 
 /// Build a Simulation configured for the Apollo 8 scenario.
 ///
-/// Returns (sim, body_index).
-fn build_apollo8_sim(frame_switches: Vec<FrameSwitchConfig>) -> (Simulation, usize) {
+/// Returns (sim, body_index, moon_source_index).
+///
+/// If `enable_frame_switch` is true, a distance-based frame switch to the
+/// Moon's inertial frame is configured.
+fn build_apollo8_sim(enable_frame_switch: bool) -> (Simulation, usize, usize) {
     let data_dir = test_data_dir();
     let bsp_path = data_dir.join("de405.bsp");
     assert!(
@@ -160,13 +163,22 @@ fn build_apollo8_sim(frame_switches: Vec<FrameSwitchConfig>) -> (Simulation, usi
             ],
         },
         integ_source: None,
-        frame_switches,
+        frame_switches: if enable_frame_switch {
+            vec![FrameSwitchConfig {
+                target_source: moon,
+                switch_sense: SwitchSense::OnApproach,
+                switch_distance: SWITCH_DISTANCE,
+                active: true,
+            }]
+        } else {
+            vec![]
+        },
         ..Default::default()
     });
 
     sim.validate().expect("validation failed");
 
-    (sim, body)
+    (sim, body, moon)
 }
 
 /// Load reference CSV and return position vectors at each timestep.
@@ -247,7 +259,7 @@ fn load_reference_sixdof(filename: &str) -> Vec<RefState> {
 
 #[test]
 fn tier3_apollo8_eci_integ() {
-    let (mut sim, body_idx) = build_apollo8_sim(vec![]);
+    let (mut sim, body_idx, _moon) = build_apollo8_sim(false);
 
     let ref_states = load_reference_sixdof("apollo8_eci_sixdof_state.csv");
 
@@ -296,12 +308,7 @@ fn tier3_apollo8_eci_integ() {
 /// Moon-centered after.
 #[test]
 fn tier3_apollo8_frame_switch() {
-    let (mut sim, body_idx) = build_apollo8_sim(vec![FrameSwitchConfig {
-        target_source: 2, // moon source index
-        switch_sense: SwitchSense::OnApproach,
-        switch_distance: SWITCH_DISTANCE,
-        active: true,
-    }]);
+    let (mut sim, body_idx, _moon) = build_apollo8_sim(true);
 
     let ref_positions = load_reference_positions("apollo8_frame_switch_V_1_State.csv");
 

--- a/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
@@ -94,6 +94,7 @@ fn tier3_simulation_drag_run6b_rotated() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
@@ -81,18 +81,22 @@ fn tier3_simulation_drag_run6b_rotated() {
     time.set_ut1_tai_offset(ut1_tai_offset);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),

--- a/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
@@ -90,6 +90,7 @@ fn tier3_simulation_drag_run6b() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
@@ -77,18 +77,22 @@ fn tier3_simulation_drag_run6b() {
     time.set_ut1_tai_offset(ut1_tai_offset);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run10.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run10.rs
@@ -90,18 +90,22 @@ fn tier3_simulation_run10a_gravity_torque() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {
@@ -387,18 +391,22 @@ fn tier3_simulation_run10c_gravity_torque_elliptical() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {
@@ -542,18 +550,22 @@ fn tier3_simulation_run10d_gravity_torque_elliptical_rate() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run10.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run10.rs
@@ -103,6 +103,7 @@ fn tier3_simulation_run10a_gravity_torque() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -404,6 +405,7 @@ fn tier3_simulation_run10c_gravity_torque_elliptical() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -563,6 +565,7 @@ fn tier3_simulation_run10d_gravity_torque_elliptical_rate() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run2.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run2.rs
@@ -69,6 +69,7 @@ fn tier3_simulation_run2_3dof() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -213,6 +214,7 @@ fn tier3_simulation_run2_6dof() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run2.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run2.rs
@@ -56,18 +56,22 @@ fn tier3_simulation_run2_3dof() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {
@@ -196,18 +200,22 @@ fn tier3_simulation_run2_6dof() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run3.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run3.rs
@@ -99,6 +99,7 @@ fn run_sh_simulation_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: OMEGA_EARTH,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run3.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run3.rs
@@ -89,15 +89,19 @@ fn run_sh_simulation_test(
 
     // Earth source with planet-fixed rotation (Simulation updates it each step).
     // Initialize with identity — first step() will compute the real rotation.
-    let earth = sim.add_source(GravitySourceEntry {
-        source: sh_source,
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY), // presence triggers ephemeris update
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: sh_source,
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY), // presence triggers ephemeris update
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
@@ -122,6 +122,7 @@ fn tier3_simulation_run4_3rd_body() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -142,6 +143,7 @@ fn tier3_simulation_run4_3rd_body() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );
@@ -161,6 +163,7 @@ fn tier3_simulation_run4_3rd_body() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
@@ -109,49 +109,61 @@ fn tier3_simulation_run4_3rd_body() {
     let mut sim = Simulation::new(time, dt);
 
     // Earth: central body at origin (not differential)
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Sun: third-body (differential acceleration)
     let tdb_jd = sim.time.tdb_julian_date();
     let initial_sun = earth_centered_position(EphemerisBody::Sun, tdb_jd, &ephemeris);
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Moon: third-body (differential acceleration)
     let initial_moon = earth_centered_position(EphemerisBody::Moon, tdb_jd, &ephemeris);
-    let moon = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_moon,
-            model: GravityModel::PointMass,
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_moon,
+                model: GravityModel::PointMass,
+            },
+            position: initial_moon,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_moon,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // ISS mass properties (parsed from Modified_data/mass.py)
     let inertia = glam::DMat3::from_cols(
@@ -214,10 +226,14 @@ fn tier3_simulation_run4_3rd_body() {
         // Compute TDB JD for the target time using the epoch's TDB JD plus
         // elapsed simulation days. This uses the proper TDB timescale.
         let target_tdb_jd = tdb_jd + record.time / 86400.0;
-        sim.sources[sun].position =
-            earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris);
-        sim.sources[moon].position =
-            earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris);
+        sim.set_source_position(
+            sun,
+            earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris),
+        );
+        sim.set_source_position(
+            moon,
+            earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris),
+        );
 
         sim.step_until(record.time);
 

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run5.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run5.rs
@@ -122,18 +122,22 @@ fn run_atmosphere_test(
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Drag OFF, gravity torque OFF (common_input defaults).
     // Gravity gradient is computed (gradient=true) but not used as torque.

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run5.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run5.rs
@@ -135,6 +135,7 @@ fn run_atmosphere_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
@@ -115,18 +115,22 @@ fn tier3_simulation_run6b_drag() {
     // Earth source with planet-fixed rotation — the Simulation's ephemeris stage
     // updates it each step via RNP, so the atmosphere system sees correct geodetic
     // coordinates. Without this, MET density is evaluated at wrong lat/lon.
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY), // triggers ephemeris update each step
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY), // triggers ephemeris update each step
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     // Configure atmosphere with planet rotation lookup
     sim.atmosphere = Some(AtmosphereConfig {
@@ -323,18 +327,22 @@ fn tier3_simulation_run6a_const_density_drag() {
 
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_grav.mu,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
@@ -128,6 +128,7 @@ fn tier3_simulation_run6b_drag() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -340,6 +341,7 @@ fn tier3_simulation_run6a_const_density_drag() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
@@ -142,6 +142,7 @@ fn run_7_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: OMEGA_EARTH,
             central: true,
         },
     );
@@ -161,6 +162,7 @@ fn run_7_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );
@@ -177,6 +179,7 @@ fn run_7_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
@@ -132,42 +132,54 @@ fn run_7_test(
         mu: sh_data.mu,
         model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
     };
-    let earth = sim.add_source(GravitySourceEntry {
-        source: sh_source,
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: sh_source,
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
 
     // Sun and Moon: third-body differential acceleration (mu from JEOD gravity files)
     let tdb_jd = sim.time.tdb_julian_date();
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            position: earth_centered_position(EphemerisBody::Sun, tdb_jd, &ephemeris),
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: earth_centered_position(EphemerisBody::Sun, tdb_jd, &ephemeris),
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
-    let moon = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_moon,
-            model: GravityModel::PointMass,
+    );
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_moon,
+                model: GravityModel::PointMass,
+            },
+            position: earth_centered_position(EphemerisBody::Moon, tdb_jd, &ephemeris),
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: earth_centered_position(EphemerisBody::Moon, tdb_jd, &ephemeris),
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Drag configuration (only for RUN_7C/7D)
     let drag_config = if with_drag {
@@ -269,10 +281,14 @@ fn run_7_test(
     for record in &trajectory[1..] {
         // Update Sun/Moon positions from ephemeris
         let target_tdb_jd = tdb_jd + record.time / 86400.0;
-        sim.sources[sun].position =
-            earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris);
-        sim.sources[moon].position =
-            earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris);
+        sim.set_source_position(
+            sun,
+            earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris),
+        );
+        sim.set_source_position(
+            moon,
+            earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris),
+        );
 
         sim.step_until(record.time);
         let body = sim.body(0);

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
@@ -86,6 +86,7 @@ fn setup_run9(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
@@ -73,18 +73,22 @@ fn setup_run9(
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -130,18 +130,22 @@ fn tier3_simulation_earth_moon_clem() {
         .expect("Moon DE421 libration rotation");
 
     // Moon at origin with LP150Q SH gravity + per-step DE421 BPC rotation.
-    let moon = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: moon_mu,
-            model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: moon_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(moon_rotation),
+            rotation_model: RotationModel::MoonDE421,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(moon_rotation),
-        rotation_model: RotationModel::MoonDE421,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
     // Earth as 3rd-body with per-step ephemeris updates
     let epoch_tdb_jd = sim.time.tdb_julian_date();
@@ -149,28 +153,34 @@ fn tier3_simulation_earth_moon_clem() {
         .get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)
         .expect("Earth-Moon state from DE421");
 
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
-        },
-        earth_pos_from_moon,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            earth_pos_from_moon,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
 
     // Sun as 3rd-body with per-step ephemeris updates (also SRP source)
     let (sun_pos_from_moon, _) = ephemeris
         .get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)
         .expect("Sun-Moon state from DE421");
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        sun_pos_from_moon,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            sun_pos_from_moon,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Moon);
     sim.sun_source = Some(sun);
 

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -143,6 +143,7 @@ fn tier3_simulation_earth_moon_clem() {
             rotation_model: RotationModel::MoonDE421,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_euler.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler.rs
@@ -63,18 +63,22 @@ fn tier3_simulation_euler() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_euler.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler.rs
@@ -76,6 +76,7 @@ fn tier3_simulation_euler() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
@@ -84,6 +84,7 @@ fn run_euler_test(csv_filename: &str, label: &str, test_name: &str, quat_tol: f6
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
@@ -71,18 +71,22 @@ fn run_euler_test(csv_filename: &str, label: &str, test_name: &str, quat_tol: f6
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_gj.rs
+++ b/crates/jeod_runner/tests/tier3_sim_gj.rs
@@ -68,18 +68,22 @@ fn run_gj_test(
     time.time_scale_factor = time_scale_factor;
     let mut sim = Simulation::new(time, sim_dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: MU_GJ_TEST,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_GJ_TEST,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_gj.rs
+++ b/crates/jeod_runner/tests/tier3_sim_gj.rs
@@ -81,6 +81,7 @@ fn run_gj_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_lvlh.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh.rs
@@ -57,18 +57,22 @@ fn tier3_simulation_lvlh() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_lvlh.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh.rs
@@ -70,6 +70,7 @@ fn tier3_simulation_lvlh() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_edge.rs
@@ -79,6 +79,7 @@ fn run_lvlh_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_edge.rs
@@ -66,18 +66,22 @@ fn run_lvlh_test(
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -114,28 +114,35 @@ fn tier3_simulation_mars_dawn() {
     let mut sim = Simulation::new(time, 10.0);
 
     // Mars at origin with IAU rotation + MRO110B2 SH gravity
-    let mars = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mars_mu,
-            model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+    let mars = sim.add_source(
+        "Mars",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mars_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY), // Triggers Mars rotation update
+            rotation_model: RotationModel::MarsIAU,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY), // Triggers Mars rotation update
-        rotation_model: RotationModel::MarsIAU,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
     // Sun as 3rd-body with per-step DE421 ephemeris updates
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        sun_pos_from_mars,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            sun_pos_from_mars,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(
         sun,
         jeod_sim::EphemerisBody::Sun,

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -127,6 +127,7 @@ fn tier3_simulation_mars_dawn() {
             rotation_model: RotationModel::MarsIAU,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mercury.rs
@@ -63,14 +63,17 @@ fn propagate_mercury_periapses(
 
     let (init_pos, init_vel) = mercury_perihelion_state();
 
-    let sun = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     let mut ctrl = GravityControl::new_spherical(sun, false);
     ctrl.relativistic = relativistic;
@@ -249,14 +252,17 @@ fn tier3_simulation_mercury_relativistic_effect() {
     // Newtonian run
     let time_n = SimulationTime::at_j2000(leap_table.clone());
     let mut sim_n = Simulation::new(time_n, dt);
-    let sun_n = sim_n.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let sun_n = sim_n.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
     sim_n.add_body(VehicleConfig {
         trans: TranslationalState {
             position: init_pos,
@@ -275,14 +281,17 @@ fn tier3_simulation_mercury_relativistic_effect() {
     // Relativistic run
     let time_r = SimulationTime::at_j2000(leap_table);
     let mut sim_r = Simulation::new(time_r, dt);
-    let sun_r = sim_r.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let sun_r = sim_r.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
     let mut ctrl = GravityControl::new_spherical(sun_r, false);
     ctrl.relativistic = true;
     sim_r.add_body(VehicleConfig {

--- a/crates/jeod_runner/tests/tier3_sim_met.rs
+++ b/crates/jeod_runner/tests/tier3_sim_met.rs
@@ -79,18 +79,22 @@ fn tier3_simulation_met_run5a() {
     time.set_ut1_tai_offset(ut1_tai_offset);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),

--- a/crates/jeod_runner/tests/tier3_sim_met.rs
+++ b/crates/jeod_runner/tests/tier3_sim_met.rs
@@ -92,6 +92,7 @@ fn tier3_simulation_met_run5a() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_ned.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned.rs
@@ -85,18 +85,22 @@ fn tier3_simulation_geodetic() {
     let mut sim = Simulation::new(time, ned_dt);
 
     // Earth: point-mass gravity (JEOD SIM_NED uses spherical=1) with RNP rotation
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY), // triggers RNP update for geodetic
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY), // triggers RNP update for geodetic
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_ned.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned.rs
@@ -98,6 +98,7 @@ fn tier3_simulation_geodetic() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
@@ -71,18 +71,22 @@ fn run_ned_test(
 
     let mut sim = Simulation::new(time, ned_dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    );
 
     let (r_eq, r_pol) = if use_spherical_earth {
         (GEO_R_SPH, GEO_R_SPH) // Spherical: r_eq = r_pol

--- a/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
@@ -84,6 +84,7 @@ fn run_ned_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_orbelem.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem.rs
@@ -57,18 +57,22 @@ fn tier3_simulation_orbelem() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_orbelem.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem.rs
@@ -70,6 +70,7 @@ fn tier3_simulation_orbelem() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
@@ -143,6 +143,7 @@ fn verify_orbit_family(csv_name: &str, label: &str, skip_degenerate_scalars: boo
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
@@ -130,18 +130,22 @@ fn verify_orbit_family(csv_name: &str, label: &str, skip_degenerate_scalars: boo
     // dt=1e-9 keeps position drift below 1e-5 m.
     let mut sim = Simulation::new(time, 1e-9);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
@@ -80,6 +80,7 @@ fn tier3_simulation_orbinit_cross_consistency() {
                 delta_c20: 0.0,
                 rotation_model: RotationModel::default(),
                 tidal_config: None,
+                planet_omega: 0.0,
                 central: true,
             },
         );

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
@@ -67,18 +67,22 @@ fn tier3_simulation_orbinit_cross_consistency() {
         let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
         let mut sim = Simulation::new(time, 10.0);
 
-        let earth = sim.add_source(GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_earth,
-                model: GravityModel::PointMass,
+        let earth = sim.add_source(
+            "Earth",
+            GravitySourceEntry {
+                source: GravitySource {
+                    mu: mu_earth,
+                    model: GravityModel::PointMass,
+                },
+                position: DVec3::ZERO,
+                velocity: DVec3::ZERO,
+                t_inertial_pfix: None,
+                delta_c20: 0.0,
+                rotation_model: RotationModel::default(),
+                tidal_config: None,
+                central: true,
             },
-            position: DVec3::ZERO,
-            velocity: DVec3::ZERO,
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-        });
+        );
 
         sim.add_body(VehicleConfig {
             trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_planetary.rs
+++ b/crates/jeod_runner/tests/tier3_sim_planetary.rs
@@ -91,14 +91,17 @@ fn run_planetary_scenario(label: &str, csv_name: &str) {
     let time = SimulationTime::at_j2000(leap_table);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_planetary.rs
+++ b/crates/jeod_runner/tests/tier3_sim_planetary.rs
@@ -91,17 +91,18 @@ fn run_planetary_scenario(label: &str, csv_name: &str) {
     let time = SimulationTime::at_j2000(leap_table);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
+    let earth = sim.add_source("Earth", {
+        let mut e = GravitySourceEntry::new(
             GravitySource {
                 mu: mu_earth,
                 model: GravityModel::PointMass,
             },
             DVec3::ZERO,
             None,
-        ),
-    );
+        );
+        e.central = true;
+        e
+    });
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_polar_motion.rs
+++ b/crates/jeod_runner/tests/tier3_sim_polar_motion.rs
@@ -92,18 +92,22 @@ fn tier3_simulation_run2p_polar_motion() {
     let yp = YP_ARCSEC * ARCSEC_TO_RAD;
     sim.polar_motion = Some((xp, yp));
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {

--- a/crates/jeod_runner/tests/tier3_sim_polar_motion.rs
+++ b/crates/jeod_runner/tests/tier3_sim_polar_motion.rs
@@ -105,6 +105,7 @@ fn tier3_simulation_run2p_polar_motion() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
+++ b/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
@@ -87,6 +87,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -109,6 +110,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
+++ b/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
@@ -74,36 +74,44 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
     let mut sim = Simulation::new(time, dt);
 
     // Earth at origin
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Sun from DE421 (query in TDB JD, not TAI JD)
     let tdb_jd = sim.time.tdb_julian_date();
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position at epoch");
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun);
     sim.ephemeris = Some(ephemeris);
@@ -158,7 +166,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
         sim.set_body_position(0, record.position);
 
         // Compute our shadow fraction at the current Sun position
-        let sun_pos = sim.sources[sun].position;
+        let sun_pos = sim.source_position(sun);
         let our_frac =
             compute_shadow_fraction(record.position, sun_pos, DVec3::ZERO, R_EARTH, SOLAR_RADIUS);
 

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
@@ -70,18 +70,22 @@ fn tier3_simulation_solar_beta() {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Sun source -- position from DE421 at J2000.0.
     // mu=0 matches the JEOD RUN_2 reference (Earth-only gravity). Sun is used
@@ -92,18 +96,22 @@ fn tier3_simulation_solar_beta() {
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, j2000_jd)
         .expect("Sun position at J2000");
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.sun_source = Some(sun);
 
     sim.add_body(VehicleConfig {
@@ -137,7 +145,7 @@ fn tier3_simulation_solar_beta() {
         let (sun_pos, _) = ephemeris
             .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
             .expect("Sun position query");
-        sim.sources[sun].position = sun_pos;
+        sim.set_source_position(sun, sun_pos);
 
         sim.step_until(record.time);
 

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
@@ -83,6 +83,7 @@ fn tier3_simulation_solar_beta() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -109,6 +110,7 @@ fn tier3_simulation_solar_beta() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
@@ -114,39 +114,47 @@ fn run_solar_beta_test(
     } else {
         None
     };
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_earth,
-            model: gravity_model,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: gravity_model,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: initial_rotation,
+            delta_c20: 0.0,
+            rotation_model: if use_sh_gravity {
+                RotationModel::EarthRNP
+            } else {
+                RotationModel::default()
+            },
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: initial_rotation,
-        delta_c20: 0.0,
-        rotation_model: if use_sh_gravity {
-            RotationModel::EarthRNP
-        } else {
-            RotationModel::default()
-        },
-        tidal_config: None,
-    });
+    );
 
     // Sun source — position from DE421 at epoch
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, EPOCH_TDB_JD)
         .expect("Sun position at epoch");
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun);
     sim.ephemeris = Some(ephemeris);

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
@@ -131,6 +131,7 @@ fn run_solar_beta_test(
                 RotationModel::default()
             },
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -152,6 +153,7 @@ fn run_solar_beta_test(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -215,6 +215,7 @@ fn tier3_simulation_srp_flat_plate() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -238,6 +239,7 @@ fn tier3_simulation_srp_flat_plate() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -202,18 +202,22 @@ fn tier3_simulation_srp_flat_plate() {
     let mut sim = Simulation::new(time, srp_dt);
 
     // Earth at origin (gravity source + shadow body)
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: srp_mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: srp_mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Sun (position updated each logging interval from ephemeris).
     // mu=0 matches the JEOD SIM_3_ORBIT reference sim, which uses Sun only
@@ -221,18 +225,22 @@ fn tier3_simulation_srp_flat_plate() {
     // vehicle_baseline.py. 3rd-body gravity is validated independently by
     // tier3_sim_dyncomp_run4, run7, and tier3_sim_torque_simple.
     let initial_sun = srp_sun_position(0.0, epoch_tdb_jd, &ephemeris);
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.sun_source = Some(sun);
 
     sim.add_body(VehicleConfig {
@@ -285,7 +293,7 @@ fn tier3_simulation_srp_flat_plate() {
         let t = (step_i as f64) * srp_dt;
 
         // Update Sun position every step (matching JEOD's per-step ephemeris update)
-        sim.sources[sun].position = sun_table.at(t);
+        sim.set_source_position(sun, sun_table.at(t));
 
         sim.step();
 

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -172,6 +172,7 @@ fn tier3_srp_1st_order_trajectory() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -192,6 +193,7 @@ fn tier3_srp_1st_order_trajectory() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -159,34 +159,42 @@ fn tier3_srp_1st_order_trajectory() {
     let time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, srp_dt);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: srp_mu_earth,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: srp_mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Sun: mu=0 because the JEOD SIM_3_ORBIT_1st_ORDER reference sim uses Sun
     // only for SRP direction, not gravitational perturbation.
     let initial_sun = srp_sun_position(0.0, epoch_tai_tjt, &ephemeris);
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.sun_source = Some(sun);
 
     sim.add_body(VehicleConfig {
@@ -226,7 +234,10 @@ fn tier3_srp_1st_order_trajectory() {
     let mut ref_states = Vec::with_capacity(trajectory.len() - 1);
 
     for record in &trajectory[1..] {
-        sim.sources[sun].position = srp_sun_position(record.time, epoch_tai_tjt, &ephemeris);
+        sim.set_source_position(
+            sun,
+            srp_sun_position(record.time, epoch_tai_tjt, &ephemeris),
+        );
         sim.step_until(record.time);
 
         let body = sim.body(0);

--- a/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
@@ -112,18 +112,22 @@ fn run_srp_basic_test(csv_filename: &str, label: &str) {
     let mut sim = Simulation::new(time, dt);
 
     // Sun at origin (SIM_1_BASIC integrates in Sun.inertial frame)
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
     sim.sun_source = Some(sun);
 
     // Vehicle at ~1 AU from Sun, zero velocity, 6-plate flat-plate SRP

--- a/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
@@ -125,6 +125,7 @@ fn run_srp_basic_test(csv_filename: &str, label: &str) {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
@@ -135,46 +135,58 @@ fn tier3_simulation_tide_run01() {
         ],
     };
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: earth_mu,
-            model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            rotation_model: RotationModel::EarthRNP,
+            delta_c20: 0.0,
+            tidal_config: Some(tidal_config),
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        rotation_model: RotationModel::EarthRNP,
-        delta_c20: 0.0,
-        tidal_config: Some(tidal_config),
-    });
+    );
 
     // Sun: 3rd-body differential
-    let sun = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Moon: 3rd-body differential
-    let moon = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_moon,
-            model: GravityModel::PointMass,
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_moon,
+                model: GravityModel::PointMass,
+            },
+            position: initial_moon,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_moon,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // ISS mass (from Modified_data/mass.py — same as torque_simple)
     let inertia = DMat3::from_cols(
@@ -221,11 +233,11 @@ fn tier3_simulation_tide_run01() {
         let sun_pos = earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris);
         let moon_pos = earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris);
 
-        sim.sources[sun].position = sun_pos;
-        sim.sources[moon].position = moon_pos;
+        sim.set_source_position(sun, sun_pos);
+        sim.set_source_position(moon, moon_pos);
 
         // Update tidal body positions (Moon=0, Sun=1 in tidal_config)
-        if let Some(ref mut tc) = sim.sources[earth].tidal_config {
+        if let Some(tc) = sim.source_tidal_config_mut(earth) {
             tc.tidal_bodies[0].position_inertial = moon_pos;
             tc.tidal_bodies[1].position_inertial = sun_pos;
         }
@@ -234,7 +246,7 @@ fn tier3_simulation_tide_run01() {
         let body = sim.body(0);
 
         // Compare dC20
-        let our_dc20 = sim.sources[earth].delta_c20;
+        let our_dc20 = sim.source_delta_c20(earth);
         let dc20_err = (our_dc20 - ref_dc20).abs();
         max_dc20_err = max_dc20_err.max(dc20_err);
 

--- a/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
@@ -148,6 +148,7 @@ fn tier3_simulation_tide_run01() {
             rotation_model: RotationModel::EarthRNP,
             delta_c20: 0.0,
             tidal_config: Some(tidal_config),
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -166,6 +167,7 @@ fn tier3_simulation_tide_run01() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );
@@ -184,6 +186,7 @@ fn tier3_simulation_tide_run01() {
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
@@ -96,14 +96,17 @@ fn tier3_sim_time_reversal_run1() {
     let time = SimulationTime::new(init.tai_tjt, leap_table);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_earth_gemt1,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_earth_gemt1,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     // JEOD initializes attitude in LVLH: Yaw=0, Pitch=-11.6°, Roll=0, omega=0.
     // Compute the LVLH frame, then apply the Euler rotation.

--- a/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
@@ -96,17 +96,18 @@ fn tier3_sim_time_reversal_run1() {
     let time = SimulationTime::new(init.tai_tjt, leap_table);
     let mut sim = Simulation::new(time, dt);
 
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
+    let earth = sim.add_source("Earth", {
+        let mut e = GravitySourceEntry::new(
             GravitySource {
                 mu: mu_earth_gemt1,
                 model: GravityModel::PointMass,
             },
             DVec3::ZERO,
             None,
-        ),
-    );
+        );
+        e.central = true;
+        e
+    });
 
     // JEOD initializes attitude in LVLH: Yaw=0, Pitch=-11.6°, Roll=0, omega=0.
     // Compute the LVLH frame, then apply the Euler rotation.

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -163,23 +163,27 @@ fn build_simulation(
             model: GravityModel::PointMass,
         }
     };
-    let earth = sim.add_source(GravitySourceEntry {
-        source: earth_source,
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: if config.earth_nonspherical || config.gradient_degree > 0 {
-            Some(DMat3::IDENTITY) // triggers RNP update each step
-        } else {
-            None
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source,
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: if config.earth_nonspherical || config.gradient_degree > 0 {
+                Some(DMat3::IDENTITY) // triggers RNP update each step
+            } else {
+                None
+            },
+            delta_c20: 0.0,
+            rotation_model: if config.earth_nonspherical || config.gradient_degree > 0 {
+                RotationModel::EarthRNP
+            } else {
+                RotationModel::None
+            },
+            tidal_config: None,
+            central: true,
         },
-        delta_c20: 0.0,
-        rotation_model: if config.earth_nonspherical || config.gradient_degree > 0 {
-            RotationModel::EarthRNP
-        } else {
-            RotationModel::None
-        },
-        tidal_config: None,
-    });
+    );
 
     // Sun/Moon mu (spherical-only files lack degree/order fields)
     let mu_sun =
@@ -192,33 +196,41 @@ fn build_simulation(
     // Sun: third-body differential acceleration (matches JEOD: spherical, gradient=false)
     let epoch_tdb_jd = sim.time.tdb_julian_date();
     let initial_sun = earth_centered_position(EphemerisBody::Sun, epoch_tdb_jd, ephemeris);
-    let sun_idx = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            position: initial_sun,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_sun,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Moon: third-body differential acceleration (matches JEOD: spherical, gradient=false)
     let initial_moon = earth_centered_position(EphemerisBody::Moon, epoch_tdb_jd, ephemeris);
-    let moon_idx = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_moon,
-            model: GravityModel::PointMass,
+    let moon_idx = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_moon,
+                model: GravityModel::PointMass,
+            },
+            position: initial_moon,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            central: false,
         },
-        position: initial_moon,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::default(),
-        tidal_config: None,
-    });
+    );
 
     // Earth gravity control
     let mut earth_ctrl = if config.earth_nonspherical {
@@ -309,10 +321,14 @@ fn run_propagation_test(
     for record in &records[1..] {
         // Update Sun/Moon positions from ephemeris using proper TDB timescale
         let target_tdb_jd = setup.epoch_tdb_jd + record.time / 86400.0;
-        sim.sources[setup.sun_idx].position =
-            earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris);
-        sim.sources[setup.moon_idx].position =
-            earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris);
+        sim.set_source_position(
+            setup.sun_idx,
+            earth_centered_position(EphemerisBody::Sun, target_tdb_jd, &ephemeris),
+        );
+        sim.set_source_position(
+            setup.moon_idx,
+            earth_centered_position(EphemerisBody::Moon, target_tdb_jd, &ephemeris),
+        );
 
         sim.step_until(record.time);
 

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -181,6 +181,7 @@ fn build_simulation(
                 RotationModel::None
             },
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -209,6 +210,7 @@ fn build_simulation(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );
@@ -228,6 +230,7 @@ fn build_simulation(
             delta_c20: 0.0,
             rotation_model: RotationModel::default(),
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/crates/jeod_sim/src/rotation_model.rs
+++ b/crates/jeod_sim/src/rotation_model.rs
@@ -20,3 +20,27 @@ pub enum RotationModel {
     /// Requires the simulation's `ephemeris` field to be set with BPC loaded.
     MoonDE421,
 }
+
+impl RotationModel {
+    /// Planet angular velocity about the spin axis (rad/s), if the model has
+    /// a constant rate.
+    ///
+    /// JEOD sets `ang_vel_this = [0, 0, planet_omega]` on the pfix frame's
+    /// rotational state. Earth and Mars have constant spin rates from JEOD
+    /// data files (`data_rnp_j2000.cc`, `data_rnp_mars.cc`). Moon models
+    /// have time-varying angular velocity due to libration; they return
+    /// `None` here — callers should compute angular velocity from the
+    /// rotation derivative when needed.
+    pub fn planet_omega(&self) -> Option<f64> {
+        match self {
+            // JEOD: RNPJ2000_ptr->planet_omega = 7.292115146706388e-5
+            Self::EarthRNP => Some(7.292_115_146_706_388e-5),
+            // JEOD: RNPMars_ptr->planet_omega = 350.891985303 * deg/day → rad/s
+            // 350.891985303 * (π/180) / 86400
+            Self::MarsIAU => Some(350.891_985_303 * std::f64::consts::PI / 180.0 / 86400.0),
+            // Moon libration — angular velocity is not constant.
+            Self::MoonIAU | Self::MoonDE421 => None,
+            Self::None => None,
+        }
+    }
+}

--- a/crates/jeod_sim/src/rotation_model.rs
+++ b/crates/jeod_sim/src/rotation_model.rs
@@ -20,27 +20,3 @@ pub enum RotationModel {
     /// Requires the simulation's `ephemeris` field to be set with BPC loaded.
     MoonDE421,
 }
-
-impl RotationModel {
-    /// Planet angular velocity about the spin axis (rad/s), if the model has
-    /// a constant rate.
-    ///
-    /// JEOD sets `ang_vel_this = [0, 0, planet_omega]` on the pfix frame's
-    /// rotational state. Earth and Mars have constant spin rates from JEOD
-    /// data files (`data_rnp_j2000.cc`, `data_rnp_mars.cc`). Moon models
-    /// have time-varying angular velocity due to libration; they return
-    /// `None` here — callers should compute angular velocity from the
-    /// rotation derivative when needed.
-    pub fn planet_omega(&self) -> Option<f64> {
-        match self {
-            // JEOD: RNPJ2000_ptr->planet_omega = 7.292115146706388e-5
-            Self::EarthRNP => Some(7.292_115_146_706_388e-5),
-            // JEOD: RNPMars_ptr->planet_omega = 350.891985303 * deg/day → rad/s
-            // 350.891985303 * (π/180) / 86400
-            Self::MarsIAU => Some(350.891_985_303 * std::f64::consts::PI / 180.0 / 86400.0),
-            // Moon libration — angular velocity is not constant.
-            Self::MoonIAU | Self::MoonDE421 => None,
-            Self::None => None,
-        }
-    }
-}

--- a/crates/jeod_sim/src/validation.rs
+++ b/crates/jeod_sim/src/validation.rs
@@ -69,7 +69,7 @@ pub enum ValidationError {
     },
     /// Body uses a non-root integration frame (or has an active frame switch to
     /// a non-root frame) but has features that assume root-inertial coordinates.
-    NonEciFrameWithEciDependentFeatures { body_idx: usize },
+    NonRootFrameWithRootDependentFeatures { body_idx: usize },
     /// Source has an ephemeris mapping but its inertial frame is the root frame.
     /// The root frame must remain at the origin; ephemeris position updates
     /// would be silently ignored.
@@ -258,7 +258,7 @@ impl std::fmt::Display for ValidationError {
                      to have a GravityControl entry."
                 )
             }
-            Self::NonEciFrameWithEciDependentFeatures { body_idx } => {
+            Self::NonRootFrameWithRootDependentFeatures { body_idx } => {
                 write!(
                     f,
                     "Body {body_idx}: non-root integration frame with features that \
@@ -292,7 +292,7 @@ impl ValidationError {
     pub fn is_warning(&self) -> bool {
         matches!(
             self,
-            Self::UninitializedState | Self::NonEciFrameWithEciDependentFeatures { .. }
+            Self::UninitializedState | Self::NonRootFrameWithRootDependentFeatures { .. }
         )
     }
 }

--- a/crates/jeod_sim/src/validation.rs
+++ b/crates/jeod_sim/src/validation.rs
@@ -56,16 +56,18 @@ pub enum ValidationError {
     EarthLightingWithoutSunSource { body_idx: usize },
     /// Body has `earth_lighting_config` but simulation has no `moon_source`.
     EarthLightingWithoutMoonSource { body_idx: usize },
-    /// Frame switch `central_source` index exceeds number of gravity sources.
-    FrameSwitchCentralSourceOutOfRange {
+    /// Frame switch `target_source` index exceeds number of gravity sources.
+    FrameSwitchTargetSourceOutOfRange {
         body_idx: usize,
-        central_source: usize,
+        target_source: usize,
         num_sources: usize,
     },
-    /// Frame switch `central_source` is not in the body's gravity controls.
-    FrameSwitchCentralSourceNotInControls {
+    /// Frame switch `target_source` is not in the body's gravity controls.
+    /// The post-switch gravity reclassification requires a control entry for
+    /// the target source (it becomes the non-differential central body).
+    FrameSwitchTargetSourceNotInControls {
         body_idx: usize,
-        central_source: usize,
+        target_source: usize,
     },
     /// Body uses a non-root integration frame (or has an active frame switch to
     /// a non-root frame) but has features that assume root-inertial coordinates.
@@ -235,27 +237,27 @@ impl std::fmt::Display for ValidationError {
                      moon_source. Set Simulation::moon_source for earth lighting computation."
                 )
             }
-            Self::FrameSwitchCentralSourceOutOfRange {
+            Self::FrameSwitchTargetSourceOutOfRange {
                 body_idx,
-                central_source,
+                target_source,
                 num_sources,
             } => {
                 write!(
                     f,
-                    "Body {body_idx}: frame switch central_source index {central_source} \
+                    "Body {body_idx}: frame switch target_source index {target_source} \
                      is out of range (simulation has {num_sources} gravity sources)."
                 )
             }
-            Self::FrameSwitchCentralSourceNotInControls {
+            Self::FrameSwitchTargetSourceNotInControls {
                 body_idx,
-                central_source,
+                target_source,
             } => {
                 write!(
                     f,
-                    "Body {body_idx}: frame switch central_source index {central_source} \
-                     is not present in the body's gravity_controls. The post-switch \
-                     differential/central gravity classification requires the source \
-                     to have a GravityControl entry."
+                    "Body {body_idx}: frame switch target_source index {target_source} \
+                     is not in the body's gravity_controls. The post-switch gravity \
+                     reclassification requires the target source to have a \
+                     GravityControl entry (it becomes the non-differential central body)."
                 )
             }
             Self::NonRootFrameWithRootDependentFeatures { body_idx } => {

--- a/crates/jeod_sim/src/validation.rs
+++ b/crates/jeod_sim/src/validation.rs
@@ -67,8 +67,8 @@ pub enum ValidationError {
         body_idx: usize,
         central_source: usize,
     },
-    /// Body uses a non-ECI integration frame (or has an active frame switch to
-    /// a non-Earth frame) but has ECI-dependent derived-state features enabled.
+    /// Body uses a non-root integration frame (or has an active frame switch to
+    /// a non-root frame) but has features that assume root-inertial coordinates.
     NonEciFrameWithEciDependentFeatures { body_idx: usize },
     /// Source has an ephemeris mapping but its inertial frame is the root frame.
     /// The root frame must remain at the origin; ephemeris position updates
@@ -261,11 +261,11 @@ impl std::fmt::Display for ValidationError {
             Self::NonEciFrameWithEciDependentFeatures { body_idx } => {
                 write!(
                     f,
-                    "Body {body_idx}: non-ECI integration frame with ECI-dependent \
-                     features enabled (drag, SRP, orbital elements, euler angles, LVLH, \
-                     geodetic, solar beta, or earth lighting). These derived states \
-                     assume Earth-centered inertial coordinates and will produce \
-                     incorrect results in other frames."
+                    "Body {body_idx}: non-root integration frame with features that \
+                     assume root-inertial coordinates (drag, SRP, orbital elements, \
+                     euler angles, LVLH, geodetic, solar beta, or earth lighting). \
+                     These derived states assume the simulation's central-body \
+                     inertial frame and will produce incorrect results in other frames."
                 )
             }
             Self::EphemerisOnRootSource { source_idx } => {

--- a/crates/jeod_sim/src/validation.rs
+++ b/crates/jeod_sim/src/validation.rs
@@ -70,6 +70,10 @@ pub enum ValidationError {
     /// Body uses a non-ECI integration frame (or has an active frame switch to
     /// a non-Earth frame) but has ECI-dependent derived-state features enabled.
     NonEciFrameWithEciDependentFeatures { body_idx: usize },
+    /// Source has an ephemeris mapping but its inertial frame is the root frame.
+    /// The root frame must remain at the origin; ephemeris position updates
+    /// would be silently ignored.
+    EphemerisOnRootSource { source_idx: usize },
 }
 
 impl std::fmt::Display for ValidationError {
@@ -262,6 +266,15 @@ impl std::fmt::Display for ValidationError {
                      geodetic, solar beta, or earth lighting). These derived states \
                      assume Earth-centered inertial coordinates and will produce \
                      incorrect results in other frames."
+                )
+            }
+            Self::EphemerisOnRootSource { source_idx } => {
+                write!(
+                    f,
+                    "Source {source_idx}: has an ephemeris mapping but its inertial frame \
+                     is the root frame. The root frame must remain at the origin; \
+                     ephemeris position updates would be silently ignored. Remove the \
+                     ephemeris mapping for the central body source."
                 )
             }
         }

--- a/tests/bevy_parity.rs
+++ b/tests/bevy_parity.rs
@@ -127,14 +127,17 @@ fn run_simulation_steps() -> SixDofState {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
 
-    let earth = sim.add_source(jeod_runner::GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        jeod_runner::GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     sim.add_body(jeod_runner::VehicleConfig {
         trans: initial_trans(),
@@ -263,14 +266,17 @@ fn tier3_bevy_rkf45_matches_simulation_bit_identical() {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
 
-    let earth = sim.add_source(jeod_runner::GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        jeod_runner::GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     sim.add_body(jeod_runner::VehicleConfig {
         trans: initial_trans(),

--- a/tests/bevy_parity.rs
+++ b/tests/bevy_parity.rs
@@ -127,17 +127,16 @@ fn run_simulation_steps() -> SixDofState {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
 
-    let earth = sim.add_source(
-        "Earth",
-        jeod_runner::GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = jeod_runner::GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
 
     sim.add_body(jeod_runner::VehicleConfig {
         trans: initial_trans(),
@@ -266,17 +265,16 @@ fn tier3_bevy_rkf45_matches_simulation_bit_identical() {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
 
-    let earth = sim.add_source(
-        "Earth",
-        jeod_runner::GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = jeod_runner::GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
 
     sim.add_body(jeod_runner::VehicleConfig {
         trans: initial_trans(),

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -222,6 +222,7 @@ fn tier3_bevy_geodetic_derived_state() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );
@@ -489,6 +490,7 @@ fn tier3_bevy_polar_geodetic() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );
@@ -874,6 +876,7 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -95,10 +95,9 @@ fn tier3_bevy_derived_states() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     let sun_idx = sim.add_source(
         "Sun",
         GravitySourceEntry::new(
@@ -353,10 +352,9 @@ fn tier3_bevy_eccentric_derived_states() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     let sun_idx = sim.add_source(
         "Sun",
         GravitySourceEntry::new(
@@ -600,10 +598,9 @@ fn tier3_bevy_equatorial_solar_beta() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     let sun_idx = sim.add_source(
         "Sun",
         GravitySourceEntry::new(

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -95,15 +95,21 @@ fn tier3_bevy_derived_states() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     let mut body = new_sim_body_sixdof(earth_idx, false);
@@ -207,15 +213,19 @@ fn tier3_bevy_geodetic_derived_state() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: earth_source(),
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source(),
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
 
     let body = VehicleConfig {
         trans: iss_trans(),
@@ -343,15 +353,21 @@ fn tier3_bevy_eccentric_derived_states() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     sim.add_body(VehicleConfig {
@@ -465,15 +481,19 @@ fn tier3_bevy_polar_geodetic() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: earth_source(),
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source(),
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
 
     sim.add_body(VehicleConfig {
         trans: polar_trans,
@@ -580,15 +600,21 @@ fn tier3_bevy_equatorial_solar_beta() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     sim.add_body(VehicleConfig {
@@ -841,15 +867,19 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: earth_source(),
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source(),
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
 
     sim.add_body(VehicleConfig {
         trans,
@@ -1107,14 +1137,17 @@ fn tier3_bevy_solar_beta() {
     let bevy_beta = app.world().get::<SolarBetaC>(vehicle).unwrap().0;
 
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     sim.add_body(VehicleConfig {

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -80,7 +80,10 @@ fn tier3_bevy_drag_atmosphere_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
         r_eq: 6_378_137.0,
@@ -166,7 +169,10 @@ fn tier3_bevy_constant_density_drag_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
         r_eq: 6_378_137.0,
@@ -258,15 +264,19 @@ fn tier3_bevy_met_atmosphere_drag_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: earth_source(),
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: jeod_runner::RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source(),
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: jeod_runner::RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met),
         r_eq: 6_378_137.0,
@@ -353,15 +363,19 @@ fn tier3_bevy_met_run5a() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: earth_source(),
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: jeod_runner::RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source(),
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: jeod_runner::RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met),
         r_eq: 6_378_137.0,
@@ -452,15 +466,19 @@ fn tier3_bevy_drag_run6b() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: earth_source(),
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: jeod_runner::RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: earth_source(),
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: jeod_runner::RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met),
         r_eq: 6_378_137.0,

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -80,10 +80,9 @@ fn tier3_bevy_drag_atmosphere_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
         r_eq: 6_378_137.0,
@@ -169,10 +168,9 @@ fn tier3_bevy_constant_density_drag_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
         r_eq: 6_378_137.0,

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -272,6 +272,7 @@ fn tier3_bevy_met_atmosphere_drag_sixdof() {
             delta_c20: 0.0,
             rotation_model: jeod_runner::RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );
@@ -371,6 +372,7 @@ fn tier3_bevy_met_run5a() {
             delta_c20: 0.0,
             rotation_model: jeod_runner::RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );
@@ -474,6 +476,7 @@ fn tier3_bevy_drag_run6b() {
             delta_c20: 0.0,
             rotation_model: jeod_runner::RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );

--- a/tests/bevy_parity_gj.rs
+++ b/tests/bevy_parity_gj.rs
@@ -136,17 +136,16 @@ fn run_gj_parity(
     time.time_scale_factor = time_scale_factor;
     let mut sim = Simulation::new(time, sim_dt);
 
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_GJ_TEST,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_GJ_TEST,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
 
     sim.add_body(VehicleConfig {
         trans,

--- a/tests/bevy_parity_gj.rs
+++ b/tests/bevy_parity_gj.rs
@@ -136,14 +136,17 @@ fn run_gj_parity(
     time.time_scale_factor = time_scale_factor;
     let mut sim = Simulation::new(time, sim_dt);
 
-    let earth_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_GJ_TEST,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_GJ_TEST,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     sim.add_body(VehicleConfig {
         trans,

--- a/tests/bevy_parity_gravity_torque.rs
+++ b/tests/bevy_parity_gravity_torque.rs
@@ -62,10 +62,9 @@ fn tier3_bevy_gravity_torque_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
 
     let mut body = new_sim_body_sixdof(earth_idx, true);
     body.compute_gravity_gradient = true;
@@ -172,10 +171,9 @@ fn tier3_bevy_external_torque_per_body() {
     // Path B: Simulation::step() pipeline with set_body_external_torque
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, step_dt);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_src, DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_src, DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
         rot: Some(tumble_rot()),

--- a/tests/bevy_parity_gravity_torque.rs
+++ b/tests/bevy_parity_gravity_torque.rs
@@ -62,7 +62,10 @@ fn tier3_bevy_gravity_torque_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
 
     let mut body = new_sim_body_sixdof(earth_idx, true);
     body.compute_gravity_gradient = true;
@@ -169,7 +172,10 @@ fn tier3_bevy_external_torque_per_body() {
     // Path B: Simulation::step() pipeline with set_body_external_torque
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, step_dt);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_src, DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_src, DVec3::ZERO, None),
+    );
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
         rot: Some(tumble_rot()),

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -81,15 +81,19 @@ fn tier3_bevy_sh4x4_rnp() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: sh_source,
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::EarthRNP,
-        tidal_config: None,
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: sh_source,
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            central: true,
+        },
+    );
 
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
@@ -187,15 +191,19 @@ fn tier3_bevy_tidal_sh4x4() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry {
-        source: sh_source,
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        rotation_model: RotationModel::EarthRNP,
-        delta_c20: 0.0,
-        tidal_config: Some(tidal_config),
-    });
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: sh_source,
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            rotation_model: RotationModel::EarthRNP,
+            delta_c20: 0.0,
+            tidal_config: Some(tidal_config),
+            central: true,
+        },
+    );
 
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
@@ -243,7 +251,10 @@ fn tier3_bevy_run2p_polar_motion() {
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
     sim.polar_motion = Some((xp, yp));
 
     sim.add_body(VehicleConfig {
@@ -309,14 +320,17 @@ fn run_gj_parity(label: &str, config: GaussJacksonConfig, dt: f64, n_steps: usiz
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, dt);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     sim.add_body(VehicleConfig {
         trans: gj_trans,

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -251,10 +251,9 @@ fn tier3_bevy_run2p_polar_motion() {
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     sim.polar_motion = Some((xp, yp));
 
     sim.add_body(VehicleConfig {
@@ -320,17 +319,16 @@ fn run_gj_parity(label: &str, config: GaussJacksonConfig, dt: f64, n_steps: usiz
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, dt);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
 
     sim.add_body(VehicleConfig {
         trans: gj_trans,

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -91,6 +91,7 @@ fn tier3_bevy_sh4x4_rnp() {
             delta_c20: 0.0,
             rotation_model: RotationModel::EarthRNP,
             tidal_config: None,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );
@@ -201,6 +202,7 @@ fn tier3_bevy_tidal_sh4x4() {
             rotation_model: RotationModel::EarthRNP,
             delta_c20: 0.0,
             tidal_config: Some(tidal_config),
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
             central: true,
         },
     );

--- a/tests/bevy_parity_lighting.rs
+++ b/tests/bevy_parity_lighting.rs
@@ -107,22 +107,28 @@ fn run_earth_lighting_parity(label: &str, veh_pos: DVec3, sun_pos: DVec3, moon_p
 
     // ── Simulation ──
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
-    let moon_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        moon_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    let moon_idx = sim.add_source(
+        "Moon",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            moon_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
     sim.moon_source = Some(moon_idx);
 
@@ -313,22 +319,28 @@ fn tier3_bevy_earth_lighting_pipeline() {
 
     // ── Simulation ──
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
-    let moon_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        moon_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    let moon_idx = sim.add_source(
+        "Moon",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            moon_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
     sim.moon_source = Some(moon_idx);
 

--- a/tests/bevy_parity_point_mass.rs
+++ b/tests/bevy_parity_point_mass.rs
@@ -520,6 +520,7 @@ fn tier3_sim_mars_rotation_dispatch() {
             rotation_model: RotationModel::MarsIAU,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -574,6 +575,7 @@ fn tier3_sim_multi_source_rotation() {
             rotation_model: RotationModel::EarthRNP,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -591,6 +593,7 @@ fn tier3_sim_multi_source_rotation() {
             rotation_model: RotationModel::MarsIAU,
             delta_c20: 0.0,
             tidal_config: None,
+            planet_omega: 0.0,
             central: false,
         },
     );

--- a/tests/bevy_parity_point_mass.rs
+++ b/tests/bevy_parity_point_mass.rs
@@ -61,7 +61,10 @@ fn tier3_bevy_point_mass_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
     sim.add_body(new_sim_body_sixdof(earth_idx, false));
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS);
@@ -315,14 +318,17 @@ fn tier3_sim_time_reversal_round_trip() {
     println!("Scenario P: Time reversal round-trip");
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
         rot: Some(tumble_rot()),
@@ -371,14 +377,17 @@ fn tier3_sim_relative_state_consistency() {
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
-    let earth = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
@@ -501,18 +510,22 @@ fn tier3_sim_mars_rotation_dispatch() {
     let mut sim = Simulation::new(time, DT);
 
     let mars_mu = 4.282_837_452_7e13;
-    let mars = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mars_mu,
-            model: GravityModel::PointMass,
+    let mars = sim.add_source(
+        "Mars",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mars_mu,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(glam::DMat3::IDENTITY),
+            rotation_model: RotationModel::MarsIAU,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(glam::DMat3::IDENTITY),
-        rotation_model: RotationModel::MarsIAU,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: TranslationalState {
@@ -528,7 +541,7 @@ fn tier3_sim_mars_rotation_dispatch() {
     sim.validate().unwrap();
     sim.step_n(10);
 
-    let rot = sim.sources[mars].t_inertial_pfix.unwrap();
+    let rot = sim.source_pfix_rotation(mars).unwrap();
     assert!(
         rot != glam::DMat3::IDENTITY,
         "Mars rotation should differ from identity after 10 steps"
@@ -551,31 +564,39 @@ fn tier3_sim_multi_source_rotation() {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
 
-    let earth = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: MU_EARTH,
-            model: GravityModel::PointMass,
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(glam::DMat3::IDENTITY),
+            rotation_model: RotationModel::EarthRNP,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(glam::DMat3::IDENTITY),
-        rotation_model: RotationModel::EarthRNP,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
-    let mars = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: 4.282_837_452_7e13,
-            model: GravityModel::PointMass,
+    let mars = sim.add_source(
+        "Mars",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 4.282_837_452_7e13,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::new(2.28e11, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(glam::DMat3::IDENTITY),
+            rotation_model: RotationModel::MarsIAU,
+            delta_c20: 0.0,
+            tidal_config: None,
+            central: false,
         },
-        position: DVec3::new(2.28e11, 0.0, 0.0),
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(glam::DMat3::IDENTITY),
-        rotation_model: RotationModel::MarsIAU,
-        delta_c20: 0.0,
-        tidal_config: None,
-    });
+    );
 
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
@@ -588,8 +609,8 @@ fn tier3_sim_multi_source_rotation() {
     sim.validate().unwrap();
     sim.step_n(10);
 
-    let earth_rot = sim.sources[earth].t_inertial_pfix.unwrap();
-    let mars_rot = sim.sources[mars].t_inertial_pfix.unwrap();
+    let earth_rot = sim.source_pfix_rotation(earth).unwrap();
+    let mars_rot = sim.source_pfix_rotation(mars).unwrap();
 
     assert!(earth_rot != glam::DMat3::IDENTITY, "Earth rotation updated");
     assert!(mars_rot != glam::DMat3::IDENTITY, "Mars rotation updated");

--- a/tests/bevy_parity_point_mass.rs
+++ b/tests/bevy_parity_point_mass.rs
@@ -61,10 +61,9 @@ fn tier3_bevy_point_mass_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     sim.add_body(new_sim_body_sixdof(earth_idx, false));
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS);
@@ -318,17 +317,16 @@ fn tier3_sim_time_reversal_round_trip() {
     println!("Scenario P: Time reversal round-trip");
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
     sim.add_body(VehicleConfig {
         trans: iss_trans(),
         rot: Some(tumble_rot()),
@@ -377,17 +375,16 @@ fn tier3_sim_relative_state_consistency() {
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, DT);
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
 
     sim.add_body(VehicleConfig {
         trans: iss_trans(),

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -115,15 +115,21 @@ fn tier3_bevy_full_stack_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
@@ -295,16 +301,22 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
 
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
 
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     sim.add_body(VehicleConfig {
@@ -418,14 +430,17 @@ fn run_shadow_parity(label: &str, srp_plates: Vec<(FlatPlate, FlatPlateParams, F
 
     // ── Simulation ──
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     let mut body = new_sim_body_sixdof(earth_idx, false);
@@ -512,14 +527,17 @@ fn run_srp_basic_parity(
 
     // ── Simulation ──
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
     sim.sun_source = Some(sun_idx);
 
     let mut body = new_sim_body_sixdof(earth_idx, false);

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -115,10 +115,9 @@ fn tier3_bevy_full_stack_sixdof() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     let sun_idx = sim.add_source(
         "Sun",
         GravitySourceEntry::new(
@@ -301,10 +300,9 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
 
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
 
     let sun_idx = sim.add_source(
         "Sun",

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -70,14 +70,17 @@ fn tier3_bevy_solar_beta_equ() {
 
     let eph_sim = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        initial_sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            initial_sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun_idx, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun_idx);
     sim.ephemeris = Some(eph_sim);
@@ -158,14 +161,17 @@ fn tier3_bevy_solar_beta_obliquity() {
 
     let eph_sim = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: 0.0,
-            model: GravityModel::PointMass,
-        },
-        initial_sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            initial_sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun_idx, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun_idx);
     sim.ephemeris = Some(eph_sim);
@@ -298,28 +304,34 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
     // ── Simulation ──
     let eph_sim = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_SUN,
-            model: GravityModel::PointMass,
-        },
-        initial_sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            initial_sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun_idx, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun_idx);
 
     let moon_idx = if include_moon {
         let mu_moon = 4.902_800_066e12;
         let moon_pos = initial_moon_pos.unwrap();
-        let idx = sim.add_source(GravitySourceEntry::new(
-            GravitySource {
-                mu: mu_moon,
-                model: GravityModel::PointMass,
-            },
-            moon_pos,
-            None,
-        ));
+        let idx = sim.add_source(
+            "Moon",
+            GravitySourceEntry::new(
+                GravitySource {
+                    mu: mu_moon,
+                    model: GravityModel::PointMass,
+                },
+                moon_pos,
+                None,
+            ),
+        );
         sim.set_source_ephemeris(idx, EphemerisBody::Moon, EphemerisBody::Earth);
         sim.moon_source = Some(idx);
         Some(idx)
@@ -494,26 +506,33 @@ fn tier3_bevy_mars_dawn() {
     let eph_sim = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let mars_idx = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_mars,
-            model: GravityModel::PointMass,
+    let mars_idx = sim.add_source(
+        "Mars",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_mars,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::MarsIAU,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: DVec3::ZERO,
-        t_inertial_pfix: Some(DMat3::IDENTITY),
-        delta_c20: 0.0,
-        rotation_model: RotationModel::MarsIAU,
-        tidal_config: None,
-    });
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_SUN,
-            model: GravityModel::PointMass,
-        },
-        sun_rel_mars,
-        None,
-    ));
+    );
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            sun_rel_mars,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun_idx, EphemerisBody::Sun, EphemerisBody::Mars);
     sim.sun_source = Some(sun_idx);
     sim.ephemeris = Some(eph_sim);
@@ -584,14 +603,17 @@ fn tier3_bevy_mercury_relativistic() {
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
-        },
-        DVec3::ZERO,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            DVec3::ZERO,
+            None,
+        ),
+    );
 
     let mut sim_sun_ctrl = GravityControl::new_spherical(sun_idx, false);
     sim_sun_ctrl.relativistic = true;
@@ -674,18 +696,22 @@ fn tier3_bevy_relativistic_moving_source() {
     // ── Simulation ──
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let sun_idx = sim.add_source(GravitySourceEntry {
-        source: GravitySource {
-            mu: mu_sun,
-            model: GravityModel::PointMass,
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: source_velocity,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            central: true,
         },
-        position: DVec3::ZERO,
-        velocity: source_velocity,
-        t_inertial_pfix: None,
-        delta_c20: 0.0,
-        rotation_model: RotationModel::None,
-        tidal_config: None,
-    });
+    );
 
     let mut sim_sun_ctrl = GravityControl::new_spherical(sun_idx, false);
     sim_sun_ctrl.relativistic = true;
@@ -814,25 +840,31 @@ fn tier3_bevy_earth_moon_clem() {
 
     let eph_sim = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (mut sim, earth_idx) = new_sim_earth(DT);
-    let sun_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: MU_SUN,
-            model: GravityModel::PointMass,
-        },
-        initial_sun_pos,
-        None,
-    ));
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            initial_sun_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(sun_idx, EphemerisBody::Sun, EphemerisBody::Earth);
     sim.sun_source = Some(sun_idx);
 
-    let moon_sim_idx = sim.add_source(GravitySourceEntry::new(
-        GravitySource {
-            mu: mu_moon,
-            model: GravityModel::PointMass,
-        },
-        initial_moon_pos,
-        None,
-    ));
+    let moon_sim_idx = sim.add_source(
+        "Moon",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_moon,
+                model: GravityModel::PointMass,
+            },
+            initial_moon_pos,
+            None,
+        ),
+    );
     sim.set_source_ephemeris(moon_sim_idx, EphemerisBody::Moon, EphemerisBody::Earth);
     sim.moon_source = Some(moon_sim_idx);
     sim.ephemeris = Some(eph_sim);

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -603,17 +603,16 @@ fn tier3_bevy_mercury_relativistic() {
 
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
-    let sun_idx = sim.add_source(
-        "Sun",
-        GravitySourceEntry::new(
-            GravitySource {
-                mu: mu_sun,
-                model: GravityModel::PointMass,
-            },
-            DVec3::ZERO,
-            None,
-        ),
+    let mut sun_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: mu_sun,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
     );
+    sun_entry.central = true;
+    let sun_idx = sim.add_source("Sun", sun_entry);
 
     let mut sim_sun_ctrl = GravityControl::new_spherical(sun_idx, false);
     sim_sun_ctrl.relativistic = true;

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -519,6 +519,7 @@ fn tier3_bevy_mars_dawn() {
             delta_c20: 0.0,
             rotation_model: RotationModel::MarsIAU,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );
@@ -708,6 +709,7 @@ fn tier3_bevy_relativistic_moving_source() {
             delta_c20: 0.0,
             rotation_model: RotationModel::None,
             tidal_config: None,
+            planet_omega: 0.0,
             central: true,
         },
     );

--- a/tests/parity_helpers/mod.rs
+++ b/tests/parity_helpers/mod.rs
@@ -155,7 +155,10 @@ pub fn assert_trans_eq(label: &str, a: &TranslationalState, b: &TranslationalSta
 pub fn new_sim_earth(dt: f64) -> (Simulation, usize) {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
-    let earth_idx = sim.add_source(GravitySourceEntry::new(earth_source(), DVec3::ZERO, None));
+    let earth_idx = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
+    );
     (sim, earth_idx)
 }
 

--- a/tests/parity_helpers/mod.rs
+++ b/tests/parity_helpers/mod.rs
@@ -155,10 +155,9 @@ pub fn assert_trans_eq(label: &str, a: &TranslationalState, b: &TranslationalSta
 pub fn new_sim_earth(dt: f64) -> (Simulation, usize) {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
-    let earth_idx = sim.add_source(
-        "Earth",
-        GravitySourceEntry::new(earth_source(), DVec3::ZERO, None),
-    );
+    let mut earth_entry = GravitySourceEntry::new(earth_source(), DVec3::ZERO, None);
+    earth_entry.central = true;
+    let earth_idx = sim.add_source("Earth", earth_entry);
     (sim, earth_idx)
 }
 


### PR DESCRIPTION
## Summary

Closes #67. Unifies celestial body position/rotation tracking into the arena-based `FrameTree`, replacing the flat `sources` vector and hardcoded `IntegrationFrame` enum.

- **FrameTree gains `reparent()`, `find_by_name()`, `is_descendant_of()`** — port of JEOD's `transplant_node()` for moving frames while preserving absolute state
- **Simulation owns a `FrameTree`** with root "Earth.inertial" — each gravity source gets inertial + optional pfix frame nodes, each body gets a frame node under its integration frame
- **Ephemeris updates sync into tree** — source positions/velocities and planet-fixed rotations update tree nodes each step
- **Sub-stage interpolation uses tree** — RK4 sub-stages interpolate source positions from tree base values, replacing the `time_frac` parameter
- **Frame switching uses `reparent()`** — replaces direct origin arithmetic with tree re-parenting that automatically recomputes relative state
- **`IntegrationFrame` enum removed** — frames now identified by `FrameId` (source index resolves to tree node)
- **`sources` vector removed** — gravity model data stored in parallel `GravityData` struct; position/rotation lives in tree nodes

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --tests -- -D warnings` passes
- [x] 386 unit + Tier 2 tests pass
- [x] 184 Tier 3 tests pass (excl. `earth_moon` — CI runs it separately)
- [x] Apollo 8 frame switching test passes via tree `reparent()`
- [x] Bevy-vs-Simulation parity tests pass (bit-identical)
- [x] All tolerances identical — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)