### PR TITLE
Port DynManager multi-integrable-object ODE scheduling + thermal integrable object

### DIFF
--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -35,10 +35,11 @@ use jeod_sim::gravity::accumulate_gravity;
 use jeod_sim::integration::{integrate_bodies_contact_coupled, integrate_body, CoupledBodyInput};
 use jeod_sim::validation::ValidationError;
 use jeod_sim::{
-    evaluate_contact_pair, AerodynamicForce, AtmosphereState, ContactFacet, DragConfig,
-    DynamicsConfig, EulerSequence, FrameDerivatives, GeodeticState, GravityAcceleration,
-    GravityControls, GravitySource, JeodQuat, LvlhFrame, MassProperties, OrbitalElements,
-    PlanetConfig, RadiationForce, RotationalState, SimulationTime, TotalForce, TranslationalState,
+    evaluate_contact_pair, integrate_body_coupled, AerodynamicForce, AtmosphereState, ContactFacet,
+    CoupledStageEval, DragConfig, DynamicsConfig, EulerSequence, FrameDerivatives, GeodeticState,
+    GravityAcceleration, GravityControls, GravitySource, JeodQuat, LvlhFrame, MassProperties,
+    OrbitalElements, PlanetConfig, RadiationForce, RotationalState, SimulationTime, TotalForce,
+    TranslationalState,
 };
 
 pub mod builder;
