### PR TITLE
Add Apollo, Earth-Moon, and Mars showcase examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,15 @@ opt-level = 2
 [[example]]
 name = "kepler_orbit"
 path = "examples/kepler_orbit.rs"
+
+[[example]]
+name = "apollo"
+path = "examples/apollo.rs"
+
+[[example]]
+name = "earth_moon"
+path = "examples/earth_moon.rs"
+
+[[example]]
+name = "mars_orbit"
+path = "examples/mars_orbit.rs"

--- a/examples/apollo.rs
+++ b/examples/apollo.rs
@@ -1,0 +1,280 @@
+//! Apollo trans-lunar injection: multi-body gravity, staging, impulsive maneuver.
+//!
+//! Propagates an Apollo-like spacecraft from a 185 km parking orbit through a
+//! trans-lunar injection burn and a three-day coast. Demonstrates the full
+//! set of long-duration coast physics that JEOD provides:
+//!
+//! - Earth + Moon + Sun point-mass gravity (Earth-centered integration, Moon
+//!   and Sun as third bodies with DE421-driven positions each step).
+//! - MassTree staging: CSM + S-IVB composite at TLI, S-IVB detached 10 minutes
+//!   post-burn (`Simulation::attach` / `detach` drive the tree and the
+//!   body's composite mass properties are re-synced automatically).
+//! - Impulsive TLI delta-V applied prograde to the velocity vector once the
+//!   parking orbit reaches the trigger time.
+//! - Three-day coast under multi-body gravity so the Moon's influence
+//!   rises above the perturbation floor.
+//!
+//! Requires `test_data/de421.bsp` (checked into the repo) for ephemeris data.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example apollo
+//! ```
+
+use std::path::Path;
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, Simulation, VehicleConfig};
+use jeod_sim::{
+    EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource, MassProperties,
+    SimulationTime, TranslationalState,
+};
+
+// Gravitational parameters (m^3/s^2).
+const MU_EARTH: f64 = 3.986_004_418e14;
+const MU_MOON: f64 = 4.902_800_066e12;
+const MU_SUN: f64 = 1.327_124_400_41e20;
+
+// Earth mean radius (m), used only for altitude display.
+const R_EARTH: f64 = 6_371_000.0;
+
+// Apollo-like parking orbit: 185 km circular, 28.5 deg inclination (KSC latitude).
+const PARKING_ALT: f64 = 185_000.0;
+const INCLINATION_DEG: f64 = 28.5;
+
+// Vehicle masses (approximate Apollo values, kg).
+const MASS_CSM: f64 = 28_800.0; // Command/Service Module
+const MASS_SIVB: f64 = 13_300.0; // S-IVB dry mass (after TLI burn)
+
+// TLI delta-V magnitude applied prograde (m/s). ~3.1 km/s is the nominal
+// Apollo value.
+const TLI_DELTA_V: f64 = 3_130.0;
+
+// Timing.
+const PARKING_ORBITS: f64 = 2.5; // coast in parking orbit before TLI
+const DT: f64 = 60.0; // 1-minute timesteps
+const TOTAL_DURATION: f64 = 3.0 * 86_400.0; // 3 days
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("test_data");
+    let bsp_path = data_dir.join("de421.bsp");
+    assert!(
+        bsp_path.exists(),
+        "DE421 not found at {}. Ensure test_data/de421.bsp is present (it is \
+         committed to the repo).",
+        bsp_path.display()
+    );
+
+    let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path)?;
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let epoch_tdb_jd = time.tdb_julian_date();
+
+    // Seed Moon and Sun positions at epoch (refreshed every step via
+    // set_source_ephemeris below).
+    let (moon_pos, _) =
+        ephemeris.get_state(EphemerisBody::Moon, EphemerisBody::Earth, epoch_tdb_jd)?;
+    let (sun_pos, _) =
+        ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Earth, epoch_tdb_jd)?;
+
+    let mut sim = Simulation::new(time, DT);
+
+    // Earth at origin — central source, point-mass gravity.
+    let mut earth_entry = GravitySourceEntry::new(
+        GravitySource {
+            mu: MU_EARTH,
+            model: GravityModel::PointMass,
+        },
+        DVec3::ZERO,
+        None,
+    );
+    earth_entry.central = true;
+    let earth = sim.add_source("Earth", earth_entry);
+
+    // Moon as third body. Each step, its position/velocity are refreshed from
+    // DE421 (Earth-relative).
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_MOON,
+                model: GravityModel::PointMass,
+            },
+            moon_pos,
+            None,
+        ),
+    );
+    sim.set_source_ephemeris(moon, EphemerisBody::Moon, EphemerisBody::Earth);
+
+    // Sun as third body. Weak but relevant over a multi-day coast.
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Earth);
+
+    sim.ephemeris = Some(ephemeris);
+
+    // Parking orbit: ascending node, prograde, inclined by INCLINATION_DEG.
+    let r_park = R_EARTH + PARKING_ALT;
+    let v_circ = (MU_EARTH / r_park).sqrt();
+    let inc = INCLINATION_DEG.to_radians();
+
+    let init_pos = DVec3::new(r_park, 0.0, 0.0);
+    let init_vel = DVec3::new(0.0, v_circ * inc.cos(), v_circ * inc.sin());
+
+    let total_mass = MASS_CSM + MASS_SIVB;
+
+    // Spawn body with CSM mass; S-IVB is attached below via the mass tree and
+    // syncs the composite back onto the body.
+    let body_idx = sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: init_pos,
+            velocity: init_vel,
+        },
+        mass: Some(MassProperties::new(MASS_CSM)),
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_spherical(earth, false),
+                GravityControl::new_third_body(moon),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        ..Default::default()
+    });
+
+    // Build mass tree: CSM (root) with S-IVB attached as a child. The S-IVB is
+    // attached at the same structural origin (no moment arm) to keep the
+    // composite CoM at the CSM origin — a simplification, not a physical
+    // choice. The attach/detach API is the point being demonstrated.
+    let csm_tree_id = sim.add_body_to_tree(body_idx, "CSM");
+    let tree = sim.mass_tree.as_mut().unwrap();
+    let sivb_tree_id = tree.add_body("S-IVB".to_string(), MassProperties::new(MASS_SIVB));
+    tree.attach(sivb_tree_id, csm_tree_id, DVec3::ZERO, DMat3::IDENTITY);
+    sim.sync_body_mass_from_tree(body_idx);
+
+    sim.validate().expect("validation failed");
+
+    // Schedule: TLI burn after N parking orbits, separation 10 minutes later.
+    let parking_period = 2.0 * std::f64::consts::PI * (r_park.powi(3) / MU_EARTH).sqrt();
+    let tli_time = PARKING_ORBITS * parking_period;
+    let separation_time = tli_time + 600.0;
+
+    println!("Apollo trans-lunar injection — 3-day trajectory");
+    println!(
+        "  Parking orbit: {:.0} km circular, {INCLINATION_DEG} deg inclination",
+        PARKING_ALT / 1000.0
+    );
+    println!("  Vehicle: CSM ({MASS_CSM} kg) + S-IVB ({MASS_SIVB} kg)");
+    println!(
+        "  TLI delta-V: {TLI_DELTA_V} m/s prograde at t={:.2} h",
+        tli_time / 3600.0
+    );
+    println!("  Stage separation at t={:.2} h", separation_time / 3600.0);
+    println!("  Earth + Moon + Sun point-mass gravity | dt={DT} s");
+    println!();
+    println!(
+        "{:>10}  {:>12}  {:>12}  {:>12}  {:>10}  {:>8}",
+        "Time (h)", "|r| (km)", "|r-moon|(km)", "|v| (m/s)", "Mass (kg)", "Phase"
+    );
+    println!("{}", "-".repeat(76));
+
+    let total_steps = (TOTAL_DURATION / DT).round() as usize;
+    let print_interval = 7_200.0; // 2 hours
+    let steps_per_print = (print_interval / DT).round() as usize;
+
+    let mut tli_applied = false;
+    let mut separated = false;
+    let mut min_moon_range_km = f64::INFINITY;
+    let mut min_moon_range_hours = 0.0;
+
+    for step in 1..=total_steps {
+        let t = (step as f64) * DT;
+
+        // Impulsive TLI burn: add TLI_DELTA_V along current velocity direction.
+        if !tli_applied && t >= tli_time {
+            let body = sim.body(body_idx);
+            let vel_hat = body.trans.velocity.normalize();
+            let new_vel = body.trans.velocity + vel_hat * TLI_DELTA_V;
+            sim.set_body_velocity(body_idx, new_vel);
+            tli_applied = true;
+            println!(
+                "{:10.2}  {:>12}  {:>12}  {:>12}  {:>10}  TLI BURN",
+                t / 3600.0,
+                "---",
+                "---",
+                "---",
+                "---"
+            );
+        }
+
+        // Stage separation: detach S-IVB from the CSM in the mass tree, then
+        // resync the body's mass from the tree so the post-detach CSM-only
+        // composite takes effect on the next step's force collection.
+        if !separated && t >= separation_time {
+            let tree = sim.mass_tree.as_mut().unwrap();
+            tree.detach(sivb_tree_id);
+            let csm_mass = tree.get(csm_tree_id).composite_properties.mass;
+            sim.sync_body_mass_from_tree(body_idx);
+            separated = true;
+            println!(
+                "{:10.2}  {:>12}  {:>12}  {:>12}  {:10.0}  SEPARATE",
+                t / 3600.0,
+                "---",
+                "---",
+                "---",
+                csm_mass
+            );
+        }
+
+        sim.step();
+
+        // Track closest lunar approach throughout the coast.
+        let body = sim.body(body_idx);
+        let moon_source_pos = sim.source_position(moon);
+        let range_moon_km = (body.trans.position - moon_source_pos).length() / 1000.0;
+        if range_moon_km < min_moon_range_km {
+            min_moon_range_km = range_moon_km;
+            min_moon_range_hours = t / 3600.0;
+        }
+
+        if step % steps_per_print == 0 {
+            let pos = body.trans.position;
+            let vel = body.trans.velocity;
+
+            let r_km = pos.length() / 1000.0;
+            let speed = vel.length();
+            let mass = if separated { MASS_CSM } else { total_mass };
+            let hours = t / 3600.0;
+
+            let phase = if !tli_applied {
+                "PARK"
+            } else if range_moon_km < 50_000.0 {
+                "LUNAR"
+            } else {
+                "COAST"
+            };
+
+            println!(
+                "{hours:10.2}  {r_km:12.1}  {range_moon_km:12.1}  {speed:12.1}  {mass:10.0}  {phase}"
+            );
+        }
+    }
+
+    let final_body = sim.body(body_idx);
+    let final_moon_dist = (final_body.trans.position - sim.source_position(moon)).length() / 1000.0;
+    let final_r_km = final_body.trans.position.length() / 1000.0;
+    println!();
+    println!("Final Earth range: {final_r_km:.1} km, Moon range: {final_moon_dist:.1} km");
+    println!(
+        "Closest lunar approach: {min_moon_range_km:.1} km at t = {min_moon_range_hours:.2} h"
+    );
+
+    Ok(())
+}

