### PR TITLE
Add Tier 3 analytical tests for relative dynamics, solar beta, and LVLH

### DIFF
--- a/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
@@ -1,0 +1,312 @@
+//! Tier 3: Extended LVLH-frame tests (analytical).
+//!
+//! These tests propagate through `Simulation::step()` and verify analytical
+//! properties of the LVLH frame at each checkpoint.
+//!
+//! * `tier3_lvlh_retrograde_orbit` — retrograde circular orbit: the orbit
+//!   normal flips sign, so the LVLH Y-axis (row 1 of T_parent_this) flips
+//!   sign relative to a prograde orbit with the same radius.
+//! * `tier3_lvlh_eccentric_orbit` — elliptical orbit: LVLH angular velocity
+//!   |ω| = |h| / r² varies with r; verify the observed magnitudes at perigee
+//!   and apogee match the closed-form values.
+//! * `tier3_lvlh_periodicity` — after one orbital period the LVLH frame
+//!   returns to its initial orientation to high precision.
+//!
+//! No Docker reference data required.
+
+mod sim_test_helpers;
+use sim_test_helpers::*;
+
+use glam::DVec3;
+use jeod_runner::{
+    DerivedStateConfig, GravitySourceEntry, RotationModel, Simulation, VehicleConfig,
+};
+use jeod_sim::{
+    GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime,
+    TranslationalState,
+};
+
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
+fn make_earth_lvlh_sim(dt: f64, mu_earth: f64, body: TranslationalState) -> Simulation {
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let mut sim = Simulation::new(time, dt);
+
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+
+    sim.add_body(VehicleConfig {
+        trans: body,
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        derived: DerivedStateConfig {
+            lvlh: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    sim
+}
+
+/// Extract the LVLH Y-hat axis (row 1 of T_parent_this) expressed in the
+/// parent (inertial) frame.
+fn lvlh_y_hat(t_parent_this: &glam::DMat3) -> DVec3 {
+    // Row 1 is the Y-axis expressed in parent: columns of DMat3 are
+    // column-major, so row 1 is (col(0).y, col(1).y, col(2).y).
+    DVec3::new(
+        t_parent_this.col(0).y,
+        t_parent_this.col(1).y,
+        t_parent_this.col(2).y,
+    )
+}
+
+#[test]
+fn tier3_lvlh_retrograde_orbit() {
+    // Prograde orbit: position +X, velocity +Y → h = +Z → Y-hat = -Z.
+    // Retrograde orbit: position +X, velocity -Y → h = -Z → Y-hat = +Z.
+    //
+    // We propagate both for one step, read the Y-hat from the LVLH frame,
+    // and verify the sign flip.
+    let mu_earth = load_mu_earth();
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+    let dt = 10.0;
+
+    // Prograde (equatorial)
+    let mut sim_prograde = make_earth_lvlh_sim(
+        dt,
+        mu_earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    );
+    sim_prograde.validate().unwrap();
+    sim_prograde.step_until(dt);
+    let lvlh_p = sim_prograde
+        .body(0)
+        .lvlh_frame
+        .expect("prograde: LVLH not computed");
+    let y_p = lvlh_y_hat(&lvlh_p.t_parent_this);
+
+    // Retrograde (equatorial, velocity reversed)
+    let mut sim_retro = make_earth_lvlh_sim(
+        dt,
+        mu_earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, -v, 0.0),
+        },
+    );
+    sim_retro.validate().unwrap();
+    sim_retro.step_until(dt);
+    let lvlh_r = sim_retro
+        .body(0)
+        .lvlh_frame
+        .expect("retrograde: LVLH not computed");
+    let y_r = lvlh_y_hat(&lvlh_r.t_parent_this);
+
+    // Y-hat = -h_hat, so prograde Y ≈ -Ẑ and retrograde Y ≈ +Ẑ.
+    assert!(
+        (y_p.z + 1.0).abs() < 1e-8,
+        "prograde Y-hat Z-component: {:.6e}, expected -1",
+        y_p.z
+    );
+    assert!(
+        (y_r.z - 1.0).abs() < 1e-8,
+        "retrograde Y-hat Z-component: {:.6e}, expected +1",
+        y_r.z
+    );
+    // Sum should be ≈ 0 (one flip of sign).
+    let sum = y_p + y_r;
+    assert!(
+        sum.length() < 1e-8,
+        "Y-hat did not flip sign: y_p + y_r = {sum:?}"
+    );
+
+    // Angular velocities have equal magnitude but opposite sign on the LVLH
+    // Y-axis: ω_LVLH = [0, -wmag, 0]. For retrograde, wmag is the same
+    // (|h|/r²), and the LVLH frame Y-hat points the other way, so the angular
+    // velocity vector (expressed in LVLH coords) remains [0, -wmag, 0] in both
+    // cases, but the inertial orbit winds the other way. Sanity-check the
+    // magnitudes are equal.
+    let wmag_p = lvlh_p.ang_vel_this.length();
+    let wmag_r = lvlh_r.ang_vel_this.length();
+    assert!(
+        (wmag_p - wmag_r).abs() / wmag_p < 1e-10,
+        "LVLH ang vel magnitudes differ: prograde {wmag_p}, retrograde {wmag_r}"
+    );
+}
+
+#[test]
+fn tier3_lvlh_eccentric_orbit() {
+    // Elliptical orbit with perigee at r_p = 6778 km, apogee at r_a = 20000 km.
+    // |ω_LVLH| = |h| / r². At perigee r = r_p, velocity is perpendicular to
+    // position, so h = r_p * v_p. Same at apogee. We start at perigee.
+    let mu_earth = load_mu_earth();
+    let r_p = 6_778_137.0;
+    let r_a = 20_000_000.0;
+    let a = 0.5 * (r_p + r_a);
+    let e = (r_a - r_p) / (r_a + r_p);
+    let v_p = (mu_earth * (1.0 + e) / (a * (1.0 - e))).sqrt();
+    let v_a = (mu_earth * (1.0 - e) / (a * (1.0 + e))).sqrt();
+    let dt = 10.0;
+
+    let body = TranslationalState {
+        position: DVec3::new(r_p, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v_p, 0.0),
+    };
+    let mut sim = make_earth_lvlh_sim(dt, mu_earth, body);
+    sim.validate().unwrap();
+
+    let period = 2.0 * std::f64::consts::PI * (a * a * a / mu_earth).sqrt();
+    // Angular momentum magnitude (constant along orbit).
+    let h_mag = r_p * v_p;
+    let expected_omega_peri = h_mag / (r_p * r_p);
+    let expected_omega_apo = h_mag / (r_a * r_a);
+
+    // Step through first full period, tracking observed omega near perigee
+    // (small r) and apogee (large r) by finding the radius extrema.
+    let n_steps = (period / dt) as usize;
+    let mut min_r = f64::INFINITY;
+    let mut max_r = 0.0_f64;
+    let mut omega_at_min_r = 0.0_f64;
+    let mut omega_at_max_r = 0.0_f64;
+    for step in 1..=n_steps {
+        sim.step_until(step as f64 * dt);
+        let body = sim.body(0);
+        let r = body.trans.position.length();
+        let lvlh = body.lvlh_frame.expect("LVLH not computed");
+        let omega = lvlh.ang_vel_this.length();
+        if r < min_r {
+            min_r = r;
+            omega_at_min_r = omega;
+        }
+        if r > max_r {
+            max_r = r;
+            omega_at_max_r = omega;
+        }
+    }
+
+    // Perigee check. Perigee is close to but might not exactly hit r_p on
+    // our sampled grid; allow a small relative tolerance.
+    assert!(
+        ((min_r - r_p).abs() / r_p) < 5e-4,
+        "perigee radius drift: min_r = {min_r}, expected {r_p}"
+    );
+    assert!(
+        ((max_r - r_a).abs() / r_a) < 5e-4,
+        "apogee radius drift: max_r = {max_r}, expected {r_a}"
+    );
+    // Omega ratio (perigee/apogee) should match (r_a/r_p)².
+    let expected_ratio = (r_a / r_p).powi(2);
+    let observed_ratio = omega_at_min_r / omega_at_max_r;
+    assert!(
+        ((observed_ratio - expected_ratio).abs() / expected_ratio) < 5e-3,
+        "omega ratio: observed {observed_ratio}, expected {expected_ratio}"
+    );
+    // Absolute omega values within a few parts per thousand (sampling error).
+    assert!(
+        ((omega_at_min_r - expected_omega_peri).abs() / expected_omega_peri) < 5e-3,
+        "omega at perigee: {omega_at_min_r}, expected {expected_omega_peri}"
+    );
+    assert!(
+        ((omega_at_max_r - expected_omega_apo).abs() / expected_omega_apo) < 5e-3,
+        "omega at apogee: {omega_at_max_r}, expected {expected_omega_apo}"
+    );
+    // Also sanity-check v_a against v_p via conservation of angular momentum:
+    // h = r_p v_p = r_a v_a. (Use it to prevent dead_code warnings on v_a.)
+    let predicted_v_a = h_mag / r_a;
+    assert!(
+        (predicted_v_a - v_a).abs() / v_a < 1e-12,
+        "v_a consistency: predicted {predicted_v_a}, closed-form {v_a}"
+    );
+}
+
+#[test]
+fn tier3_lvlh_periodicity() {
+    // After one orbital period, a circular Keplerian orbit returns to its
+    // initial state, so the LVLH frame (which is a function of r,v) must
+    // return to its initial orientation. Because the simulation pipeline
+    // stepper advances the inertial state first and then computes derived
+    // state, we perform a "cold" LVLH computation from the initial conditions
+    // and compare it to the pipeline-reported LVLH after exactly one period.
+    //
+    // We also tune the step size so that the configured period is an exact
+    // integer multiple of dt — otherwise any LVLH mismatch is dominated by
+    // rounding the stop time to a grid point rather than by physics error.
+    let mu_earth = load_mu_earth();
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+    // Integer number of steps; choose n_steps ≈ 560 then set dt = period/n_steps.
+    let n_steps: usize = 560;
+    let dt = period / n_steps as f64;
+
+    let initial_state = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    };
+    let mut sim = make_earth_lvlh_sim(dt, mu_earth, initial_state);
+    sim.validate().unwrap();
+
+    // Reference LVLH from the initial conditions (independent of the sim).
+    let lvlh_reference =
+        jeod_sim::compute_body_lvlh_frame(initial_state.position, initial_state.velocity)
+            .t_parent_this;
+
+    // Propagate exactly one orbital period.
+    sim.step_until(n_steps as f64 * dt);
+    let lvlh_final = sim
+        .body(0)
+        .lvlh_frame
+        .expect("LVLH not computed")
+        .t_parent_this;
+
+    // For an exact-integer-step period, the only residual is RK4 truncation
+    // over one orbit on a 10-s scale step, which is well under 1e-5 for a
+    // circular LEO.
+    let max_diff = max_mat_diff(&lvlh_reference, &lvlh_final);
+    assert!(
+        max_diff < 1e-5,
+        "LVLH frame failed to return to initial orientation: max diff = {max_diff:.3e}"
+    );
+
+    // Additionally verify the orbit position at one period is close to the
+    // initial position (confirms we did indeed complete ~1 full revolution).
+    let pos_return_err = (sim.body(0).trans.position - initial_state.position).length();
+    // RK4 truncation over one orbit on a dt ≈ period/560 is tens of cm.
+    assert!(
+        pos_return_err < 1.0,
+        "position not returned to initial within 1 m after 1 period: \
+         err = {pos_return_err:.3e} m"
+    );
+}

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -1,0 +1,454 @@
+//! Tier 3: Extended relative-dynamics tests (analytical).
+//!
+//! These tests exercise `compute_relative_state` and
+//! `compute_lvlh_relative_state` via the full `Simulation::step()` pipeline
+//! under closed-form initial conditions, then verify the analytical properties
+//! of the resulting trajectories:
+//!
+//! * `tier3_relative_two_coorbiting_vehicles` — identical circular orbits with a
+//!   small along-track offset; verify the LVLH-relative separation stays bounded.
+//! * `tier3_relative_hohmann_transfer_geometry` — chief in circular orbit,
+//!   deputy in a coplanar ellipse intersecting the chief; verify the separation
+//!   oscillates between periapsis and apoapsis bounds.
+//! * `tier3_relative_same_orbit_phase_difference` — two vehicles in the same
+//!   circular orbit 90° apart; verify chord length = r * sqrt(2).
+//! * `tier3_relative_different_inclinations` — chief equatorial, deputy inclined
+//!   by 1°; verify cross-track separation oscillates at the orbital period with
+//!   amplitude a * sin(1°).
+//! * `tier3_relative_round_trip_frames` — r_AB must equal -r_BA when the
+//!   reference frame is inertial (no rotational state), confirming the
+//!   symmetry of the relative-state operator.
+//!
+//! No Docker reference data required. Earth mu is read from JEOD source.
+
+use glam::DVec3;
+use jeod_runner::{
+    DerivedStateConfig, GravitySourceEntry, RotationModel, Simulation, VehicleConfig,
+};
+use jeod_sim::{
+    compute_lvlh_relative_state, compute_relative_state, GravityControl, GravityControls,
+    GravityModel, GravitySource, SimulationTime, TranslationalState,
+};
+
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
+/// Construct a Simulation with a single point-mass Earth at the origin and
+/// return `(sim, earth_source_idx)` for the caller to populate with bodies.
+fn make_earth_sim(dt: f64, mu_earth: f64) -> (Simulation, usize) {
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let mut sim = Simulation::new(time, dt);
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+    (sim, earth)
+}
+
+fn add_orbital_body(sim: &mut Simulation, earth: usize, trans: TranslationalState) {
+    sim.add_body(VehicleConfig {
+        trans,
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        derived: DerivedStateConfig {
+            lvlh: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+}
+
+#[test]
+fn tier3_relative_two_coorbiting_vehicles() {
+    // Two vehicles on the same 400 km circular equatorial orbit, separated by
+    // a small along-track phase. In the chief's LVLH frame the deputy should
+    // remain at an almost-constant along-track offset, up to truncation error
+    // from the RK4 integrator at a 10 s step.
+    let mu_earth = load_mu_earth();
+    let dt = 10.0;
+    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
+
+    let r = 6_778_137.0; // ~400 km altitude
+    let v = (mu_earth / r).sqrt();
+
+    // Chief at (r, 0, 0), velocity +y
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    );
+
+    // Deputy 100 m "ahead" — i.e., offset by a tiny true anomaly Δν
+    // so that Δs ≈ r * Δν = 100 m, Δν = 100/r rad.
+    let dnu = 100.0 / r;
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r * dnu.cos(), r * dnu.sin(), 0.0),
+            velocity: DVec3::new(-v * dnu.sin(), v * dnu.cos(), 0.0),
+        },
+    );
+
+    sim.validate().unwrap();
+
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+    let end_time = 3.0 * period;
+    let n_steps = (end_time / dt) as usize;
+
+    let mut max_sep = 0.0_f64;
+    let mut min_sep = f64::INFINITY;
+    let mut max_lvlh_x = 0.0_f64;
+    let mut max_lvlh_yz = 0.0_f64;
+
+    for step in 1..=n_steps {
+        let t = step as f64 * dt;
+        sim.step_until(t);
+
+        let chief = sim.body(0);
+        let deputy = sim.body(1);
+        let sep = (deputy.trans.position - chief.trans.position).length();
+        max_sep = max_sep.max(sep);
+        min_sep = min_sep.min(sep);
+
+        let rel = compute_lvlh_relative_state(
+            chief.trans.position,
+            chief.trans.velocity,
+            deputy.trans.position,
+            deputy.trans.velocity,
+        );
+        // LVLH: X ≈ along-track, Y ≈ -orbit-normal, Z ≈ -radial.
+        // For co-orbiting bodies, the along-track component dominates and
+        // the in-plane/out-of-plane excursions stay small.
+        max_lvlh_x = max_lvlh_x.max(rel.position.x.abs());
+        max_lvlh_yz = max_lvlh_yz
+            .max((rel.position.y * rel.position.y + rel.position.z * rel.position.z).sqrt());
+    }
+
+    // Inertial separation stays very close to the 100 m initial chord.
+    assert!(
+        (max_sep - 100.0).abs() < 0.01,
+        "co-orbiting max inertial separation {max_sep} m drifted from 100 m"
+    );
+    assert!(
+        (min_sep - 100.0).abs() < 0.01,
+        "co-orbiting min inertial separation {min_sep} m drifted from 100 m"
+    );
+    // In LVLH the along-track dominates and Y/Z excursions stay tiny
+    // (bounded by RK4 truncation over 3 orbits).
+    assert!(
+        max_lvlh_x > 99.0 && max_lvlh_x < 101.0,
+        "LVLH along-track {max_lvlh_x} m not near 100 m"
+    );
+    assert!(
+        max_lvlh_yz < 0.1,
+        "LVLH out-of-track excursion {max_lvlh_yz} m exceeds 0.1 m"
+    );
+}
+
+#[test]
+fn tier3_relative_hohmann_transfer_geometry() {
+    // Chief in circular orbit at 400 km; deputy in a coplanar ellipse whose
+    // periapsis coincides with the chief's orbit (same r, same direction of
+    // motion). The separation |r_deputy - r_chief| must oscillate because the
+    // deputy climbs to apoapsis and falls back.
+    let mu_earth = load_mu_earth();
+    let dt = 10.0;
+    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
+
+    let r_chief = 6_778_137.0;
+    let v_chief = (mu_earth / r_chief).sqrt();
+
+    // Chief: circular
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r_chief, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v_chief, 0.0),
+        },
+    );
+
+    // Deputy: periapsis at (r_chief, 0, 0), same direction of motion,
+    // apoapsis at r_apo = 1.05 * r_chief.
+    let r_apo = 1.05 * r_chief;
+    let a_d = 0.5 * (r_chief + r_apo);
+    let e_d = (r_apo - r_chief) / (r_apo + r_chief);
+    let v_peri = (mu_earth * (1.0 + e_d) / (a_d * (1.0 - e_d))).sqrt();
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r_chief, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v_peri, 0.0),
+        },
+    );
+
+    sim.validate().unwrap();
+
+    // Initial separation: both bodies at the same point → 0.
+    let init_sep = (sim.body(1).trans.position - sim.body(0).trans.position).length();
+    assert!(
+        init_sep < 1e-9,
+        "Hohmann setup: initial separation {init_sep} m should be 0"
+    );
+
+    // Propagate for one deputy period so the deputy returns to its periapsis.
+    let period_d = 2.0 * std::f64::consts::PI * (a_d * a_d * a_d / mu_earth).sqrt();
+    let n_steps = (period_d / dt) as usize;
+
+    let mut max_sep = 0.0_f64;
+    // Track separation near apoapsis: at T_d/2, deputy is at (-r_apo, ..., 0).
+    // At that time the chief has advanced by T_d/2 * ω_chief > π, so its
+    // position is indeterminate by analytical inspection — but the range
+    // |r_a - r_c| ≤ sep ≤ r_a + r_c must hold.
+
+    for step in 1..=n_steps {
+        let t = step as f64 * dt;
+        sim.step_until(t);
+
+        let chief = sim.body(0);
+        let deputy = sim.body(1);
+        let sep = (deputy.trans.position - chief.trans.position).length();
+        max_sep = max_sep.max(sep);
+    }
+
+    // Upper bound: r_apo + r_chief (deputy-apoapsis, chief-antipode).
+    // Lower bound on achievable max separation: r_apo - r_chief when they
+    // happen to be co-radial at opposite points.
+    assert!(
+        max_sep > 0.8 * (r_apo - r_chief),
+        "Hohmann-geometry max separation {max_sep} m below expected oscillation"
+    );
+    assert!(
+        max_sep < r_apo + r_chief + 1.0,
+        "Hohmann-geometry max separation {max_sep} m exceeds geometric bound {}",
+        r_apo + r_chief
+    );
+}
+
+#[test]
+fn tier3_relative_same_orbit_phase_difference() {
+    // Two vehicles in the same circular orbit, 90° apart in true anomaly.
+    // At t=0 their positions are on the same circle of radius r, subtending
+    // 90° at Earth, so the chord length is r * sqrt(2). Because they share
+    // the orbital period, this separation is preserved forever.
+    let mu_earth = load_mu_earth();
+    let dt = 10.0;
+    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
+
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+
+    // Body A: at (r, 0, 0), velocity (0, v, 0)
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    );
+
+    // Body B: at (0, r, 0) [90° ahead], velocity (-v, 0, 0)
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(0.0, r, 0.0),
+            velocity: DVec3::new(-v, 0.0, 0.0),
+        },
+    );
+
+    sim.validate().unwrap();
+
+    let expected_sep = r * std::f64::consts::SQRT_2;
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+
+    let mut max_dev = 0.0_f64;
+
+    // Check at t=0 first (before any step)
+    {
+        let a = sim.body(0);
+        let b = sim.body(1);
+        let rel = compute_relative_state(&a.trans, None, &b.trans, None);
+        let sep = rel.position.length();
+        max_dev = max_dev.max((sep - expected_sep).abs());
+    }
+
+    // Check every 30 s over 2 orbits
+    let n_steps = (2.0 * period / dt) as usize;
+    for step in 1..=n_steps {
+        let t = step as f64 * dt;
+        sim.step_until(t);
+        let a = sim.body(0);
+        let b = sim.body(1);
+        let rel = compute_relative_state(&a.trans, None, &b.trans, None);
+        let sep = rel.position.length();
+        max_dev = max_dev.max((sep - expected_sep).abs());
+    }
+
+    // RK4 on a 10 s step over 2 orbits produces sub-mm deviations.
+    assert!(
+        max_dev < 1e-2,
+        "same-orbit 90° phase: separation drift {max_dev} m exceeds 1e-2 m"
+    );
+}
+
+#[test]
+fn tier3_relative_different_inclinations() {
+    // Chief on equatorial circular orbit; deputy on the same circular orbit
+    // inclined by +1° about the +X axis (i.e., node on the +X axis, AOL 0).
+    // Both start at (r, 0, 0). Cross-track excursion (out-of-plane in chief's
+    // frame) oscillates at the orbital period with amplitude r * sin(1°).
+    let mu_earth = load_mu_earth();
+    let dt = 5.0;
+    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
+
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+    let inc = 1.0_f64.to_radians();
+
+    // Chief: equatorial
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    );
+
+    // Deputy: inclined, same initial position, velocity tipped into +Z
+    // by inc. Rotation about +X by +inc sends (0, v, 0) → (0, v cos i, v sin i).
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+        },
+    );
+
+    sim.validate().unwrap();
+
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+    let n_steps = (2.0 * period / dt) as usize;
+    let expected_amplitude = r * inc.sin();
+
+    let mut max_abs_z = 0.0_f64; // inertial Z separation (cross-track)
+    for step in 1..=n_steps {
+        let t = step as f64 * dt;
+        sim.step_until(t);
+
+        let chief = sim.body(0);
+        let deputy = sim.body(1);
+        let dz = (deputy.trans.position - chief.trans.position).z.abs();
+        max_abs_z = max_abs_z.max(dz);
+    }
+
+    // Amplitude should match r * sin(inc) within integration tolerance.
+    let amp_err = (max_abs_z - expected_amplitude).abs();
+    assert!(
+        amp_err < 1.0,
+        "cross-track amplitude error {amp_err} m (got {max_abs_z}, \
+         expected {expected_amplitude}) exceeds 1 m"
+    );
+}
+
+#[test]
+fn tier3_relative_round_trip_frames() {
+    // When neither body has a rotational state, the relative-state operator
+    // has a clean symmetry: r_AB = -r_BA and v_AB = -v_BA. We verify this on
+    // the propagated trajectory at several checkpoints.
+    let mu_earth = load_mu_earth();
+    let dt = 10.0;
+    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
+
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+
+    // Body 0 at (r, 0, 0); Body 1 in a different coplanar circular orbit.
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    );
+    let r2 = r + 500_000.0;
+    let v2 = (mu_earth / r2).sqrt();
+    add_orbital_body(
+        &mut sim,
+        earth,
+        TranslationalState {
+            position: DVec3::new(r2, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v2, 0.0),
+        },
+    );
+
+    sim.validate().unwrap();
+
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+    let n_steps = (period / dt) as usize;
+
+    let mut max_sum_pos = 0.0_f64;
+    let mut max_sum_vel = 0.0_f64;
+
+    for step in 1..=n_steps {
+        let t = step as f64 * dt;
+        sim.step_until(t);
+
+        let a = sim.body(0);
+        let b = sim.body(1);
+
+        // State of A wrt B
+        let ab = compute_relative_state(&b.trans, None, &a.trans, None);
+        // State of B wrt A
+        let ba = compute_relative_state(&a.trans, None, &b.trans, None);
+
+        let pos_sum = (ab.position + ba.position).length();
+        let vel_sum = (ab.velocity + ba.velocity).length();
+        max_sum_pos = max_sum_pos.max(pos_sum);
+        max_sum_vel = max_sum_vel.max(vel_sum);
+    }
+
+    // The two relative states must add to zero (floating-point exact by
+    // construction: both compute (p_s - p_r) with opposite role assignments).
+    assert!(
+        max_sum_pos < 1e-9,
+        "round-trip: ab.position + ba.position has magnitude {max_sum_pos} m"
+    );
+    assert!(
+        max_sum_vel < 1e-9,
+        "round-trip: ab.velocity + ba.velocity has magnitude {max_sum_vel} m/s"
+    );
+}

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -134,7 +134,8 @@ fn tier3_relative_two_coorbiting_vehicles() {
 
         let chief = sim.body(0);
         let deputy = sim.body(1);
-        let sep = (deputy.trans.position - chief.trans.position).length();
+        let rel_inertial = compute_relative_state(&chief.trans, None, &deputy.trans, None);
+        let sep = rel_inertial.position.length();
         max_sep = max_sep.max(sep);
         min_sep = min_sep.min(sep);
 

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -214,7 +214,8 @@ fn tier3_relative_hohmann_transfer_geometry() {
     sim.validate().unwrap();
 
     // Initial separation: both bodies at the same point → 0.
-    let init_sep = (sim.body(1).trans.position - sim.body(0).trans.position).length();
+    let init_rel = compute_relative_state(&sim.body(0).trans, None, &sim.body(1).trans, None);
+    let init_sep = init_rel.position.length();
     assert!(
         init_sep < 1e-9,
         "Hohmann setup: initial separation {init_sep} m should be 0"
@@ -236,7 +237,8 @@ fn tier3_relative_hohmann_transfer_geometry() {
 
         let chief = sim.body(0);
         let deputy = sim.body(1);
-        let sep = (deputy.trans.position - chief.trans.position).length();
+        let rel = compute_relative_state(&chief.trans, None, &deputy.trans, None);
+        let sep = rel.position.length();
         max_sep = max_sep.max(sep);
     }
 
@@ -430,13 +432,13 @@ fn tier3_relative_round_trip_frames() {
         let a = sim.body(0);
         let b = sim.body(1);
 
-        // State of A wrt B
-        let ab = compute_relative_state(&b.trans, None, &a.trans, None);
-        // State of B wrt A
-        let ba = compute_relative_state(&a.trans, None, &b.trans, None);
+        // State of A wrt B (reference = B, subject = A).
+        let a_wrt_b = compute_relative_state(&b.trans, None, &a.trans, None);
+        // State of B wrt A (reference = A, subject = B).
+        let b_wrt_a = compute_relative_state(&a.trans, None, &b.trans, None);
 
-        let pos_sum = (ab.position + ba.position).length();
-        let vel_sum = (ab.velocity + ba.velocity).length();
+        let pos_sum = (a_wrt_b.position + b_wrt_a.position).length();
+        let vel_sum = (a_wrt_b.velocity + b_wrt_a.velocity).length();
         max_sum_pos = max_sum_pos.max(pos_sum);
         max_sum_vel = max_sum_vel.max(vel_sum);
     }
@@ -445,10 +447,10 @@ fn tier3_relative_round_trip_frames() {
     // construction: both compute (p_s - p_r) with opposite role assignments).
     assert!(
         max_sum_pos < 1e-9,
-        "round-trip: ab.position + ba.position has magnitude {max_sum_pos} m"
+        "round-trip: a_wrt_b.position + b_wrt_a.position has magnitude {max_sum_pos} m"
     );
     assert!(
         max_sum_vel < 1e-9,
-        "round-trip: ab.velocity + ba.velocity has magnitude {max_sum_vel} m/s"
+        "round-trip: a_wrt_b.velocity + b_wrt_a.velocity has magnitude {max_sum_vel} m/s"
     );
 }

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -303,7 +303,7 @@ fn tier3_relative_same_orbit_phase_difference() {
         max_dev = max_dev.max((sep - expected_sep).abs());
     }
 
-    // Check every 30 s over 2 orbits
+    // Check every dt seconds over 2 orbits
     let n_steps = (2.0 * period / dt) as usize;
     for step in 1..=n_steps {
         let t = step as f64 * dt;

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
@@ -1,0 +1,372 @@
+//! Tier 3: Extended solar-beta tests (analytical).
+//!
+//! These tests build controlled orbit/Sun geometries and propagate through
+//! `Simulation::step()` with a fake Sun source at a chosen position. The
+//! reported solar-beta angle is checked against the closed-form value
+//! β = asin(ĥ · ŝ).
+//!
+//! * `tier3_solar_beta_equatorial_at_equinox` — equatorial orbit with Sun in
+//!   the orbital (equatorial) plane → β ≈ 0.
+//! * `tier3_solar_beta_polar_orbit` — polar orbit. Over one year, β can swing
+//!   across the full [-90°, +90°] range. We verify three snapshot geometries.
+//! * `tier3_solar_beta_iss_orbit` — ISS inclination (51.6°); for Sun on the
+//!   +Z axis β = inclination, for Sun in the orbital plane β = 0.
+//! * `tier3_solar_beta_sun_in_orbital_plane` — Sun direction in the orbital
+//!   plane regardless of orbit inclination → β = 0.
+//! * `tier3_solar_beta_sun_perpendicular_to_plane` — Sun along the orbit
+//!   normal → |β| = 90°.
+//! * `tier3_solar_beta_bounded` — for every propagated checkpoint of a mid-
+//!   inclination orbit with a fixed Sun position, |β| ≤ 90° + inclination.
+//!
+//! No Docker reference data required.
+
+use glam::DVec3;
+use jeod_runner::{
+    DerivedStateConfig, GravitySourceEntry, RotationModel, Simulation, VehicleConfig,
+};
+use jeod_sim::{
+    GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime,
+    TranslationalState,
+};
+
+fn load_mu_earth() -> f64 {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
+        jeod_root.display()
+    );
+    jeod_sim::coefficients::load_mu_from_jeod_cc(
+        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
+    )
+    .expect("load Earth mu from GGM05C")
+}
+
+/// Sun at a cartoon distance in the +X direction produces `sun_direction = +X`
+/// for any body near the origin; at this scale the relative-Sun vector from
+/// any LEO body is effectively parallel to the Sun position vector.
+const SUN_DISTANCE_M: f64 = 1.495_978_707e11; // 1 AU
+
+/// Build a Simulation with:
+///   * central-body Earth at origin (point-mass gravity),
+///   * a "Sun" source at `sun_position` with mu = 0 (kinematic only),
+///   * a single vehicle configured with `solar_beta: true`.
+///
+/// Returns the simulation ready to be `validate`d and stepped.
+fn build_solar_beta_sim(
+    mu_earth: f64,
+    dt: f64,
+    sun_position: DVec3,
+    body_state: TranslationalState,
+) -> Simulation {
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let mut sim = Simulation::new(time, dt);
+
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: sun_position,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+        },
+    );
+    sim.sun_source = Some(sun);
+
+    sim.add_body(VehicleConfig {
+        trans: body_state,
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        derived: DerivedStateConfig {
+            solar_beta: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    sim
+}
+
+#[test]
+fn tier3_solar_beta_equatorial_at_equinox() {
+    // Equatorial circular orbit → orbit normal = +Z.
+    // Sun in the equatorial (x–y) plane → ŝ ⊥ ĥ → β = 0.
+    let mu_earth = load_mu_earth();
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+
+    let mut sim = build_solar_beta_sim(
+        mu_earth,
+        10.0,
+        DVec3::new(SUN_DISTANCE_M, 0.0, 0.0),
+        TranslationalState {
+            position: DVec3::new(r, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    );
+    sim.validate().unwrap();
+
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+    let n_steps = (period / 10.0) as usize;
+
+    let mut max_beta = 0.0_f64;
+    for step in 1..=n_steps {
+        sim.step_until(step as f64 * 10.0);
+        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        max_beta = max_beta.max(beta.abs());
+    }
+
+    // The Sun-direction deviates slightly from +X as the body orbits (since
+    // sun_direction = sun_position - body_position). For r/SUN_DISTANCE ~ 4.5e-5
+    // the worst-case projection onto ĥ = +Z is zero (coplanar), so β is
+    // limited by floating-point noise and the small offset: well under 1e-4 rad.
+    assert!(
+        max_beta < 1e-4,
+        "equatorial+in-plane sun: max |beta| = {max_beta:.3e} rad exceeds 1e-4"
+    );
+}
+
+#[test]
+fn tier3_solar_beta_polar_orbit() {
+    // Polar orbit about Earth — orbit plane contains +Z, so orbit normal is
+    // perpendicular to +Z. Over a full year the Sun sweeps the ecliptic; we
+    // verify three snapshot geometries by instantiating distinct simulations.
+    //
+    //   (1) Sun along +X (equinox-like):   ĥ·ŝ = 0 → β = 0
+    //   (2) Sun along +Y:                  β = ±90° if orbit normal = ±Y
+    //   (3) Sun along +Z:                  Sun is in the orbital plane → β = 0
+    let mu_earth = load_mu_earth();
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+
+    // Polar orbit: position +X, velocity +Z → h = r × v = r v (+Y)
+    let body = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 0.0, v),
+    };
+
+    let cases = [
+        (DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), 0.0_f64), // Sun along +X
+        (DVec3::new(0.0, SUN_DISTANCE_M, 0.0), 90.0_f64), // Sun along +Y
+        (DVec3::new(0.0, 0.0, SUN_DISTANCE_M), 0.0_f64), // Sun along +Z
+    ];
+
+    for (sun_pos, expected_deg) in cases {
+        let mut sim = build_solar_beta_sim(mu_earth, 10.0, sun_pos, body);
+        sim.validate().unwrap();
+        sim.step_until(10.0); // derived state is populated after first step
+        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        let expected = expected_deg.to_radians();
+        assert!(
+            (beta.abs() - expected).abs() < 1e-4,
+            "polar orbit, Sun at {sun_pos:?}: |beta| = {} rad, expected {}",
+            beta.abs(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn tier3_solar_beta_iss_orbit() {
+    // ISS-like circular orbit at 51.6° inclination. With
+    //   r = (r, 0, 0), v = (0, v cos i, v sin i)
+    //   h = r × v = (0, -r v sin i, r v cos i)
+    //   ĥ = (0, -sin i, cos i)
+    //
+    // For Sun along +Z:    ĥ·ẑ = cos i  →  β = asin(cos i) = π/2 − i
+    // For Sun along +X:    ĥ·x̂ = 0      →  β = 0
+    // For Sun along −Y:    ĥ·(−ŷ) = sin i →  β = asin(sin i) = i
+    //
+    // We verify all three cases.
+    let mu_earth = load_mu_earth();
+    let r = 6_778_137.0;
+    let v = (mu_earth / r).sqrt();
+    let inc = 51.6_f64.to_radians();
+
+    let body = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    };
+
+    // Case 1: Sun in the equatorial plane (+X). β ≈ 0.
+    {
+        let mut sim =
+            build_solar_beta_sim(mu_earth, 10.0, DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), body);
+        sim.validate().unwrap();
+        sim.step_until(10.0);
+        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        assert!(
+            beta.abs() < 1e-4,
+            "ISS orbit + Sun in equatorial plane: |beta| = {beta} rad (expected ≈0)"
+        );
+    }
+
+    // Case 2: Sun along +Z → β = π/2 − i.
+    {
+        let mut sim =
+            build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, 0.0, SUN_DISTANCE_M), body);
+        sim.validate().unwrap();
+        sim.step_until(10.0);
+        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        let expected = std::f64::consts::FRAC_PI_2 - inc;
+        assert!(
+            (beta - expected).abs() < 1e-4,
+            "ISS orbit + Sun along +Z: beta = {beta} rad (expected {expected} = π/2 − i)"
+        );
+    }
+
+    // Case 3: Sun along −Y → β = i. This exercises the bound that β can
+    // reach the full inclination angle at a favorable Sun direction.
+    {
+        let mut sim =
+            build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, -SUN_DISTANCE_M, 0.0), body);
+        sim.validate().unwrap();
+        sim.step_until(10.0);
+        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        assert!(
+            (beta - inc).abs() < 1e-4,
+            "ISS orbit + Sun along −Y: beta = {beta} rad (expected {inc} = inclination)"
+        );
+    }
+}
+
+#[test]
+fn tier3_solar_beta_sun_in_orbital_plane() {
+    // Sun direction exactly in the orbital plane → ĥ · ŝ = 0 → β = 0.
+    // Check this for a 30° inclination orbit where the Sun sits exactly at
+    // the ascending node direction (in the equatorial plane the node is +X).
+    let mu_earth = load_mu_earth();
+    let r = 7_000_000.0;
+    let v = (mu_earth / r).sqrt();
+    let inc = 30.0_f64.to_radians();
+
+    // Position along +X (ascending node), velocity tipped into the orbit plane.
+    let body = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    };
+    // Orbit normal: h = r × v = (r, 0, 0) × (0, v cos i, v sin i)
+    //              = (0·v sin i − 0·v cos i, 0·0 − r·v sin i, r·v cos i − 0·0)
+    //              = (0, −r v sin i, r v cos i). Direction = (0, −sin i, cos i).
+    // Sun along +X lies in the plane since +X · (orbit normal) = 0.
+    let mut sim = build_solar_beta_sim(mu_earth, 10.0, DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), body);
+    sim.validate().unwrap();
+    sim.step_until(10.0);
+    let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+    assert!(
+        beta.abs() < 1e-4,
+        "Sun in orbital plane: |beta| = {beta} rad exceeds 1e-4"
+    );
+}
+
+#[test]
+fn tier3_solar_beta_sun_perpendicular_to_plane() {
+    // Sun along the orbit normal → ĥ · ŝ = ±1 → |β| = π/2.
+    // Construct an equatorial orbit (normal = +Z) and place Sun along +Z.
+    let mu_earth = load_mu_earth();
+    let r = 7_000_000.0;
+    let v = (mu_earth / r).sqrt();
+
+    let body = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    };
+
+    let mut sim = build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, 0.0, SUN_DISTANCE_M), body);
+    sim.validate().unwrap();
+    sim.step_until(10.0);
+    let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+
+    let pi_2 = std::f64::consts::FRAC_PI_2;
+    // Tolerance accounts for the small LEO offset from the origin vs the Sun
+    // at 1 AU: the body-Sun direction is slightly off +Z by r/AU ≈ 4.7e-5 rad.
+    assert!(
+        (beta.abs() - pi_2).abs() < 1e-4,
+        "Sun perpendicular to orbit plane: |beta| = {} rad (expected π/2 = {})",
+        beta.abs(),
+        pi_2
+    );
+}
+
+#[test]
+fn tier3_solar_beta_bounded() {
+    // For any orbit and any Sun position, |β| ≤ π/2. We propagate an
+    // inclined orbit for several periods and verify this bound at every
+    // integration step. (The tighter bound mentioned in the spec —
+    // π/2 + inclination — does not apply to β itself, which is always a
+    // signed angle in [-π/2, +π/2] by construction; our asserted bound is
+    // the mathematical limit |β| ≤ π/2.)
+    let mu_earth = load_mu_earth();
+    let r = 7_000_000.0;
+    let v = (mu_earth / r).sqrt();
+    let inc = 45.0_f64.to_radians();
+
+    let body = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    };
+
+    let mut sim = build_solar_beta_sim(
+        mu_earth,
+        10.0,
+        // Arbitrary Sun direction with components in all three axes.
+        DVec3::new(
+            0.7 * SUN_DISTANCE_M,
+            0.5 * SUN_DISTANCE_M,
+            0.2 * SUN_DISTANCE_M,
+        ),
+        body,
+    );
+    sim.validate().unwrap();
+
+    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
+    let n_steps = (3.0 * period / 10.0) as usize;
+
+    let pi_2 = std::f64::consts::FRAC_PI_2;
+    let mut max_abs_beta = 0.0_f64;
+    for step in 1..=n_steps {
+        sim.step_until(step as f64 * 10.0);
+        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        // Absolute bound from the asin definition.
+        assert!(
+            beta.abs() <= pi_2 + 1e-12,
+            "step {step}: |beta| = {} exceeds π/2",
+            beta.abs()
+        );
+        max_abs_beta = max_abs_beta.max(beta.abs());
+    }
+
+    // Confirm the β swing is nontrivial for this geometry so the test
+    // actually exercises the bound rather than asserting near zero.
+    assert!(
+        max_abs_beta > 0.05,
+        "max |beta| = {max_abs_beta} rad — geometry too degenerate to test bound"
+    );
+}

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
@@ -10,13 +10,13 @@
 //! * `tier3_solar_beta_polar_orbit` — polar orbit. Over one year, β can swing
 //!   across the full [-90°, +90°] range. We verify three snapshot geometries.
 //! * `tier3_solar_beta_iss_orbit` — ISS inclination (51.6°); for Sun on the
