### PR TITLE
Add Tier 3 dyncomp combinations and force/torque response tests

### DIFF
--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
@@ -1,0 +1,670 @@
+//! Tier 3: Analytical physics-combination tests inspired by SIM_dyncomp RUNs.
+//!
+//! The numbered SIM_dyncomp RUN_* scenarios already have Docker-backed
+//! cross-validation tests (tier3_sim_dyncomp_run2..run10). This file adds
+//! analytical verification tests for physics combinations and laws that are
+//! exercised by those RUNs but which admit closed-form / conservation-law
+//! verification without a JEOD reference CSV.
+//!
+//! JEOD scenario mapping:
+//! - tier3_dyncomp_point_mass_3dof_conservation:
+//!   RUN_2 family (point-mass gravity): energy + angular momentum
+//!   conservation for Keplerian orbits.
+//! - tier3_dyncomp_sh_plus_thirdbody_conservation:
+//!   RUN_7A/7B (SH + Sun/Moon): third-body perturbations do not conserve
+//!   orbital angular momentum, but total energy bounded over short spans.
+//! - tier3_dyncomp_drag_plus_sh_monotonic_decay:
+//!   RUN_6/RUN_7C/7D (drag with non-spherical gravity): semi-major axis
+//!   must trend monotonically downward under drag.
+//! - tier3_dyncomp_6dof_rigid_body_invariance:
+//!   RUN_8A (torque-free rotation in orbit): inertial angular momentum is
+//!   conserved, body-frame omega varies (Euler's equations).
+//! - tier3_dyncomp_external_force_impulse_response:
+//!   RUN_9C/9D (external force): delta-v = F * dt / m during force window.
+//! - tier3_dyncomp_external_torque_impulse_response:
+//!   RUN_9A/9B/9C (external torque): delta-omega = tau * dt / I on axis.
+//! - tier3_dyncomp_attitude_stability_major_axis:
+//!   Related to RUN_8B (LVLH rate) attitude propagation: spin about the
+//!   major principal axis is stable (intermediate-axis theorem).
+
+mod sim_test_helpers;
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::{
+    GravityControl, GravityControls, GravityModel, GravitySource, JeodQuat, MassProperties,
+    RotationalState, SimulationTime, TranslationalState,
+};
+
+/// Earth gravitational parameter (m^3/s^2).
+const MU_EARTH: f64 = 3.986_004_418e14;
+/// Earth mean equatorial radius (m).
+const R_EARTH: f64 = 6_378_137.0;
+/// Sun gravitational parameter (m^3/s^2).
+const MU_SUN: f64 = 1.327_124_400_18e20;
+/// Moon gravitational parameter (m^3/s^2).
+const MU_MOON: f64 = 4.902_800_066e12;
+/// Typical Earth–Sun distance (m, ~1 AU).
+const R_EARTH_SUN: f64 = 1.495_978_707e11;
+/// Typical Earth–Moon distance (m).
+const R_EARTH_MOON: f64 = 3.844_0e8;
+
+/// Add a central Earth gravity source (point-mass).
+fn add_earth_point_mass(sim: &mut Simulation) -> usize {
+    sim.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    )
+}
+
+/// Circular orbit at 400 km altitude (ISS-like) in the equatorial plane.
+fn iss_circular_state() -> (DVec3, DVec3) {
+    let r = R_EARTH + 400_000.0;
+    let v = (MU_EARTH / r).sqrt();
+    (DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0))
+}
+
+/// Specific orbital energy: v^2/2 - mu/r.
+fn orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {
+    0.5 * vel.length_squared() - mu / pos.length()
+}
+
+/// Build a 3-DOF point-mass orbit simulation (pure Kepler).
+fn make_kepler_sim(pos: DVec3, vel: DVec3, mass: f64, dt: f64) -> Simulation {
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    let earth = add_earth_point_mass(&mut sim);
+
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: pos,
+            velocity: vel,
+        },
+        rot: None,
+        mass: Some(MassProperties::new(mass)),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+    sim
+}
+
+// ─── Test 1: Point-mass Kepler conservation ───
+
+/// 3-DOF point-mass orbit (RUN_2 configuration without reference data):
+/// specific orbital energy and angular momentum are conserved by Kepler
+/// dynamics. Any drift is numerical integrator error.
+#[test]
+fn tier3_dyncomp_point_mass_3dof_conservation() {
+    let (pos, vel) = iss_circular_state();
+    let dt = 10.0;
+    let mut sim = make_kepler_sim(pos, vel, 1000.0, dt);
+
+    let e0 = orbital_energy(pos, vel, MU_EARTH);
+    let h0 = pos.cross(vel);
+
+    // Propagate for 3 orbits.
+    let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
+    let n_steps = (3.0 * period / dt) as usize;
+    sim.step_n(n_steps);
+
+    let body = sim.body(0);
+    let e1 = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let h1 = body.trans.position.cross(body.trans.velocity);
+
+    let de = (e1 - e0).abs() / e0.abs();
+    let dh = (h1 - h0).length() / h0.length();
+
+    println!("  3 orbits Kepler: relative dE={de:.3e}, relative dH={dh:.3e}");
+
+    // RK4 at dt=10s: observed well below these bounds.
+    assert!(de < 1.0e-7, "Kepler energy drift {de:.3e} too large");
+    assert!(
+        dh < 1.0e-8,
+        "Kepler angular momentum drift {dh:.3e} too large"
+    );
+}
+
+// ─── Test 2: SH + third-body produces non-conservation of h ───
+
+/// RUN_7A/7B physics (SH gravity + Sun + Moon third body): third bodies
+/// exert torques about Earth, so orbital angular momentum about Earth is
+/// NOT strictly conserved. Its direction drifts (nodal regression, inclination
+/// wobble), yet total orbital energy stays bounded over short spans.
+///
+/// For this analytical test we use point-mass Earth (the non-sphericity from
+/// SH adds secular drift but is not required to exhibit third-body torques).
+#[test]
+fn tier3_dyncomp_sh_plus_thirdbody_conservation() {
+    let (pos, vel) = iss_circular_state();
+    let dt = 10.0;
+
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let mut sim = Simulation::new(time, dt);
+
+    let earth = add_earth_point_mass(&mut sim);
+
+    // Sun/Moon placed off the orbital (X-Y) plane so their differential
+    // accelerations produce a torque on the orbit about axes in the plane
+    // (nodal regression / inclination wobble).  A purely in-plane third body
+    // only perturbs the energy and periapsis — it does not tilt the orbital
+    // plane.
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            // Sun ~23.4° out of the equator (ecliptic obliquity).
+            position: DVec3::new(R_EARTH_SUN * 0.9175, 0.0, R_EARTH_SUN * 0.3977),
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+        },
+    );
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_MOON,
+                model: GravityModel::PointMass,
+            },
+            // Moon ~5° off the ecliptic — put it off the XY plane too.
+            position: DVec3::new(0.0, R_EARTH_MOON * 0.9063, R_EARTH_MOON * 0.4226),
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+        },
+    );
+
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: pos,
+            velocity: vel,
+        },
+        rot: None,
+        mass: Some(MassProperties::new(1000.0)),
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_spherical(earth, false),
+                GravityControl::new_third_body(sun),
+                GravityControl::new_third_body(moon),
+            ],
+        },
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+
+    let e0 = orbital_energy(pos, vel, MU_EARTH);
+    let h0 = pos.cross(vel);
+
+    // Integrate for one orbit.
+    let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
+    let n_steps = (period / dt) as usize;
+    sim.step_n(n_steps);
+
+    let body = sim.body(0);
+    let e1 = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let h1 = body.trans.position.cross(body.trans.velocity);
+
+    // Orbital energy about Earth should remain bounded (~third-body magnitude
+    // times one orbit).  Angular momentum *direction* should shift measurably.
+    let relative_de = (e1 - e0).abs() / e0.abs();
+    let dh_angle = {
+        let cos_th = h0.dot(h1) / (h0.length() * h1.length());
+        cos_th.clamp(-1.0, 1.0).acos()
+    };
+
+    println!("  1 orbit SH+3body: relative dE={relative_de:.3e}, dH_angle={dh_angle:.3e} rad");
+
+    // Energy change from third bodies over one LEO orbit is tiny but not zero.
+    assert!(
+        relative_de < 1.0e-5,
+        "Third-body relative energy drift {relative_de:.3e} too large"
+    );
+
+    // Verify the third-body torques had a measurable effect: the angular
+    // momentum vector must have moved more than pure-Kepler numerical noise.
+    assert!(
+        dh_angle > 1.0e-10,
+        "Third-body torque should tilt orbital plane; dH_angle={dh_angle:.3e} is pure noise"
+    );
+}
+
+// ─── Test 3: drag leads to monotonic decay of SMA ───
+
+/// RUN_6/RUN_7C/7D physics (gravity + drag): in a spherical-gravity + drag
+/// LEO orbit, the semi-major axis must trend monotonically downward.  We
+/// sample at orbital-period intervals (filtering out the in-orbit oscillation
+/// of instantaneous position) and verify strict monotonic decrease.
+#[test]
+fn tier3_dyncomp_drag_plus_sh_monotonic_decay() {
+    use jeod_sim::{AtmosphereConfig, AtmosphereModel, DragConfig, ExponentialAtmosphere};
+
+    let (pos, vel) = iss_circular_state();
+    let dt = 10.0;
+    let mass = 1000.0;
+
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    let earth = add_earth_point_mass(&mut sim);
+
+    // Constant-density drag atmosphere so we have repeatable per-orbit decay.
+    sim.atmosphere = Some(AtmosphereConfig {
+        model: AtmosphereModel::Exponential(ExponentialAtmosphere {
+            rho_0: 1e-11,
+            h_0: 400_000.0,
+            scale_height: 50_000.0,
+        }),
+        r_eq: R_EARTH,
+        r_pol: R_EARTH * (1.0 - 1.0 / 298.257_223_563),
+        planet_omega: 0.0,
+    });
+    sim.atmosphere_planet_source = Some(earth);
+
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: pos,
+            velocity: vel,
+        },
+        rot: Some(RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        }),
+        mass: Some(MassProperties::new(mass)),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        drag: Some(DragConfig {
+            cd: 2.2,
+            area: 20.0,
+            constant_density: Some(1e-11), // boosted density for clear decay
+        }),
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+
+    // Sample SMA at orbital-period intervals for several orbits.
+    let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
+    let steps_per_orbit = (period / dt) as usize;
+
+    let mut sma_samples = Vec::new();
+    for _ in 0..5 {
+        sim.step_n(steps_per_orbit);
+        let body = sim.body(0);
+        let e = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+        let a = -MU_EARTH / (2.0 * e);
+        sma_samples.push(a);
+    }
+
+    println!("  SMA per orbit: {:?}", sma_samples);
+
+    // Strictly monotonic decrease.
+    for window in sma_samples.windows(2) {
+        assert!(
+            window[1] < window[0],
+            "SMA did not decrease monotonically: {} -> {}",
+            window[0],
+            window[1]
+        );
+    }
+
+    // Total decay should be non-trivial (> 10 m over 5 orbits at this density).
+    let total_decay = sma_samples[0] - sma_samples[sma_samples.len() - 1];
+    assert!(
+        total_decay > 10.0,
+        "Total SMA decay {total_decay:.2} m is implausibly small"
+    );
+}
+
+// ─── Test 4: torque-free rigid-body rotation conserves inertial H ───
+
+/// RUN_8A physics (spherical Earth gravity + no torque + asymmetric inertia):
+/// For a rigid body with no applied torque, Euler's equations give the
+/// body-frame omega a time-varying path, but the *inertial-frame* angular
+/// momentum vector is rigorously conserved.
+#[test]
+fn tier3_dyncomp_6dof_rigid_body_invariance() {
+    let (pos, vel) = iss_circular_state();
+    let dt = 0.5;
+
+    // Asymmetric diagonal inertia (principal axes aligned with body frame).
+    let i_x = 1000.0;
+    let i_y = 2500.0;
+    let i_z = 2500.0;
+    let inertia = DMat3::from_cols(
+        DVec3::new(i_x, 0.0, 0.0),
+        DVec3::new(0.0, i_y, 0.0),
+        DVec3::new(0.0, 0.0, i_z),
+    );
+    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::ZERO);
+
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    let earth = add_earth_point_mass(&mut sim);
+
+    // Initial omega tipped off the major axis to exercise all three Euler eqs.
+    let omega0_body = DVec3::new(0.1, 0.02, 0.0); // rad/s
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: pos,
+            velocity: vel,
+        },
+        rot: Some(RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: omega0_body,
+        }),
+        mass: Some(mass_props),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        // Gravity gradient torque OFF (RUN_8 has it off).
+        compute_gravity_gradient: false,
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+
+    // H_inertial(0) = T^T * I * omega_body
+    let body = sim.body(0);
+    let q0 = body.rot.as_ref().unwrap().quaternion;
+    let t0 = q0.left_quat_to_transformation(); // inertial→body
+    let h_body0 = inertia * omega0_body;
+    let h_inertial_0 = t0.transpose() * h_body0;
+
+    // Propagate for 60 seconds.
+    sim.step_n((60.0 / dt) as usize);
+
+    let body = sim.body(0);
+    let q1 = body.rot.as_ref().unwrap().quaternion;
+    let omega1_body = body.rot.as_ref().unwrap().ang_vel_body;
+    let t1 = q1.left_quat_to_transformation();
+    let h_body1 = inertia * omega1_body;
+    let h_inertial_1 = t1.transpose() * h_body1;
+
+    let dh_rel = (h_inertial_1 - h_inertial_0).length() / h_inertial_0.length();
+    let mag_rel = (h_body1.length() - h_body0.length()).abs() / h_body0.length();
+
+    println!(
+        "  60s torque-free: |H_inertial| conservation {dh_rel:.3e}, |H_body| mag error {mag_rel:.3e}"
+    );
+
+    assert!(
+        dh_rel < 1.0e-6,
+        "Inertial H not conserved: relative error {dh_rel:.3e}"
+    );
+    assert!(
+        mag_rel < 1.0e-6,
+        "|H| magnitude not conserved: relative error {mag_rel:.3e}"
+    );
+
+    // Sanity: with asymmetric inertia and tipped omega, body-frame omega DOES
+    // change (otherwise the test would be trivial).
+    let domega = (omega1_body - omega0_body).length();
+    assert!(
+        domega > 1.0e-4,
+        "body omega did not evolve; test trivially passes: |domega|={domega:.3e}"
+    );
+}
+
+// ─── Test 5: external force delta-v ───
+
+/// RUN_9C physics (external force application): during a constant force window,
+/// the body's velocity increment equals F*dt/m along the force direction.
+#[test]
+fn tier3_dyncomp_external_force_impulse_response() {
+    let (pos, vel0) = iss_circular_state();
+    let dt = 1.0;
+    let mass = 1000.0;
+    let mut sim = make_kepler_sim(pos, vel0, mass, dt);
+
+    let force_inertial = DVec3::new(50.0, 0.0, 0.0); // 50 N along +X inertial
+    let force_duration = 10.0;
+
+    // Record velocity immediately before force window.
+    let v_before = sim.body(0).trans.velocity;
+
+    // Apply force for force_duration seconds.
+    sim.set_body_external_force(0, force_inertial);
+    sim.step_n((force_duration / dt) as usize);
+    sim.set_body_external_force(0, DVec3::ZERO);
+
+    let v_after = sim.body(0).trans.velocity;
+    let delta_v = v_after - v_before;
+
+    // Expected delta-v components from impulse: F*dt/m
+    // The orbital motion contributes extra delta-v from gravity during the
+    // window, so we subtract the no-force reference to isolate the force.
+    let mut ref_sim = make_kepler_sim(pos, vel0, mass, dt);
+    // Advance the reference simulation by the same elapsed time as the force
+    // window started at t=0 and lasted `force_duration`.
+    ref_sim.step_n((force_duration / dt) as usize);
+    let v_reference = ref_sim.body(0).trans.velocity;
+
+    let force_delta_v = v_after - v_reference;
+    let expected_dv = force_inertial * force_duration / mass;
+
+    let err = (force_delta_v - expected_dv).length();
+    let rel_err = err / expected_dv.length();
+
+    println!(
+        "  Impulse: measured dv={:?}, expected={:?}, rel_err={rel_err:.3e}",
+        force_delta_v, expected_dv
+    );
+
+    // Generous tolerance: RK4 integration of combined force+gravity introduces
+    // second-order cross-terms, but the first-order F*t/m should dominate.
+    assert!(
+        rel_err < 1.0e-4,
+        "External-force delta-v error {rel_err:.3e} too large"
+    );
+
+    // Delta-v direction should match force direction.
+    let cos_align = force_delta_v.normalize().dot(force_inertial.normalize());
+    assert!(
+        cos_align > 0.9999,
+        "delta-v direction {force_delta_v:?} not aligned with force {force_inertial:?}: cos={cos_align}"
+    );
+
+    // Use delta_v to suppress unused-variable warning (it's informational).
+    let _ = delta_v;
+}
+
+// ─── Test 6: external torque delta-omega ───
+
+/// RUN_9A physics (external torque application): during a constant torque
+/// window, the body-frame angular velocity increment about a principal axis
+/// equals tau*dt/I.
+#[test]
+fn tier3_dyncomp_external_torque_impulse_response() {
+    let (pos, vel0) = iss_circular_state();
+    let dt = 1.0;
+    let mass = 1000.0;
+
+    // Diagonal inertia — apply torque along the body x-axis (principal axis).
+    let i_x = 1000.0;
+    let i_y = 2500.0;
+    let i_z = 2500.0;
+    let inertia = DMat3::from_cols(
+        DVec3::new(i_x, 0.0, 0.0),
+        DVec3::new(0.0, i_y, 0.0),
+        DVec3::new(0.0, 0.0, i_z),
+    );
+    let mass_props = MassProperties::with_inertia(mass, inertia, DVec3::ZERO);
+
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    let earth = add_earth_point_mass(&mut sim);
+
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: pos,
+            velocity: vel0,
+        },
+        rot: Some(RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        }),
+        mass: Some(mass_props),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        compute_gravity_gradient: false,
+        ..Default::default()
+    });
+    sim.validate().unwrap();
+
+    let torque_body = DVec3::new(10.0, 0.0, 0.0); // 10 N·m about x
+    let torque_duration = 10.0;
+
+    // Apply torque window.
+    sim.set_body_external_torque(0, torque_body);
+    sim.step_n((torque_duration / dt) as usize);
+    sim.set_body_external_torque(0, DVec3::ZERO);
+
+    let omega_after = sim.body(0).rot.as_ref().unwrap().ang_vel_body;
+    // Expected: omega_x = tau_x * dt / I_xx (y, z remain ~zero).
+    let expected_omega_x = torque_body.x * torque_duration / i_x;
+
+    let err_x = (omega_after.x - expected_omega_x).abs();
+    let rel_err = err_x / expected_omega_x.abs();
+    println!(
+        "  Torque impulse: omega={:?}, expected omega_x={expected_omega_x:.6}, rel_err={rel_err:.3e}",
+        omega_after
+    );
+
+    assert!(
+        rel_err < 1.0e-6,
+        "Torque delta-omega error {rel_err:.3e} too large"
+    );
+    assert!(
+        omega_after.y.abs() < 1.0e-8,
+        "omega_y should remain zero, got {}",
+        omega_after.y
+    );
+    assert!(
+        omega_after.z.abs() < 1.0e-8,
+        "omega_z should remain zero, got {}",
+        omega_after.z
+    );
+}
+
+// ─── Test 7: major-axis spin stability (intermediate-axis theorem) ───
+
+/// Related to RUN_8B (rotational propagation): the intermediate-axis theorem
+/// (Dzhanibekov effect) predicts stable rotation about the axis of maximum
+/// inertia and unstable rotation about the intermediate axis.
+///
+/// Here we verify the *stable* case: a body spinning about its major
+/// (largest-inertia) axis with small perpendicular perturbations must keep
+/// nearly all its angular momentum along that axis.
+#[test]
+fn tier3_dyncomp_attitude_stability_major_axis() {
+    let (pos, vel) = iss_circular_state();
+    let dt = 0.1;
+
+    // I_z is the largest principal moment (major axis).
+    let i_x = 500.0;
+    let i_y = 1000.0;
+    let i_z = 2500.0; // major axis
+    let inertia = DMat3::from_cols(
+        DVec3::new(i_x, 0.0, 0.0),
+        DVec3::new(0.0, i_y, 0.0),
+        DVec3::new(0.0, 0.0, i_z),
+    );
+    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::ZERO);
+
+    // Spin about z with 1% perturbation on x and y.
+    let omega0 = DVec3::new(0.01, 0.01, 1.0); // rad/s
+
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    let earth = add_earth_point_mass(&mut sim);
+
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: pos,
+            velocity: vel,
+        },
+        rot: Some(RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: omega0,
+        }),
+        mass: Some(mass_props),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        compute_gravity_gradient: false,
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+
+    // Propagate 60 s and sample omega regularly.
+    let mut max_perp = 0.0_f64;
+    for _ in 0..600 {
+        sim.step_n(1);
+        let omega = sim.body(0).rot.as_ref().unwrap().ang_vel_body;
+        let perp = (omega.x.powi(2) + omega.y.powi(2)).sqrt();
+        if perp > max_perp {
+            max_perp = perp;
+        }
+    }
+
+    let omega_final = sim.body(0).rot.as_ref().unwrap().ang_vel_body;
+    println!(
+        "  Major-axis spin: omega_final={:?}, max |omega_perp|={max_perp:.6} rad/s",
+        omega_final
+    );
+
+    // The perpendicular components of omega oscillate but stay bounded near
+    // the initial 0.01 rad/s perturbation.  For stable major-axis rotation the
+    // bound should stay well below the spin rate (1 rad/s).
+    assert!(
+        max_perp < 0.05,
+        "Major-axis spin unstable: |omega_perp| grew to {max_perp:.3}"
+    );
+    // Spin about z must remain dominant.
+    assert!(
+        omega_final.z.abs() > 0.99,
+        "Z-axis spin should be preserved, got {:.4}",
+        omega_final.z
+    );
+}

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
@@ -10,12 +10,15 @@
 //! - tier3_dyncomp_point_mass_3dof_conservation:
 //!   RUN_2 family (point-mass gravity): energy + angular momentum
 //!   conservation for Keplerian orbits.
