### PR TITLE
Audit test files and fix manual equations / hardcoded constants (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "jeod_frames",
  "jeod_gravity",
  "jeod_math",
+ "jeod_planet",
  "jeod_test_data",
 ]
 
@@ -2400,6 +2401,7 @@ dependencies = [
  "jeod_ephemeris",
  "jeod_gravity",
  "jeod_math",
+ "jeod_planet",
  "jeod_test_data",
  "jeod_time",
 ]
@@ -2410,6 +2412,7 @@ version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
  "jeod_ephemeris",
+ "jeod_planet",
  "jeod_test_data",
  "thiserror 2.0.18",
 ]

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -12,3 +12,4 @@ glam = { workspace = true }
 jeod_math = { path = "../jeod_math", features = ["test-utils"] }
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_gravity = { path = "../jeod_gravity" }
+jeod_planet = { path = "../jeod_planet" }

--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -173,7 +173,7 @@ pub fn init_from_time_periapsis(
     // JEOD dyn_body_init_orbit.cc:295 factorization:
     //   mean_anomaly = t_peri * sqrt(mu / a) / a
     // Algebraically equivalent to M = n*t with n = sqrt(mu/a^3), but matches
-    // JEOD's arithmetic order so the f64 result is bit-identical.
+    // JEOD's arithmetic order to minimize rounding differences in parity tests.
     let mean_anomaly = time_periapsis * (mu / semi_major_axis).sqrt() / semi_major_axis;
 
     init_from_mean_anomaly(

--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -127,6 +127,66 @@ pub fn init_from_mean_anomaly(
     TranslationalState { position, velocity }
 }
 
+/// Initialize translational state from Keplerian orbital elements with the
+/// `SmaEccIncAscnodeArgperTimeperi` element set (time since periapsis).
+///
+/// Port of the `LocationTimePeri` branch of JEOD `DynBodyInitOrbit::apply()`
+/// at `models/dynamics/body_action/src/dyn_body_init_orbit.cc:293-295`:
+///
+/// ```cpp
+/// if (location == LocationTimePeri) {
+///     mean_anomaly = time_periapsis * std::sqrt(planet->grav_source->mu / semi_major_axis) / semi_major_axis;
+/// }
+/// ```
+///
+/// Converts `time_periapsis` (seconds elapsed since periapsis passage) to
+/// mean anomaly via `M = n · t_peri` where `n = sqrt(mu / a^3)`, then defers
+/// to [`init_from_mean_anomaly`].
+///
+/// # Arguments
+/// * `semi_major_axis` - Semi-major axis (m)
+/// * `eccentricity` - Orbital eccentricity
+/// * `inclination` - Inclination (rad)
+/// * `raan` - Right ascension of ascending node (rad)
+/// * `arg_periapsis` - Argument of periapsis (rad)
+/// * `time_periapsis` - Time elapsed **since** periapsis passage (s). JEOD
+///   convention: positive when t > t_peri (i.e., after periapsis).
+/// * `mu` - Gravitational parameter of central body (m^3/s^2)
+pub fn init_from_time_periapsis(
+    semi_major_axis: f64,
+    eccentricity: f64,
+    inclination: f64,
+    raan: f64,
+    arg_periapsis: f64,
+    time_periapsis: f64,
+    mu: f64,
+) -> TranslationalState {
+    assert!(
+        mu > 0.0,
+        "init_from_time_periapsis: mu must be positive, got {mu}"
+    );
+    assert!(
+        semi_major_axis > 0.0 && semi_major_axis.is_finite(),
+        "init_from_time_periapsis: semi_major_axis must be positive and finite, got {semi_major_axis}"
+    );
+
+    // JEOD dyn_body_init_orbit.cc:295 factorization:
+    //   mean_anomaly = t_peri * sqrt(mu / a) / a
+    // Algebraically equivalent to M = n*t with n = sqrt(mu/a^3), but matches
+    // JEOD's arithmetic order so the f64 result is bit-identical.
+    let mean_anomaly = time_periapsis * (mu / semi_major_axis).sqrt() / semi_major_axis;
+
+    init_from_mean_anomaly(
+        semi_major_axis,
+        eccentricity,
+        inclination,
+        raan,
+        arg_periapsis,
+        mean_anomaly,
+        mu,
+    )
+}
+
 /// Initialize translational state from LVLH-relative position and velocity.
 ///
 /// Computes the LVLH frame from a reference orbit state, then transforms the
@@ -303,21 +363,16 @@ mod tests {
             jeod_test_data::reference_state::load_reference_state(&root, "ISS", "inertial");
 
         // ISS set01 uses SmaEccIncAscnodeArgperTimeperi.
-        // Compute mean anomaly from time_periapsis: M = n * t_peri
-        let a = init.semi_major_axis;
-        let n = (EARTH_MU / (a * a * a)).sqrt();
         let t_peri = init
             .time_periapsis
             .expect("ISS set01 should have time_periapsis");
-        let mean_anomaly = n * t_peri;
-
-        let state = init_from_mean_anomaly(
+        let state = init_from_time_periapsis(
             init.semi_major_axis,
             init.eccentricity,
             init.inclination,
             init.ascending_node,
             init.arg_periapsis,
-            mean_anomaly,
+            t_peri,
             EARTH_MU,
         );
 

--- a/crates/jeod_dynamics/src/lib.rs
+++ b/crates/jeod_dynamics/src/lib.rs
@@ -14,7 +14,7 @@ pub mod state;
 pub use abm4::{abm4_translational_step, Abm4State};
 pub use body_init::{
     compute_ned_rotation, init_from_lvlh, init_from_mean_anomaly, init_from_ned,
-    init_from_orbital_elements,
+    init_from_orbital_elements, init_from_time_periapsis,
 };
 pub use constraints::{apply_constraint, BaumgarteSolver, HolonomicConstraint, PendulumConstraint};
 pub use forces::{

--- a/crates/jeod_dynamics/tests/tier2_body_init.rs
+++ b/crates/jeod_dynamics/tests/tier2_body_init.rs
@@ -13,10 +13,14 @@
 //! The expected state comes from `reference_inertial_trans_state.py`, which
 //! contains the NASA JSC Flight Operations Directorate state vector.
 
-use jeod_dynamics::{init_from_mean_anomaly, init_from_orbital_elements, TranslationalState};
+use jeod_dynamics::{
+    init_from_mean_anomaly, init_from_orbital_elements, init_from_time_periapsis,
+    TranslationalState,
+};
 
-/// Earth gravitational parameter (m^3/s^2), matching JEOD's value.
-const EARTH_MU: f64 = 3.986_004_415e14;
+/// Earth gravitational parameter (m^3/s^2), from JEOD `earth_GGM05C.cc`.
+/// Sourced from `jeod_planet::presets::EARTH.mu`.
+const EARTH_MU: f64 = jeod_planet::presets::EARTH.mu;
 
 /// Load the JEOD path, panicking with a clear message if not available.
 fn jeod_root() -> std::path::PathBuf {
@@ -98,23 +102,19 @@ fn iss_set01_time_periapsis() {
     );
     let expected = load_iss_reference(&root);
 
-    // set01 provides time_periapsis — compute mean anomaly from it.
-    // M = n * t_peri, where n = sqrt(mu / a^3).
-    // JEOD convention: time_periapsis is time SINCE periapsis.
-    let a = init.semi_major_axis;
-    let n = (EARTH_MU / (a * a * a)).sqrt();
+    // set01 provides time_periapsis — use the dedicated ported function,
+    // which matches JEOD dyn_body_init_orbit.cc:295 exactly.
     let t_peri = init
         .time_periapsis
         .expect("ISS set01 must have time_periapsis");
-    let mean_anomaly = n * t_peri;
 
-    let computed = init_from_mean_anomaly(
+    let computed = init_from_time_periapsis(
         init.semi_major_axis,
         init.eccentricity,
         init.inclination,
         init.ascending_node,
         init.arg_periapsis,
-        mean_anomaly,
+        t_peri,
         EARTH_MU,
     );
 
@@ -254,23 +254,19 @@ fn iss_set10_true_anomaly() {
 fn iss_element_sets_cross_consistent() {
     let root = jeod_root();
 
-    // set01: time_periapsis -> mean anomaly -> Cartesian
+    // set01: time_periapsis -> mean anomaly -> Cartesian (via the ported helper).
     let init01 = jeod_test_data::orbital_init::load_orbital_init(
         &root,
         "ISS",
         "trans_Orbit_inertial_body_set01",
     );
-    let a = init01.semi_major_axis;
-    let n = (EARTH_MU / (a * a * a)).sqrt();
-    let t_peri = init01.time_periapsis.unwrap();
-    let mean_anomaly_01 = n * t_peri;
-    let state01 = init_from_mean_anomaly(
+    let state01 = init_from_time_periapsis(
         init01.semi_major_axis,
         init01.eccentricity,
         init01.inclination,
         init01.ascending_node,
         init01.arg_periapsis,
-        mean_anomaly_01,
+        init01.time_periapsis.unwrap(),
         EARTH_MU,
     );
 

--- a/crates/jeod_gravity/tests/jeod_validation.rs
+++ b/crates/jeod_gravity/tests/jeod_validation.rs
@@ -88,7 +88,13 @@ fn point_mass_reasonable_at_jeod_positions() {
     );
 
     let cases = load_gravity_test_cases(&root);
-    let mu_earth = 3.986_004_415e14;
+
+    // Load mu directly from JEOD GGM02C (the file JEOD's grav_geospherical
+    // test itself references). This matches `spherical_harmonics_40_test_vectors`
+    // below and avoids a literal duplicate of the JEOD-source value.
+    let ggm02c_path = root.join("models/environment/gravity/data/src/earth_GGM02C.cc");
+    let data = coefficients::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C coefficients");
+    let mu_earth = data.mu;
 
     for case in &cases {
         let result = jeod_gravity::calc_spherical(mu_earth, case.position);

--- a/crates/jeod_interactions/Cargo.toml
+++ b/crates/jeod_interactions/Cargo.toml
@@ -12,5 +12,6 @@ jeod_dynamics = { path = "../jeod_dynamics" }
 jeod_ephemeris = { path = "../jeod_ephemeris" }
 jeod_gravity = { path = "../jeod_gravity" }
 jeod_math = { path = "../jeod_math" }
+jeod_planet = { path = "../jeod_planet" }
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_time = { path = "../jeod_time" }

--- a/crates/jeod_interactions/tests/integration_physics.rs
+++ b/crates/jeod_interactions/tests/integration_physics.rs
@@ -13,7 +13,7 @@ use jeod_gravity::calc_spherical;
 use jeod_interactions::{
     compute_ballistic_drag, compute_flat_plate_srp_thermal, compute_gravity_torque,
     compute_shadow_fraction, solar_flux_at_distance, DragConfig, FlatPlate, FlatPlateParams,
-    FlatPlateThermal,
+    FlatPlateThermal, SOLAR_RADIUS,
 };
 use jeod_math::geodetic::cartesian_to_geodetic;
 use jeod_math::JeodQuat;
@@ -24,8 +24,6 @@ const MU_EARTH: f64 = jeod_planet::presets::EARTH.mu;
 const R_EARTH: f64 = jeod_planet::presets::EARTH.r_eq;
 /// Earth polar radius (m) — JEOD `earth.cc` via presets.
 const R_EARTH_POL: f64 = jeod_planet::presets::EARTH.r_pol;
-/// Sun effective radius (m) — used for penumbra geometry in shadow_fraction().
-const R_SUN: f64 = 6.98e8;
 
 /// MET-internal GMST formula (from JEOD atmos_MET_TME.cc, Jacchia's Almanac polynomial).
 ///
@@ -324,7 +322,8 @@ fn leo_eclipse_fraction() {
     };
 
     for _ in 0..steps {
-        let frac = compute_shadow_fraction(state.position, sun_pos, body_pos, R_EARTH, R_SUN);
+        let frac =
+            compute_shadow_fraction(state.position, sun_pos, body_pos, R_EARTH, SOLAR_RADIUS);
         if frac < 0.5 {
             shadow_count += 1;
         }

--- a/crates/jeod_interactions/tests/integration_physics.rs
+++ b/crates/jeod_interactions/tests/integration_physics.rs
@@ -18,10 +18,14 @@ use jeod_interactions::{
 use jeod_math::geodetic::cartesian_to_geodetic;
 use jeod_math::JeodQuat;
 
-const MU_EARTH: f64 = 3.986_004_415e14; // m^3/s^2
-const R_EARTH: f64 = 6_378_137.0; // m
-const R_EARTH_POL: f64 = R_EARTH * (1.0 - 1.0 / 298.257_223_563); // JEOD: r_eq * (1 - flat_coeff)
-const R_SUN: f64 = 6.98e8; // m
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+const MU_EARTH: f64 = jeod_planet::presets::EARTH.mu;
+/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = jeod_planet::presets::EARTH.r_eq;
+/// Earth polar radius (m) — JEOD `earth.cc` via presets.
+const R_EARTH_POL: f64 = jeod_planet::presets::EARTH.r_pol;
+/// Sun effective radius (m) — used for penumbra geometry in shadow_fraction().
+const R_SUN: f64 = 6.98e8;
 
 /// MET-internal GMST formula (from JEOD atmos_MET_TME.cc, Jacchia's Almanac polynomial).
 ///

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -13,4 +13,5 @@ test-utils = []
 [dev-dependencies]
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_ephemeris = { path = "../jeod_ephemeris" }
+jeod_planet = { path = "../jeod_planet" }
 

--- a/crates/jeod_math/tests/jeod_validation.rs
+++ b/crates/jeod_math/tests/jeod_validation.rs
@@ -6,8 +6,9 @@ use jeod_math::JeodQuat;
 use jeod_math::OrbitalElements;
 use jeod_test_data::{euler_test, jeod_path, orbital_data, orbital_init, reference_state};
 
-/// Earth's gravitational parameter in m^3/s^2 (matches JEOD's value).
-const MU_EARTH: f64 = 3.986_004_415e14;
+/// Earth's gravitational parameter (m^3/s^2) from JEOD `earth_GGM05C.cc`.
+/// Sourced from `jeod_planet::presets::EARTH.mu` — the canonical constant.
+const MU_EARTH: f64 = jeod_planet::presets::EARTH.mu;
 
 // =========================================================================
 // Orbital elements: ISS reference data
@@ -43,25 +44,19 @@ fn validate_iss_orbital_elements_to_cartesian() {
     );
 
     // Build OrbitalElements from the init data.
-    // We need to compute true anomaly from time_periapsis.
-    // For this test, we use the JEOD-provided elements to compute Cartesian state
-    // and compare against the reference.
     //
-    // The init data uses SmaEccIncAscnodeArgperTimeperi set, which specifies
-    // time of periapsis passage. We need mean anomaly to convert elements -> Cartesian.
-    //
-    // From time_periapsis and orbital period, we can compute mean anomaly:
-    //   n = sqrt(mu / a^3)  (mean motion)
-    //   M = n * t_peri      (mean anomaly, but note t_peri is time SINCE periapsis)
+    // The init data uses SmaEccIncAscnodeArgperTimeperi, which specifies
+    // time elapsed SINCE periapsis passage. JEOD's
+    // `dyn_body_init_orbit.cc:295` converts this to mean anomaly as:
+    //   mean_anomaly = time_periapsis * sqrt(mu / a) / a
+    // which is algebraically identical to M = n·t_peri with n = sqrt(mu/a^3)
+    // but matches JEOD's arithmetic order for bit-parity with the port.
     let a = init.semi_major_axis;
-    let n = (MU_EARTH / (a * a * a)).sqrt();
-
-    // time_periapsis is the elapsed time since periapsis passage (seconds).
-    // Mean anomaly is simply M = n * t_peri (radians).
     let t_peri = init
         .time_periapsis
         .expect("ISS set01 should have time_periapsis");
-    let mean_anomaly = n * t_peri;
+    let mean_anomaly = t_peri * (MU_EARTH / a).sqrt() / a;
+    let n = (MU_EARTH / (a * a * a)).sqrt();
 
     let mut oe = OrbitalElements::default();
     oe.semi_major_axis = init.semi_major_axis;

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -125,7 +125,7 @@ fn pipeline_earth_lighting_smoke() {
         },
         derived: DerivedStateConfig {
             earth_lighting: Some(EarthLightingConfig {
-                earth_radius: 6_378_137.0,
+                earth_radius: jeod_sim::EARTH.shadow_radius,
                 moon_radius: 1_737_400.0,
                 sun_radius: 6.96e8,
             }),

--- a/crates/jeod_runner/tests/sim_test_helpers/mod.rs
+++ b/crates/jeod_runner/tests/sim_test_helpers/mod.rs
@@ -13,8 +13,9 @@ use std::path::Path;
 #[allow(unused_imports)] // Not all test binaries use dyncomp CSV loading
 pub use jeod_test_data::dyncomp_csv::{load_dyncomp_csv, DyncompRecord};
 
-/// Earth rotation rate (JEOD RNPJ2000 default).
-pub const OMEGA_EARTH: f64 = 7.292_115_146_706_388e-5;
+/// Earth rotation rate (JEOD RNPJ2000 default), sourced from
+/// `jeod_sim::planet_config::EARTH.omega`.
+pub const OMEGA_EARTH: f64 = jeod_sim::planet_config::EARTH.omega;
 
 /// Build `MassProperties` from parsed JEOD mass initialization data.
 ///

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -47,10 +47,14 @@ const TOTAL_TIME: f64 = 100.0;
 const SWITCH_DISTANCE: f64 = 66.1e6;
 
 // Gravitational parameters — match JEOD's spherical gravity data exactly:
-// earth_spherical.cc, moon_spherical.cc, sun_spherical.cc
-const MU_EARTH: f64 = 3.986_004_415e14;
+// earth_spherical.cc, moon_spherical.cc, sun_spherical.cc.
+// MU_EARTH and MU_SUN match their GGM05C/presets counterparts.
+// MU_MOON = 4902.801076e9 (moon_spherical.cc / moon_LP150Q.cc) deliberately
+// differs from jeod_sim::MOON.shape.mu = 4902.79980693169e9 (moon_GRAIL150.cc)
+// because this Apollo 8 test targets the spherical-gravity verification run.
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 const MU_MOON: f64 = 4.902_801_076e12;
-const MU_SUN: f64 = 1.327_124_40e20;
+const MU_SUN: f64 = jeod_sim::SUN.shape.mu;
 
 fn test_data_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test_data")

--- a/crates/jeod_runner/tests/tier3_sim_drag_6dof.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_6dof.rs
@@ -14,11 +14,11 @@ use jeod_sim::{
     SimulationTime, TranslationalState,
 };
 
-/// Standard gravitational parameter for Earth (m^3/s^2).
-const MU_EARTH: f64 = 3.986_004_418e14;
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
-/// Earth mean equatorial radius (m).
-const R_EARTH: f64 = 6_378_137.0;
+/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
 
 /// Compute specific orbital energy: E = v^2/2 - mu/r
 fn orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {

--- a/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
@@ -18,11 +18,11 @@ use jeod_sim::{
     SimulationTime, TranslationalState,
 };
 
-/// Standard gravitational parameter for Earth (m^3/s^2).
-const MU_EARTH: f64 = 3.986_004_418e14;
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
-/// Earth mean equatorial radius (m).
-const R_EARTH: f64 = 6_378_137.0;
+/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
 
 /// Compute specific orbital energy: E = v^2/2 - mu/r
 fn orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {

--- a/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
@@ -101,8 +101,8 @@ fn tier3_simulation_drag_run6b_rotated() {
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::EARTH.shape.r_eq,
+        r_pol: jeod_sim::EARTH.shape.r_pol,
         planet_omega: OMEGA_EARTH,
     });
     sim.atmosphere_planet_source = Some(earth);

--- a/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
@@ -97,8 +97,8 @@ fn tier3_simulation_drag_run6b() {
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::EARTH.shape.r_eq,
+        r_pol: jeod_sim::EARTH.shape.r_pol,
         planet_omega: OMEGA_EARTH,
     });
     sim.atmosphere_planet_source = Some(earth);

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
@@ -39,14 +39,14 @@ use jeod_sim::{
     RotationalState, SimulationTime, TranslationalState,
 };
 
-/// Earth gravitational parameter (m^3/s^2).
-const MU_EARTH: f64 = 3.986_004_418e14;
-/// Earth mean equatorial radius (m).
-const R_EARTH: f64 = 6_378_137.0;
-/// Sun gravitational parameter (m^3/s^2).
-const MU_SUN: f64 = 1.327_124_400_18e20;
-/// Moon gravitational parameter (m^3/s^2).
-const MU_MOON: f64 = 4.902_800_066e12;
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
+/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
+/// Sun gravitational parameter (m^3/s^2) — JEOD `sun_spherical.cc`.
+const MU_SUN: f64 = jeod_sim::SUN.shape.mu;
+/// Moon gravitational parameter (m^3/s^2) — JEOD `moon_GRAIL150.cc`.
+const MU_MOON: f64 = jeod_sim::MOON.shape.mu;
 /// Typical Earth–Sun distance (m, ~1 AU).
 const R_EARTH_SUN: f64 = 1.495_978_707e11;
 /// Typical Earth–Moon distance (m).

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
@@ -136,8 +136,8 @@ fn tier3_simulation_run6b_drag() {
     // Configure atmosphere with planet rotation lookup
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::EARTH.shape.r_eq,
+        r_pol: jeod_sim::EARTH.shape.r_pol,
         planet_omega: OMEGA_EARTH,
     });
     sim.atmosphere_planet_source = Some(earth);
@@ -348,8 +348,8 @@ fn tier3_simulation_run6a_const_density_drag() {
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::EARTH.shape.r_eq,
+        r_pol: jeod_sim::EARTH.shape.r_pol,
         planet_omega: OMEGA_EARTH,
     });
     sim.atmosphere_planet_source = Some(earth);

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
@@ -195,8 +195,8 @@ fn run_7_test(
         };
         sim.atmosphere = Some(AtmosphereConfig {
             model: AtmosphereModel::Met(met_model),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+            r_eq: jeod_sim::EARTH.shape.r_eq,
+            r_pol: jeod_sim::EARTH.shape.r_pol,
             planet_omega: OMEGA_EARTH,
         });
         sim.atmosphere_planet_source = Some(earth);

--- a/crates/jeod_runner/tests/tier3_sim_integ_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_analytical.rs
@@ -17,7 +17,7 @@ use jeod_sim::{
 };
 
 /// Earth gravitational parameter (m^3/s^2) from JEOD earth_GGM05C.
-const MU_EARTH: f64 = 398_600.441_50e9;
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
 /// Semi-major axis for ISS-like circular orbit (m).
 const SMA: f64 = 6_778_000.0;

--- a/crates/jeod_runner/tests/tier3_sim_integ_comparison.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_comparison.rs
@@ -14,7 +14,7 @@ use jeod_sim::{
 };
 
 /// Earth gravitational parameter (m^3/s^2) from JEOD earth_GGM05C.
-const MU_EARTH: f64 = 398_600.441_50e9;
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
 /// Semi-major axis for ISS-like circular orbit (m).
 const SMA: f64 = 6_778_000.0;

--- a/crates/jeod_runner/tests/tier3_sim_integ_gj_orders.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_gj_orders.rs
@@ -21,7 +21,7 @@ use jeod_sim::{
 };
 
 /// Earth gravitational parameter (m^3/s^2) from JEOD earth_GGM05C.
-const MU_EARTH: f64 = 398_600.441_50e9;
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
 /// Semi-major axis for ISS-like circular orbit (m).
 const SMA: f64 = 6_778_000.0;

--- a/crates/jeod_runner/tests/tier3_sim_met.rs
+++ b/crates/jeod_runner/tests/tier3_sim_met.rs
@@ -99,8 +99,8 @@ fn tier3_simulation_met_run5a() {
 
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met_model),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::EARTH.shape.r_eq,
+        r_pol: jeod_sim::EARTH.shape.r_pol,
         planet_omega: OMEGA_EARTH,
     });
     sim.atmosphere_planet_source = Some(earth);

--- a/crates/jeod_runner/tests/tier3_sim_ned.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned.rs
@@ -23,8 +23,8 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
-const GEO_R_EQ: f64 = 6_378_137.0;
-const GEO_R_POL: f64 = GEO_R_EQ * (1.0 - 1.0 / 298.257_223_563);
+const GEO_R_EQ: f64 = jeod_sim::EARTH.shape.r_eq;
+const GEO_R_POL: f64 = jeod_sim::EARTH.shape.r_pol;
 
 /// Derived-state verif directory (shared Modified_data/ lives here, not in SIM_NED/).
 const DERIVED_STATE_VERIF: &str = "models/dynamics/derived_state/verif";

--- a/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
@@ -24,8 +24,8 @@ use jeod_test_data::crossval::{CrossvalReport, StateLog};
 
 use jeod_sim::LeapSecondTable;
 
-const GEO_R_EQ: f64 = 6_378_137.0;
-const GEO_R_POL: f64 = GEO_R_EQ * (1.0 - 1.0 / 298.257_223_563);
+const GEO_R_EQ: f64 = jeod_sim::EARTH.shape.r_eq;
+const GEO_R_POL: f64 = jeod_sim::EARTH.shape.r_pol;
 /// Spherical Earth radius (JEOD uses r_eq for spherical model).
 const GEO_R_SPH: f64 = GEO_R_EQ;
 

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_families.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_families.rs
@@ -20,11 +20,11 @@ use jeod_sim::{
 };
 use sim_test_helpers::state_from_elements;
 
-/// Earth gravitational parameter (m^3/s^2) -- GGM05C value.
-const MU_EARTH: f64 = 3.986_004_415e14;
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
-/// Earth equatorial radius (m).
-const R_EARTH: f64 = 6_378_137.0;
+/// Earth equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
 
 /// Build a Simulation with point-mass Earth gravity and a single body
 /// at the given translational state. Returns the simulation ready to step.

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
@@ -17,11 +17,11 @@ use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
 use jeod_sim::{GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime};
 use sim_test_helpers::state_from_elements;
 
-/// Earth gravitational parameter (m^3/s^2) -- GGM05C value.
-const MU_EARTH: f64 = 3.986_004_415e14;
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
-/// Earth equatorial radius (m).
-const R_EARTH: f64 = 6_378_137.0;
+/// Earth equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
 
 /// Build a Simulation, propagate for approximately one full orbit (for bound
 /// orbits), recover orbital elements, and verify shape/orientation elements

--- a/tests/bevy_parity.rs
+++ b/tests/bevy_parity.rs
@@ -21,7 +21,7 @@ use jeod_sim::{
     JeodQuat, MassProperties, RotationalState, SixDofState, TranslationalState,
 };
 
-const MU_EARTH: f64 = 3.986_004_415e14;
+const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 const DT: f64 = 10.0;
 const NUM_STEPS: usize = 100;
 

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -163,13 +163,7 @@ fn tier3_bevy_derived_states() {
 fn tier3_bevy_geodetic_derived_state() {
     println!("Scenario J: Geodetic derived state with RNP");
 
-    let earth_shape = PlanetShape {
-        name: "Earth",
-        mu: MU_EARTH,
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-        flat_coeff: 1.0 / 298.257_223_563,
-    };
+    let earth_shape = jeod_sim::EARTH.shape;
 
     // ── Bevy ──
     let mut app = App::new();
@@ -429,7 +423,8 @@ fn tier3_bevy_polar_geodetic() {
         velocity: DVec3::new(0.0, 0.0, 7668.56),
     };
 
-    let r_sph = 6_378_137.0;
+    // Spherical-Earth shape: use the canonical r_eq for both axes (flat_coeff=0).
+    let r_sph = jeod_sim::EARTH.shape.r_eq;
     let earth_shape = PlanetShape {
         name: "Earth",
         mu: MU_EARTH,
@@ -915,15 +910,15 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
 
 #[test]
 fn tier3_bevy_ned_sph_inc() {
-    let r_sph = 6_378_137.0;
+    let r_sph = jeod_sim::EARTH.shape.r_eq;
     run_ned_parity("ned_sph_inc", iss_trans(), r_sph, r_sph);
 }
 
 #[test]
 fn tier3_bevy_ned_sph_polar() {
-    let r_sph = 6_378_137.0;
+    let r_sph = jeod_sim::EARTH.shape.r_eq;
     let polar_trans = TranslationalState {
-        position: DVec3::new(6_778_137.0, 0.0, 0.0),
+        position: DVec3::new(jeod_sim::EARTH.shape.r_eq + 400_000.0, 0.0, 0.0),
         velocity: DVec3::new(0.0, 0.0, 7668.56),
     };
     run_ned_parity("ned_sph_polar", polar_trans, r_sph, r_sph);

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -39,8 +39,8 @@ fn tier3_bevy_drag_atmosphere_sixdof() {
     app.insert_resource(AtmosphereModelR {
         config: AtmosphereConfig {
             model: AtmosphereModel::Exponential(exp_atmos),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+            r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+            r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
             planet_omega: 0.0,
         },
         planet_entity: None,
@@ -85,8 +85,8 @@ fn tier3_bevy_drag_atmosphere_sixdof() {
     let earth_idx = sim.add_source("Earth", earth_entry);
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+        r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
         planet_omega: 0.0,
     });
 
@@ -127,8 +127,8 @@ fn tier3_bevy_constant_density_drag_sixdof() {
     app.insert_resource(AtmosphereModelR {
         config: AtmosphereConfig {
             model: AtmosphereModel::Exponential(exp_atmos),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+            r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+            r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
             planet_omega: 0.0,
         },
         planet_entity: None,
@@ -173,8 +173,8 @@ fn tier3_bevy_constant_density_drag_sixdof() {
     let earth_idx = sim.add_source("Earth", earth_entry);
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
+        r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+        r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
         planet_omega: 0.0,
     });
 
@@ -231,9 +231,9 @@ fn tier3_bevy_met_atmosphere_drag_sixdof() {
     app.insert_resource(AtmosphereModelR {
         config: AtmosphereConfig {
             model: AtmosphereModel::Met(met),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-            planet_omega: 7.292_115_146_706_388e-5,
+            r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+            r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
         },
         planet_entity: Some(planet),
     });
@@ -278,9 +278,9 @@ fn tier3_bevy_met_atmosphere_drag_sixdof() {
     );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-        planet_omega: 7.292_115_146_706_388e-5,
+        r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+        r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+        planet_omega: jeod_sim::planet_config::EARTH.omega,
     });
     sim.atmosphere_planet_source = Some(earth_idx);
 
@@ -327,9 +327,9 @@ fn tier3_bevy_met_run5a() {
     app.insert_resource(AtmosphereModelR {
         config: AtmosphereConfig {
             model: AtmosphereModel::Met(met),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-            planet_omega: 7.292_115_146_706_388e-5,
+            r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+            r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
         },
         planet_entity: Some(planet),
     });
@@ -378,9 +378,9 @@ fn tier3_bevy_met_run5a() {
     );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-        planet_omega: 7.292_115_146_706_388e-5,
+        r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+        r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+        planet_omega: jeod_sim::planet_config::EARTH.omega,
     });
     sim.atmosphere_planet_source = Some(earth_idx);
 
@@ -435,9 +435,9 @@ fn tier3_bevy_drag_run6b() {
     app.insert_resource(AtmosphereModelR {
         config: AtmosphereConfig {
             model: AtmosphereModel::Met(met),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-            planet_omega: 7.292_115_146_706_388e-5,
+            r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+            r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
         },
         planet_entity: Some(planet),
     });
@@ -482,9 +482,9 @@ fn tier3_bevy_drag_run6b() {
     );
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Met(met),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-        planet_omega: 7.292_115_146_706_388e-5,
+        r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+        r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+        planet_omega: jeod_sim::planet_config::EARTH.omega,
     });
     sim.atmosphere_planet_source = Some(earth_idx);
 

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -138,11 +138,11 @@ fn tier3_bevy_tidal_sh4x4() {
         radius_primary: radius,
         tidal_bodies: vec![
             TidalBody {
-                mu: 4902.79980693169e9,
+                mu: jeod_sim::MOON.shape.mu,
                 position_inertial: moon_pos,
             },
             TidalBody {
-                mu: 1.327_124_40e20,
+                mu: jeod_sim::SUN.shape.mu,
                 position_inertial: sun_pos,
             },
         ],

--- a/tests/bevy_parity_lighting.rs
+++ b/tests/bevy_parity_lighting.rs
@@ -54,7 +54,7 @@ fn tier3_sim_earth_lighting_consistency() {
 // ── Earth lighting parity tests ──
 
 fn run_earth_lighting_parity(label: &str, veh_pos: DVec3, sun_pos: DVec3, moon_pos: DVec3) {
-    let earth_r = 6_378_137.0;
+    let earth_r = jeod_sim::EARTH.shadow_radius;
     let moon_r = 1_737_400.0;
     let sun_r = 6.96e8;
 
@@ -267,7 +267,7 @@ fn tier3_bevy_earth_lighting_t10() {
 
 #[test]
 fn tier3_bevy_earth_lighting_pipeline() {
-    let earth_r = 6_378_137.0;
+    let earth_r = jeod_sim::EARTH.shadow_radius;
     let moon_r = 1_737_400.0;
     let sun_r = 6.96e8;
     let sun_pos = DVec3::new(1.496e11, 0.0, 0.0);

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -57,9 +57,9 @@ fn tier3_bevy_full_stack_sixdof() {
     app.insert_resource(AtmosphereModelR {
         config: AtmosphereConfig {
             model: AtmosphereModel::Exponential(exp_atmos),
-            r_eq: 6_378_137.0,
-            r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-            planet_omega: 7.292_115_146_706_388e-5,
+            r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+            r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+            planet_omega: jeod_sim::planet_config::EARTH.omega,
         },
         planet_entity: None,
     });
@@ -133,9 +133,9 @@ fn tier3_bevy_full_stack_sixdof() {
     sim.sun_source = Some(sun_idx);
     sim.atmosphere = Some(AtmosphereConfig {
         model: AtmosphereModel::Exponential(exp_atmos),
-        r_eq: 6_378_137.0,
-        r_pol: 6_378_137.0 * (1.0 - 1.0 / 298.257_223_563),
-        planet_omega: 7.292_115_146_706_388e-5,
+        r_eq: jeod_sim::planet_config::EARTH.shape.r_eq,
+        r_pol: jeod_sim::planet_config::EARTH.shape.r_pol,
+        planet_omega: jeod_sim::planet_config::EARTH.omega,
     });
 
     let mut body = new_sim_body_sixdof(earth_idx, true);
@@ -254,7 +254,7 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
             ShadowBodyC {
-                radius: 6_378_137.0,
+                radius: jeod_sim::planet_config::EARTH.shadow_radius,
             },
         ))
         .id();
@@ -335,7 +335,7 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
         })),
         shadow_body: Some(RunnerShadowBody {
             source_idx: earth_idx,
-            radius: 6_378_137.0,
+            radius: jeod_sim::planet_config::EARTH.shadow_radius,
         }),
         ..Default::default()
     });

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -745,13 +745,13 @@ fn tier3_bevy_earth_moon_clem() {
     let initial_sun_pos = sun_initial_pos();
     let initial_moon_pos = moon_initial_pos();
 
-    let r_perigee = 6_378_137.0 + 400_000.0;
+    let r_perigee = jeod_sim::EARTH.shape.r_eq + 400_000.0;
     let v_perigee = 10_500.0;
     let clem_trans = TranslationalState {
         position: DVec3::new(r_perigee, 0.0, 0.0),
         velocity: DVec3::new(0.0, v_perigee, 0.0),
     };
-    let mu_moon = 4.902_800_066e12;
+    let mu_moon = jeod_sim::MOON.shape.mu;
 
     let cx_area = 5.0;
     let albedo = 0.3;

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -237,7 +237,7 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
         .id();
 
     let moon_entity = if let Some(moon_pos) = initial_moon_pos {
-        let mu_moon = 4.902_800_066e12;
+        let mu_moon = jeod_sim::MOON.shape.mu;
         Some(
             app.world_mut()
                 .spawn((
@@ -319,7 +319,7 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
     sim.sun_source = Some(sun_idx);
 
     let moon_idx = if include_moon {
-        let mu_moon = 4.902_800_066e12;
+        let mu_moon = jeod_sim::MOON.shape.mu;
         let moon_pos = initial_moon_pos.unwrap();
         let idx = sim.add_source(
             "Moon",
@@ -561,7 +561,7 @@ fn tier3_bevy_mars_dawn() {
 fn tier3_bevy_mercury_relativistic() {
     println!("Mercury relativistic: Sun point-mass with PPN correction");
 
-    let mu_sun = 1.327_124_400_18e20;
+    let mu_sun = jeod_sim::SUN.shape.mu;
     let r_perihelion = 4.6e10;
     let v_perihelion = 5.898e4;
     let mercury_trans = TranslationalState {
@@ -647,7 +647,7 @@ fn tier3_bevy_mercury_relativistic() {
 fn tier3_bevy_relativistic_moving_source() {
     println!("Relativistic moving source: Sun with non-zero velocity");
 
-    let mu_sun = 1.327_124_400_18e20;
+    let mu_sun = jeod_sim::SUN.shape.mu;
     let r_perihelion = 4.6e10;
     let v_perihelion = 5.898e4;
     let mercury_trans = TranslationalState {

--- a/tests/parity_helpers/mod.rs
+++ b/tests/parity_helpers/mod.rs
@@ -20,8 +20,10 @@ use jeod_sim::{
     MassProperties, RotationalState, SixDofState, TranslationalState,
 };
 
-pub const MU_EARTH: f64 = 3.986_004_415e14;
-pub const MU_SUN: f64 = 1.327_124_40e20;
+/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc` via presets.
+pub const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
+/// Sun gravitational parameter (m^3/s^2) — JEOD `sun_spherical.cc` via presets.
+pub const MU_SUN: f64 = jeod_sim::SUN.shape.mu;
 pub const DT: f64 = 10.0;
 pub const NUM_STEPS: usize = 100;
 


### PR DESCRIPTION
Closes #50.

## Summary

Audit of ~86 test files against the five categories in #50. Ran the
audit scans from the issue body and triaged every match:

| Category | Total matches | FIX | FOLLOW-UP | FALSE POSITIVE |
|---|---:|---:|---:|---:|
| Manual physics equations (PI/sqrt/powi/etc.) | ~100 sites | 0 (all test infra) | 0 | ~100 |
| Workarounds (continue/skip/TODO/close-enough) | ~45 sites | 0 | 0 | ~45 |
| Missing JEOD function ports | 1 (`time_periapsis` branch) | 1 | 0 | 0 |
| Hardcoded planet constants | ~40 sites across 30 files | ~40 | 0 | 0 |
| External force/torque path | ~15 uses of `set_body_external_*` | 0 (proper API) | 0 | ~15 |

**FIX: 41 sites across 30 files.** **FOLLOW-UP: 0 issues filed.**
**FALSE POSITIVE: ~160 sites.** No serious findings.

## Findings detail

### Fixes applied

**Ported the missing `init_from_time_periapsis` function.**
Six test sites across three crates manually inlined JEOD's
`LocationTimePeri` mean-anomaly formula from `dyn_body_init_orbit.cc:295`:
`M = t_peri * sqrt(mu / a) / a`. We now have a dedicated
`jeod_dynamics::init_from_time_periapsis` that mirrors JEOD's
arithmetic order exactly, re-exported through `jeod_dynamics`.

**Fixed wrong MU_EARTH value.** Four tests used `3.986_004_418e14`
(IERS 2010), which does not exist in JEOD source. They now use
`jeod_sim::EARTH.shape.mu = 3.986_004_415e14` (GGM05C), matching every
other file in the repo.

**Removed hardcoded `mu_earth` literal in `jeod_gravity/tests/jeod_validation.rs`.**
`point_mass_reasonable_at_jeod_positions` now loads mu from the same
GGM02C coefficient file referenced by the rest of the test module.

**Deduplicated `MU_EARTH`/`R_EARTH`/`omega`/`mu_sun`/`mu_moon` literals
across test files.** Replaced literals with references to the canonical
`jeod_sim::EARTH.shape.{mu,r_eq,r_pol}`, `jeod_sim::EARTH.omega`,
`jeod_sim::SUN.shape.mu`, and `jeod_sim::MOON.shape.mu` in:

- `tests/parity_helpers/mod.rs`, `tests/bevy_parity.rs`,
  `tests/bevy_parity_{drag,srp,third_body,highfidelity,derived_state,lighting}.rs`
- `crates/jeod_dynamics/tests/tier2_body_init.rs`
- `crates/jeod_math/tests/jeod_validation.rs`
- `crates/jeod_interactions/tests/integration_physics.rs`
- `crates/jeod_runner/tests/sim_test_helpers/mod.rs`
- `crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs`
- `crates/jeod_runner/tests/tier3_sim_{orbinit_families,orbinit_roundtrip}.rs`
- `crates/jeod_runner/tests/tier3_sim_drag_{6dof,analytical,rot_verif,verif}.rs`
- `crates/jeod_runner/tests/tier3_sim_dyncomp_{combinations,run6,run7}.rs`
- `crates/jeod_runner/tests/tier3_sim_integ_{analytical,comparison,gj_orders}.rs`
- `crates/jeod_runner/tests/tier3_sim_{met,ned,ned_edge}.rs`
- `crates/jeod_runner/tests/pipeline_earth_lighting.rs`

The one intentional divergence is `tier3_apollo8_frame_switch.rs`:
`MU_MOON = 4902.801076e9` targets JEOD's `moon_spherical.cc` /
`moon_LP150Q.cc` value, which differs from GRAIL150
(`jeod_sim::MOON.shape.mu = 4902.79980693169e9`). Added a comment
documenting this deliberately.

### False positives (scanned but not issues)

- **Analytical reference formulas.** `j2_regression.rs` computes the
  analytical J2 nodal regression rate as its reference — this is the
  oracle against which our propagator is measured. Similarly the
  `tier3_sim_integ_*` tests compute analytical circular-orbit position
  and period as references. These are legitimately "manual physics"
  for reference, not physics that should be ported.
- **Test post-processing.** Mercury perihelion-advance detection uses
  `r·v/|r|` zero-crossing and 2π phase unwrapping. These are
  event-detection and regression-fit utilities, not JEOD physics
  functions.
- **JEOD non-propagating verification sims.** `tier3_sim_drag_{ver,flatplate_ver,rot_verif}.rs`
  reproduce JEOD's scheduled velocity `7500·cos(t·π/180)` /
  `7500·sin(t·π/180)` because JEOD itself prescribes these and
  explicitly disables integration in the S_define. `tier3_sim_shadow_2a.rs`
  similarly uses prescribed motion because JEOD's SIM_2A_SHADOW_CALC
  does. Both are documented at the top of their respective files and
  match JEOD's case definitions exactly.
- **Parallel-axis theorem in `tier3_mass_attach_detach.rs`** — the
  file's own comment explicitly states the test oracle must be
  structurally independent of the production implementation.
- **`continue`/`skip` occurrences.** All are CSV header-row skipping,
  empty-line skipping, loop filters on `grad_active`, or markdown
  table parsing in `invariant_coverage.rs`. No graceful skips that
  hide missing data.
- **`external_force`/`external_torque`.** Tests use
  `Simulation::set_body_external_force` / `set_body_external_torque`,
  which are the proper Simulation API that plumbs into
  `jeod_sim::collect_and_resolve_forces`. This is the canonical JEOD
  force-collection path.

### Serious findings

None. No computational-independence violations, no graceful skips
were found.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --tests -- -D warnings` passes
- [x] `cargo nextest run --workspace` — 822 tests run: 822 passed (1 slow), 2 skipped
  (1 slow = earth_moon, 17-minute run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)