-//!   +Z axis β = inclination, for Sun in the orbital plane β = 0.
+//!   +Z axis β = π/2 − inclination, for Sun in the orbital plane β = 0.
 //! * `tier3_solar_beta_sun_in_orbital_plane` — Sun direction in the orbital
 //!   plane regardless of orbit inclination → β = 0.
 //! * `tier3_solar_beta_sun_perpendicular_to_plane` — Sun along the orbit
 //!   normal → |β| = 90°.
 //! * `tier3_solar_beta_bounded` — for every propagated checkpoint of a mid-
-//!   inclination orbit with a fixed Sun position, |β| ≤ 90° + inclination.
+//!   inclination orbit with a fixed Sun position, |β| ≤ 90°.
 //!
 //! No Docker reference data required.
 


### PR DESCRIPTION
## Summary
Add 14 new analytical Tier 3 tests exercising `compute_relative_state`, `compute_lvlh_relative_state`, solar beta, and LVLH frame computation through the full `Simulation::step()` pipeline.

**Note:** This PR is based on #82 (WS-B2 frame path queries). Once #82 merges, this PR will auto-retarget to main.

## Changes
- `crates/jeod_runner/tests/tier3_sim_relative_extended.rs` — 5 tests (new)
- `crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs` — 6 tests (new)
- `crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs` — 3 tests (new)