-//! - tier3_dyncomp_sh_plus_thirdbody_conservation:
-//!   RUN_7A/7B (SH + Sun/Moon): third-body perturbations do not conserve
-//!   orbital angular momentum, but total energy bounded over short spans.
-//! - tier3_dyncomp_drag_plus_sh_monotonic_decay:
-//!   RUN_6/RUN_7C/7D (drag with non-spherical gravity): semi-major axis
-//!   must trend monotonically downward under drag.
+//! - tier3_dyncomp_point_mass_plus_thirdbody_conservation:
+//!   RUN_7A/7B analog (third-body torque effect from Sun/Moon): third bodies
+//!   do not conserve orbital angular momentum, but total energy stays bounded
+//!   over short spans. Uses point-mass Earth; full SH adds secular drift but
+//!   is not required to exhibit third-body torques.
+//! - tier3_dyncomp_drag_point_mass_monotonic_decay:
+//!   RUN_6/RUN_7C/7D analog (drag with gravity): semi-major axis must trend
+//!   monotonically downward under drag. Uses point-mass Earth; SH adds a
+//!   secular J2 SMA correction but is not required for monotonic decay.
 //! - tier3_dyncomp_6dof_rigid_body_invariance:
 //!   RUN_8A (torque-free rotation in orbit): inertial angular momentum is
 //!   conserved, body-frame omega varies (Euler's equations).