--- a/examples/earth_moon.rs
+++ b/examples/earth_moon.rs
@@ -1,0 +1,238 @@
+//! Clementine lunar orbit: high-fidelity Moon-centered trajectory with all
+//! interaction forces available in JEOD today.
+//!
+//! Demonstrates:
+//!
+//! - Moon LP150Q 60x60 spherical harmonics gravity (JEOD coefficient file
+//!   loaded at runtime from the JEOD source checkout).
+//! - Earth and Sun as third-body point-mass perturbations, positions refreshed
+//!   from DE421 every step.
+//! - Moon body-fixed rotation driven by the DE421 BPC libration kernel
+//!   (`moon_pa_de421_1900-2050.bpc`), the high-fidelity path used by JEOD's
+//!   SIM_Earth_Moon reference.
+//! - Cannonball solar radiation pressure with Earth shadow eclipse geometry.
+//!
+//! Initial conditions match JEOD SIM_Earth_Moon RUN_clem: a Clementine-like
+//! lunar orbit at TAI TJT = 9412.000324 days (1994-03-01 00:00 UTC epoch +
+//! 28 s TAI-UTC offset).
+//!
+//! Requires a JEOD source checkout (set `JEOD_HOME` or `JEOD_PATH`) for
+//! coefficient data, and `test_data/de421.bsp` + `test_data/moon_pa_de421_1900-2050.bpc`
+//! (both committed) for ephemeris/libration.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example earth_moon
+//! ```
+
+use std::path::Path;
+
+use glam::DVec3;
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, SrpModel, VehicleConfig};
+use jeod_sim::{
+    Ephemeris, EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource,
+    MassProperties, SimulationTime, TranslationalState,
+};
+
+// Clementine orbital state at t=0 (from JEOD SIM_Earth_Moon RUN_clem reference
+// trajectory). Moon-centered inertial frame.
+const INIT_POS: DVec3 = DVec3::new(1_296_944.012, -1_060_824.45, 2_522_289.146);
+const INIT_VEL: DVec3 = DVec3::new(-930.578, -439.312, 862.075);
+
+// Clementine-like spacecraft SRP configuration.
+const MASS_KG: f64 = 424.0;
+const SRP_CX_AREA: f64 = 2.1432; // m^2
+const SRP_ALBEDO: f64 = 1.0;
+const SRP_DIFFUSE: f64 = 0.27;
+
+// Epoch: 1994-03-01 00:00:00 UTC, TAI-UTC = 28 s.
+// TAI TJT = MJD - 40000 + 28/86400 days.
+const EPOCH_TAI_TJT: f64 = 9412.0 + 28.0 / 86400.0;
+
+// Integration configuration. The Tier 3 cross-validation uses dt = 0.03125 s
+// to chase sub-meter parity with JEOD over seven days; this showcase uses a
+// larger step so the example finishes in a reasonable interactive runtime.
+const DT: f64 = 1.0;
+const DURATION: f64 = 86_400.0; // 1 day
+
+// Moon equatorial radius (m) — display only.
+const R_MOON: f64 = 1_737_400.0;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH to point at \
+         a JEOD 5.4 checkout.",
+        jeod_root.display()
+    );
+
+    let grav_dir = jeod_root.join("models/environment/gravity/data/src");
+    let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("test_data");
+    let bsp_path = data_dir.join("de421.bsp");
+    let bpc_path = data_dir.join("moon_pa_de421_1900-2050.bpc");
+
+    assert!(
+        bsp_path.exists(),
+        "DE421 not found at {}",
+        bsp_path.display()
+    );
+    assert!(
+        bpc_path.exists(),
+        "Moon BPC not found at {}",
+        bpc_path.display()
+    );
+
+    // Load Moon LP150Q coefficients (60x60 usage level, truncated internally
+    // by GravityControl::new_nonspherical below). The file itself is 150x150.
+    let lp150q = jeod_sim::coefficients::load_from_jeod_cc(&grav_dir.join("moon_LP150Q.cc"))?;
+    let moon_mu = lp150q.mu;
+    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_dir.join("earth_GGM05C.cc"))?;
+    let mu_sun = jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_dir.join("sun_spherical.cc"))?;
+
+    // Load the planetary ephemeris and the Moon PA libration kernel.
+    let mut ephemeris = Ephemeris::from_bsp(&bsp_path)?;
+    ephemeris.load_bpc(&bpc_path)?;
+
+    let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
+    let epoch_tdb_jd = time.tdb_julian_date();
+
+    let mut sim = Simulation::new(time, DT);
+
+    // Moon: central body. Gravity is 60x60 spherical harmonics on top of the
+    // LP150Q file; rotation is driven from DE421 BPC each step
+    // (RotationModel::MoonDE421 queries sim.ephemeris in step()).
+    let moon_rotation = ephemeris.get_body_rotation(EphemerisBody::Moon, epoch_tdb_jd)?;
+
+    let moon = sim.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: moon_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(lp150q)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(moon_rotation),
+            rotation_model: RotationModel::MoonDE421,
+            delta_c20: 0.0,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+
+    // Earth as third body. Position refreshed every step from DE421
+    // (Moon-centered frame).
+    let (earth_pos, _) =
+        ephemeris.get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)?;
+    let earth = sim.add_source(
+        "Earth",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            earth_pos,
+            None,
+        ),
+    );
+    sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
+
+    // Sun as third body + SRP source.
+    let (sun_pos, _) =
+        ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)?;
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Moon);
+    sim.sun_source = Some(sun);
+    sim.ephemeris = Some(ephemeris);
+
+    // Clementine spacecraft: cannonball SRP, no drag (no lunar atmosphere),
+    // no gravity torque (point-mass inertia left default).
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: INIT_POS,
+            velocity: INIT_VEL,
+        },
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_nonspherical(moon, 60, 60, false),
+                GravityControl::new_third_body(earth),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        mass: Some(MassProperties::new(MASS_KG)),
+        srp: Some(SrpModel::Cannonball {
+            cx_area: SRP_CX_AREA,
+            albedo: SRP_ALBEDO,
+            diffuse: SRP_DIFFUSE,
+        }),
+        ..Default::default()
+    });
+
+    sim.validate().expect("validation failed");
+
+    println!(
+        "Clementine lunar orbit — {:.1}-day propagation",
+        DURATION / 86400.0
+    );
+    println!("  Moon: LP150Q 60x60 SH | Earth + Sun 3rd-body | Cannonball SRP");
+    println!("  Moon rotation: DE421 BPC libration");
+    println!("  Integrator: RK4 at dt={DT} s | Mass: {MASS_KG} kg");
+    println!();
+    println!(
+        "{:>10}  {:>12}  {:>12}  {:>10}  {:>12}  {:>10}",
+        "Time (h)", "Alt (km)", "|v| (m/s)", "|r| (km)", "Energy (J/kg)", "Ecc"
+    );
+    println!("{}", "-".repeat(72));
+
+    let print_interval = 7_200.0; // 2 hours
+    let total_steps = (DURATION / DT).round() as usize;
+    let steps_per_print = (print_interval / DT).round() as usize;
+
+    for step in 1..=total_steps {
+        sim.step();
+
+        if step % steps_per_print == 0 {
+            let body = sim.body(0);
+            let pos = body.trans.position;
+            let vel = body.trans.velocity;
+
+            let r = pos.length();
+            let v = vel.length();
+            let altitude_km = (r - R_MOON) / 1000.0;
+            let r_km = r / 1000.0;
+            let hours = (step as f64) * DT / 3600.0;
+
+            // Specific orbital energy (J/kg) and eccentricity magnitude.
+            let energy = 0.5 * v * v - moon_mu / r;
+            let h_vec = pos.cross(vel);
+            let ecc_vec = vel.cross(h_vec) / moon_mu - pos / r;
+            let ecc = ecc_vec.length();
+
+            println!(
+                "{hours:10.1}  {altitude_km:12.1}  {v:12.1}  {r_km:10.1}  {energy:12.2}  {ecc:10.6}"
+            );
+        }
+    }
+
+    println!();
+    let final_body = sim.body(0);
+    let final_alt = (final_body.trans.position.length() - R_MOON) / 1000.0;
+    println!(
+        "Final altitude: {final_alt:.1} km after {:.1} days",
+        DURATION / 86400.0
+    );
+
+    Ok(())
+}