## Relative dynamics tests (5)
- `tier3_relative_two_coorbiting_vehicles` — 100m along-track offset stays bounded over 3 orbits
- `tier3_relative_hohmann_transfer_geometry` — separation bounded by `r_apo + r_chief`
- `tier3_relative_same_orbit_phase_difference` — 90deg chord = r*sqrt(2) preserved for 2 orbits
- `tier3_relative_different_inclinations` — cross-track amplitude matches `r*sin(1deg)` within 1m
- `tier3_relative_round_trip_frames` — `r_AB + r_BA = 0` and `v_AB + v_BA = 0`

## Solar beta tests (6)
- `tier3_solar_beta_equatorial_at_equinox` — Sun in equatorial plane -> beta ~ 0
- `tier3_solar_beta_polar_orbit` — 3 snapshot Sun geometries
- `tier3_solar_beta_iss_orbit` — ISS inclination (51.6deg) validation
- `tier3_solar_beta_sun_in_orbital_plane` — verified for 30deg inclined orbit
- `tier3_solar_beta_sun_perpendicular_to_plane` — |beta| = pi/2 within 1e-4 rad
- `tier3_solar_beta_bounded` — |beta| <= pi/2 at every step

## LVLH tests (3)
- `tier3_lvlh_retrograde_orbit` — Y-hat Z-component flips sign
- `tier3_lvlh_eccentric_orbit` — `omega = |h|/r^2` at perigee/apogee within 0.5%
- `tier3_lvlh_periodicity` — frame returns to initial orientation after one orbit within 1e-5

## Test plan
- [x] All 14 tests pass
- [x] All existing tests pass
- [x] `cargo fmt --check` and `cargo clippy --workspace --tests -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)