@@ -143,17 +146,18 @@ fn tier3_dyncomp_point_mass_3dof_conservation() {
     );
 }
 
-// ─── Test 2: SH + third-body produces non-conservation of h ───
+// ─── Test 2: Point-mass Earth + third-body produces non-conservation of h ───
 
-/// RUN_7A/7B physics (SH gravity + Sun + Moon third body): third bodies
-/// exert torques about Earth, so orbital angular momentum about Earth is
-/// NOT strictly conserved. Its direction drifts (nodal regression, inclination
+/// Analytical analog of RUN_7A/7B: Sun + Moon third-body gravity exerts
+/// torques about Earth, so orbital angular momentum about Earth is NOT
+/// strictly conserved. Its direction drifts (nodal regression, inclination
 /// wobble), yet total orbital energy stays bounded over short spans.
 ///
-/// For this analytical test we use point-mass Earth (the non-sphericity from
-/// SH adds secular drift but is not required to exhibit third-body torques).
+/// This test intentionally uses point-mass Earth gravity only. Full
+/// spherical-harmonic Earth gravity would add secular drift, but it is not
+/// required to demonstrate the third-body torque effect checked here.
 #[test]
-fn tier3_dyncomp_sh_plus_thirdbody_conservation() {
+fn tier3_dyncomp_point_mass_plus_thirdbody_conservation() {
     let (pos, vel) = iss_circular_state();
     let dt = 10.0;
 
@@ -261,12 +265,17 @@ fn tier3_dyncomp_sh_plus_thirdbody_conservation() {
 
 // ─── Test 3: drag leads to monotonic decay of SMA ───
 
-/// RUN_6/RUN_7C/7D physics (gravity + drag): in a spherical-gravity + drag
-/// LEO orbit, the semi-major axis must trend monotonically downward.  We
-/// sample at orbital-period intervals (filtering out the in-orbit oscillation
-/// of instantaneous position) and verify strict monotonic decrease.
+/// Analytical analog of RUN_6/RUN_7C/7D (gravity + drag): in a point-mass
+/// Earth + drag LEO orbit, the semi-major axis must trend monotonically
+/// downward. We sample at orbital-period intervals (filtering out the
+/// in-orbit oscillation of instantaneous position) and verify strict
+/// monotonic decrease.
+///
+/// This test intentionally uses point-mass Earth gravity only. Full
+/// spherical-harmonic Earth gravity would add secular J2 effects but is
+/// not required to demonstrate monotonic SMA decay under drag.
 #[test]
-fn tier3_dyncomp_drag_plus_sh_monotonic_decay() {
+fn tier3_dyncomp_drag_point_mass_monotonic_decay() {
     use jeod_sim::{AtmosphereConfig, AtmosphereModel, DragConfig, ExponentialAtmosphere};
 
     let (pos, vel) = iss_circular_state();

--- a/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
+++ b/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
@@ -1,0 +1,334 @@
+//! Tier 3: Analytical verification of SIM_force_torque physics.
+//!
+//! JEOD's `dyn_body/verif/SIM_force_torque/` is an empty-space test rig that
+//! verifies force and torque accumulation, non-transmitted forces, and the
+//! equations of motion by scheduling time-stamped force/torque changes and
+//! checking that the body traces out a predictable trajectory.
+//!
+//! Our rig has no "empty space" ephemeris mode — instead we build a central
+//! gravity source that the body does not reference (empty `GravityControls`).
+//! With no gravity control applied, the body responds only to external
+//! force/torque, giving the same behavior as JEOD's EmptySpace mode for the
+//! purposes of these analytical checks.
+//!
+//! JEOD scenario mapping (SIM_force_torque/SET_test/RUN_test/input.py):
+//! - The scheduled `trick.add_read` blocks successively apply a z-axis
+//!   force that yields 1 m/s^2, 2 m/s^2, 3 m/s^2 on the composite body,
+//!   then play with non-transmitted forces, yaw/roll maneuvers, etc.
+//! - Our tests below pick out the three primary physics verifications in
+//!   that sim: uniform F/m translation, tau/I rotation, and independence
+//!   of the two when the force is applied at the center of mass.
+
+mod sim_test_helpers;
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::{
+    GravityControls, GravityModel, GravitySource, JeodQuat, MassProperties, RotationalState,
+    SimulationTime, TranslationalState,
+};
+
+/// A negligible gravity source kept in the frame tree but not referenced by
+/// any body.  Simulation requires a root frame; using `central: true` with
+/// `mu=0` gives us the frame without any gravitational effect.
+fn add_dummy_central_source(sim: &mut Simulation) {
+    sim.add_source(
+        "central_point",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+}
+
+/// Build an empty-space 3-DOF simulation with a single mass-only body.
+fn make_free_body_3dof(mass: f64, dt: f64) -> Simulation {
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    add_dummy_central_source(&mut sim);
+
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+        },
+        rot: None,
+        mass: Some(MassProperties::new(mass)),
+        gravity_controls: GravityControls { controls: vec![] },
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+    sim
+}
+
+/// Build an empty-space 6-DOF simulation with a single rigid body.
+fn make_free_body_6dof(mass: f64, inertia: DMat3, dt: f64) -> Simulation {
+    let mut sim = Simulation::new(
+        SimulationTime::at_j2000(jeod_sim::default_leap_second_table()),
+        dt,
+    );
+    add_dummy_central_source(&mut sim);
+
+    let mass_props = MassProperties::with_inertia(mass, inertia, DVec3::ZERO);
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+        },
+        rot: Some(RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        }),
+        mass: Some(mass_props),
+        gravity_controls: GravityControls { controls: vec![] },
+        compute_gravity_gradient: false,
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+    sim
+}
+
+// ─── Test 1: F = m*a on a free body ───
+
+/// Constant force on a free body produces uniform acceleration a = F/m.
+/// After applying F for T seconds starting from rest:
+///   v(T) = F*T/m
+///   x(T) = 0.5 * F*T^2/m
+#[test]
+fn tier3_force_constant_acceleration() {
+    let mass = 100.0; // kg
+    let dt = 0.1; // s
+    let t_total = 10.0; // s
+    let force = DVec3::new(3.0, -2.0, 1.0); // N (arbitrary direction)
+
+    let mut sim = make_free_body_3dof(mass, dt);
+    sim.set_body_external_force(0, force);
+    sim.step_n((t_total / dt) as usize);
+
+    let body = sim.body(0);
+
+    let expected_v = force * t_total / mass;
+    let expected_x = 0.5 * force * t_total * t_total / mass;
+
+    let err_v = (body.trans.velocity - expected_v).length();
+    let err_x = (body.trans.position - expected_x).length();
+
+    let rel_v = err_v / expected_v.length();
+    let rel_x = err_x / expected_x.length();
+
+    println!(
+        "  F=m*a: v={:?}, expected={:?}, rel_err={rel_v:.3e}",
+        body.trans.velocity, expected_v
+    );
+    println!(
+        "         x={:?}, expected={:?}, rel_err={rel_x:.3e}",
+        body.trans.position, expected_x
+    );
+
+    // RK4 is exact for linear ODEs up to roundoff; tolerances are tight.
+    assert!(rel_v < 1.0e-12, "velocity rel err {rel_v:.3e}");
+    assert!(rel_x < 1.0e-12, "position rel err {rel_x:.3e}");
+}
+
+// ─── Test 2: tau = I*alpha on a symmetric body (constant torque) ───
+
+/// Constant torque about a principal axis of a body with diagonal inertia:
+///   omega(T) = tau*T/I (on that axis; zero on others)
+///   theta(T) = 0.5 * tau*T^2/I
+/// For an initially aligned body, after 10 s with tau_x=1 N·m and I_x=10:
+///   omega_x = 1 rad/s, theta_x = 5 rad.
+#[test]
+fn tier3_torque_constant_angular_acceleration() {
+    let mass = 100.0;
+    let i_x = 10.0;
+    let i_y = 20.0;
+    let i_z = 20.0;
+    let inertia = DMat3::from_cols(
+        DVec3::new(i_x, 0.0, 0.0),
+        DVec3::new(0.0, i_y, 0.0),
+        DVec3::new(0.0, 0.0, i_z),
+    );
+    let dt = 0.01;
+    let t_total = 10.0;
+    let tau = DVec3::new(1.0, 0.0, 0.0); // N·m about body x-axis
+
+    let mut sim = make_free_body_6dof(mass, inertia, dt);
+    sim.set_body_external_torque(0, tau);
+    sim.step_n((t_total / dt) as usize);
+
+    let body = sim.body(0);
+    let omega = body.rot.as_ref().unwrap().ang_vel_body;
+
+    let expected_omega_x = tau.x * t_total / i_x;
+
+    let rel_err = (omega.x - expected_omega_x).abs() / expected_omega_x.abs();
+    println!(
+        "  tau=I*alpha: omega={:?}, expected_x={expected_omega_x}, rel_err={rel_err:.3e}",
+        omega
+    );
+
+    assert!(rel_err < 1.0e-10, "omega_x rel err {rel_err:.3e}");
+
+    // Perpendicular components stay zero (diagonal inertia, torque on principal
+    // axis, no initial rate).
+    assert!(
+        omega.y.abs() < 1.0e-12,
+        "omega_y should be zero, got {}",
+        omega.y
+    );
+    assert!(
+        omega.z.abs() < 1.0e-12,
+        "omega_z should be zero, got {}",
+        omega.z
+    );
+}
+
+// ─── Test 3: force at CoM decouples translation and rotation ───
+
+/// When a force is applied through the center of mass and an independent
+/// torque is applied on the body, translation and rotation are decoupled:
+///   linear motion follows v = F*t/m regardless of torque
+///   angular motion follows omega = tau*t/I regardless of force
+#[test]
+fn tier3_force_and_torque_decoupled() {
+    let mass = 100.0;
+    let i_x = 10.0;
+    let i_y = 10.0;
+    let i_z = 10.0;
+    let inertia = DMat3::from_cols(
+        DVec3::new(i_x, 0.0, 0.0),
+        DVec3::new(0.0, i_y, 0.0),
+        DVec3::new(0.0, 0.0, i_z),
+    );
+    let dt = 0.01;
+    let t_total = 5.0;
+    let force = DVec3::new(2.0, 0.0, 0.0); // N along inertial x
+    let tau = DVec3::new(0.0, 0.0, 1.0); // N·m about body z
+
+    // Case A: only force.
+    let mut sim_a = make_free_body_6dof(mass, inertia, dt);
+    sim_a.set_body_external_force(0, force);
+    sim_a.step_n((t_total / dt) as usize);
+    let v_a = sim_a.body(0).trans.velocity;
+    let omega_a = sim_a.body(0).rot.as_ref().unwrap().ang_vel_body;
+
+    // Case B: only torque.
+    let mut sim_b = make_free_body_6dof(mass, inertia, dt);
+    sim_b.set_body_external_torque(0, tau);
+    sim_b.step_n((t_total / dt) as usize);
+    let v_b = sim_b.body(0).trans.velocity;
+    let omega_b = sim_b.body(0).rot.as_ref().unwrap().ang_vel_body;
+
+    // Case C: both.
+    let mut sim_c = make_free_body_6dof(mass, inertia, dt);
+    sim_c.set_body_external_force(0, force);
+    sim_c.set_body_external_torque(0, tau);
+    sim_c.step_n((t_total / dt) as usize);
+    let v_c = sim_c.body(0).trans.velocity;
+    let omega_c = sim_c.body(0).rot.as_ref().unwrap().ang_vel_body;
+
+    println!("  A (force only): v={:?}, omega={:?}", v_a, omega_a);
+    println!("  B (torque only): v={:?}, omega={:?}", v_b, omega_b);
+    println!("  C (both): v={:?}, omega={:?}", v_c, omega_c);
+
+    // Decoupling: case C's translation matches A, rotation matches B.
+    let dv = (v_c - v_a).length();
+    let domega = (omega_c - omega_b).length();
+
+    assert!(
+        dv < 1.0e-12,
+        "Case C translation should match Case A: |dv|={dv:.3e}"
+    );
+    assert!(
+        domega < 1.0e-12,
+        "Case C rotation should match Case B: |domega|={domega:.3e}"
+    );
+
+    // Case B should have zero velocity (torque alone doesn't translate).
+    assert!(
+        v_b.length() < 1.0e-12,
+        "Torque-only should produce no translation: |v|={}",
+        v_b.length()
+    );
+    // Case A should have zero angular velocity (force at CoM doesn't rotate).
+    assert!(
+        omega_a.length() < 1.0e-12,
+        "Force at CoM should produce no rotation: |omega|={}",
+        omega_a.length()
+    );
+
+    // Absolute magnitudes match F=ma and tau=I*alpha analytical predictions.
+    let expected_v_x = force.x * t_total / mass;
+    let expected_omega_z = tau.z * t_total / i_z;
+    assert!((v_a.x - expected_v_x).abs() < 1.0e-12);
+    assert!((omega_b.z - expected_omega_z).abs() < 1.0e-12);
+}
+
+// ─── Test 4: force/torque time integral cancellation returns body to origin ───
+
+/// Mirrors JEOD's SIM_force_torque scheduling:
+///   From t=7 to t=9 apply force that reverses from +F to -F so that net
+///   velocity change is zero and net position change is also zero after
+///   the symmetric impulse pair.
+///
+/// Here: 5 seconds at +F, then 5 seconds at -F.  Velocity returns to zero,
+/// and position returns to the midpoint coordinate (not the starting point;
+/// that would require asymmetric bang-bang).  A symmetric triangle of
+/// acceleration is enough to assert that the body behaves linearly.
+#[test]
+fn tier3_force_symmetric_impulse_returns_to_rest() {
+    let mass = 100.0;
+    let dt = 0.1;
+    let force = DVec3::new(5.0, 0.0, 0.0);
+    let half_duration = 5.0;
+
+    let mut sim = make_free_body_3dof(mass, dt);
+    sim.set_body_external_force(0, force);
+    sim.step_n((half_duration / dt) as usize);
+    let v_mid = sim.body(0).trans.velocity;
+
+    sim.set_body_external_force(0, -force);
+    sim.step_n((half_duration / dt) as usize);
+    let v_end = sim.body(0).trans.velocity;
+    let x_end = sim.body(0).trans.position;
+
+    // Velocity should be back to zero within roundoff.
+    println!("  v_mid = {v_mid:?}");
+    println!("  v_end = {v_end:?}");
+    println!("  x_end = {x_end:?}");
+    assert!(
+        v_end.length() < 1.0e-10,
+        "Velocity should return to rest: |v|={}",
+        v_end.length()
+    );
+
+    // Position must be nonzero (body has drifted).  Analytical:
+    //   v during [0,5]:  (F/m)*t peaks at v_mid = 0.25 m/s
+    //   x at t=5:        0.5 * a * 5^2 = 0.625 m
+    //   v during [5,10]: v_mid - (F/m)*(t-5), zero at t=10
+    //   x at t=10:       x(5) + v_mid*5 - 0.5*a*5^2 = 1.25 m
+    let expected_x = 2.0 * 0.5 * force.x / mass * half_duration * half_duration;
+    let rel = (x_end.x - expected_x).abs() / expected_x;
+    println!(
+        "  x_end.x = {}, expected = {}, rel_err = {rel:.3e}",
+        x_end.x, expected_x
+    );
+    assert!(
+        rel < 1.0e-12,
+        "symmetric impulse position rel err {rel:.3e}"
+    );
+}

--- a/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
+++ b/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
@@ -278,17 +278,17 @@ fn tier3_force_and_torque_decoupled() {
     assert!((omega_b.z - expected_omega_z).abs() < 1.0e-12);
 }
 
-// ─── Test 4: force/torque time integral cancellation returns body to origin ───
+// ─── Test 4: symmetric +F/-F forcing returns body to rest with residual displacement ───
 
 /// Mirrors JEOD's SIM_force_torque scheduling:
-///   From t=7 to t=9 apply force that reverses from +F to -F so that net
-///   velocity change is zero and net position change is also zero after
-///   the symmetric impulse pair.
+///   From t=7 to t=9 apply force that reverses from +F to -F so that the
+///   net velocity change is zero after the symmetric impulse pair.
 ///
-/// Here: 5 seconds at +F, then 5 seconds at -F.  Velocity returns to zero,
-/// and position returns to the midpoint coordinate (not the starting point;
-/// that would require asymmetric bang-bang).  A symmetric triangle of
-/// acceleration is enough to assert that the body behaves linearly.
+/// Here: 5 seconds at +F, then 5 seconds at -F. Velocity returns to zero,
+/// but position remains positive because the body continues to drift while
+/// decelerating; analytically, the final displacement is twice the position
+/// reached at `t = half_duration`. A symmetric triangle of acceleration is
+/// enough to assert that the body behaves linearly.
 #[test]
 fn tier3_force_symmetric_impulse_returns_to_rest() {
     let mass = 100.0;


### PR DESCRIPTION
## Summary
Add 11 new Tier 3 analytical tests covering physics combinations in JEOD SIM_dyncomp and SIM_force_torque that weren't exercised by existing Docker-backed tests.

## Changes
- `crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs` — 7 tests (new)
- `crates/jeod_runner/tests/tier3_sim_force_torque_response.rs` — 4 tests (new)

## Coverage audit
Existing `tier3_sim_dyncomp_run2..run10` cover RUN_2, 3A/B, 4, 5A/B/C, 6A/B/C/D, 7A/B/C/D, 9A/9C/9D, 10A/B/C/D via Docker cross-validation. New tests cover analytical physics properties that wouldn't benefit from Docker data.

## SIM_dyncomp combinations (7 tests)
- `tier3_dyncomp_point_mass_3dof_conservation` — RUN_2 physics (energy, ang-mom)
- `tier3_dyncomp_point_mass_plus_thirdbody_conservation` — RUN_7A/7B analog (point-mass Earth + Sun/Moon; SH not required to exhibit third-body torques)
- `tier3_dyncomp_drag_point_mass_monotonic_decay` — RUN_6/7C/7D analog (point-mass Earth + drag; SH not required for SMA decay)
- `tier3_dyncomp_6dof_rigid_body_invariance` — RUN_8A physics (torque-free ang-mom)
- `tier3_dyncomp_external_force_impulse_response` — RUN_9C/9D physics (delta-V = F*dt/m)
- `tier3_dyncomp_external_torque_impulse_response` — RUN_9A/9B physics (delta-omega = tau*dt/I)
- `tier3_dyncomp_attitude_stability_major_axis` — RUN_8B physics (intermediate axis theorem)

## SIM_force_torque response (4 tests)
- `tier3_force_constant_acceleration` — F = m*a
- `tier3_torque_constant_angular_acceleration` — tau = I*alpha
- `tier3_force_and_torque_decoupled` — force at CoM decouples translation/rotation
- `tier3_force_symmetric_impulse_returns_to_rest` — symmetric bang-bang leaves body at rest with residual displacement

## Test plan
- [x] All 11 tests pass via `Simulation::step()` end-to-end
- [x] No Docker data required (analytical verification)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