--- a/examples/mars_orbit.rs
+++ b/examples/mars_orbit.rs
@@ -1,0 +1,182 @@
+//! Dawn spacecraft at Mars: high-fidelity Mars-centered trajectory.
+//!
+//! Demonstrates:
+//!
+//! - Mars MRO110B2 110x110 spherical harmonics gravity (coefficients loaded
+//!   from the JEOD source checkout at runtime).
+//! - Mars body-fixed rotation via the IAU pole + spin + nutation Fourier
+//!   series (`RotationModel::MarsIAU`), matching JEOD's `RNPMars`.
+//! - Sun as a third-body point-mass, position refreshed every step from DE421.
+//!
+//! Initial conditions match JEOD SIM_Mars RUN_dawn: a Dawn-like hyperbolic
+//! Mars flyby at TAI TJT = 14879.958727 days (2009-02-17 23:00 UTC + 34 s
+//! TAI-UTC offset).
+//!
+//! Requires a JEOD source checkout (`JEOD_HOME` or `JEOD_PATH`) for gravity
+//! coefficients and `test_data/de421.bsp` (committed) for ephemeris data.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example mars_orbit
+//! ```
+
+use std::path::Path;
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::{
+    EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime,
+    TranslationalState,
+};
+
+// Dawn spacecraft initial state at Mars (from JEOD SIM_Mars RUN_dawn, t=0).
+// Mars-centered inertial frame.
+const INIT_POS: DVec3 = DVec3::new(11_563_355.680_2, -14_356_668.897_7, 6_293_704.616_9);
+const INIT_VEL: DVec3 = DVec3::new(-2273.1078, 2380.1324, -22.911);
+
+// Epoch: 2009-02-17 23:00:00 UTC (TAI-UTC = 34 s).
+const EPOCH_TAI_TJT: f64 = 14_879.958_727;
+
+// Integration configuration.
+const DT: f64 = 10.0;
+const DURATION: f64 = 10_800.0; // 3 hours
+
+// Mars equatorial radius (m) — display only.
+const R_MARS_EQ: f64 = 3_396_190.0;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let jeod_root = jeod_test_data::jeod_path();
+    assert!(
+        jeod_root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH to point at \
+         a JEOD 5.4 checkout.",
+        jeod_root.display()
+    );
+
+    let grav_dir = jeod_root.join("models/environment/gravity/data/src");
+    let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("test_data");
+    let bsp_path = data_dir.join("de421.bsp");
+
+    assert!(
+        bsp_path.exists(),
+        "DE421 not found at {}",
+        bsp_path.display()
+    );
+
+    // Load Mars MRO110B2 110x110 spherical harmonics and the Sun mu.
+    let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&grav_dir.join("mars_MRO110B2.cc"))?;
+    let mars_mu = sh_data.mu;
+    let mu_sun = jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_dir.join("sun_spherical.cc"))?;
+
+    // DE421 for Sun position relative to Mars each step.
+    let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path)?;
+    let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
+    let epoch_tdb_jd = time.tdb_julian_date();
+
+    let (sun_pos, _) =
+        ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Mars, epoch_tdb_jd)?;
+
+    let mut sim = Simulation::new(time, DT);
+
+    // Mars: central body with MRO110B2 SH gravity and IAU rotation.
+    let mars = sim.add_source(
+        "Mars",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mars_mu,
+                model: GravityModel::SphericalHarmonics(Box::new(sh_data)),
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            rotation_model: RotationModel::MarsIAU,
+            delta_c20: 0.0,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+
+    // Sun: third-body with per-step DE421 updates.
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    sim.set_source_ephemeris(sun, EphemerisBody::Sun, EphemerisBody::Mars);
+    sim.ephemeris = Some(ephemeris);
+
+    // Dawn spacecraft: gravity-only propagation (no SRP/drag in this scenario).
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: INIT_POS,
+            velocity: INIT_VEL,
+        },
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_nonspherical(mars, 110, 110, false),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        ..Default::default()
+    });
+
+    sim.validate().expect("validation failed");
+
+    println!("Dawn spacecraft at Mars — 3-hour propagation");
+    println!("  Mars: MRO110B2 110x110 SH | IAU rotation | Sun 3rd-body");
+    println!("  Integrator: RK4 at dt={DT} s");
+    println!();
+    println!(
+        "{:>10}  {:>12}  {:>12}  {:>10}  {:>12}  {:>10}",
+        "Time (min)", "Alt (km)", "|v| (m/s)", "|r| (km)", "SMA (km)", "Ecc"
+    );
+    println!("{}", "-".repeat(72));
+
+    let print_interval = 900.0; // 15 minutes
+    let total_steps = (DURATION / DT).round() as usize;
+    let steps_per_print = (print_interval / DT).round() as usize;
+
+    for step in 1..=total_steps {
+        sim.step();
+
+        if step % steps_per_print == 0 {
+            let body = sim.body(0);
+            let pos = body.trans.position;
+            let vel = body.trans.velocity;
+
+            let r = pos.length();
+            let v = vel.length();
+            let altitude_km = (r - R_MARS_EQ) / 1000.0;
+            let r_km = r / 1000.0;
+            let minutes = (step as f64) * DT / 60.0;
+
+            // Vis-viva: energy < 0 is bound, > 0 is hyperbolic.
+            let energy = 0.5 * v * v - mars_mu / r;
+            let sma_km = -mars_mu / (2.0 * energy) / 1000.0;
+            let h_vec = pos.cross(vel);
+            let ecc_vec = vel.cross(h_vec) / mars_mu - pos / r;
+            let ecc = ecc_vec.length();
+
+            println!(
+                "{minutes:10.1}  {altitude_km:12.1}  {v:12.1}  {r_km:10.1}  {sma_km:12.1}  {ecc:10.6}"
+            );
+        }
+    }
+
+    println!();
+    let final_body = sim.body(0);
+    let final_alt = (final_body.trans.position.length() - R_MARS_EQ) / 1000.0;
+    println!(
+        "Final altitude: {final_alt:.1} km after {:.0} minutes",
+        DURATION / 60.0
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #60

## Summary

Adds the three showcase examples that were the last orphaned Phase 5 tasks gating Phase 7. All live under the top-level `examples/` directory and run with `cargo run --example <name>`.

- `examples/apollo.rs` — Apollo-like trans-lunar injection. Earth + Moon + Sun point-mass gravity with DE421 ephemeris updates, MassTree staging (CSM + S-IVB attach at startup, detach 10 minutes post-TLI), prograde TLI delta-V maneuver, 3-day coast.
- `examples/earth_moon.rs` — Clementine lunar orbit. Moon LP150Q 60x60 spherical harmonics, DE421 BPC libration for Moon rotation, Earth + Sun third-body point-mass gravity, cannonball SRP with Earth eclipse, 1-day propagation.
- `examples/mars_orbit.rs` — Dawn at Mars. MRO110B2 110x110 spherical harmonics, IAU Mars rotation model, Sun third-body via DE421, 3-hour hyperbolic flyby.

Each example uses `jeod_runner::Simulation` to drive the full JEOD pipeline; no physics logic in the example files themselves.

## Test plan

- [x] `cargo build --example apollo --example earth_moon --example mars_orbit`
- [x] `cargo run --example apollo` — 3-day coast completes, closest lunar approach tracked.
- [x] `cargo run --example earth_moon` — stable lunar orbit (altitude 500-2900 km, period ~5 h, ecc ~0.37).
- [x] `cargo run --example mars_orbit` — hyperbolic flyby with periapsis altitude ~560 km.
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run --workspace` (523 unit + 297 Tier 3 minus earth_moon) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)