@@ -466,6 +467,32 @@ pub struct VehicleOutput {
 // Internal body state (private — not part of public API)
 // ══════════════════════════════════════════════════════════════════════════════
 
+/// Step-constant SRP inputs cached in Stage 5 for the coupled Rk4 thermal
+/// path, then consumed in Stage 8's per-stage closure.
+///
+/// The shadow `illum_factor` and solar `flux_inertial_hat` are evaluated
+/// once at step start — JEOD's scheduled-class shadow evaluation in
+/// SIM_3_ORBIT. Per-stage plate-frame rotation of the flux happens inside
+/// the stage closure.
+// JEOD_INV: IN.32 — IntegrableObject per-stage protocol consumes these
+// cached step-constant inputs alongside the stage-dependent plate state.
+#[derive(Debug, Clone, Copy)]
+struct SrpStageInputs {
+    /// Unit flux direction from Sun to vehicle in inertial frame (step start).
+    flux_inertial_hat: DVec3,
+    /// Solar flux magnitude at vehicle distance (W/m²).
+    flux_mag: f64,
+    /// Shadow illumination factor from step-start shadow evaluation.
+    illum_factor: f64,
+    /// Center of gravity in structural frame.
+    center_grav: DVec3,
+    /// Which derivative-class order is in effect. `DerivativeFirstOrder`
+    /// captures stage-1 temp_dots and reuses them at stages 2-4 so the
+    /// RK4 combine collapses to Euler; `DerivativeRk4` uses true per-stage
+    /// derivatives.
+    order: jeod_sim::ThermalIntegrationOrder,
+}
+
 /// Internal per-body simulation state. Combines user config with bookkeeping
 /// and output fields. Not exposed publicly — users interact through
 /// [`VehicleConfig`] (input) and [`VehicleOutput`] (output).
@@ -501,6 +528,12 @@ struct SimBody {
     aero_force: Option<AerodynamicForce>,
     radiation_force: Option<RadiationForce>,
     gravity_torque: Option<DVec3>,
+    /// Cached SRP inputs for the Rk4-coupled thermal path. Populated in
+    /// Stage 5 (interactions) and consumed by the stage closure in Stage 8
+    /// (integration) when `flat_plate_state.integration_order ==
+    /// ThermalIntegrationOrder::Rk4Coupled`. `None` when SRP is off, too
+    /// close to the Sun, or the 1st-order (Euler) thermal path is in use.
+    srp_stage_inputs: Option<SrpStageInputs>,
 
     // ── Derived state config ──
     orbital_elements_source: Option<usize>,
@@ -580,6 +613,7 @@ impl SimBody {
             aero_force: None,
             radiation_force: None,
             gravity_torque: None,
+            srp_stage_inputs: None,
 
             orbital_elements_source: config.derived.orbital_elements_source,
             euler_sequence: config.derived.euler_sequence,
@@ -1717,6 +1751,7 @@ impl Simulation {
 
             // Solar radiation pressure (flat-plate)
             body.radiation_force = None;
+            body.srp_stage_inputs = None;
             if let Some(sun_position) = sun_pos {
                 if let Some(ref mut fps) = body.flat_plate_state {
                     // Flat-plate SRP with thermal emission
@@ -1727,7 +1762,8 @@ impl Simulation {
                         let flux_inertial_hat = sun_to_vehicle / distance;
                         let flux_mag = jeod_sim::solar_flux_at_distance(distance);
 
-                        // Shadow fraction
+                        // Shadow fraction (step-constant — matches JEOD's
+                        // scheduled-class shadow evaluation in SIM_3_ORBIT).
                         let illum_factor = body
                             .shadow_body
                             .map(|(idx, radius)| {
@@ -1748,28 +1784,50 @@ impl Simulation {
                             })
                             .unwrap_or(1.0);
 
-                        // Rotate flux direction to structural frame
-                        let flux_struct_hat = t_inertial_struct * flux_inertial_hat;
-
                         let center_grav = body.mass.as_ref().map_or(DVec3::ZERO, |m| m.position);
 
-                        let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
-                            &fps.plates,
-                            &fps.t_pow4_cached,
-                            flux_struct_hat,
-                            flux_mag,
-                            center_grav,
-                            illum_factor,
-                        );
+                        match fps.integration_order {
+                            jeod_sim::ThermalIntegrationOrder::Scheduled => {
+                                // Scheduled-class: compute SRP force + Euler T
+                                // update once per step (JEOD SIM_3_ORBIT).
+                                let flux_struct_hat = t_inertial_struct * flux_inertial_hat;
+                                let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
+                                    &fps.plates,
+                                    &fps.t_pow4_cached,
+                                    flux_struct_hat,
+                                    flux_mag,
+                                    center_grav,
+                                    illum_factor,
+                                );
 
-                        // Force: rotate from structural to inertial. Torque: stays structural.
-                        let force_inertial = t_inertial_struct.transpose() * srp_result.force;
-                        body.radiation_force = Some(RadiationForce {
-                            force: force_inertial,
-                            torque: srp_result.torque,
-                        });
+                                // Force: structural → inertial. Torque: stays structural.
+                                let force_inertial =
+                                    t_inertial_struct.transpose() * srp_result.force;
+                                body.radiation_force = Some(RadiationForce {
+                                    force: force_inertial,
+                                    torque: srp_result.torque,
+                                });
 
-                        fps.integrate_temperatures(&srp_result.temp_dots, dt);
+                                fps.integrate_temperatures(&srp_result.temp_dots, dt);
+                            }
+                            jeod_sim::ThermalIntegrationOrder::DerivativeFirstOrder
+                            | jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => {
+                                // Derivative-class: SRP force (and optionally T)
+                                // recomputed per RK4 stage. Stash the step-start
+                                // inputs here; Stage 8 consumes them via
+                                // `integrate_body_coupled` below.
+                                body.srp_stage_inputs = Some(SrpStageInputs {
+                                    flux_inertial_hat,
+                                    flux_mag,
+                                    illum_factor,
+                                    center_grav,
+                                    order: fps.integration_order,
+                                });
+                                // `radiation_force` is left None here; Stage 8
+                                // writes a representative final-stage value so
+                                // `VehicleOutput` still reports SRP force.
+                            }
+                        }
                     }
                 } else if let Some((cx_area, albedo, diffuse)) = body.cannonball_srp {
                     let illum_factor = body
@@ -2004,24 +2062,131 @@ impl Simulation {
             // a &mut SimBody, and Rust's disjoint-field split borrow lets
             // the closure capture &body.gravity_controls while other
             // fields of `body` are borrowed mutably for the integrator.
+            let time_scale_factor = self.time.time_scale_factor;
             for (body_idx, body) in self.bodies.iter_mut().enumerate() {
-                let controls = &body.gravity_controls;
-                integrate_body(
-                    &body.config,
-                    &mut body.trans,
-                    body.rot.as_mut(),
-                    body.mass.as_ref(),
-                    |pos, vel, time_frac| {
-                        eval_body_gravity(controls, body_idx, pos, vel, time_frac)
-                    },
-                    body.total_force.force,
-                    body.total_force.torque,
-                    dt,
-                    self.time.time_scale_factor,
-                    body.integrator,
-                    body.gj_state.as_mut(),
-                    body.abm4_state.as_mut(),
-                );
+                if let Some(srp_inputs) = body.srp_stage_inputs {
+                    // JEOD_INV: IN.32 — Rk4Coupled thermal: SRP force +
+                    // temp_dots recomputed at each RK4 stage from the
+                    // intermediate orbital + thermal state. Aero /
+                    // external / gravity-gradient torque are step-constant
+                    // (scheduled-class) and captured once from total_force.
+                    assert!(
+                        matches!(body.integrator, jeod_dynamics::IntegratorType::Rk4),
+                        "Rk4Coupled thermal integration requires RK4 integrator \
+                         (body {body_idx}); use FirstOrder or switch integrator.",
+                    );
+                    let t_struct_body = body.t_struct_body;
+                    let non_grav_non_srp_force = body.total_force.force;
+                    let constant_torque = body.total_force.torque;
+                    let config = body.config;
+                    let controls = &body.gravity_controls;
+                    // Stash the final-stage SRP result so we can write a
+                    // representative `radiation_force` for `VehicleOutput`.
+                    let mut final_srp_inertial_force = DVec3::ZERO;
+                    let mut final_srp_torque = DVec3::ZERO;
+                    // For DerivativeFirstOrder: capture stage-1 temp_dots and
+                    // feed them back at stages 2-4, collapsing the RK4 thermal
+                    // combine to Euler (matches JEOD's ER7_Utils first-order
+                    // integrator behavior while still evaluating SRP per stage
+                    // for the orbital RK4).
+                    let mut k1_temp_dots: Option<Vec<f64>> = None;
+                    let mass_copy = body.mass;
+
+                    integrate_body_coupled(
+                        &config,
+                        &mut body.trans,
+                        body.rot.as_mut(),
+                        mass_copy.as_ref(),
+                        |stage_trans, stage_rot, stage_thermal, time_frac| {
+                            let gravity_accel = eval_body_gravity(
+                                controls,
+                                body_idx,
+                                stage_trans.position,
+                                stage_trans.velocity,
+                                time_frac,
+                            );
+                            let t_inertial_body = stage_rot.map_or(DMat3::IDENTITY, |r| {
+                                r.quaternion.left_quat_to_transformation()
+                            });
+                            let t_inertial_struct = jeod_sim::compute_t_inertial_struct(
+                                &t_struct_body,
+                                &t_inertial_body,
+                            );
+                            let flux_struct_hat = t_inertial_struct * srp_inputs.flux_inertial_hat;
+                            let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
+                                &stage_thermal.plates,
+                                &stage_thermal.t_pow4_cached,
+                                flux_struct_hat,
+                                srp_inputs.flux_mag,
+                                srp_inputs.center_grav,
+                                srp_inputs.illum_factor,
+                            );
+                            let srp_force_inertial =
+                                t_inertial_struct.transpose() * srp_result.force;
+                            // Stage 4 (time_frac == 1.0) is the representative
+                            // final-state SRP — cached for writeback below.
+                            final_srp_inertial_force = srp_force_inertial;
+                            final_srp_torque = srp_result.torque;
+                            let temp_dots = match srp_inputs.order {
+                                jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => {
+                                    srp_result.temp_dots
+                                }
+                                jeod_sim::ThermalIntegrationOrder::DerivativeFirstOrder => {
+                                    // Capture at stage 1 (time_frac == 0.0);
+                                    // reuse at stages 2-4 so RK4 combine
+                                    // collapses to Euler over k1.
+                                    if time_frac == 0.0 {
+                                        k1_temp_dots = Some(srp_result.temp_dots.clone());
+                                        srp_result.temp_dots
+                                    } else {
+                                        k1_temp_dots
+                                            .clone()
+                                            .expect("stage 1 runs before stages 2-4")
+                                    }
+                                }
+                                jeod_sim::ThermalIntegrationOrder::Scheduled => {
+                                    unreachable!(
+                                        "Scheduled thermal bodies do not enter the coupled path"
+                                    )
+                                }
+                            };
+                            CoupledStageEval {
+                                gravity_accel,
+                                non_grav_force: non_grav_non_srp_force + srp_force_inertial,
+                                torque: constant_torque + srp_result.torque,
+                                temp_dots,
+                            }
+                        },
+                        body.flat_plate_state
+                            .as_mut()
+                            .expect("srp_stage_inputs implies flat_plate_state"),
+                        dt,
+                        time_scale_factor,
+                    );
+
+                    body.radiation_force = Some(RadiationForce {
+                        force: final_srp_inertial_force,
+                        torque: final_srp_torque,
+                    });
+                } else {
+                    let controls = &body.gravity_controls;
+                    integrate_body(
+                        &body.config,
+                        &mut body.trans,
+                        body.rot.as_mut(),
+                        body.mass.as_ref(),
+                        |pos, vel, time_frac| {
+                            eval_body_gravity(controls, body_idx, pos, vel, time_frac)
+                        },
+                        body.total_force.force,
+                        body.total_force.torque,
+                        dt,
+                        time_scale_factor,
+                        body.integrator,
+                        body.gj_state.as_mut(),
+                        body.abm4_state.as_mut(),
+                    );
+                }
             }
         } else {
             // ── Contact-coupled path: multi-body RK4 where contact forces
@@ -2044,6 +2209,17 @@ impl Simulation {
                     .iter()
                     .all(|b| b.rot.is_some() && b.mass.is_some()),
                 "contact pairs require 6-DOF (rotational state + mass) on all bodies"
+            );
+            // Rk4Coupled thermal is not extended to the contact-coupled
+            // kernel. JEOD's `DynamicsIntegrationGroup` handles this case
+            // natively, but our `integrate_bodies_contact_coupled` has no
+            // per-stage thermal hook yet; opt such bodies into FirstOrder
+            // or disable contact pairs.
+            assert!(
+                self.bodies.iter().all(|b| b.srp_stage_inputs.is_none()),
+                "Rk4Coupled thermal integration is not yet supported with contact pairs; \
+                 use ThermalIntegrationOrder::FirstOrder on flat-plate SRP bodies \
+                 when contact pairs are active",
             );
             // Contact pair states must share the root inertial frame, since
             // the coupled contact evaluator uses each body's stage state
@@ -2376,6 +2552,18 @@ impl Simulation {
     /// plus any derived states that were configured.
     pub fn body(&self, idx: usize) -> VehicleOutput {
         self.bodies[idx].output()
+    }
+
+    /// Read the current per-plate temperatures (K) for a body's flat-plate
+    /// SRP configuration, or `None` if the body has no flat-plate SRP.
+    ///
+    /// Useful for unit tests and data recording; returns a reference so no
+    /// allocation is needed for the common steady-state case.
+    pub fn srp_plate_temperatures(&self, body_idx: usize) -> Option<&[f64]> {
+        self.bodies[body_idx]
+            .flat_plate_state
+            .as_ref()
+            .map(|fps| fps.temperatures.as_slice())
     }
 
     /// Set the externally applied force (inertial frame, N) for a body.

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -2037,15 +2037,19 @@ impl Simulation {
                     .as_ref()
                     .and_then(|fps| fps.stage_inputs.map(|si| (si, fps.integration_order)));
                 if let Some((srp_inputs, thermal_order)) = stage_inputs_and_order {
-                    // JEOD_INV: IN.32 — Rk4Coupled thermal: SRP force +
-                    // temp_dots recomputed at each RK4 stage from the
-                    // intermediate orbital + thermal state. Aero /
-                    // external / gravity-gradient torque are step-constant
-                    // (scheduled-class) and captured once from total_force.
+                    // JEOD_INV: IN.32 — derivative-class thermal: SRP force
+                    // (and temp_dots for DerivativeRk4) recomputed at each
+                    // RK4 stage from the intermediate orbital + thermal
+                    // state. Aero / external / gravity-gradient torque are
+                    // step-constant (scheduled-class) and captured once
+                    // from total_force.
                     assert!(
                         matches!(body.integrator, jeod_dynamics::IntegratorType::Rk4),
-                        "Rk4Coupled thermal integration requires RK4 integrator \
-                         (body {body_idx}); use FirstOrder or switch integrator.",
+                        "ThermalIntegrationOrder::{thermal_order:?} requires \
+                         jeod_dynamics::IntegratorType::Rk4 for body {body_idx}; \
+                         switch the body integrator to Rk4, or choose \
+                         ThermalIntegrationOrder::Scheduled to avoid the coupled \
+                         RK4 thermal path.",
                     );
                     let t_struct_body = body.t_struct_body;
                     let non_grav_non_srp_force = body.total_force.force;
@@ -2182,11 +2186,12 @@ impl Simulation {
                     .all(|b| b.rot.is_some() && b.mass.is_some()),
                 "contact pairs require 6-DOF (rotational state + mass) on all bodies"
             );
-            // Rk4Coupled thermal is not extended to the contact-coupled
-            // kernel. JEOD's `DynamicsIntegrationGroup` handles this case
-            // natively, but our `integrate_bodies_contact_coupled` has no
-            // per-stage thermal hook yet; opt such bodies into FirstOrder
-            // or disable contact pairs.
+            // Derivative-class thermal (DerivativeFirstOrder /
+            // DerivativeRk4) is not extended to the contact-coupled kernel.
+            // JEOD's `DynamicsIntegrationGroup` handles this case natively,
+            // but our `integrate_bodies_contact_coupled` has no per-stage
+            // SRP/thermal hook yet; opt such bodies into
+            // `ThermalIntegrationOrder::Scheduled` or disable contact pairs.
             assert!(
                 self.bodies.iter().all(|b| b
                     .flat_plate_state

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -2152,6 +2152,22 @@ impl Simulation {
                         force: final_srp_inertial_force,
                         torque: final_srp_torque,
                     });
+                    // Backfill `TotalForce` and `FrameDerivatives` with the
+                    // final-stage SRP contribution so downstream observers
+                    // reading these see SRP-inclusive values — matching the
+                    // Scheduled-mode invariant that `total_force` reflects
+                    // every applied force and `frame_derivs` the resulting
+                    // accelerations. In derivative modes this is a
+                    // "representative stage" (stage 4) snapshot, same as
+                    // `radiation_force` above.
+                    body.total_force.force += final_srp_inertial_force;
+                    let final_srp_torque_body = t_struct_body * final_srp_torque;
+                    body.total_force.torque += final_srp_torque_body;
+                    if let Some(mass) = body.mass {
+                        body.frame_derivs.trans_accel +=
+                            final_srp_inertial_force * mass.inverse_mass;
+                        body.frame_derivs.rot_accel += mass.inverse_inertia * final_srp_torque_body;
+                    }
                 } else {
                     let controls = &body.gravity_controls;
                     integrate_body(

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1786,8 +1786,7 @@ impl Simulation {
                                 // inputs on the plate state; Stage 8 consumes
                                 // them via `integrate_body_coupled` below.
                                 fps.stage_inputs = Some(jeod_sim::FlatPlateStageInputs {
-                                    flux_inertial_hat,
-                                    flux_mag,
+                                    sun_position,
                                     illum_factor,
                                     center_grav,
                                 });
@@ -2088,12 +2087,20 @@ impl Simulation {
                                 &t_struct_body,
                                 &t_inertial_body,
                             );
-                            let flux_struct_hat = t_inertial_struct * srp_inputs.flux_inertial_hat;
+                            // Per-stage flux recompute from intermediate vehicle
+                            // position — matches JEOD's derivative-class
+                            // `RadiationSource::calculate_flux`. Sun position is
+                            // step-constant (ephemeris is scheduled-class).
+                            let sun_to_vehicle = stage_trans.position - srp_inputs.sun_position;
+                            let distance = sun_to_vehicle.length().max(1.0);
+                            let stage_flux_inertial_hat = sun_to_vehicle / distance;
+                            let stage_flux_mag = jeod_sim::solar_flux_at_distance(distance);
+                            let flux_struct_hat = t_inertial_struct * stage_flux_inertial_hat;
                             let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
                                 &stage_thermal.plates,
                                 &stage_thermal.t_pow4_cached,
                                 flux_struct_hat,
-                                srp_inputs.flux_mag,
+                                stage_flux_mag,
                                 srp_inputs.center_grav,
                                 srp_inputs.illum_factor,
                             );

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -467,32 +467,6 @@ pub struct VehicleOutput {
 // Internal body state (private — not part of public API)
 // ══════════════════════════════════════════════════════════════════════════════
 
-/// Step-constant SRP inputs cached in Stage 5 for the coupled Rk4 thermal
-/// path, then consumed in Stage 8's per-stage closure.
-///
-/// The shadow `illum_factor` and solar `flux_inertial_hat` are evaluated
-/// once at step start — JEOD's scheduled-class shadow evaluation in
-/// SIM_3_ORBIT. Per-stage plate-frame rotation of the flux happens inside
-/// the stage closure.
-// JEOD_INV: IN.32 — IntegrableObject per-stage protocol consumes these
-// cached step-constant inputs alongside the stage-dependent plate state.
-#[derive(Debug, Clone, Copy)]
-struct SrpStageInputs {
-    /// Unit flux direction from Sun to vehicle in inertial frame (step start).
-    flux_inertial_hat: DVec3,
-    /// Solar flux magnitude at vehicle distance (W/m²).
-    flux_mag: f64,
-    /// Shadow illumination factor from step-start shadow evaluation.
-    illum_factor: f64,
-    /// Center of gravity in structural frame.
-    center_grav: DVec3,
-    /// Which derivative-class order is in effect. `DerivativeFirstOrder`
-    /// captures stage-1 temp_dots and reuses them at stages 2-4 so the
-    /// RK4 combine collapses to Euler; `DerivativeRk4` uses true per-stage
-    /// derivatives.
-    order: jeod_sim::ThermalIntegrationOrder,
-}
-
 /// Internal per-body simulation state. Combines user config with bookkeeping
 /// and output fields. Not exposed publicly — users interact through
 /// [`VehicleConfig`] (input) and [`VehicleOutput`] (output).
@@ -528,12 +502,6 @@ struct SimBody {
     aero_force: Option<AerodynamicForce>,
     radiation_force: Option<RadiationForce>,
     gravity_torque: Option<DVec3>,
-    /// Cached SRP inputs for the Rk4-coupled thermal path. Populated in
-    /// Stage 5 (interactions) and consumed by the stage closure in Stage 8
-    /// (integration) when `flat_plate_state.integration_order ==
-    /// ThermalIntegrationOrder::Rk4Coupled`. `None` when SRP is off, too
-    /// close to the Sun, or the 1st-order (Euler) thermal path is in use.
-    srp_stage_inputs: Option<SrpStageInputs>,
 
     // ── Derived state config ──
     orbital_elements_source: Option<usize>,
@@ -613,7 +581,6 @@ impl SimBody {
             aero_force: None,
             radiation_force: None,
             gravity_torque: None,
-            srp_stage_inputs: None,
 
             orbital_elements_source: config.derived.orbital_elements_source,
             euler_sequence: config.derived.euler_sequence,
@@ -1751,7 +1718,9 @@ impl Simulation {
 
             // Solar radiation pressure (flat-plate)
             body.radiation_force = None;
-            body.srp_stage_inputs = None;
+            if let Some(ref mut fps) = body.flat_plate_state {
+                fps.stage_inputs = None;
+            }
             if let Some(sun_position) = sun_pos {
                 if let Some(ref mut fps) = body.flat_plate_state {
                     // Flat-plate SRP with thermal emission
@@ -1814,14 +1783,13 @@ impl Simulation {
                             | jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => {
                                 // Derivative-class: SRP force (and optionally T)
                                 // recomputed per RK4 stage. Stash the step-start
-                                // inputs here; Stage 8 consumes them via
-                                // `integrate_body_coupled` below.
-                                body.srp_stage_inputs = Some(SrpStageInputs {
+                                // inputs on the plate state; Stage 8 consumes
+                                // them via `integrate_body_coupled` below.
+                                fps.stage_inputs = Some(jeod_sim::FlatPlateStageInputs {
                                     flux_inertial_hat,
                                     flux_mag,
                                     illum_factor,
                                     center_grav,
-                                    order: fps.integration_order,
                                 });
                                 // `radiation_force` is left None here; Stage 8
                                 // writes a representative final-stage value so
@@ -2064,7 +2032,11 @@ impl Simulation {
             // fields of `body` are borrowed mutably for the integrator.
             let time_scale_factor = self.time.time_scale_factor;
             for (body_idx, body) in self.bodies.iter_mut().enumerate() {
-                if let Some(srp_inputs) = body.srp_stage_inputs {
+                let stage_inputs_and_order = body
+                    .flat_plate_state
+                    .as_ref()
+                    .and_then(|fps| fps.stage_inputs.map(|si| (si, fps.integration_order)));
+                if let Some((srp_inputs, thermal_order)) = stage_inputs_and_order {
                     // JEOD_INV: IN.32 — Rk4Coupled thermal: SRP force +
                     // temp_dots recomputed at each RK4 stage from the
                     // intermediate orbital + thermal state. Aero /
@@ -2127,7 +2099,7 @@ impl Simulation {
                             // final-state SRP — cached for writeback below.
                             final_srp_inertial_force = srp_force_inertial;
                             final_srp_torque = srp_result.torque;
-                            let temp_dots = match srp_inputs.order {
+                            let temp_dots = match thermal_order {
                                 jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => {
                                     srp_result.temp_dots
                                 }
@@ -2216,9 +2188,12 @@ impl Simulation {
             // per-stage thermal hook yet; opt such bodies into FirstOrder
             // or disable contact pairs.
             assert!(
-                self.bodies.iter().all(|b| b.srp_stage_inputs.is_none()),
-                "Rk4Coupled thermal integration is not yet supported with contact pairs; \
-                 use ThermalIntegrationOrder::FirstOrder on flat-plate SRP bodies \
+                self.bodies.iter().all(|b| b
+                    .flat_plate_state
+                    .as_ref()
+                    .is_none_or(|fps| fps.stage_inputs.is_none())),
+                "Derivative-class thermal integration is not yet supported with contact pairs; \
+                 use ThermalIntegrationOrder::Scheduled on flat-plate SRP bodies \
                  when contact pairs are active",
             );
             // Contact pair states must share the root inertial frame, since

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -2116,8 +2116,9 @@ impl Simulation {
                                         srp_result.temp_dots
                                     } else {
                                         k1_temp_dots
-                                            .clone()
+                                            .as_ref()
                                             .expect("stage 1 runs before stages 2-4")
+                                            .clone()
                                     }
                                 }
                                 jeod_sim::ThermalIntegrationOrder::Scheduled => {

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -2126,10 +2126,17 @@ impl Simulation {
                                     )
                                 }
                             };
+                            // `srp_result.torque` is structural-frame per
+                            // `FlatPlateSrpResult` docs; `constant_torque`
+                            // is body-frame (from `collect_and_resolve_forces`).
+                            // Rotate to body frame before summing so the
+                            // coupled integrator's rotational dynamics
+                            // are correct when t_struct_body != IDENTITY.
+                            let srp_torque_body = t_struct_body * srp_result.torque;
                             CoupledStageEval {
                                 gravity_accel,
                                 non_grav_force: non_grav_non_srp_force + srp_force_inertial,
-                                torque: constant_torque + srp_result.torque,
+                                torque: constant_torque + srp_torque_body,
                                 temp_dots,
                             }
                         },

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -263,6 +263,7 @@ fn tier3_simulation_srp_flat_plate() {
             plates,
             temperatures: vec![init_temp; num_plates],
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
+            ..Default::default()
         })),
         shadow_body: Some(ShadowBody {
             source_idx: earth,

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -19,7 +19,7 @@ use jeod_runner::{
 use jeod_sim::{
     Ephemeris, EphemerisBody, FlatPlate, FlatPlateParams, FlatPlateState, FlatPlateThermal,
     GravityControl, GravityControls, GravityModel, GravitySource, MassProperties, SimulationTime,
-    TranslationalState,
+    ThermalIntegrationOrder, TranslationalState,
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use std::path::Path;
@@ -217,6 +217,9 @@ fn tier3_srp_1st_order_trajectory() {
             plates,
             temperatures: vec![init_temp; num_plates],
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
+            // JEOD SIM_3_ORBIT_1st_ORDER uses scheduled-class temp_dot
+            // (Forward Euler), so opt into that integration order here.
+            integration_order: ThermalIntegrationOrder::FirstOrder,
             ..Default::default()
         })),
         shadow_body: Some(ShadowBody {

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -217,9 +217,10 @@ fn tier3_srp_1st_order_trajectory() {
             plates,
             temperatures: vec![init_temp; num_plates],
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
-            // JEOD SIM_3_ORBIT_1st_ORDER uses scheduled-class temp_dot
-            // (Forward Euler), so opt into that integration order here.
-            integration_order: ThermalIntegrationOrder::FirstOrder,
+            // JEOD SIM_3_ORBIT_1st_ORDER wires `rad_pressure.update` as a
+            // derivative-class job (per RK4 stage) with ER7_Utils
+            // first-order integrator on temperature. Match that here.
+            integration_order: ThermalIntegrationOrder::DerivativeFirstOrder,
             ..Default::default()
         })),
         shadow_body: Some(ShadowBody {
@@ -280,5 +281,5 @@ fn tier3_srp_1st_order_trajectory() {
     let max_pos_error = report.max_position_component();
     println!("  Max position error: {:.6e} m", max_pos_error);
 
-    report.assert_position([8.296e1, 8.491e1, 3.686e1]);
+    report.assert_position([7.709e1, 8.021e1, 3.481e1]);
 }

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -217,6 +217,7 @@ fn tier3_srp_1st_order_trajectory() {
             plates,
             temperatures: vec![init_temp; num_plates],
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
+            ..Default::default()
         })),
         shadow_body: Some(ShadowBody {
             source_idx: earth,

--- a/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
@@ -146,6 +146,7 @@ fn run_srp_basic_test(csv_filename: &str, label: &str) {
             plates,
             temperatures: vec![init_temp; num_plates],
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
+            ..Default::default()
         })),
         ..Default::default()
     });

--- a/crates/jeod_runner/tests/tier3_sim_srp_rk4_thermal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_rk4_thermal.rs
@@ -1,0 +1,152 @@
+//! Sanity test for `ThermalIntegrationOrder::DerivativeRk4`.
+//!
+//! No JEOD reference sim exercises the full RK4 thermal path today, so this
+//! test exists to keep the code exercised and catch silent regressions when
+//! the runner's Stage 5 / Stage 8 dispatch or the [`jeod_sim::IntegrableObject`]
+//! trait implementation changes. Runs the same low-altitude scenario three
+//! times — once with each of [`ThermalIntegrationOrder::Scheduled`],
+//! [`ThermalIntegrationOrder::DerivativeFirstOrder`], and
+//! [`ThermalIntegrationOrder::DerivativeRk4`] — and asserts that each mode
+//! produces a non-trivially different final-step temperature, proving the
+//! fork is actually dispatched and each variant runs to completion.
+//!
+//! This is NOT a Tier 3 cross-validation — there is no external reference.
+
+use glam::{DMat3, DVec3};
+use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, SrpModel, VehicleConfig};
+use jeod_sim::{
+    FlatPlate, FlatPlateParams, FlatPlateState, FlatPlateThermal, GravityModel, GravitySource,
+    JeodQuat, MassProperties, RotationalState, SimulationTime, ThermalIntegrationOrder,
+    TranslationalState,
+};
+
+fn single_plate() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
+    vec![(
+        FlatPlate {
+            area: 10.0,
+            normal: -DVec3::X,
+            position: DVec3::ZERO,
+        },
+        FlatPlateParams {
+            albedo: 0.3,
+            diffuse: 0.5,
+        },
+        FlatPlateThermal {
+            emissivity: 0.9,
+            heat_capacity_per_area: 500.0,
+            thermal_power_dump: 0.0,
+        },
+    )]
+}
+
+/// Returns `(final_plate_temperature, final_position)` after 20 steps.
+fn run_with_order(order: ThermalIntegrationOrder) -> (f64, DVec3) {
+    let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let dt = 10.0;
+    let mut sim = Simulation::new(time, dt);
+
+    let sun = sim.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+        },
+    );
+    sim.sun_source = Some(sun);
+
+    let init_temp = 300.0;
+    let plates = single_plate();
+    // Spin about Z at 0.05 rad/s so the plate normal rotates slowly —
+    // enough per-stage variation to distinguish the three scheduling modes
+    // without driving the RK4 integrator into gross overshoot from
+    // undersampled rotation.
+    let mass =
+        MassProperties::with_inertia(100.0, DMat3::from_diagonal(DVec3::splat(10.0)), DVec3::ZERO);
+    sim.add_body(VehicleConfig {
+        trans: TranslationalState {
+            position: DVec3::new(1.5e11, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        },
+        rot: Some(RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::new(0.0, 0.0, 0.05),
+        }),
+        mass: Some(mass),
+        srp: Some(SrpModel::FlatPlate(FlatPlateState {
+            plates,
+            temperatures: vec![init_temp],
+            t_pow4_cached: vec![init_temp.powi(4)],
+            integration_order: order,
+            ..Default::default()
+        })),
+        ..Default::default()
+    });
+
+    sim.validate().unwrap();
+    // 20 steps at dt=10s.
+    for _ in 0..20 {
+        sim.step();
+    }
+
+    let t = sim
+        .srp_plate_temperatures(0)
+        .expect("flat-plate SRP configured")[0];
+    let pos = sim.body(0).trans.position;
+    (t, pos)
+}
+
+#[test]
+fn tier3_srp_rk4_thermal_differs_from_scheduled() {
+    let (t_sched, p_sched) = run_with_order(ThermalIntegrationOrder::Scheduled);
+    let (t_first, p_first) = run_with_order(ThermalIntegrationOrder::DerivativeFirstOrder);
+    let (t_rk4, p_rk4) = run_with_order(ThermalIntegrationOrder::DerivativeRk4);
+
+    // Each mode must produce a valid (positive, finite) temperature.
+    for (label, t) in [
+        ("Scheduled", t_sched),
+        ("DerivativeFirstOrder", t_first),
+        ("DerivativeRk4", t_rk4),
+    ] {
+        assert!(t > 0.0 && t.is_finite(), "{label}: invalid temperature {t}");
+    }
+
+    // Derivative-class modes evaluate SRP per RK4 stage (varying with
+    // intermediate attitude), so the orbital trajectory must differ from
+    // Scheduled's step-constant-SRP orbital integration, even when T
+    // agrees to high precision (k1 is the same at step start in all
+    // modes, so the first-step thermal differences accumulate only
+    // through orbital-state feedback over many steps).
+    let p_threshold = 1e-12_f64;
+    assert!(
+        (p_sched - p_first).length() > p_threshold,
+        "Scheduled and DerivativeFirstOrder produced identical trajectory \
+         ({p_sched:?}); the Stage 8 dispatch fork may not be engaging."
+    );
+    // RK4 thermal vs first-order thermal must differ in the T evolution
+    // whenever T moves fast enough to matter across a stage.
+    let t_threshold = 1e-9_f64;
+    assert!(
+        (t_first - t_rk4).abs() > t_threshold,
+        "DerivativeFirstOrder and DerivativeRk4 produced identical T \
+         ({t_first}); the per-stage temp_dot branch may not be engaging."
+    );
+
+    println!(
+        "After 20 steps: Scheduled T={t_sched:.6} |p|={:.3}; \
+         DerivativeFirstOrder T={t_first:.6} |p|={:.3}; \
+         DerivativeRk4 T={t_rk4:.6} |p|={:.3}",
+        p_sched.length(),
+        p_first.length(),
+        p_rk4.length(),
+    );
+}

--- a/crates/jeod_sim/src/integrable.rs
+++ b/crates/jeod_sim/src/integrable.rs
@@ -1,0 +1,69 @@
+//! `IntegrableObject` trait — port of JEOD's multi-ODE RK4 scheduling.
+//!
+//! JEOD's `DynamicsIntegrationGroup` (dynamics/dyn_manager/src/dynamics_integration_group.cc)
+//! drives a heterogeneous collection of `IntegrableObject` instances through
+//! the RK4 stage loop. Each `IntegrableObject` exposes a per-stage protocol
+//! (snapshot at step start → advance to intermediate → combine derivatives at
+//! step end) that the group coordinates so multiple ODEs (orbital state,
+//! thermal state, and future sub-states) integrate in lockstep against the
+//! same stage boundaries.
+//!
+//! This module defines the Rust equivalent trait. Today the orbital state
+//! is integrated directly by the enclosing RK4 kernel (translational and
+//! rotational state are not trait implementors), and the only trait
+//! implementor is [`crate::FlatPlateState`] for thermal plate temperatures.
+//! The trait exists to pin down the per-stage protocol as a documentation
+//! and extension point: additional sub-states (e.g. fuel slosh, battery
+//! thermal) become drop-in implementors.
+//!
+//! # Per-step protocol
+//!
+//! For a single RK4 step with dynamic timestep `dt`, the enclosing kernel:
+//!
+//! 1. Calls [`IntegrableObject::snapshot`] once at the top of the step,
+//!    which saves the current state as the step-start base.
+//! 2. Evaluates stage 1 derivatives against the step-start state.
+//! 3. Calls [`IntegrableObject::advance_intermediate`] with the stage-1
+//!    derivative and `h = dt/2` to set state = snapshot + k1·dt/2.
+//! 4. Evaluates stage 2 derivatives.
+//! 5. Calls `advance_intermediate` with the stage-2 derivative and `h = dt/2`.
+//! 6. Evaluates stage 3 derivatives.
+//! 7. Calls `advance_intermediate` with the stage-3 derivative and `h = dt`.
+//! 8. Evaluates stage 4 derivatives.
+//! 9. Calls [`IntegrableObject::finalize_rk4`] with all four derivatives
+//!    and `dt`, which produces the final step result (implementors may
+//!    apply clamping or constraint enforcement at this step).
+//!
+//! State is represented as a flat `&[f64]` slice of length
+//! [`IntegrableObject::n_states`]. Derivative slices passed to
+//! `advance_intermediate` and `finalize_rk4` share that length.
+
+/// An integrable sub-state that advances in lockstep with the vehicle's
+/// orbital state through an RK4 stage loop.
+///
+/// See module docs for the per-step snapshot → advance → finalize protocol.
+pub trait IntegrableObject {
+    /// Number of scalar state variables the object owns. Derivative slices
+    /// passed to [`Self::advance_intermediate`] and [`Self::finalize_rk4`]
+    /// must have this length.
+    fn n_states(&self) -> usize;
+
+    /// Save the current state as the step-start snapshot. Called once at
+    /// the top of each RK4 step, before stage 1's derivative evaluation.
+    fn snapshot(&mut self);
+
+    /// Advance state to `snapshot + deriv * h` in place.
+    ///
+    /// Called between stages using the previous stage's derivative. `h` is
+    /// the intermediate time delta (e.g. `dt/2` before stages 2 and 3,
+    /// full `dt` before stage 4).
+    fn advance_intermediate(&mut self, deriv: &[f64], h: f64);
+
+    /// Combine four stage derivatives into the final state using the
+    /// classical RK4 formula `(k1 + 2·k2 + 2·k3 + k4) · dt / 6`, possibly
+    /// with implementor-specific clamping or constraint enforcement.
+    ///
+    /// Called once after all four stages have been evaluated, with the
+    /// full dynamic timestep `dt`.
+    fn finalize_rk4(&mut self, k1: &[f64], k2: &[f64], k3: &[f64], k4: &[f64], dt: f64);
+}

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -788,7 +788,10 @@ pub fn integrate_body_coupled(
     );
     let k1_accel = compute_total_accel(&eval1, mass);
     let k1_v = vel0;
-    let k1_tdots = eval1.temp_dots.clone();
+    // Move `temp_dots` out of `eval1`; we've already read everything we
+    // need from `eval1` via `compute_total_accel` above, and the Vec
+    // allocation is large enough to matter when the plate count is high.
+    let k1_tdots = eval1.temp_dots;
 
     // Stage 2: evaluate at t + dt/2 using k1
     let half_dt = integ_dyndt * 0.5;
@@ -805,7 +808,7 @@ pub fn integrate_body_coupled(
     );
     let k2_accel = compute_total_accel(&eval2, mass);
     let k2_v = s2_trans.velocity;
-    let k2_tdots = eval2.temp_dots.clone();
+    let k2_tdots = eval2.temp_dots;
 
     // Stage 3: evaluate at t + dt/2 using k2
     let s3_trans = TranslationalState {
@@ -821,7 +824,7 @@ pub fn integrate_body_coupled(
     );
     let k3_accel = compute_total_accel(&eval3, mass);
     let k3_v = s3_trans.velocity;
-    let k3_tdots = eval3.temp_dots.clone();
+    let k3_tdots = eval3.temp_dots;
 
     // Stage 4: evaluate at t + dt using k3
     let s4_trans = TranslationalState {
@@ -914,7 +917,9 @@ fn integrate_coupled_sixdof(
     );
     let (k1_accel, k1_qdot, k1_alpha) = eval_rot_derivs(&eval1, rot);
     let k1_v = vel0;
-    let k1_tdots = eval1.temp_dots.clone();
+    // Move temp_dots out of eval1 rather than cloning — `eval_rot_derivs`
+    // has already consumed everything we need from the borrow above.
+    let k1_tdots = eval1.temp_dots;
 
     // Stage 2
     let half_dt = integ_dyndt * 0.5;
@@ -932,7 +937,7 @@ fn integrate_coupled_sixdof(
     );
     let (k2_accel, k2_qdot, k2_alpha) = eval_rot_derivs(&eval2, &s2_rot);
     let k2_v = s2_trans.velocity;
-    let k2_tdots = eval2.temp_dots.clone();
+    let k2_tdots = eval2.temp_dots;
 
     // Stage 3
     let s3_trans = TranslationalState {
@@ -949,7 +954,7 @@ fn integrate_coupled_sixdof(
     );
     let (k3_accel, k3_qdot, k3_alpha) = eval_rot_derivs(&eval3, &s3_rot);
     let k3_v = s3_trans.velocity;
-    let k3_tdots = eval3.temp_dots.clone();
+    let k3_tdots = eval3.temp_dots;
 
     // Stage 4
     let s4_trans = TranslationalState {

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -713,6 +713,10 @@ pub struct CoupledStageEval {
 /// - `stage_fn`: closure that evaluates derivatives at an intermediate state.
 ///   Called 4 times (once per RK4 stage). Must recompute gravity, SRP
 ///   force/torque, and thermal derivatives at the given intermediate state.
+///   The `f64` argument is `time_frac` — the fraction of `dt` elapsed at
+///   this stage (0.0 for stage 1, 0.5 for stages 2 and 3, 1.0 for stage 4),
+///   matching `integrate_body`'s gravity-closure convention so callers can
+///   reuse the same ephemeris-interpolation logic.
 /// - `thermal`: flat-plate thermal state (temperatures mutated in place)
 /// - `dt`: simulation timestep in seconds
 /// - `time_scale_factor`: ratio of dynamic time to simulation time
@@ -732,6 +736,7 @@ pub fn integrate_body_coupled(
         &TranslationalState,
         Option<&RotationalState>,
         &FlatPlateState,
+        f64,
     ) -> CoupledStageEval,
     thermal: &mut FlatPlateState,
     dt: f64,
@@ -774,8 +779,8 @@ pub fn integrate_body_coupled(
     // JEOD_INV: IN.32 — snapshot thermal state at step start before stage 1.
     thermal.snapshot();
 
-    // Stage 1: evaluate at current state
-    let eval1 = stage_fn(trans, None, thermal);
+    // Stage 1: evaluate at current state (time_frac = 0.0)
+    let eval1 = stage_fn(trans, None, thermal, 0.0);
     debug_assert_eq!(
         eval1.temp_dots.len(),
         n_plates,
@@ -792,7 +797,7 @@ pub fn integrate_body_coupled(
         velocity: vel0 + k1_accel * half_dt,
     };
     thermal.advance_intermediate(&k1_tdots, half_dt);
-    let eval2 = stage_fn(&s2_trans, None, thermal);
+    let eval2 = stage_fn(&s2_trans, None, thermal, 0.5);
     debug_assert_eq!(
         eval2.temp_dots.len(),
         n_plates,
@@ -808,7 +813,7 @@ pub fn integrate_body_coupled(
         velocity: vel0 + k2_accel * half_dt,
     };
     thermal.advance_intermediate(&k2_tdots, half_dt);
-    let eval3 = stage_fn(&s3_trans, None, thermal);
+    let eval3 = stage_fn(&s3_trans, None, thermal, 0.5);
     debug_assert_eq!(
         eval3.temp_dots.len(),
         n_plates,
@@ -824,7 +829,7 @@ pub fn integrate_body_coupled(
         velocity: vel0 + k3_accel * integ_dyndt,
     };
     thermal.advance_intermediate(&k3_tdots, integ_dyndt);
-    let eval4 = stage_fn(&s4_trans, None, thermal);
+    let eval4 = stage_fn(&s4_trans, None, thermal, 1.0);
     debug_assert_eq!(
         eval4.temp_dots.len(),
         n_plates,
@@ -858,6 +863,7 @@ fn integrate_coupled_sixdof(
         &TranslationalState,
         Option<&RotationalState>,
         &FlatPlateState,
+        f64,
     ) -> CoupledStageEval,
     thermal: &mut FlatPlateState,
     integ_dyndt: f64,
@@ -899,8 +905,8 @@ fn integrate_coupled_sixdof(
         (accel, k_qdot, k_alpha)
     };
 
-    // Stage 1
-    let eval1 = stage_fn(trans, Some(rot), thermal);
+    // Stage 1 (time_frac = 0.0)
+    let eval1 = stage_fn(trans, Some(rot), thermal, 0.0);
     debug_assert_eq!(
         eval1.temp_dots.len(),
         n_plates,
@@ -918,7 +924,7 @@ fn integrate_coupled_sixdof(
     };
     let s2_rot = make_rot(step_q(q0, k1_qdot, half_dt), omega0 + k1_alpha * half_dt);
     thermal.advance_intermediate(&k1_tdots, half_dt);
-    let eval2 = stage_fn(&s2_trans, Some(&s2_rot), thermal);
+    let eval2 = stage_fn(&s2_trans, Some(&s2_rot), thermal, 0.5);
     debug_assert_eq!(
         eval2.temp_dots.len(),
         n_plates,
@@ -935,7 +941,7 @@ fn integrate_coupled_sixdof(
     };
     let s3_rot = make_rot(step_q(q0, k2_qdot, half_dt), omega0 + k2_alpha * half_dt);
     thermal.advance_intermediate(&k2_tdots, half_dt);
-    let eval3 = stage_fn(&s3_trans, Some(&s3_rot), thermal);
+    let eval3 = stage_fn(&s3_trans, Some(&s3_rot), thermal, 0.5);
     debug_assert_eq!(
         eval3.temp_dots.len(),
         n_plates,
@@ -955,7 +961,7 @@ fn integrate_coupled_sixdof(
         omega0 + k3_alpha * integ_dyndt,
     );
     thermal.advance_intermediate(&k3_tdots, integ_dyndt);
-    let eval4 = stage_fn(&s4_trans, Some(&s4_rot), thermal);
+    let eval4 = stage_fn(&s4_trans, Some(&s4_rot), thermal, 1.0);
     debug_assert_eq!(
         eval4.temp_dots.len(),
         n_plates,
@@ -1067,7 +1073,7 @@ mod tests {
             &mut trans2,
             None,
             Some(&mass),
-            |inter_trans, _inter_rot, _inter_thermal| CoupledStageEval {
+            |inter_trans, _inter_rot, _inter_thermal, _time_frac| CoupledStageEval {
                 gravity_accel: {
                     let pos = inter_trans.position;
                     -mu / pos.length().powi(3) * pos

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -5,6 +5,7 @@ use jeod_dynamics::{
 };
 use jeod_math::JeodQuat;
 
+use crate::integrable::IntegrableObject;
 use crate::interactions::FlatPlateState;
 
 /// Per-body state for multi-body coupled RK4 integration.
@@ -770,8 +771,8 @@ pub fn integrate_body_coupled(
 
     let pos0 = trans.position;
     let vel0 = trans.velocity;
-    let temps0: Vec<f64> = thermal.temperatures.clone();
-    let t_pow4_0: Vec<f64> = thermal.t_pow4_cached.clone();
+    // JEOD_INV: IN.32 — snapshot thermal state at step start before stage 1.
+    thermal.snapshot();
 
     // Stage 1: evaluate at current state
     let eval1 = stage_fn(trans, None, thermal);
@@ -782,7 +783,7 @@ pub fn integrate_body_coupled(
     );
     let k1_accel = compute_total_accel(&eval1, mass);
     let k1_v = vel0;
-    let k1_tdots = &eval1.temp_dots;
+    let k1_tdots = eval1.temp_dots.clone();
 
     // Stage 2: evaluate at t + dt/2 using k1
     let half_dt = integ_dyndt * 0.5;
@@ -790,7 +791,7 @@ pub fn integrate_body_coupled(
         position: pos0 + k1_v * half_dt,
         velocity: vel0 + k1_accel * half_dt,
     };
-    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, k1_tdots, half_dt);
+    thermal.advance_intermediate(&k1_tdots, half_dt);
     let eval2 = stage_fn(&s2_trans, None, thermal);
     debug_assert_eq!(
         eval2.temp_dots.len(),
@@ -806,7 +807,7 @@ pub fn integrate_body_coupled(
         position: pos0 + k2_v * half_dt,
         velocity: vel0 + k2_accel * half_dt,
     };
-    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k2_tdots, half_dt);
+    thermal.advance_intermediate(&k2_tdots, half_dt);
     let eval3 = stage_fn(&s3_trans, None, thermal);
     debug_assert_eq!(
         eval3.temp_dots.len(),
@@ -822,7 +823,7 @@ pub fn integrate_body_coupled(
         position: pos0 + k3_v * integ_dyndt,
         velocity: vel0 + k3_accel * integ_dyndt,
     };
-    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k3_tdots, integ_dyndt);
+    thermal.advance_intermediate(&k3_tdots, integ_dyndt);
     let eval4 = stage_fn(&s4_trans, None, thermal);
     debug_assert_eq!(
         eval4.temp_dots.len(),
@@ -837,16 +838,13 @@ pub fn integrate_body_coupled(
     trans.position = pos0 + (k1_v + k2_v * 2.0 + k3_v * 2.0 + k4_v) * sixth_dt;
     trans.velocity = vel0 + (k1_accel + k2_accel * 2.0 + k3_accel * 2.0 + k4_accel) * sixth_dt;
 
-    // Combine thermal state with overshoot clamping
-    thermal.finalize_rk4_temperatures(
-        &temps0,
-        &t_pow4_0,
-        k1_tdots,
+    // Combine thermal state with overshoot clamping.
+    thermal.finalize_rk4(
+        &k1_tdots,
         &k2_tdots,
         &k3_tdots,
         &eval4.temp_dots,
         integ_dyndt,
-        n_plates,
     );
 }
 
@@ -869,8 +867,8 @@ fn integrate_coupled_sixdof(
     let vel0 = trans.velocity;
     let q0 = rot.quaternion.data;
     let omega0 = rot.ang_vel_body;
-    let temps0: Vec<f64> = thermal.temperatures.clone();
-    let t_pow4_0: Vec<f64> = thermal.t_pow4_cached.clone();
+    // JEOD_INV: IN.32 — snapshot thermal state at step start before stage 1.
+    thermal.snapshot();
 
     let make_rot = |q: [f64; 4], omega: DVec3| RotationalState {
         quaternion: JeodQuat::new(q[0], q[1], q[2], q[3]),
@@ -910,7 +908,7 @@ fn integrate_coupled_sixdof(
     );
     let (k1_accel, k1_qdot, k1_alpha) = eval_rot_derivs(&eval1, rot);
     let k1_v = vel0;
-    let k1_tdots = &eval1.temp_dots;
+    let k1_tdots = eval1.temp_dots.clone();
 
     // Stage 2
     let half_dt = integ_dyndt * 0.5;
@@ -919,7 +917,7 @@ fn integrate_coupled_sixdof(
         velocity: vel0 + k1_accel * half_dt,
     };
     let s2_rot = make_rot(step_q(q0, k1_qdot, half_dt), omega0 + k1_alpha * half_dt);
-    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, k1_tdots, half_dt);
+    thermal.advance_intermediate(&k1_tdots, half_dt);
     let eval2 = stage_fn(&s2_trans, Some(&s2_rot), thermal);
     debug_assert_eq!(
         eval2.temp_dots.len(),
@@ -936,7 +934,7 @@ fn integrate_coupled_sixdof(
         velocity: vel0 + k2_accel * half_dt,
     };
     let s3_rot = make_rot(step_q(q0, k2_qdot, half_dt), omega0 + k2_alpha * half_dt);
-    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k2_tdots, half_dt);
+    thermal.advance_intermediate(&k2_tdots, half_dt);
     let eval3 = stage_fn(&s3_trans, Some(&s3_rot), thermal);
     debug_assert_eq!(
         eval3.temp_dots.len(),
@@ -956,7 +954,7 @@ fn integrate_coupled_sixdof(
         step_q(q0, k3_qdot, integ_dyndt),
         omega0 + k3_alpha * integ_dyndt,
     );
-    advance_thermal_intermediate(thermal, &temps0, &t_pow4_0, &k3_tdots, integ_dyndt);
+    thermal.advance_intermediate(&k3_tdots, integ_dyndt);
     let eval4 = stage_fn(&s4_trans, Some(&s4_rot), thermal);
     debug_assert_eq!(
         eval4.temp_dots.len(),
@@ -983,16 +981,13 @@ fn integrate_coupled_sixdof(
     rot.quaternion = JeodQuat::new(final_q[0], final_q[1], final_q[2], final_q[3]);
     jeod_dynamics::normalize_integ(&mut rot.quaternion);
 
-    // Combine thermal state with overshoot clamping
-    thermal.finalize_rk4_temperatures(
-        &temps0,
-        &t_pow4_0,
-        k1_tdots,
+    // Combine thermal state with overshoot clamping.
+    thermal.finalize_rk4(
+        &k1_tdots,
         &k2_tdots,
         &k3_tdots,
         &eval4.temp_dots,
         integ_dyndt,
-        n_plates,
     );
 }
 
@@ -1011,25 +1006,6 @@ fn compute_total_accel(eval: &CoupledStageEval, mass: Option<&MassProperties>) -
         );
     };
     eval.gravity_accel + non_grav_accel
-}
-
-/// Advance thermal state to an intermediate RK4 position.
-///
-/// Sets temperatures to `temps0 + k_tdots * h` and updates cached T^4.
-/// Used between RK4 stages so the next `stage_fn` call sees intermediate
-/// temperatures for thermal emission force coupling.
-fn advance_thermal_intermediate(
-    thermal: &mut FlatPlateState,
-    temps0: &[f64],
-    _t_pow4_0: &[f64],
-    k_tdots: &[f64],
-    h: f64,
-) {
-    for i in 0..thermal.temperatures.len() {
-        let t = (temps0[i] + k_tdots[i] * h).max(0.0);
-        thermal.temperatures[i] = t;
-        thermal.t_pow4_cached[i] = t * t * t * t;
-    }
 }
 
 #[cfg(test)]
@@ -1084,6 +1060,7 @@ mod tests {
             plates: vec![],
             temperatures: vec![],
             t_pow4_cached: vec![],
+            ..Default::default()
         };
         integrate_body_coupled(
             &config,

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -240,9 +240,25 @@ impl IntegrableObject for FlatPlateState {
     }
 
     fn advance_intermediate(&mut self, deriv: &[f64], h: f64) {
+        // `zip()` truncates silently if any iterator is shorter — assert
+        // length parity across every backing vector so a mismatched
+        // snapshot or stale derivative fails fast rather than leaving the
+        // state partially updated.
+        let n = self.temperatures.len();
+        debug_assert_eq!(
+            self.t_pow4_cached.len(),
+            n,
+            "t_pow4_cached length must equal temperatures length",
+        );
+        debug_assert_eq!(
+            self.temps_snapshot.len(),
+            n,
+            "temps_snapshot length must equal temperatures length; \
+             call IntegrableObject::snapshot before advance_intermediate",
+        );
         debug_assert_eq!(
             deriv.len(),
-            self.temperatures.len(),
+            n,
             "advance_intermediate derivative length must equal temperature count",
         );
         for ((t, t_pow4), (&t0, &d)) in self

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -240,36 +240,36 @@ impl IntegrableObject for FlatPlateState {
     }
 
     fn advance_intermediate(&mut self, deriv: &[f64], h: f64) {
-        // `zip()` truncates silently if any iterator is shorter — assert
-        // length parity across every backing vector so a mismatched
-        // snapshot or stale derivative fails fast rather than leaving the
-        // state partially updated.
+        // Length parity across every backing vector must hold in all
+        // builds: iterating with `zip()` truncates silently on mismatch
+        // and would leave the state partially updated. Use `assert_eq!`
+        // so release builds also fail fast, then index directly.
         let n = self.temperatures.len();
-        debug_assert_eq!(
+        assert_eq!(
             self.t_pow4_cached.len(),
             n,
             "t_pow4_cached length must equal temperatures length",
         );
-        debug_assert_eq!(
+        assert_eq!(
             self.temps_snapshot.len(),
             n,
             "temps_snapshot length must equal temperatures length; \
              call IntegrableObject::snapshot before advance_intermediate",
         );
-        debug_assert_eq!(
+        assert_eq!(
             deriv.len(),
             n,
             "advance_intermediate derivative length must equal temperature count",
         );
-        for ((t, t_pow4), (&t0, &d)) in self
-            .temperatures
-            .iter_mut()
-            .zip(self.t_pow4_cached.iter_mut())
-            .zip(self.temps_snapshot.iter().zip(deriv.iter()))
-        {
-            let new_t = (t0 + d * h).max(0.0);
-            *t = new_t;
-            *t_pow4 = new_t * new_t * new_t * new_t;
+        // `zip()` would truncate silently on length mismatch; the asserts
+        // above guarantee parity so this indexed loop is safe. Allow the
+        // range-loop lint because the alternative (nested `zip`s) is
+        // precisely the pattern we're trying to avoid.
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..n {
+            let new_t = (self.temps_snapshot[i] + deriv[i] * h).max(0.0);
+            self.temperatures[i] = new_t;
+            self.t_pow4_cached[i] = new_t * new_t * new_t * new_t;
         }
     }
 

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -106,10 +106,23 @@ pub struct FlatPlateState {
     /// Cached T^4 per plate from previous step (for thermal emission).
     /// Same length as `plates`.
     pub t_pow4_cached: Vec<f64>,
-    /// Which integrator drives the temperature ODE. Defaults to
-    /// [`ThermalIntegrationOrder::Scheduled`] (JEOD's SIM_3_ORBIT pattern —
-    /// scheduled-class `rad_pressure.update` + Euler T); switch to a
-    /// derivative-class mode to run SRP per RK4 stage through
+    /// Which integrator drives the temperature ODE.
+    ///
+    /// Defaults to [`ThermalIntegrationOrder::Scheduled`], which matches
+    /// JEOD's scheduled-class `SIM_3_ORBIT` behavior (SRP force + Euler T
+    /// computed once per step).
+    ///
+    /// Use [`ThermalIntegrationOrder::DerivativeFirstOrder`] to match
+    /// JEOD's derivative-class `SIM_3_ORBIT_1st_ORDER`: SRP force is
+    /// recomputed per RK4 stage (varying with intermediate orbital
+    /// attitude) while T is integrated via ER7_Utils first-order from
+    /// the stage-1 derivative.
+    ///
+    /// Use [`ThermalIntegrationOrder::DerivativeRk4`] for tighter
+    /// per-stage SRP and thermal coupling; no current JEOD Tier 3
+    /// reference uses that mode.
+    ///
+    /// Both derivative-class modes run through
     /// [`crate::integrate_body_coupled`].
     pub integration_order: ThermalIntegrationOrder,
     /// Step-start SRP inputs populated by the Stage-5 interactions code

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -5,12 +5,28 @@ use jeod_interactions::{
     DragConfig, FlatPlate, FlatPlateParams, FlatPlateThermal,
 };
 
+use crate::integrable::IntegrableObject;
+
 /// Flat-plate SRP configuration with mutable thermal state.
 ///
 /// Bundles plate geometry/optical/thermal properties with per-plate temperature
 /// state. Used by both the `Simulation` runner and Bevy adapter so that
 /// temperature integration logic is shared.
-#[derive(Debug, Clone)]
+///
+/// Implements [`IntegrableObject`] so temperatures can integrate through the
+/// RK4 stage loop alongside orbital state (see
+/// [`crate::integrate_body_coupled`]). Construct with `..Default::default()`
+/// so the trait's snapshot scratch initializes empty:
+///
+/// ```ignore
+/// FlatPlateState {
+///     plates,
+///     temperatures: vec![300.0; n],
+///     t_pow4_cached: vec![300.0_f64.powi(4); n],
+///     ..Default::default()
+/// }
+/// ```
+#[derive(Debug, Clone, Default)]
 pub struct FlatPlateState {
     /// Per-plate geometry, optical, and thermal properties.
     pub plates: Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)>,
@@ -19,6 +35,16 @@ pub struct FlatPlateState {
     /// Cached T^4 per plate from previous step (for thermal emission).
     /// Same length as `plates`.
     pub t_pow4_cached: Vec<f64>,
+    /// Step-start temperature snapshot, populated by
+    /// [`IntegrableObject::snapshot`] and read by
+    /// [`IntegrableObject::advance_intermediate`] /
+    /// [`IntegrableObject::finalize_rk4`]. Managed by the RK4 kernel; do
+    /// not set manually.
+    #[doc(hidden)]
+    pub temps_snapshot: Vec<f64>,
+    /// Step-start T^4 snapshot; companion to `temps_snapshot`.
+    #[doc(hidden)]
+    pub t_pow4_snapshot: Vec<f64>,
 }
 
 impl FlatPlateState {
@@ -61,42 +87,83 @@ impl FlatPlateState {
     ///
     /// Combines k1–k4 temperature derivatives via the standard RK4 formula
     /// and applies JEOD overshoot clamping (thermal_integrable_object.cc:106-121).
-    /// Called by [`crate::integration::integrate_body_coupled`] after all four
-    /// stages have been evaluated.
+    /// Reads the step-start snapshots from `temps_snapshot` /
+    /// `t_pow4_snapshot`, which [`IntegrableObject::snapshot`] populated at
+    /// the start of the step.
     ///
-    /// This is the coupled-integration counterpart of [`Self::integrate_temperatures`]:
-    /// instead of deriving k2–k4 internally from k1's `power_absorb`, the four
-    /// derivatives were computed at intermediate orbital positions by the stage
-    /// closure.
-    #[allow(clippy::too_many_arguments)]
+    /// This is the coupled-integration counterpart of
+    /// [`Self::integrate_temperatures`]: instead of deriving k2–k4 internally
+    /// from k1's `power_absorb`, the four derivatives were computed at
+    /// intermediate orbital positions by the stage closure.
     pub fn finalize_rk4_temperatures(
         &mut self,
-        temps0: &[f64],
-        t_pow4_0: &[f64],
         k1_tdots: &[f64],
         k2_tdots: &[f64],
         k3_tdots: &[f64],
         k4_tdots: &[f64],
         dt: f64,
-        n_plates: usize,
     ) {
-        for i in 0..n_plates {
-            let (plate, _, thermal) = &self.plates[i];
+        let n = self.temperatures.len();
+        for i in 0..n {
+            let area = self.plates[i].0.area;
+            let emissivity = self.plates[i].2.emissivity;
+            let heat_capacity_per_area = self.plates[i].2.heat_capacity_per_area;
             let (new_temp, new_t_pow4) = jeod_interactions::integrate_plate_temperature_rk4(
-                temps0[i],
-                t_pow4_0[i],
+                self.temps_snapshot[i],
+                self.t_pow4_snapshot[i],
                 k1_tdots[i],
                 k2_tdots[i],
                 k3_tdots[i],
                 k4_tdots[i],
-                plate.area,
-                thermal.emissivity,
-                thermal.heat_capacity_per_area,
+                area,
+                emissivity,
+                heat_capacity_per_area,
                 dt,
             );
             self.temperatures[i] = new_temp;
             self.t_pow4_cached[i] = new_t_pow4;
         }
+    }
+}
+
+// JEOD_INV: IN.32 — IntegrableObject per-stage snapshot/advance/finalize protocol.
+// Port of JEOD er7_utils::IntegrableObject (trick_source/er7_utils/integration/
+// core/include/integrable_object.hh) as consumed by DynamicsIntegrationGroup.
+// FlatPlateState's temperature vector is the only sub-state that uses this
+// protocol today; orbital translational/rotational state is integrated
+// directly by the enclosing RK4 kernel.
+impl IntegrableObject for FlatPlateState {
+    fn n_states(&self) -> usize {
+        self.temperatures.len()
+    }
+
+    fn snapshot(&mut self) {
+        self.temps_snapshot.clear();
+        self.temps_snapshot.extend_from_slice(&self.temperatures);
+        self.t_pow4_snapshot.clear();
+        self.t_pow4_snapshot.extend_from_slice(&self.t_pow4_cached);
+    }
+
+    fn advance_intermediate(&mut self, deriv: &[f64], h: f64) {
+        debug_assert_eq!(
+            deriv.len(),
+            self.temperatures.len(),
+            "advance_intermediate derivative length must equal temperature count",
+        );
+        for ((t, t_pow4), (&t0, &d)) in self
+            .temperatures
+            .iter_mut()
+            .zip(self.t_pow4_cached.iter_mut())
+            .zip(self.temps_snapshot.iter().zip(deriv.iter()))
+        {
+            let new_t = (t0 + d * h).max(0.0);
+            *t = new_t;
+            *t_pow4 = new_t * new_t * new_t * new_t;
+        }
+    }
+
+    fn finalize_rk4(&mut self, k1: &[f64], k2: &[f64], k3: &[f64], k4: &[f64], dt: f64) {
+        self.finalize_rk4_temperatures(k1, k2, k3, k4, dt);
     }
 }
 

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -7,28 +7,48 @@ use jeod_interactions::{
 
 use crate::integrable::IntegrableObject;
 
-/// Which integrator drives plate temperatures.
+/// Which integrator drives plate temperatures, and at what scheduling
+/// class.
 ///
-/// JEOD offers two scheduling patterns for `ThermalIntegrableObject`:
-/// a "scheduled" `compute_temp_dot` job (the temperature derivative is
-/// evaluated once per step and held constant across RK4 stages —
-/// `radiation.sm` in SIM_3_ORBIT_1st_ORDER), or a full integrable-object
-/// ODE with derivatives recomputed at each stage (`radiation.sm` in
-/// SIM_3_ORBIT, the standard derivative-class integration).
+/// JEOD's `rad_pressure.update()` can be wired in three ways (observed in
+/// `models/interactions/radiation_pressure/verif/S_modules/*.sm`):
 ///
-/// Expressed as a flag so that Tier 3 tests can pick the scheduling
-/// pattern that matches their JEOD reference CSV.
+/// * **Scheduled** (`radiation.sm` — SIM_3_ORBIT): `rad_pressure.update` is
+///   a `("scheduled")` job that runs once per DYNAMICS interval, outside
+///   the integration loop. Temperature is advanced by first-order Euler
+///   over the full step, and the SRP force fed to the orbital integrator
+///   is step-constant.
+/// * **DerivativeFirstOrder** (`radiation_1st_order.sm` — SIM_3_ORBIT_1st_ORDER):
+///   `rad_pressure.update` is `("derivative")` and runs at every RK4
+///   derivative evaluation, so the SRP force varies with intermediate
+///   orbital position. The thermal integrator is ER7_Utils first-order —
+///   i.e., temperature is advanced using the step-start derivative only.
+/// * **DerivativeRk4** (no JEOD Tier 3 reference): `rad_pressure.update`
+///   runs per stage AND temperature integrates via full RK4 (all four
+///   derivatives). Not required to match any current JEOD reference CSV;
+///   exposed as an API option for mission-level missions that want the
+///   more accurate coupling going forward.
+///
+/// Default is [`ThermalIntegrationOrder::Scheduled`] — backward-compatible
+/// with the pre-Commit-3 runner behavior and matches the SIM_3_ORBIT
+/// reference without any opt-in.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ThermalIntegrationOrder {
-    /// Forward Euler with the step-start `temp_dot` (`k1`) only. Matches
-    /// JEOD's scheduled-class `compute_temp_dot` pattern as used in
-    /// `SIM_3_ORBIT_1st_ORDER`.
-    FirstOrder,
-    /// RK4 with per-stage derivative recomputation; temperature
-    /// integrates inside the orbital RK4 loop via [`IntegrableObject`].
-    /// Matches JEOD's standard `SIM_3_ORBIT` derivative-class pattern.
+    /// SRP force + Euler T update computed once per step (step-constant
+    /// SRP across RK4 stages). Matches JEOD's `(DYNAMICS, "scheduled")`
+    /// radiation module in SIM_3_ORBIT.
     #[default]
-    Rk4Coupled,
+    Scheduled,
+    /// SRP force recomputed per RK4 stage (varies with intermediate
+    /// orbital state); temperature advanced at step end using only the
+    /// stage-1 derivative. Matches JEOD's derivative-class + first-order
+    /// ER7_Utils integrator in SIM_3_ORBIT_1st_ORDER.
+    DerivativeFirstOrder,
+    /// SRP force and temperature both recomputed per RK4 stage; full RK4
+    /// thermal integration inside the orbital RK4 loop. No current JEOD
+    /// reference uses this pattern — provided for mission code that wants
+    /// the tighter coupling.
+    DerivativeRk4,
 }
 
 /// Flat-plate SRP configuration with mutable thermal state.

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -7,6 +7,33 @@ use jeod_interactions::{
 
 use crate::integrable::IntegrableObject;
 
+/// Step-constant SRP inputs cached at step start for the derivative-class
+/// thermal paths.
+///
+/// Populated by Stage 5 (interactions) when
+/// [`ThermalIntegrationOrder::DerivativeFirstOrder`] or
+/// [`ThermalIntegrationOrder::DerivativeRk4`] is selected; consumed by
+/// Stage 8 (integration)'s per-stage closure inside
+/// [`crate::integrate_body_coupled`]. `None` for
+/// [`ThermalIntegrationOrder::Scheduled`] — the Stage 5 Euler fast path
+/// remains active.
+///
+/// Shared by the standalone `Simulation` runner and the Bevy adapter so
+/// both drive the coupled integrator with identical step-start data.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FlatPlateStageInputs {
+    /// Unit flux direction from Sun to vehicle in inertial frame (step start).
+    pub flux_inertial_hat: DVec3,
+    /// Solar flux magnitude at vehicle distance (W/m²).
+    pub flux_mag: f64,
+    /// Shadow illumination factor from step-start shadow evaluation
+    /// (constant across RK4 stages — matches JEOD scheduled-class
+    /// shadow in SIM_3_ORBIT).
+    pub illum_factor: f64,
+    /// Center of gravity in structural frame.
+    pub center_grav: DVec3,
+}
+
 /// Which integrator drives plate temperatures, and at what scheduling
 /// class.
 ///
@@ -80,10 +107,16 @@ pub struct FlatPlateState {
     /// Same length as `plates`.
     pub t_pow4_cached: Vec<f64>,
     /// Which integrator drives the temperature ODE. Defaults to
-    /// [`ThermalIntegrationOrder::Rk4Coupled`] (JEOD's standard
-    /// derivative-class pattern); switch to [`ThermalIntegrationOrder::FirstOrder`]
-    /// for parity with JEOD's scheduled-class `SIM_3_ORBIT_1st_ORDER`.
+    /// [`ThermalIntegrationOrder::Scheduled`] (JEOD's SIM_3_ORBIT pattern —
+    /// scheduled-class `rad_pressure.update` + Euler T); switch to a
+    /// derivative-class mode to run SRP per RK4 stage through
+    /// [`crate::integrate_body_coupled`].
     pub integration_order: ThermalIntegrationOrder,
+    /// Step-start SRP inputs populated by the Stage-5 interactions code
+    /// when `integration_order` is derivative-class. `None` in
+    /// `Scheduled` mode. Consumed by the Stage-8 integration closure;
+    /// cleared at the start of the next step's Stage 5.
+    pub stage_inputs: Option<FlatPlateStageInputs>,
     /// Step-start temperature snapshot, populated by
     /// [`IntegrableObject::snapshot`] and read by
     /// [`IntegrableObject::advance_intermediate`] /

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -7,6 +7,30 @@ use jeod_interactions::{
 
 use crate::integrable::IntegrableObject;
 
+/// Which integrator drives plate temperatures.
+///
+/// JEOD offers two scheduling patterns for `ThermalIntegrableObject`:
+/// a "scheduled" `compute_temp_dot` job (the temperature derivative is
+/// evaluated once per step and held constant across RK4 stages —
+/// `radiation.sm` in SIM_3_ORBIT_1st_ORDER), or a full integrable-object
+/// ODE with derivatives recomputed at each stage (`radiation.sm` in
+/// SIM_3_ORBIT, the standard derivative-class integration).
+///
+/// Expressed as a flag so that Tier 3 tests can pick the scheduling
+/// pattern that matches their JEOD reference CSV.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ThermalIntegrationOrder {
+    /// Forward Euler with the step-start `temp_dot` (`k1`) only. Matches
+    /// JEOD's scheduled-class `compute_temp_dot` pattern as used in
+    /// `SIM_3_ORBIT_1st_ORDER`.
+    FirstOrder,
+    /// RK4 with per-stage derivative recomputation; temperature
+    /// integrates inside the orbital RK4 loop via [`IntegrableObject`].
+    /// Matches JEOD's standard `SIM_3_ORBIT` derivative-class pattern.
+    #[default]
+    Rk4Coupled,
+}
+
 /// Flat-plate SRP configuration with mutable thermal state.
 ///
 /// Bundles plate geometry/optical/thermal properties with per-plate temperature
@@ -35,6 +59,11 @@ pub struct FlatPlateState {
     /// Cached T^4 per plate from previous step (for thermal emission).
     /// Same length as `plates`.
     pub t_pow4_cached: Vec<f64>,
+    /// Which integrator drives the temperature ODE. Defaults to
+    /// [`ThermalIntegrationOrder::Rk4Coupled`] (JEOD's standard
+    /// derivative-class pattern); switch to [`ThermalIntegrationOrder::FirstOrder`]
+    /// for parity with JEOD's scheduled-class `SIM_3_ORBIT_1st_ORDER`.
+    pub integration_order: ThermalIntegrationOrder,
     /// Step-start temperature snapshot, populated by
     /// [`IntegrableObject::snapshot`] and read by
     /// [`IntegrableObject::advance_intermediate`] /

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -22,13 +22,18 @@ use crate::integrable::IntegrableObject;
 /// both drive the coupled integrator with identical step-start data.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FlatPlateStageInputs {
-    /// Unit flux direction from Sun to vehicle in inertial frame (step start).
-    pub flux_inertial_hat: DVec3,
-    /// Solar flux magnitude at vehicle distance (W/m²).
-    pub flux_mag: f64,
+    /// Sun position in inertial frame, captured at step start. The
+    /// coupled stage closure recomputes `sun_to_vehicle`,
+    /// `flux_inertial_hat`, and `flux_mag` per RK4 stage from this plus
+    /// the stage's `TranslationalState.position`, matching JEOD's
+    /// derivative-class `RadiationSource::calculate_flux` which reads
+    /// the intermediate vehicle structure frame at every call (see
+    /// `models/interactions/radiation_pressure/src/radiation_source.cc`).
+    pub sun_position: DVec3,
     /// Shadow illumination factor from step-start shadow evaluation
     /// (constant across RK4 stages — matches JEOD scheduled-class
-    /// shadow in SIM_3_ORBIT).
+    /// shadow in SIM_3_ORBIT; third-body frames are not propagated
+    /// between RK4 stages within JEOD either).
     pub illum_factor: f64,
     /// Center of gravity in structural frame.
     pub center_grav: DVec3,

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -38,6 +38,7 @@ pub mod atmosphere;
 pub mod derived;
 pub mod forces;
 pub mod gravity;
+pub mod integrable;
 pub mod integration;
 pub mod interactions;
 pub mod pipeline;
@@ -57,6 +58,7 @@ pub use gravity::{
     accumulate_gravity, accumulate_relativistic_corrections, ResolvedRelativisticSource,
     ResolvedSource,
 };
+pub use integrable::IntegrableObject;
 pub use integration::{
     integrate_bodies_contact_coupled, integrate_body, integrate_body_coupled, CoupledBodyInput,
     CoupledIntegScratch, CoupledStageEval,

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -65,7 +65,7 @@ pub use integration::{
 };
 pub use interactions::{
     compute_cannonball_srp, compute_drag, compute_gravity_torque, evaluate_contact_pair,
-    ContactPairEval, FlatPlateState,
+    ContactPairEval, FlatPlateState, ThermalIntegrationOrder,
 };
 pub use jeod_dynamics::{
     Abm4State, GaussJacksonConfig, GaussJacksonState, IntegratorResult, IntegratorType,

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -65,7 +65,7 @@ pub use integration::{
 };
 pub use interactions::{
     compute_cannonball_srp, compute_drag, compute_gravity_torque, evaluate_contact_pair,
-    ContactPairEval, FlatPlateState, ThermalIntegrationOrder,
+    ContactPairEval, FlatPlateStageInputs, FlatPlateState, ThermalIntegrationOrder,
 };
 pub use jeod_dynamics::{
     Abm4State, GaussJacksonConfig, GaussJacksonState, IntegratorResult, IntegratorType,

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -272,6 +272,7 @@ Our port wraps ANISE (`crates/jeod_ephemeris`, 243 lines: `ephemeris.rs` + `bodi
 | IN.29 | RadiationThirdBody activation lookup: name must resolve to an existing third body in the model; otherwise error (`radiation_pressure.cc` invalid_function_call, three sites) | error | runtime | n/a |
 | IN.30 | Contact pair bodies must be distinct (`unique_pair` in `contact.cc`) | fatal | initialization | enforced (`register_contact_pair` asserts `body_a != body_b`) |
 | IN.31 | Contact forces evaluated at every derivative evaluation (JEOD `check_contact` is a derivative-class job in `contact.sm`) | structural (Trick job scheduling) | runtime | enforced (`Simulation::step_internal` uses `integrate_bodies_contact_coupled` when contact pairs are registered, evaluating every pair at each RK4 stage) |
+| IN.32 | IntegrableObject per-step protocol: `snapshot` once at step start, `advance_intermediate` before stages 2–4, `finalize_rk4` after stage 4 — mirrors JEOD's `er7_utils::IntegrableObject` driven by `DynamicsIntegrationGroup` (`trick_source/er7_utils/integration/core/include/integrable_object.hh`; `models/dynamics/dyn_manager/src/dynamics_integration_group.cc`) | structural (trait contract) | runtime | enforced (`crates/jeod_sim/src/integrable.rs`; `FlatPlateState` impl in `interactions.rs`; invoked by `integrate_body_coupled`/`integrate_coupled_sixdof`) |
 
 ## Section DS: Derived States
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -261,13 +261,14 @@ pub fn integration_system(
         Option<&mut RotationalStateC>,
         Option<&MassPropertiesC>,
         &GravityControlsC,
-        &TotalForceC,
+        &mut TotalForceC,
         Option<&IntegratorTypeC>,
         Option<&mut GaussJacksonStateC>,
         Option<&mut Abm4StateC>,
         Option<&mut FlatPlateConfigC>,
         Option<&StructuralTransformC>,
         Option<&mut RadiationForceC>,
+        Option<&mut FrameDerivativesC>,
     )>,
     sources: Query<(
         &GravitySourceC,
@@ -334,13 +335,14 @@ pub fn integration_system(
         mut rot_state,
         mass,
         controls,
-        total_force,
+        mut total_force,
         integrator,
         mut gj_state,
         mut abm4_state,
         mut flat_config,
         struct_xform,
         mut srp_force,
+        mut frame_derivs,
     ) in &mut bodies
     {
         let integrator_type = integrator.map_or(jeod_sim::IntegratorType::Rk4, |c| c.0);
@@ -452,6 +454,21 @@ pub fn integration_system(
             if let Some(ref mut srp_force) = srp_force {
                 srp_force.force = final_srp_inertial_force;
                 srp_force.torque = final_srp_torque;
+            }
+
+            // Backfill `TotalForceC` and `FrameDerivativesC` with the
+            // final-stage SRP contribution so downstream observers see
+            // SRP-inclusive values, matching the Scheduled-mode invariant
+            // that `TotalForceC` / `FrameDerivativesC` reflect every
+            // applied force / resulting acceleration. In derivative modes
+            // this is a "representative stage" (stage 4) snapshot, same
+            // as `RadiationForceC` above.
+            total_force.force += final_srp_inertial_force;
+            let final_srp_torque_body = t_struct_body * final_srp_torque;
+            total_force.torque += final_srp_torque_body;
+            if let (Some(ref mut fd), Some(mass_p)) = (frame_derivs.as_mut(), mass_copy) {
+                fd.trans_accel += final_srp_inertial_force * mass_p.inverse_mass;
+                fd.rot_accel += mass_p.inverse_inertia * final_srp_torque_body;
             }
             continue;
         }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -815,6 +815,21 @@ pub fn flat_plate_srp_system(
         srp_force.force = force_inertial;
         srp_force.torque = srp_result.torque;
 
+        // The Bevy adapter currently only implements scheduled-class
+        // thermal (Euler once per step). Derivative-class modes require
+        // forking the integration schedule, which the `Simulation` runner
+        // does but this adapter does not yet — fail loudly so callers
+        // don't silently get the wrong thermal behavior.
+        assert!(
+            matches!(
+                flat_config.integration_order,
+                jeod_sim::ThermalIntegrationOrder::Scheduled,
+            ),
+            "Bevy adapter supports only ThermalIntegrationOrder::Scheduled; \
+             use jeod_runner::Simulation for DerivativeFirstOrder / DerivativeRk4 \
+             (see issue #114 follow-up for Bevy parity)",
+        );
+
         // Integrate plate temperatures (forward Euler) — shared with Simulation runner
         if dt > 0.0 {
             flat_config.integrate_temperatures(&srp_result.temp_dots, dt);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -252,7 +252,7 @@ pub fn force_collection_system(
 /// The integration method is determined by the optional `IntegratorTypeC`
 /// component (RK4, RKF45, GaussJackson, Abm4). When absent, RK4 is used.
 /// GaussJackson requires `GaussJacksonStateC`; ABM4 requires `Abm4StateC`.
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn integration_system(
     mut bodies: Query<(
         Entity,
@@ -265,6 +265,9 @@ pub fn integration_system(
         Option<&IntegratorTypeC>,
         Option<&mut GaussJacksonStateC>,
         Option<&mut Abm4StateC>,
+        Option<&mut FlatPlateConfigC>,
+        Option<&StructuralTransformC>,
+        Option<&mut RadiationForceC>,
     )>,
     sources: Query<(
         &GravitySourceC,
@@ -282,6 +285,48 @@ pub fn integration_system(
         return;
     }
 
+    // Helper closure for gravity at an intermediate state — reused by both
+    // the standard and coupled dispatch branches.
+    let eval_gravity = |entity: Entity,
+                        controls: &GravityControlsC,
+                        pos: DVec3,
+                        vel: DVec3|
+     -> DVec3 {
+        let mut accel =
+            jeod_sim::accumulate_gravity(pos, &controls.0, DVec3::ZERO, |source_entity| {
+                match sources.get(source_entity) {
+                    Ok((s, r, p, _, tidal, tidal_config)) => Some(jeod_sim::ResolvedSource {
+                        source: &s.0,
+                        rotation: r.map(|r| &r.0),
+                        position: p.0,
+                        delta_c20: tidal.map_or(0.0, |t| t.0),
+                        has_delta_coeffs: tidal_config.is_some(),
+                    }),
+                    Err(_) => {
+                        panic!(
+                            "Entity {entity:?}: GravityControl references source \
+                         {source_entity:?} which does not exist or lacks \
+                         GravitySourceC + SourceInertialPositionC."
+                        );
+                    }
+                }
+            })
+            .grav_accel;
+
+        accel +=
+            jeod_sim::accumulate_relativistic_corrections(pos, vel, &controls.0, |source_entity| {
+                sources.get(source_entity).ok().map(|(s, _, p, v, _, _)| {
+                    jeod_sim::ResolvedRelativisticSource {
+                        mu: s.mu,
+                        position: p.0,
+                        velocity: v.map_or(DVec3::ZERO, |v| v.0),
+                    }
+                })
+            });
+
+        accel
+    };
+
     for (
         entity,
         config,
@@ -293,6 +338,9 @@ pub fn integration_system(
         integrator,
         mut gj_state,
         mut abm4_state,
+        mut flat_config,
+        struct_xform,
+        mut srp_force,
     ) in &mut bodies
     {
         let integrator_type = integrator.map_or(jeod_sim::IntegratorType::Rk4, |c| c.0);
@@ -313,53 +361,100 @@ pub fn integration_system(
                  Abm4StateC(Abm4State::new()) to the entity."
             );
         }
+
+        // Derivative-class thermal fork: the SRP system cached step-start
+        // inputs into `flat_config.stage_inputs`. Recompute SRP force +
+        // temperature derivatives per RK4 stage through
+        // `integrate_body_coupled`. See `jeod_runner::Simulation::step_internal`
+        // for the sister implementation.
+        let stage_inputs_and_order = flat_config
+            .as_ref()
+            .and_then(|fc| fc.stage_inputs.map(|si| (si, fc.integration_order)));
+        if let Some((srp_inputs, thermal_order)) = stage_inputs_and_order {
+            assert!(
+                matches!(integrator_type, jeod_sim::IntegratorType::Rk4),
+                "Entity {entity:?}: derivative-class ThermalIntegrationOrder \
+                 requires RK4 integrator; use Scheduled or switch integrator.",
+            );
+            let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
+            let non_grav_non_srp_force = total_force.force;
+            let constant_torque = total_force.torque;
+            let mut final_srp_inertial_force = DVec3::ZERO;
+            let mut final_srp_torque = DVec3::ZERO;
+            let mut k1_temp_dots: Option<Vec<f64>> = None;
+            let mass_copy = mass.map(|m| m.0);
+            let thermal = flat_config
+                .as_mut()
+                .expect("stage_inputs_and_order => flat_config present");
+            jeod_sim::integrate_body_coupled(
+                config,
+                &mut state.0,
+                rot_state.as_mut().map(|r| &mut r.0),
+                mass_copy.as_ref(),
+                |stage_trans, stage_rot, stage_thermal, _time_frac| {
+                    let gravity_accel =
+                        eval_gravity(entity, controls, stage_trans.position, stage_trans.velocity);
+                    let t_inertial_body = stage_rot.map_or(glam::DMat3::IDENTITY, |r| {
+                        r.quaternion.left_quat_to_transformation()
+                    });
+                    let t_inertial_struct =
+                        jeod_sim::compute_t_inertial_struct(&t_struct_body, &t_inertial_body);
+                    let flux_struct_hat = t_inertial_struct * srp_inputs.flux_inertial_hat;
+                    let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
+                        &stage_thermal.plates,
+                        &stage_thermal.t_pow4_cached,
+                        flux_struct_hat,
+                        srp_inputs.flux_mag,
+                        srp_inputs.center_grav,
+                        srp_inputs.illum_factor,
+                    );
+                    let srp_force_inertial = t_inertial_struct.transpose() * srp_result.force;
+                    final_srp_inertial_force = srp_force_inertial;
+                    final_srp_torque = srp_result.torque;
+                    let temp_dots = match thermal_order {
+                        jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => srp_result.temp_dots,
+                        jeod_sim::ThermalIntegrationOrder::DerivativeFirstOrder => {
+                            if _time_frac == 0.0 {
+                                k1_temp_dots = Some(srp_result.temp_dots.clone());
+                                srp_result.temp_dots
+                            } else {
+                                k1_temp_dots
+                                    .clone()
+                                    .expect("stage 1 runs before stages 2-4")
+                            }
+                        }
+                        jeod_sim::ThermalIntegrationOrder::Scheduled => {
+                            unreachable!("Scheduled bodies do not enter the coupled path")
+                        }
+                    };
+                    jeod_sim::CoupledStageEval {
+                        gravity_accel,
+                        non_grav_force: non_grav_non_srp_force + srp_force_inertial,
+                        torque: constant_torque + srp_result.torque,
+                        temp_dots,
+                    }
+                },
+                &mut thermal.0,
+                dt,
+                sim_time.0.time_scale_factor,
+            );
+
+            // Write representative `RadiationForceC` from stage 4 so
+            // `VehicleOutput`-equivalent observers still see the SRP force.
+            if let Some(ref mut srp_force) = srp_force {
+                srp_force.force = final_srp_inertial_force;
+                srp_force.torque = final_srp_torque;
+            }
+            continue;
+        }
+
+        // Standard (Scheduled or no-SRP) path.
         jeod_sim::integrate_body(
             config,
             &mut state.0,
             rot_state.as_mut().map(|r| &mut r.0),
             mass.map(|m| &m.0),
-            |pos, vel, _time_frac| {
-                let mut accel =
-                    jeod_sim::accumulate_gravity(pos, &controls.0, DVec3::ZERO, |source_entity| {
-                        match sources.get(source_entity) {
-                            Ok((s, r, p, _, tidal, tidal_config)) => {
-                                Some(jeod_sim::ResolvedSource {
-                                    source: &s.0,
-                                    rotation: r.map(|r| &r.0),
-                                    position: p.0,
-                                    delta_c20: tidal.map_or(0.0, |t| t.0),
-                                    has_delta_coeffs: tidal_config.is_some(),
-                                })
-                            }
-                            Err(_) => {
-                                panic!(
-                                    "Entity {entity:?}: GravityControl references source \
-                                     {source_entity:?} which does not exist or lacks \
-                                     GravitySourceC + SourceInertialPositionC."
-                                );
-                            }
-                        }
-                    })
-                    .grav_accel;
-
-                // Relativistic correction at each integrator stage.
-                accel += jeod_sim::accumulate_relativistic_corrections(
-                    pos,
-                    vel,
-                    &controls.0,
-                    |source_entity| {
-                        sources.get(source_entity).ok().map(|(s, _, p, v, _, _)| {
-                            jeod_sim::ResolvedRelativisticSource {
-                                mu: s.mu,
-                                position: p.0,
-                                velocity: v.map_or(DVec3::ZERO, |v| v.0),
-                            }
-                        })
-                    },
-                );
-
-                accel
-            },
+            |pos, vel, _time_frac| eval_gravity(entity, controls, pos, vel),
             total_force.force,
             total_force.torque,
             dt,
@@ -779,60 +874,75 @@ pub fn flat_plate_srp_system(
     let dt = time.delta_secs_f64();
 
     for (mut flat_config, state, rot, mass, struct_xform, mut srp_force) in &mut query {
+        // Clear any previous-step cached stage inputs; repopulated below
+        // for derivative-class modes.
+        flat_config.stage_inputs = None;
+
         let sun_to_vehicle = state.position - sun_state.position;
         let distance = sun_to_vehicle.length();
         if distance < 1.0 {
+            // Too close to the Sun to compute flux: leave force/torque/
+            // stage_inputs at zero and continue.
+            srp_force.force = DVec3::ZERO;
+            srp_force.torque = DVec3::ZERO;
             continue;
         }
         let flux_inertial_hat = sun_to_vehicle / distance;
         let flux_mag = jeod_sim::solar_flux_at_distance(distance);
 
-        // Shadow fraction
+        // Shadow fraction (step-constant; matches JEOD's scheduled-class
+        // shadow evaluation across all three integration orders).
         let illum_factor = compute_illum_factor(state.position, sun_state.position, &shadow_bodies);
-
-        // Rotate flux to structural frame
-        let t_inertial_body = rot.map_or(glam::DMat3::IDENTITY, |r| {
-            r.quaternion.left_quat_to_transformation()
-        });
-        let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
-        let t_inertial_struct =
-            jeod_sim::compute_t_inertial_struct(&t_struct_body, &t_inertial_body);
-        let flux_struct_hat = t_inertial_struct * flux_inertial_hat;
-
         let center_grav = mass.map_or(DVec3::ZERO, |m| m.position);
 
-        let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
-            &flat_config.plates,
-            &flat_config.t_pow4_cached,
-            flux_struct_hat,
-            flux_mag,
-            center_grav,
-            illum_factor,
-        );
+        match flat_config.integration_order {
+            jeod_sim::ThermalIntegrationOrder::Scheduled => {
+                // Scheduled-class (SIM_3_ORBIT): SRP force + Euler T once
+                // per step. Force fed to the orbital integrator is
+                // step-constant.
+                let t_inertial_body = rot.map_or(glam::DMat3::IDENTITY, |r| {
+                    r.quaternion.left_quat_to_transformation()
+                });
+                let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
+                let t_inertial_struct =
+                    jeod_sim::compute_t_inertial_struct(&t_struct_body, &t_inertial_body);
+                let flux_struct_hat = t_inertial_struct * flux_inertial_hat;
 
-        // Force: rotate from structural to inertial. Torque: stays structural.
-        let force_inertial = t_inertial_struct.transpose() * srp_result.force;
-        srp_force.force = force_inertial;
-        srp_force.torque = srp_result.torque;
+                let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
+                    &flat_config.plates,
+                    &flat_config.t_pow4_cached,
+                    flux_struct_hat,
+                    flux_mag,
+                    center_grav,
+                    illum_factor,
+                );
 
-        // The Bevy adapter currently only implements scheduled-class
-        // thermal (Euler once per step). Derivative-class modes require
-        // forking the integration schedule, which the `Simulation` runner
-        // does but this adapter does not yet — fail loudly so callers
-        // don't silently get the wrong thermal behavior.
-        assert!(
-            matches!(
-                flat_config.integration_order,
-                jeod_sim::ThermalIntegrationOrder::Scheduled,
-            ),
-            "Bevy adapter supports only ThermalIntegrationOrder::Scheduled; \
-             use jeod_runner::Simulation for DerivativeFirstOrder / DerivativeRk4 \
-             (see issue #114 follow-up for Bevy parity)",
-        );
+                let force_inertial = t_inertial_struct.transpose() * srp_result.force;
+                srp_force.force = force_inertial;
+                srp_force.torque = srp_result.torque;
 
-        // Integrate plate temperatures (forward Euler) — shared with Simulation runner
-        if dt > 0.0 {
-            flat_config.integrate_temperatures(&srp_result.temp_dots, dt);
+                // Integrate plate temperatures (forward Euler) — shared with
+                // `Simulation` runner via `FlatPlateState::integrate_temperatures`.
+                if dt > 0.0 {
+                    flat_config.integrate_temperatures(&srp_result.temp_dots, dt);
+                }
+            }
+            jeod_sim::ThermalIntegrationOrder::DerivativeFirstOrder
+            | jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => {
+                // Derivative-class: SRP force (and optionally T) recomputed
+                // per RK4 stage by the integration system. Cache the
+                // step-start inputs on the plate state here; leave
+                // `RadiationForceC` at zero — the integration system
+                // writes a representative final-stage value.
+                flat_config.stage_inputs = Some(jeod_sim::FlatPlateStageInputs {
+                    flux_inertial_hat,
+                    flux_mag,
+                    illum_factor,
+                    center_grav,
+                });
+                srp_force.force = DVec3::ZERO;
+                srp_force.torque = DVec3::ZERO;
+            }
         }
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -401,12 +401,20 @@ pub fn integration_system(
                     });
                     let t_inertial_struct =
                         jeod_sim::compute_t_inertial_struct(&t_struct_body, &t_inertial_body);
-                    let flux_struct_hat = t_inertial_struct * srp_inputs.flux_inertial_hat;
+                    // Per-stage flux recompute from intermediate vehicle
+                    // position — matches JEOD's derivative-class
+                    // `RadiationSource::calculate_flux`. Sun position is
+                    // step-constant (ephemeris is scheduled-class).
+                    let sun_to_vehicle = stage_trans.position - srp_inputs.sun_position;
+                    let distance = sun_to_vehicle.length().max(1.0);
+                    let stage_flux_inertial_hat = sun_to_vehicle / distance;
+                    let stage_flux_mag = jeod_sim::solar_flux_at_distance(distance);
+                    let flux_struct_hat = t_inertial_struct * stage_flux_inertial_hat;
                     let srp_result = jeod_sim::compute_flat_plate_srp_thermal(
                         &stage_thermal.plates,
                         &stage_thermal.t_pow4_cached,
                         flux_struct_hat,
-                        srp_inputs.flux_mag,
+                        stage_flux_mag,
                         srp_inputs.center_grav,
                         srp_inputs.illum_factor,
                     );
@@ -885,8 +893,8 @@ pub fn flat_plate_srp_system(
     time: Res<Time<Fixed>>,
 ) {
     let sun_state = match sun_query.single() {
-        Ok(s) => s,
-        Err(bevy::ecs::query::QuerySingleError::NoEntities(_)) => return,
+        Ok(s) => Some(s),
+        Err(bevy::ecs::query::QuerySingleError::NoEntities(_)) => None,
         Err(bevy::ecs::query::QuerySingleError::MultipleEntities(_)) => {
             panic!(
                 "Multiple entities with SunMarker found. In JEOD, RadiationPressure \
@@ -899,17 +907,24 @@ pub fn flat_plate_srp_system(
     let dt = time.delta_secs_f64();
 
     for (mut flat_config, state, rot, mass, struct_xform, mut srp_force) in &mut query {
-        // Clear any previous-step cached stage inputs; repopulated below
-        // for derivative-class modes.
+        // Clear per-step SRP state unconditionally (before the Sun check)
+        // so derivative-mode entities don't retain stale `stage_inputs` or
+        // force/torque if the Sun entity is removed between steps — which
+        // would otherwise incorrectly drive the coupled RK4 path. Mirrors
+        // the unconditional clearing in `jeod_runner::Simulation`.
         flat_config.stage_inputs = None;
+        srp_force.force = DVec3::ZERO;
+        srp_force.torque = DVec3::ZERO;
+
+        let Some(sun_state) = sun_state else {
+            continue;
+        };
 
         let sun_to_vehicle = state.position - sun_state.position;
         let distance = sun_to_vehicle.length();
         if distance < 1.0 {
-            // Too close to the Sun to compute flux: leave force/torque/
-            // stage_inputs at zero and continue.
-            srp_force.force = DVec3::ZERO;
-            srp_force.torque = DVec3::ZERO;
+            // Too close to the Sun to compute flux: force/torque/
+            // stage_inputs already zeroed above.
             continue;
         }
         let flux_inertial_hat = sun_to_vehicle / distance;
@@ -956,17 +971,14 @@ pub fn flat_plate_srp_system(
             | jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => {
                 // Derivative-class: SRP force (and optionally T) recomputed
                 // per RK4 stage by the integration system. Cache the
-                // step-start inputs on the plate state here; leave
-                // `RadiationForceC` at zero — the integration system
+                // step-start inputs on the plate state here; `RadiationForceC`
+                // stays at the zero cleared above — the integration system
                 // writes a representative final-stage value.
                 flat_config.stage_inputs = Some(jeod_sim::FlatPlateStageInputs {
-                    flux_inertial_hat,
-                    flux_mag,
+                    sun_position: sun_state.position,
                     illum_factor,
                     center_grav,
                 });
-                srp_force.force = DVec3::ZERO;
-                srp_force.torque = DVec3::ZERO;
             }
         }
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -427,10 +427,17 @@ pub fn integration_system(
                             unreachable!("Scheduled bodies do not enter the coupled path")
                         }
                     };
+                    // `srp_result.torque` is structural-frame per
+                    // `FlatPlateSrpResult` docs; `constant_torque` is
+                    // body-frame (from `collect_and_resolve_forces`).
+                    // Rotate to body frame before summing so the coupled
+                    // integrator's rotational dynamics are correct when
+                    // `t_struct_body` != IDENTITY.
+                    let srp_torque_body = t_struct_body * srp_result.torque;
                     jeod_sim::CoupledStageEval {
                         gravity_accel,
                         non_grav_force: non_grav_non_srp_force + srp_force_inertial,
-                        torque: constant_torque + srp_result.torque,
+                        torque: constant_torque + srp_torque_body,
                         temp_dots,
                     }
                 },

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -391,7 +391,7 @@ pub fn integration_system(
                 &mut state.0,
                 rot_state.as_mut().map(|r| &mut r.0),
                 mass_copy.as_ref(),
-                |stage_trans, stage_rot, stage_thermal, _time_frac| {
+                |stage_trans, stage_rot, stage_thermal, time_frac| {
                     let gravity_accel =
                         eval_gravity(entity, controls, stage_trans.position, stage_trans.velocity);
                     let t_inertial_body = stage_rot.map_or(glam::DMat3::IDENTITY, |r| {
@@ -414,13 +414,14 @@ pub fn integration_system(
                     let temp_dots = match thermal_order {
                         jeod_sim::ThermalIntegrationOrder::DerivativeRk4 => srp_result.temp_dots,
                         jeod_sim::ThermalIntegrationOrder::DerivativeFirstOrder => {
-                            if _time_frac == 0.0 {
+                            if time_frac == 0.0 {
                                 k1_temp_dots = Some(srp_result.temp_dots.clone());
                                 srp_result.temp_dots
                             } else {
                                 k1_temp_dots
-                                    .clone()
+                                    .as_ref()
                                     .expect("stage 1 runs before stages 2-4")
+                                    .clone()
                             }
                         }
                         jeod_sim::ThermalIntegrationOrder::Scheduled => {

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use bevy_jeod::{
     AtmosphereModelR, DragConfigC, DynamicsConfigC, FlatPlateConfigC, GravityControlsC,
     GravitySourceC, GravityTorqueC, MassPropertiesC, RotationalStateC, ShadowBodyC,
-    SourceInertialPositionC, SunMarker, TranslationalStateC,
+    SourceInertialPositionC, StructuralTransformC, SunMarker, TranslationalStateC,
 };
 use glam::{DMat3, DVec3};
 use jeod_runner::{GravitySourceEntry, ShadowBody as RunnerShadowBody, SrpModel, VehicleConfig};
@@ -688,5 +688,151 @@ fn tier3_bevy_srp_derivative_rk4() {
         "srp_derivative_rk4",
         jeod_sim::ThermalIntegrationOrder::DerivativeRk4,
         make_single_plate(0.3, 0.3, 0.5),
+    );
+}
+
+/// Derivative-class SRP with a **non-identity `t_struct_body`** and an
+/// **offset plate** that produces a non-zero structural-frame torque.
+///
+/// Regression test for a bug caught in review where the coupled RK4 stage
+/// closure added `srp_result.torque` (structural frame) directly to
+/// `constant_torque` (body frame) inside `CoupledStageEval`. When
+/// `t_struct_body` is identity the bug is latent; a non-identity rotation
+/// exposes it, and the Bevy + Simulation consumers would both drift from
+/// the physically-correct rotational state. Both sides now rotate the SRP
+/// torque into body frame via `t_struct_body * srp_result.torque` before
+/// summing, so this test verifies Bevy parity under the rotated frame AND
+/// that the rotational state evolves (non-identity final quaternion +
+/// non-zero angular velocity change consistent with the applied torque).
+#[test]
+fn tier3_bevy_srp_derivative_rk4_with_rotated_struct_frame() {
+    println!("SRP derivative RK4 parity with non-identity t_struct_body");
+
+    // 90° rotation about body-Z maps structural X→body Y, structural
+    // Y→body -X. Any structural-frame SRP torque with an X component
+    // becomes a body-frame torque along Y.
+    let t_struct_body = DMat3::from_cols(
+        DVec3::new(0.0, 1.0, 0.0),
+        DVec3::new(-1.0, 0.0, 0.0),
+        DVec3::new(0.0, 0.0, 1.0),
+    );
+
+    // Plate offset along structural +Y (15 m away from CoM) with the
+    // normal pointing along structural +X, so SRP pressure along -X
+    // produces a torque about structural +Z via r × F ≠ 0.
+    let offset_plate = vec![(
+        FlatPlate {
+            area: 10.0,
+            normal: DVec3::X,
+            position: DVec3::new(0.0, 15.0, 0.0),
+        },
+        FlatPlateParams {
+            albedo: 0.3,
+            diffuse: 0.3,
+        },
+        FlatPlateThermal {
+            emissivity: 0.5,
+            heat_capacity_per_area: 50.0,
+            thermal_power_dump: 0.0,
+        },
+    )];
+
+    let sun_pos = DVec3::new(1.496e11, 0.0, 0.0);
+    let order = jeod_sim::ThermalIntegrationOrder::DerivativeRk4;
+
+    // ── Bevy ──
+    let mut app = new_bevy_app(DT);
+    let planet = spawn_earth_source(&mut app);
+    let _sun = app
+        .world_mut()
+        .spawn((
+            Name::new("Sun"),
+            SunMarker,
+            TranslationalStateC(TranslationalState {
+                position: sun_pos,
+                velocity: DVec3::ZERO,
+            }),
+        ))
+        .id();
+
+    let vehicle = app
+        .world_mut()
+        .spawn((
+            TranslationalStateC(iss_trans()),
+            RotationalStateC(tumble_rot()),
+            MassPropertiesC(iss_mass()),
+            DynamicsConfigC(DynamicsConfig {
+                translational_dynamics: true,
+                rotational_dynamics: true,
+                three_dof: false,
+            }),
+            GravityControlsC(GravityControls {
+                controls: vec![GravityControl::new_spherical(planet, false)],
+            }),
+            StructuralTransformC(t_struct_body),
+            FlatPlateConfigC(jeod_sim::FlatPlateState {
+                plates: offset_plate.clone(),
+                temperatures: vec![270.0],
+                t_pow4_cached: vec![270.0_f64.powi(4)],
+                integration_order: order,
+                ..Default::default()
+            }),
+        ))
+        .id();
+
+    step_bevy(&mut app, NUM_STEPS);
+    let bevy_state = read_sixdof(app.world(), vehicle);
+
+    // ── Simulation ──
+    let (mut sim, earth_idx) = new_sim_earth(DT);
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    sim.sun_source = Some(sun_idx);
+
+    let mut body = new_sim_body_sixdof(earth_idx, false);
+    body.t_struct_body = t_struct_body;
+    body.srp = Some(SrpModel::FlatPlate(jeod_sim::FlatPlateState {
+        plates: offset_plate,
+        temperatures: vec![270.0],
+        t_pow4_cached: vec![270.0_f64.powi(4)],
+        integration_order: order,
+        ..Default::default()
+    }));
+    sim.add_body(body);
+    sim.validate().unwrap();
+    sim.step_n(NUM_STEPS);
+
+    let sim_body = sim.body(0);
+    let sim_state = SixDofState {
+        trans: sim_body.trans,
+        rot: sim_body.rot.unwrap(),
+    };
+
+    // Bevy must agree with the Simulation runner under the rotated frame.
+    // If either consumer had the structural/body frame mismatch we'd see
+    // the rotational state diverge between the two.
+    assert_sixdof_eq(
+        "Bevy vs Sim (DerivativeRk4, rotated t_struct_body)",
+        &bevy_state,
+        &sim_state,
+    );
+
+    // And the test must actually exercise torque — if the rotational
+    // state didn't change at all, the scenario isn't pressuring the
+    // frame-conversion code path.
+    let ang_vel_change = (sim_state.rot.ang_vel_body - tumble_rot().ang_vel_body).length();
+    assert!(
+        ang_vel_change > 1e-12,
+        "Offset plate produced no detectable angular velocity change ({ang_vel_change:.3e}); \
+         the torque-handling code path may not be exercised.",
     );
 }

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -578,3 +578,115 @@ fn tier3_bevy_srp_basic_varied_cr() {
     println!("SRP basic varied Cr parity");
     run_srp_basic_parity("srp_basic_varied_cr", make_single_plate(0.8, 0.1, 0.0));
 }
+
+// ── Derivative-class thermal parity (issue #114) ──
+//
+// Exercises the coupled `integrate_body_coupled` dispatch through the Bevy
+// adapter's `integration_system` and the `Simulation` runner's Stage 8.
+// Uses a 6-DOF vehicle so the orbital RK4 stages produce varying attitudes
+// and the per-stage SRP force diverges from a step-constant value,
+// actually exercising the fork.
+
+fn run_srp_deriv_parity(
+    label: &str,
+    order: jeod_sim::ThermalIntegrationOrder,
+    srp_plates: Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)>,
+) {
+    let sun_pos = DVec3::new(1.496e11, 0.0, 0.0);
+
+    // ── Bevy ──
+    let mut app = new_bevy_app(DT);
+    let planet = spawn_earth_source(&mut app);
+    let _sun = app
+        .world_mut()
+        .spawn((
+            Name::new("Sun"),
+            SunMarker,
+            TranslationalStateC(TranslationalState {
+                position: sun_pos,
+                velocity: DVec3::ZERO,
+            }),
+        ))
+        .id();
+
+    let vehicle = app
+        .world_mut()
+        .spawn((
+            TranslationalStateC(iss_trans()),
+            RotationalStateC(tumble_rot()),
+            MassPropertiesC(iss_mass()),
+            DynamicsConfigC(DynamicsConfig {
+                translational_dynamics: true,
+                rotational_dynamics: true,
+                three_dof: false,
+            }),
+            GravityControlsC(GravityControls {
+                controls: vec![GravityControl::new_spherical(planet, false)],
+            }),
+            FlatPlateConfigC(jeod_sim::FlatPlateState {
+                plates: srp_plates.clone(),
+                temperatures: vec![270.0; srp_plates.len()],
+                t_pow4_cached: vec![270.0_f64.powi(4); srp_plates.len()],
+                integration_order: order,
+                ..Default::default()
+            }),
+        ))
+        .id();
+
+    step_bevy(&mut app, NUM_STEPS);
+    let bevy_state = read_sixdof(app.world(), vehicle);
+
+    // ── Simulation ──
+    let (mut sim, earth_idx) = new_sim_earth(DT);
+    let sun_idx = sim.add_source(
+        "Sun",
+        GravitySourceEntry::new(
+            GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            sun_pos,
+            None,
+        ),
+    );
+    sim.sun_source = Some(sun_idx);
+
+    let mut body = new_sim_body_sixdof(earth_idx, false);
+    body.srp = Some(SrpModel::FlatPlate(jeod_sim::FlatPlateState {
+        plates: srp_plates.clone(),
+        temperatures: vec![270.0; srp_plates.len()],
+        t_pow4_cached: vec![270.0_f64.powi(4); srp_plates.len()],
+        integration_order: order,
+        ..Default::default()
+    }));
+    sim.add_body(body);
+    sim.validate().unwrap();
+    sim.step_n(NUM_STEPS);
+
+    let sim_body = sim.body(0);
+    let sim_state = SixDofState {
+        trans: sim_body.trans,
+        rot: sim_body.rot.unwrap(),
+    };
+    assert_sixdof_eq(&format!("Bevy vs Sim ({label})"), &bevy_state, &sim_state);
+}
+
+#[test]
+fn tier3_bevy_srp_derivative_first_order() {
+    println!("SRP derivative first-order parity");
+    run_srp_deriv_parity(
+        "srp_derivative_first_order",
+        jeod_sim::ThermalIntegrationOrder::DerivativeFirstOrder,
+        make_single_plate(0.3, 0.3, 0.5),
+    );
+}
+
+#[test]
+fn tier3_bevy_srp_derivative_rk4() {
+    println!("SRP derivative RK4 parity");
+    run_srp_deriv_parity(
+        "srp_derivative_rk4",
+        jeod_sim::ThermalIntegrationOrder::DerivativeRk4,
+        make_single_plate(0.3, 0.3, 0.5),
+    );
+}

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -105,6 +105,7 @@ fn tier3_bevy_full_stack_sixdof() {
                 plates: srp_plates.clone(),
                 temperatures: vec![270.0],
                 t_pow4_cached: vec![270.0_f64.powi(4)],
+                ..Default::default()
             }),
             GravityTorqueC::default(),
         ))
@@ -144,6 +145,7 @@ fn tier3_bevy_full_stack_sixdof() {
         plates: srp_plates,
         temperatures: vec![270.0],
         t_pow4_cached: vec![270.0_f64.powi(4)],
+        ..Default::default()
     }));
     body.compute_gravity_gradient = true;
     sim.add_body(body);
@@ -291,6 +293,7 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
                 plates: plates_data.clone(),
                 temperatures: vec![init_temp; num_plates],
                 t_pow4_cached: vec![init_temp.powi(4); num_plates],
+                ..Default::default()
             }),
         ))
         .id();
@@ -332,6 +335,7 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
             plates: plates_data,
             temperatures: vec![init_temp; num_plates],
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
+            ..Default::default()
         })),
         shadow_body: Some(RunnerShadowBody {
             source_idx: earth_idx,
@@ -422,6 +426,7 @@ fn run_shadow_parity(label: &str, srp_plates: Vec<(FlatPlate, FlatPlateParams, F
                 plates: srp_plates.clone(),
                 temperatures: vec![270.0; srp_plates.len()],
                 t_pow4_cached: vec![270.0_f64.powi(4); srp_plates.len()],
+                ..Default::default()
             }),
         ))
         .id();
@@ -449,6 +454,7 @@ fn run_shadow_parity(label: &str, srp_plates: Vec<(FlatPlate, FlatPlateParams, F
         plates: srp_plates.clone(),
         temperatures: vec![270.0; srp_plates.len()],
         t_pow4_cached: vec![270.0_f64.powi(4); srp_plates.len()],
+        ..Default::default()
     }));
     body.shadow_body = Some(RunnerShadowBody {
         source_idx: earth_idx,
@@ -519,6 +525,7 @@ fn run_srp_basic_parity(
                 plates: srp_plates.clone(),
                 temperatures: vec![270.0; srp_plates.len()],
                 t_pow4_cached: vec![270.0_f64.powi(4); srp_plates.len()],
+                ..Default::default()
             }),
         ))
         .id();
@@ -546,6 +553,7 @@ fn run_srp_basic_parity(
         plates: srp_plates.clone(),
         temperatures: vec![270.0; srp_plates.len()],
         t_pow4_cached: vec![270.0_f64.powi(4); srp_plates.len()],
+        ..Default::default()
     }));
     sim.add_body(body);
     sim.validate().unwrap();


### PR DESCRIPTION
Closes #114.

## Summary

- Ports JEOD's `er7_utils::IntegrableObject` / `DynamicsIntegrationGroup` RK4-stage protocol as `jeod_sim::IntegrableObject`. `FlatPlateState` implements the trait so thermal temperatures can integrate alongside orbital state through the coupled RK4 kernel (tasks 5.33 + 5.34).
- Distinguishes the three thermal scheduling patterns observed in JEOD's radiation verification sims (`models/interactions/radiation_pressure/verif/S_modules/*.sm`): `Scheduled` (default, SIM_3_ORBIT), `DerivativeFirstOrder` (SIM_3_ORBIT_1st_ORDER), and `DerivativeRk4` (no JEOD reference — mission-level opt-in).
- Wires derivative-class bodies through `integrate_body_coupled` in **both** `Simulation::step` (runner) **and** `integration_system` (Bevy adapter). Scheduled keeps the existing fast Stage-5 Euler path in both consumers.

## Numerical impact

| Test | Mode | Before (max pos err, m) | After (max pos err, m) |
|---|---|---|---|
| `tier3_simulation_srp_flat_plate` | Scheduled (default) | [0.033, 0.037, 0.015] | [0.033, 0.037, 0.015] (bit-identical) |
| `tier3_srp_1st_order_trajectory` | DerivativeFirstOrder (new) | [76.3, 79.0, 34.3] | [73.4, 76.4, 33.2] |

The 1st-order residual improves because derivative-class SRP feeds stage-varying forces to the orbital RK4 integrator (matching JEOD), whereas the previous Euler path fed a step-constant force. Tolerance on `tier3_srp_1st_order_trajectory` tightened to `observed × 1.05` per project policy.

## Commit structure

1. `Add IntegrableObject trait and refactor coupled RK4 kernel to use it` — no numerical change; refactors the existing coupled kernel to go through the trait.
2. `Add ThermalIntegrationOrder config and thread through SrpModel` — plumbs the enum; no runner behavior change.
3. `Route SRP through RK4-coupled thermal integration` — the actual fix; forks `Simulation::step_internal` Stage 5/8 on `integration_order`.
4. `Bevy adapter: assert Scheduled thermal until adapter parity lands` — interim guard (superseded by the next commit).
5. `Bevy adapter parity for derivative-class thermal` — promotes `SrpStageInputs` to `jeod_sim::FlatPlateStageInputs`; forks `flat_plate_srp_system` and `integration_system` in the Bevy adapter so `DerivativeFirstOrder` / `DerivativeRk4` run end-to-end through the Bevy pipeline. Adds two new Bevy parity tests exercising both derivative-class modes.

## Known limitations / follow-ups

- **Contact-coupled path**: derivative-class thermal is rejected at runtime (`assert` in `Simulation::step`). `integrate_bodies_contact_coupled` would need a per-stage thermal hook; no Tier 3 sim exercises contact+SRP-thermal together.
- **JEOD invariant catalog**: new entry IN.32 covers the IntegrableObject snapshot → advance → finalize protocol.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run --workspace` — 847 tests pass (excludes only the slow `earth_moon` tier 3; CI main-push runs that)
- [x] New `tier3_bevy_srp_derivative_first_order` and `tier3_bevy_srp_derivative_rk4` parity tests: Bevy adapter matches `Simulation` runner under both derivative-class modes.
- [x] `tier3_srp_rk4_thermal_differs_from_scheduled` smoke test: guards the Stage 8 dispatch fork against silent regressions.
- [x] `cargo nextest run --test invariant_coverage` — IN.32 consistent.
- [ ] `earth_moon` tier 3 runs in CI on main push (~17 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)