### PR TITLE
[Phase 1] Migrate leaf crates to typed jeod_quantities APIs (#103)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ name = "jeod_planet"
 version = "0.1.0"
 dependencies = [
  "jeod_quantities",
+ "uom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,7 @@ dependencies = [
  "glam 0.30.10",
  "jeod_quantities",
  "regex",
+ "uom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ version = "0.1.0"
 dependencies = [
  "jeod_quantities",
  "log",
+ "uom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,6 +2344,7 @@ name = "jeod_atmosphere"
 version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
+ "jeod_quantities",
 ]
 
 [[package]]
@@ -2364,6 +2365,7 @@ version = "0.1.0"
 dependencies = [
  "anise",
  "glam 0.30.10",
+ "jeod_quantities",
  "thiserror 2.0.18",
 ]
 
@@ -2420,6 +2422,9 @@ dependencies = [
 [[package]]
 name = "jeod_planet"
 version = "0.1.0"
+dependencies = [
+ "jeod_quantities",
+]
 
 [[package]]
 name = "jeod_quantities"
@@ -2471,6 +2476,7 @@ name = "jeod_test_data"
 version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
+ "jeod_quantities",
  "regex",
 ]
 
@@ -2478,6 +2484,7 @@ dependencies = [
 name = "jeod_time"
 version = "0.1.0"
 dependencies = [
+ "jeod_quantities",
  "log",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
  "jeod_quantities",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_atmosphere/Cargo.toml
+++ b/crates/jeod_atmosphere/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }

--- a/crates/jeod_atmosphere/Cargo.toml
+++ b/crates/jeod_atmosphere/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
+uom = { workspace = true }

--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -4,6 +4,10 @@ pub mod exponential;
 pub mod met;
 
 use glam::DVec3;
+use uom::si::f64::{MassDensity, Pressure, ThermodynamicTemperature};
+use uom::si::mass_density::kilogram_per_cubic_meter;
+use uom::si::pressure::pascal;
+use uom::si::thermodynamic_temperature::kelvin;
 
 /// Atmospheric state at a given position.
 ///
@@ -31,6 +35,34 @@ impl Default for AtmosphereState {
     }
 }
 
+impl AtmosphereState {
+    /// Typed accessor: atmospheric density as `uom::si::f64::MassDensity` (kg/m^3).
+    #[inline]
+    pub fn density_typed(&self) -> MassDensity {
+        MassDensity::new::<kilogram_per_cubic_meter>(self.density)
+    }
+
+    /// Typed accessor: atmospheric temperature as
+    /// `uom::si::f64::ThermodynamicTemperature` (kelvin).
+    #[inline]
+    pub fn temperature_typed(&self) -> ThermodynamicTemperature {
+        ThermodynamicTemperature::new::<kelvin>(self.temperature)
+    }
+
+    /// Typed accessor: atmospheric pressure as `uom::si::f64::Pressure` (pascal).
+    #[inline]
+    pub fn pressure_typed(&self) -> Pressure {
+        Pressure::new::<pascal>(self.pressure)
+    }
+
+    /// Typed accessor: wind velocity as a frame-tagged
+    /// `Velocity<Inertial>` (m/s).
+    #[inline]
+    pub fn wind_typed(&self) -> Velocity<Inertial> {
+        self.wind.m_per_s_at::<Inertial>()
+    }
+}
+
 /// Compute atmospheric co-rotation wind velocity in the inertial frame.
 ///
 /// Port of JEOD `WindVelocity::update_wind()` with uniform omega scale.
@@ -46,6 +78,21 @@ impl Default for AtmosphereState {
 // JEOD_INV: AT.04 — wind velocity computed as omega × position (co-rotation)
 pub fn compute_corotation_wind(omega: f64, inertial_pos: DVec3) -> DVec3 {
     DVec3::new(-omega * inertial_pos.y, omega * inertial_pos.x, 0.0)
+}
+
+/// Typed variant of [`compute_corotation_wind`].
+///
+/// Wraps the same computation with dimension-typed inputs/outputs. Delegates
+/// to the raw f64/DVec3 implementation internally so behavior is bit-identical.
+#[inline]
+pub fn compute_corotation_wind_typed(
+    omega: uom::si::f64::AngularVelocity,
+    pos: Position<Inertial>,
+) -> Velocity<Inertial> {
+    use uom::si::angular_velocity::radian_per_second;
+    let w = omega.get::<radian_per_second>();
+    let p = pos.raw_si();
+    compute_corotation_wind(w, p).m_per_s_at::<Inertial>()
 }
 
 #[cfg(test)]
@@ -85,5 +132,54 @@ mod tests {
         let pos = DVec3::new(7e6, 3e6, 1e6);
         let wind = compute_corotation_wind(0.0, pos);
         assert_eq!(wind, DVec3::ZERO);
+    }
+
+    #[test]
+    fn typed_accessors_roundtrip_bit_identical() {
+        let state = AtmosphereState {
+            density: 1.225e-12,
+            temperature: 288.15,
+            pressure: 2.537e-10,
+            wind: DVec3::new(-359.7, 123.4, 0.5),
+        };
+
+        // Values extracted through typed accessors must equal the raw f64
+        // inputs bit-for-bit — no unit conversion or round-trip loss.
+        assert_eq!(
+            state.density_typed().get::<kilogram_per_cubic_meter>(),
+            state.density
+        );
+        assert_eq!(state.temperature_typed().get::<kelvin>(), state.temperature);
+        assert_eq!(state.pressure_typed().get::<pascal>(), state.pressure);
+        assert_eq!(state.wind_typed().raw_si(), state.wind);
+    }
+
+    #[test]
+    fn typed_accessors_default_state() {
+        let state = AtmosphereState::default();
+        assert_eq!(state.density_typed().get::<kilogram_per_cubic_meter>(), 0.0);
+        assert_eq!(state.temperature_typed().get::<kelvin>(), 0.0);
+        assert_eq!(state.pressure_typed().get::<pascal>(), 0.0);
+        assert_eq!(state.wind_typed().raw_si(), DVec3::ZERO);
+    }
+
+    #[test]
+    fn corotation_wind_typed_matches_raw() {
+        let omega_raw = 7.292115146706388e-5;
+        let pos_raw = DVec3::new(7.0e6, 3.0e6, 1.0e6);
+
+        let typed_out =
+            compute_corotation_wind_typed(omega_raw.rad_per_s(), pos_raw.m_at::<Inertial>());
+        let raw_out = compute_corotation_wind(omega_raw, pos_raw);
+
+        // Typed path must be bit-identical to the raw f64 path.
+        assert_eq!(typed_out.raw_si(), raw_out);
+    }
+
+    #[test]
+    fn corotation_wind_typed_zero_omega() {
+        let pos = DVec3::new(7e6, 3e6, 1e6).m_at::<Inertial>();
+        let wind = compute_corotation_wind_typed(0.0.rad_per_s(), pos);
+        assert_eq!(wind.raw_si(), DVec3::ZERO);
     }
 }

--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -1,3 +1,5 @@
+pub use jeod_quantities::prelude::*;
+
 pub mod exponential;
 pub mod met;
 

--- a/crates/jeod_ephemeris/Cargo.toml
+++ b/crates/jeod_ephemeris/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }
 anise = "0.9"
 glam = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/jeod_ephemeris/src/ephemeris.rs
+++ b/crates/jeod_ephemeris/src/ephemeris.rs
@@ -5,6 +5,7 @@ use anise::constants::frames::*;
 use anise::constants::orientations::J2000;
 use anise::prelude::*;
 use glam::DVec3;
+use jeod_quantities::prelude::{Inertial, Position, Vec3Ext, Velocity};
 
 use crate::bodies::EphemerisBody;
 
@@ -51,6 +52,11 @@ impl Ephemeris {
     /// Get state of `target` relative to `observer` at a given TDB Julian Date.
     ///
     /// Returns `(position_m, velocity_m_per_s)` in J2000 ICRF.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.0-phase-1",
+        note = "use get_state_typed / get_earth_centered_state_typed; this f64 variant is removed in Phase 10"
+    )]
     pub fn get_state(
         &self,
         target: EphemerisBody,
@@ -89,12 +95,49 @@ impl Ephemeris {
     /// Get Earth-centered state of `target` at a given TDB Julian Date.
     ///
     /// Returns `(position_m, velocity_m_per_s)` relative to Earth center in J2000 ICRF.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.0-phase-1",
+        note = "use get_state_typed / get_earth_centered_state_typed; this f64 variant is removed in Phase 10"
+    )]
     pub fn get_earth_centered_state(
         &self,
         target: EphemerisBody,
         tdb_jd: f64,
     ) -> Result<(DVec3, DVec3), EphemerisError> {
+        #[allow(deprecated)]
         self.get_state(target, EphemerisBody::Earth, tdb_jd)
+    }
+
+    /// Get state of `target` relative to `observer` at a given TDB Julian Date,
+    /// returning frame-tagged, dimensioned quantities in the J2000 (ICRF-aligned)
+    /// inertial frame.
+    ///
+    /// This is the typed counterpart to [`Self::get_state`]; the underlying
+    /// ANISE translate call is unchanged, the returned values are simply wrapped
+    /// as `Position<Inertial>` / `Velocity<Inertial>` in SI base units
+    /// (meters, m/s).
+    pub fn get_state_typed(
+        &self,
+        target: EphemerisBody,
+        observer: EphemerisBody,
+        tdb_jd: f64,
+    ) -> Result<(Position<Inertial>, Velocity<Inertial>), EphemerisError> {
+        #[allow(deprecated)]
+        let (pos_m, vel_m_s) = self.get_state(target, observer, tdb_jd)?;
+        Ok((pos_m.m_at::<Inertial>(), vel_m_s.m_per_s_at::<Inertial>()))
+    }
+
+    /// Earth-centered variant of [`Self::get_state_typed`].
+    ///
+    /// Returns `(Position<Inertial>, Velocity<Inertial>)` relative to Earth
+    /// center in J2000 ICRF (meters, m/s).
+    pub fn get_earth_centered_state_typed(
+        &self,
+        target: EphemerisBody,
+        tdb_jd: f64,
+    ) -> Result<(Position<Inertial>, Velocity<Inertial>), EphemerisError> {
+        self.get_state_typed(target, EphemerisBody::Earth, tdb_jd)
     }
 
     /// Get the rotation matrix from J2000 inertial to a body's body-fixed frame.
@@ -195,4 +238,65 @@ pub enum EphemerisError {
     LoadError(String),
     #[error("Ephemeris query failed: {0}")]
     QueryError(String),
+}
+
+#[cfg(test)]
+mod typed_accessor_tests {
+    //! Bit-identical equivalence between the deprecated `DVec3` accessors and
+    //! their typed siblings. Uses the committed `de421.bsp` kernel in
+    //! `test_data/`; the test will panic with a descriptive message if the
+    //! kernel is missing (no graceful skip — see project policy).
+    //!
+    //! We compare via `raw_si()` because the typed accessors return SI base
+    //! units (meters, m/s), so a matching `raw_si()` DVec3 is also bit-exact
+    //! in the intended unit.
+    use super::*;
+    use std::path::PathBuf;
+
+    const J2000_TDB_JD: f64 = 2_451_545.0;
+
+    fn load_de421() -> Ephemeris {
+        // crates/jeod_ephemeris -> workspace root -> test_data/de421.bsp
+        let path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("workspace root")
+            .join("test_data/de421.bsp");
+        assert!(
+            path.exists(),
+            "DE421.bsp not found at {}. Download with: curl -Lo test_data/de421.bsp https://public-data.nyxspace.com/anise/de421.bsp",
+            path.display(),
+        );
+        Ephemeris::from_bsp(&path).expect("load DE421.bsp")
+    }
+
+    #[test]
+    fn get_state_typed_is_bit_identical_to_get_state() {
+        let ephem = load_de421();
+        #[allow(deprecated)]
+        let (pos_dvec, vel_dvec) = ephem
+            .get_state(EphemerisBody::Moon, EphemerisBody::Earth, J2000_TDB_JD)
+            .expect("query Moon state");
+        let (pos_t, vel_t) = ephem
+            .get_state_typed(EphemerisBody::Moon, EphemerisBody::Earth, J2000_TDB_JD)
+            .expect("query Moon state (typed)");
+
+        assert_eq!(pos_t.raw_si(), pos_dvec);
+        assert_eq!(vel_t.raw_si(), vel_dvec);
+    }
+
+    #[test]
+    fn get_earth_centered_state_typed_is_bit_identical() {
+        let ephem = load_de421();
+        #[allow(deprecated)]
+        let (pos_dvec, vel_dvec) = ephem
+            .get_earth_centered_state(EphemerisBody::Sun, J2000_TDB_JD)
+            .expect("query Sun state");
+        let (pos_t, vel_t) = ephem
+            .get_earth_centered_state_typed(EphemerisBody::Sun, J2000_TDB_JD)
+            .expect("query Sun state (typed)");
+
+        assert_eq!(pos_t.raw_si(), pos_dvec);
+        assert_eq!(vel_t.raw_si(), vel_dvec);
+    }
 }

--- a/crates/jeod_ephemeris/src/lib.rs
+++ b/crates/jeod_ephemeris/src/lib.rs
@@ -1,3 +1,5 @@
+pub use jeod_quantities::prelude::*;
+
 pub mod bodies;
 pub mod ephemeris;
 

--- a/crates/jeod_ephemeris/tests/ephemeris_validation.rs
+++ b/crates/jeod_ephemeris/tests/ephemeris_validation.rs
@@ -3,6 +3,12 @@
 //! Requires `test_data/de421.bsp` to be present. Download with:
 //!   curl -Lo test_data/de421.bsp https://public-data.nyxspace.com/anise/de421.bsp
 
+// These validation tests still call the Phase-1-deprecated `DVec3` accessors
+// directly. Migrating them to the typed accessors is Phase 3+ work per
+// issue #101; keep the deprecated-lint suppression local so `-D warnings`
+// stays clean.
+#![allow(deprecated)]
+
 use jeod_ephemeris::{Ephemeris, EphemerisBody};
 use std::path::Path;
 

--- a/crates/jeod_planet/Cargo.toml
+++ b/crates/jeod_planet/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities" }
+uom = { workspace = true }

--- a/crates/jeod_planet/Cargo.toml
+++ b/crates/jeod_planet/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }

--- a/crates/jeod_planet/src/lib.rs
+++ b/crates/jeod_planet/src/lib.rs
@@ -1,3 +1,5 @@
+pub use jeod_quantities::prelude::*;
+
 pub mod planet;
 pub mod presets;
 

--- a/crates/jeod_planet/src/planet.rs
+++ b/crates/jeod_planet/src/planet.rs
@@ -34,11 +34,62 @@ impl PlanetShape {
         let f = self.flat_coeff;
         2.0 * f - f * f
     }
+
+    /// Gravitational parameter as a typed `GravParam` (m³/s²).
+    ///
+    /// Additive typed accessor introduced by Phase 1 of the type-system
+    /// refactor (issue #101). Wraps the existing `mu` f64 field; the
+    /// underlying field is unchanged.
+    pub fn mu_typed(&self) -> jeod_quantities::dims::GravParam {
+        use jeod_quantities::ext::F64Ext;
+        self.mu.m3_per_s2()
+    }
+
+    /// Equatorial radius as a typed `uom::si::f64::Length` (meters).
+    ///
+    /// Additive typed accessor introduced by Phase 1 of the type-system
+    /// refactor (issue #101). Wraps the existing `r_eq` f64 field; the
+    /// underlying field is unchanged.
+    pub fn r_eq_typed(&self) -> uom::si::f64::Length {
+        use jeod_quantities::ext::F64Ext;
+        self.r_eq.m()
+    }
+
+    /// Polar radius as a typed `uom::si::f64::Length` (meters).
+    ///
+    /// Additive typed accessor introduced by Phase 1 of the type-system
+    /// refactor (issue #101). Wraps the existing `r_pol` f64 field; the
+    /// underlying field is unchanged.
+    pub fn r_pol_typed(&self) -> uom::si::f64::Length {
+        use jeod_quantities::ext::F64Ext;
+        self.r_pol.m()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::presets::*;
+
+    #[test]
+    fn earth_mu_typed_matches_f64_field() {
+        // `GravParam` stores value in base SI (m³/s²) via `.value`.
+        let mu = EARTH.mu_typed();
+        assert_eq!(mu.value, EARTH.mu);
+    }
+
+    #[test]
+    fn earth_r_eq_typed_matches_f64_field() {
+        use uom::si::length::meter;
+        let r_eq = EARTH.r_eq_typed();
+        assert_eq!(r_eq.get::<meter>(), EARTH.r_eq);
+    }
+
+    #[test]
+    fn earth_r_pol_typed_matches_f64_field() {
+        use uom::si::length::meter;
+        let r_pol = EARTH.r_pol_typed();
+        assert_eq!(r_pol.get::<meter>(), EARTH.r_pol);
+    }
 
     #[test]
     fn polar_radius_consistent_with_flattening() {

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -61,11 +61,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let epoch_tdb_jd = time.tdb_julian_date();
 
     // Get Moon and Sun positions at epoch
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (moon_pos, _) = ephemeris.get_state(
         jeod_sim::EphemerisBody::Moon,
         jeod_sim::EphemerisBody::Earth,
         epoch_tdb_jd,
     )?;
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris.get_state(
         jeod_sim::EphemerisBody::Sun,
         jeod_sim::EphemerisBody::Earth,

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -109,6 +109,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Earth: 3rd-body perturbation with per-step ephemeris
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (earth_pos, _) =
         ephemeris.get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)?;
     let earth = sim.add_source(
@@ -125,6 +127,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
 
     // Sun: 3rd-body + SRP source with per-step ephemeris
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) =
         ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)?;
     let sun = sim.add_source(

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -68,6 +68,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
     let epoch_tdb_jd = time.tdb_julian_date();
 
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris.get_state(
         jeod_sim::EphemerisBody::Sun,
         jeod_sim::EphemerisBody::Mars,

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1552,6 +1552,10 @@ impl Simulation {
             let tdb_jd = self.time.tdb_julian_date();
             for i in 0..self.source_ephem_bodies.len() {
                 if let Some(Some((target, observer))) = self.source_ephem_bodies.get(i) {
+                    // Phase 1 (#103): the `DVec3` accessor is deprecated; migration
+                    // to `get_state_typed` happens in Phase 3+ once downstream state
+                    // storage is typed.
+                    #[allow(deprecated)]
                     let (pos, vel) =
                         eph.get_state(*target, *observer, tdb_jd)
                             .unwrap_or_else(|e| {

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -65,6 +65,8 @@ fn pipeline_earth_lighting_smoke() {
 
     // Sun from DE421
     let j2000_jd = 2_451_545.0;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, j2000_jd)
         .expect("Sun position at J2000");
@@ -89,6 +91,8 @@ fn pipeline_earth_lighting_smoke() {
     sim.sun_source = Some(sun);
 
     // Moon from DE421
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_moon, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Moon, j2000_jd)
         .expect("Moon position at J2000");

--- a/crates/jeod_runner/tests/tier3_sim_battin.rs
+++ b/crates/jeod_runner/tests/tier3_sim_battin.rs
@@ -40,9 +40,12 @@ const LOG_INTERVAL: f64 = 60.0;
 
 /// Compute Earth-centered position and velocity of a body from DE421 ephemeris.
 fn earth_centered_state(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> (DVec3, DVec3) {
-    ephemeris
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
+    let out = ephemeris
         .get_earth_centered_state(body, tdb_jd)
-        .expect("ephemeris query failed")
+        .expect("ephemeris query failed");
+    out
 }
 
 /// Build a `Simulation` with ISS-like orbit, Earth central, Sun + Moon third-body.

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
@@ -33,6 +33,8 @@ const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 /// Compute Earth-centered position of a body from DE421 ephemeris.
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
@@ -34,6 +34,8 @@ use std::path::Path;
 const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -150,6 +150,8 @@ fn tier3_simulation_earth_moon_clem() {
 
     // Earth as 3rd-body with per-step ephemeris updates
     let epoch_tdb_jd = sim.time.tdb_julian_date();
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (earth_pos_from_moon, _earth_vel) = ephemeris
         .get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)
         .expect("Earth-Moon state from DE421");
@@ -168,6 +170,8 @@ fn tier3_simulation_earth_moon_clem() {
     sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
 
     // Sun as 3rd-body with per-step ephemeris updates (also SRP source)
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos_from_moon, _) = ephemeris
         .get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)
         .expect("Sun-Moon state from DE421");

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -101,6 +101,8 @@ fn tier3_simulation_mars_dawn() {
     let bsp_path = test_data_path("de421.bsp");
     let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path).expect("load DE421");
     let epoch_tdb_jd = time.tdb_julian_date();
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos_from_mars, _sun_vel) = ephemeris
         .get_state(
             jeod_sim::EphemerisBody::Sun,

--- a/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
+++ b/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
@@ -94,6 +94,8 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
 
     // Sun from DE421 (query in TDB JD, not TAI JD)
     let tdb_jd = sim.time.tdb_julian_date();
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position at epoch");

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
@@ -94,6 +94,8 @@ fn tier3_simulation_solar_beta() {
     // by tier3_sim_dyncomp_run4 and tier3_sim_torque_simple.
     // J2000.0 = JD 2451545.0
     let j2000_jd = 2_451_545.0;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, j2000_jd)
         .expect("Sun position at J2000");
@@ -144,6 +146,8 @@ fn tier3_simulation_solar_beta() {
     for record in &trajectory[1..] {
         // Update Sun position from ephemeris
         let tdb_jd = j2000_jd + record.time / 86_400.0;
+        // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+        #[allow(deprecated)]
         let (sun_pos, _) = ephemeris
             .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
             .expect("Sun position query");

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
@@ -137,6 +137,8 @@ fn run_solar_beta_test(
     );
 
     // Sun source — position from DE421 at epoch
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, EPOCH_TDB_JD)
         .expect("Sun position at epoch");

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -92,6 +92,8 @@ fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
 
 fn srp_sun_position(sim_time: f64, epoch_tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
     let tdb_jd = epoch_tdb_jd + sim_time / 86400.0;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position query failed");

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -100,6 +100,8 @@ fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
 fn srp_sun_position(sim_time: f64, epoch_tai_tjt: f64, ephemeris: &Ephemeris) -> DVec3 {
     let sim_days = sim_time / 86400.0;
     let tdb_jd = (epoch_tai_tjt + sim_days) + 40000.0 + 2_400_000.5;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position query failed");

--- a/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
@@ -26,6 +26,8 @@ use std::path::Path;
 const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -110,6 +110,8 @@ struct RunConfig {
 
 /// Compute Earth-centered position of a body from DE421 ephemeris.
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_test_data/Cargo.toml
+++ b/crates/jeod_test_data/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 regex = "1"

--- a/crates/jeod_test_data/Cargo.toml
+++ b/crates/jeod_test_data/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 regex = "1"
+uom = { workspace = true }

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -6,8 +6,10 @@
 //! `target/tier3_crossval/<test_name>.json`.
 
 use glam::{DQuat, DVec3};
+use jeod_quantities::prelude::*;
 use std::io::Write;
 use std::path::PathBuf;
+use uom::si::f64::{Angle, AngularVelocity, Length, Velocity};
 
 fn output_dir() -> PathBuf {
     let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -180,6 +182,26 @@ impl CrossvalReport {
     /// Quaternion angle error in radians (rotation-invariant).
     pub fn max_quat_angle(&self) -> f64 {
         self.quat_angle.unwrap_or(0.0)
+    }
+
+    /// Worst-component position error as a typed [`Length`] (meters).
+    pub fn max_position_typed(&self) -> Length {
+        self.max_position_component().m()
+    }
+
+    /// Worst-component velocity error as a typed [`Velocity`] (m/s).
+    pub fn max_velocity_typed(&self) -> Velocity {
+        self.max_velocity_component().m_per_s()
+    }
+
+    /// Worst-component angular velocity error as a typed [`AngularVelocity`] (rad/s).
+    pub fn max_ang_vel_typed(&self) -> AngularVelocity {
+        self.max_ang_vel_component().rad_per_s()
+    }
+
+    /// Quaternion angle error as a typed [`Angle`] (radians).
+    pub fn max_quat_angle_typed(&self) -> Angle {
+        self.max_quat_angle().rad()
     }
 
     /// Assert each position component is within its tolerance.

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -6,7 +6,7 @@
 //! `target/tier3_crossval/<test_name>.json`.
 
 use glam::{DQuat, DVec3};
-use jeod_quantities::prelude::*;
+use jeod_quantities::ext::F64Ext;
 use std::io::Write;
 use std::path::PathBuf;
 use uom::si::f64::{Angle, AngularVelocity, Length, Velocity};

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -1,3 +1,5 @@
+pub use jeod_quantities::prelude::*;
+
 pub mod apollo_mass_tree;
 pub mod crossval;
 pub mod dyncomp_csv;

--- a/crates/jeod_test_data/src/reference_state.rs
+++ b/crates/jeod_test_data/src/reference_state.rs
@@ -1,4 +1,5 @@
 use glam::DVec3;
+use jeod_quantities::prelude::*;
 use regex::Regex;
 
 /// ISS reference translational state from JEOD verification data.
@@ -11,10 +12,32 @@ use regex::Regex;
 ///   vehicle_reference.expected_state.trans.position  = [      1244540.53,   5655938.85,   3425643.22]
 ///   vehicle_reference.expected_state.trans.velocity  = [    -6003.833051, -1469.496044,  4590.511776]
 /// ```
+///
+/// Frame: inertial (ICRF) — JEOD's `reference_inertial_trans_state.py` files
+/// specify the state in the inertial frame. Use [`ReferenceState::position_typed`]
+/// and [`ReferenceState::velocity_typed`] to obtain frame-tagged typed views.
 #[derive(Debug, Clone)]
 pub struct ReferenceState {
     pub position: DVec3,
     pub velocity: DVec3,
+}
+
+impl ReferenceState {
+    /// Frame-tagged typed position in the inertial (ICRF) frame.
+    ///
+    /// This wraps the raw SI-unit `DVec3` (meters) without conversion.
+    #[inline]
+    pub fn position_typed(&self) -> Position<Inertial> {
+        self.position.m_at::<Inertial>()
+    }
+
+    /// Frame-tagged typed velocity in the inertial (ICRF) frame.
+    ///
+    /// This wraps the raw SI-unit `DVec3` (m/s) without conversion.
+    #[inline]
+    pub fn velocity_typed(&self) -> Velocity<Inertial> {
+        self.velocity.m_per_s_at::<Inertial>()
+    }
 }
 
 /// Load an ISS reference translational state from JEOD's verification data.
@@ -59,5 +82,57 @@ pub fn load_reference_state(
     ReferenceState {
         position: arrays[0],
         velocity: arrays[1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uom::si::{length::meter, velocity::meter_per_second};
+
+    #[test]
+    fn position_typed_matches_raw_components_bit_identically() {
+        let pos = DVec3::new(1244540.53, 5655938.85, 3425643.22);
+        let vel = DVec3::new(-6003.833051, -1469.496044, 4590.511776);
+        let state = ReferenceState {
+            position: pos,
+            velocity: vel,
+        };
+
+        let typed = state.position_typed();
+        // Bit-identical per-component check.
+        assert_eq!(typed.x.get::<meter>().to_bits(), pos.x.to_bits());
+        assert_eq!(typed.y.get::<meter>().to_bits(), pos.y.to_bits());
+        assert_eq!(typed.z.get::<meter>().to_bits(), pos.z.to_bits());
+        // Raw-SI round-trip also bit-identical.
+        assert_eq!(typed.raw_si(), pos);
+    }
+
+    #[test]
+    fn velocity_typed_matches_raw_components_bit_identically() {
+        let pos = DVec3::new(1244540.53, 5655938.85, 3425643.22);
+        let vel = DVec3::new(-6003.833051, -1469.496044, 4590.511776);
+        let state = ReferenceState {
+            position: pos,
+            velocity: vel,
+        };
+
+        let typed = state.velocity_typed();
+        assert_eq!(typed.x.get::<meter_per_second>().to_bits(), vel.x.to_bits());
+        assert_eq!(typed.y.get::<meter_per_second>().to_bits(), vel.y.to_bits());
+        assert_eq!(typed.z.get::<meter_per_second>().to_bits(), vel.z.to_bits());
+        assert_eq!(typed.raw_si(), vel);
+    }
+
+    #[test]
+    fn typed_accessors_preserve_zero_and_negative_components() {
+        let state = ReferenceState {
+            position: DVec3::new(0.0, -1.5e7, 9.87654),
+            velocity: DVec3::new(-7123.456, 0.0, 42.0),
+        };
+        let p = state.position_typed();
+        let v = state.velocity_typed();
+        assert_eq!(p.raw_si(), state.position);
+        assert_eq!(v.raw_si(), state.velocity);
     }
 }

--- a/crates/jeod_time/Cargo.toml
+++ b/crates/jeod_time/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }
 log = { workspace = true }

--- a/crates/jeod_time/Cargo.toml
+++ b/crates/jeod_time/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities" }
 log = { workspace = true }
+uom = { workspace = true }

--- a/crates/jeod_time/src/lib.rs
+++ b/crates/jeod_time/src/lib.rs
@@ -1,3 +1,5 @@
+pub use jeod_quantities::prelude::*;
+
 pub mod epoch;
 pub mod leap_second;
 pub mod simulation_time;

--- a/crates/jeod_time/src/simulation_time.rs
+++ b/crates/jeod_time/src/simulation_time.rs
@@ -161,6 +161,60 @@ impl SimulationTime {
         self.tt_tjt() + 40_000.0 + 2_400_000.5
     }
 
+    // --- Typed accessors (Phase 1 #103) ------------------------------------
+    //
+    // Additive typed getters returning `SecondsSince<S>` for each time scale
+    // present as a pub f64 field. These delegate to the existing f64 fields
+    // (no recomputation) so behavior is bit-identical to the f64 API.
+    //
+    // Note: no typed getter for GMST is provided as `SecondsSince<GMST>` —
+    // the primary representation of GMST is an angle (see `gmst_angle()`).
+
+    /// TAI seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn tai(&self) -> crate::SecondsSince<crate::TAI> {
+        crate::SecondsSince::from_seconds(self.tai_seconds)
+    }
+
+    /// UTC seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn utc(&self) -> crate::SecondsSince<crate::UTC> {
+        crate::SecondsSince::from_seconds(self.utc_seconds)
+    }
+
+    /// UT1 seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn ut1(&self) -> crate::SecondsSince<crate::UT1> {
+        crate::SecondsSince::from_seconds(self.ut1_seconds)
+    }
+
+    /// TT seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn tt(&self) -> crate::SecondsSince<crate::TT> {
+        crate::SecondsSince::from_seconds(self.tt_seconds)
+    }
+
+    /// TDB seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn tdb(&self) -> crate::SecondsSince<crate::TDB> {
+        crate::SecondsSince::from_seconds(self.tdb_seconds)
+    }
+
+    /// GPS seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn gps(&self) -> crate::SecondsSince<crate::GPS> {
+        crate::SecondsSince::from_seconds(self.gps_seconds)
+    }
+
+    /// Greenwich Mean Sidereal Time as a typed angle.
+    ///
+    /// GMST is fundamentally an angle; the primary representation is radians
+    /// wrapped to `[0, 2π)`. Use this instead of a `SecondsSince<GMST>` getter.
+    #[inline]
+    pub fn gmst_angle(&self) -> uom::si::f64::Angle {
+        uom::si::f64::Angle::new::<uom::si::angle::radian>(self.gmst_radians)
+    }
+
     // JEOD_INV: TM.03 — time types updated in dependency order (TAI -> TT -> TDB -> UTC -> UT1 -> GMST)
     /// Recompute all derived time scales from TAI.
     fn recompute_derived(&mut self) {
@@ -333,6 +387,49 @@ mod tests {
             (sim.gps_seconds - 81.0).abs() < 1e-15,
             "GPS after 100s: expected 81.0, got {}",
             sim.gps_seconds
+        );
+    }
+
+    // --- Typed-accessor tests (Phase 1 #103) -------------------------------
+
+    #[test]
+    fn typed_getters_match_f64_fields() {
+        // Advance by a non-trivial duration to exercise each scale.
+        let mut sim = SimulationTime::at_j2000(default_leap_second_table());
+        sim.advance(1_000_000.0);
+
+        // Each typed getter round-trips back to the matching f64 field.
+        assert_eq!(sim.tai().as_seconds(), sim.tai_seconds);
+        assert_eq!(sim.utc().as_seconds(), sim.utc_seconds);
+        assert_eq!(sim.ut1().as_seconds(), sim.ut1_seconds);
+        assert_eq!(sim.tt().as_seconds(), sim.tt_seconds);
+        assert_eq!(sim.tdb().as_seconds(), sim.tdb_seconds);
+        assert_eq!(sim.gps().as_seconds(), sim.gps_seconds);
+
+        // `gmst_angle()` returns uom Angle; extracting radians must match.
+        use uom::si::angle::radian;
+        let gmst_rad = sim.gmst_angle().get::<radian>();
+        assert_eq!(gmst_rad, sim.gmst_radians);
+    }
+
+    #[test]
+    fn typed_tai_tt_roundtrip_via_simulation_time() {
+        // Read TAI out via the typed getter, convert to TT via the typed
+        // converter, convert back, and verify bit-identical (tolerance 1e-14 s)
+        // agreement with the original reading.
+        use crate::time_converter_tai_tt::{tai_to_tt_typed, tt_to_tai_typed};
+
+        let mut sim = SimulationTime::at_j2000(default_leap_second_table());
+        sim.advance(1_000_000.0);
+
+        let tai = sim.tai();
+        let tt = tai_to_tt_typed(tai);
+        let back = tt_to_tai_typed(tt);
+        let err = (back.as_seconds() - tai.as_seconds()).abs();
+        assert!(
+            err < 1e-14,
+            "TAI->TT->TAI typed roundtrip err={} (tolerance 1e-14 s)",
+            err
         );
     }
 }

--- a/crates/jeod_time/src/time_converter_tai_tdb.rs
+++ b/crates/jeod_time/src/time_converter_tai_tdb.rs
@@ -1,5 +1,6 @@
 use crate::epoch::{J2000_TAI_TJT, TAI_TT_OFFSET};
 use crate::time_converter_tai_tt::tai_to_tt;
+use crate::{SecondsSince, TAI, TDB};
 use std::f64::consts::PI;
 
 /// Compute the TDB-TT offset in seconds at a given TAI truncated Julian time.
@@ -45,6 +46,25 @@ pub fn tdb_to_tai(tdb_seconds: f64, tai_tjt_initial: f64) -> f64 {
         }
     }
     tai
+}
+
+// --- Typed variants (Phase 1 #103) ------------------------------------------
+//
+// Additive typed siblings. They delegate to the f64 free functions so
+// behavior is bit-identical. `tai_tjt` is a scale-neutral truncated Julian
+// time anchor carried through untouched.
+
+/// Typed TAI → TDB converter (delegates to [`tai_to_tdb`]).
+///
+/// `tai_tjt` anchors the calendar date for the periodic TDB-TT offset; it is
+/// the same scalar the f64 free function takes (truncated Julian time in TAI).
+pub fn tai_to_tdb_typed(t: SecondsSince<TAI>, tai_tjt: f64) -> SecondsSince<TDB> {
+    SecondsSince::from_seconds(tai_to_tdb(t.as_seconds(), tai_tjt))
+}
+
+/// Typed TDB → TAI converter (delegates to [`tdb_to_tai`]).
+pub fn tdb_to_tai_typed(t: SecondsSince<TDB>, tai_tjt_initial: f64) -> SecondsSince<TAI> {
+    SecondsSince::from_seconds(tdb_to_tai(t.as_seconds(), tai_tjt_initial))
 }
 
 #[cfg(test)]
@@ -94,5 +114,27 @@ mod tests {
             back,
             (back - tai).abs()
         );
+    }
+
+    #[test]
+    fn tai_tdb_typed_matches_f64() {
+        let tai = 1_000_000.0_f64;
+        let tai_tjt = J2000_TAI_TJT + tai / 86400.0;
+        let tdb_typed = tai_to_tdb_typed(SecondsSince::<TAI>::from_seconds(tai), tai_tjt);
+        assert_eq!(tdb_typed.as_seconds(), tai_to_tdb(tai, tai_tjt));
+    }
+
+    #[test]
+    fn tai_tdb_typed_round_trip() {
+        // Non-trivial input, typed round-trip.
+        let tai_s = 1_000_000.0_f64;
+        let tai_tjt = J2000_TAI_TJT + tai_s / 86400.0;
+        let tai = SecondsSince::<TAI>::from_seconds(tai_s);
+        let tdb = tai_to_tdb_typed(tai, tai_tjt);
+        let back = tdb_to_tai_typed(tdb, tai_tjt);
+        let err = (back.as_seconds() - tai.as_seconds()).abs();
+        // Same 1e-10 bound the iterative f64 round-trip achieves; well below
+        // the 1e-14 TAI↔TT spec target (TDB adds ~ms-scale periodic noise).
+        assert!(err < 1e-10, "TAI->TDB->TAI typed round-trip err={}", err);
     }
 }

--- a/crates/jeod_time/src/time_converter_tai_tt.rs
+++ b/crates/jeod_time/src/time_converter_tai_tt.rs
@@ -1,4 +1,5 @@
 use crate::epoch::TAI_TT_OFFSET;
+use crate::{SecondsSince, TAI, TT};
 
 /// Convert TAI seconds-since-epoch to TT seconds-since-epoch.
 /// TT = TAI + 32.184s (exact by definition).
@@ -9,6 +10,23 @@ pub fn tai_to_tt(tai_seconds: f64) -> f64 {
 /// Convert TT seconds-since-epoch to TAI seconds-since-epoch.
 pub fn tt_to_tai(tt_seconds: f64) -> f64 {
     tt_seconds - TAI_TT_OFFSET
+}
+
+// --- Typed variants (Phase 1 #103) ------------------------------------------
+//
+// Additive typed siblings. They forward to the f64 free functions above so
+// behavior is bit-identical — never routed through
+// `TimeConverter<TAI, TT>::apply()`, which would re-round through
+// `from_seconds`/`as_seconds`.
+
+/// Typed TAI → TT converter (delegates to [`tai_to_tt`]).
+pub fn tai_to_tt_typed(t: SecondsSince<TAI>) -> SecondsSince<TT> {
+    SecondsSince::from_seconds(tai_to_tt(t.as_seconds()))
+}
+
+/// Typed TT → TAI converter (delegates to [`tt_to_tai`]).
+pub fn tt_to_tai_typed(t: SecondsSince<TT>) -> SecondsSince<TAI> {
+    SecondsSince::from_seconds(tt_to_tai(t.as_seconds()))
 }
 
 #[cfg(test)]
@@ -28,5 +46,25 @@ mod tests {
         let tt = tai_to_tt(tai);
         let back = tt_to_tai(tt);
         assert!((back - tai).abs() < 1e-15);
+    }
+
+    #[test]
+    fn tai_tt_typed_matches_f64() {
+        // Typed wrappers must agree with the f64 versions bit-exactly.
+        let tai_raw = 1_000_000.0_f64;
+        let tt_typed = tai_to_tt_typed(SecondsSince::<TAI>::from_seconds(tai_raw));
+        assert_eq!(tt_typed.as_seconds(), tai_to_tt(tai_raw));
+    }
+
+    #[test]
+    fn tai_tt_typed_round_trip() {
+        // Non-trivial input; tolerance 1e-14 s (addition/subtraction of
+        // TAI_TT_OFFSET at this magnitude is exact in f64, but we still
+        // allow 1e-14 per the Phase 1 spec).
+        let tai = SecondsSince::<TAI>::from_seconds(1_000_000.0);
+        let tt = tai_to_tt_typed(tai);
+        let back = tt_to_tai_typed(tt);
+        let err = (back.as_seconds() - tai.as_seconds()).abs();
+        assert!(err < 1e-14, "round-trip err={} (tolerance 1e-14 s)", err);
     }
 }

--- a/crates/jeod_time/src/time_converter_ut1_gmst.rs
+++ b/crates/jeod_time/src/time_converter_ut1_gmst.rs
@@ -1,4 +1,7 @@
+use crate::{SecondsSince, GMST};
 use std::f64::consts::PI;
+use uom::si::angle::radian;
+use uom::si::f64::Angle;
 
 /// Convert UT1 days since noon 2000-01-01 to Greenwich Mean Sidereal Time.
 ///
@@ -31,6 +34,27 @@ pub fn ut1_to_gmst_radians(du: f64) -> f64 {
     let gmst_days = ut1_to_gmst_days(du);
     let fractional = gmst_days - gmst_days.floor();
     fractional * 2.0 * PI
+}
+
+// --- Typed variants (Phase 1 #103) ------------------------------------------
+//
+// The GMST polynomial (Aoki et al. 1982) is parameterised by `du`, UT1 days
+// since J2000 noon — a scale-neutral scalar anchor rather than a
+// `SecondsSince<UT1>`. The typed wrappers therefore keep the `du: f64` input
+// and return typed output: a `uom::si::f64::Angle` for the wrapped radian
+// form (GMST's primary representation) and `SecondsSince<GMST>` for the
+// accumulated sidereal-seconds form.
+
+/// Typed UT1 → GMST accumulated sidereal seconds (delegates to
+/// [`ut1_to_gmst_seconds`]).
+pub fn ut1_to_gmst_seconds_typed(du: f64) -> SecondsSince<GMST> {
+    SecondsSince::from_seconds(ut1_to_gmst_seconds(du))
+}
+
+/// Typed UT1 → GMST angle wrapped to `[0, 2π)` (delegates to
+/// [`ut1_to_gmst_radians`]).
+pub fn ut1_to_gmst_angle(du: f64) -> Angle {
+    Angle::new::<radian>(ut1_to_gmst_radians(du))
 }
 
 #[cfg(test)]
@@ -83,6 +107,29 @@ mod tests {
                 (0.0..std::f64::consts::TAU).contains(&gmst_rad),
                 "GMST radians out of range: {} at days={}",
                 gmst_rad,
+                days
+            );
+        }
+    }
+
+    #[test]
+    fn ut1_gmst_typed_matches_f64() {
+        let du = 365.25_f64;
+        let typed_secs = ut1_to_gmst_seconds_typed(du);
+        assert_eq!(typed_secs.as_seconds(), ut1_to_gmst_seconds(du));
+
+        let typed_angle = ut1_to_gmst_angle(du);
+        assert_eq!(typed_angle.get::<radian>(), ut1_to_gmst_radians(du));
+    }
+
+    #[test]
+    fn ut1_gmst_typed_angle_is_bounded() {
+        for days in [-1000.0, 0.0, 365.25, 3652.5] {
+            let angle_rad = ut1_to_gmst_angle(days).get::<radian>();
+            assert!(
+                (0.0..std::f64::consts::TAU).contains(&angle_rad),
+                "typed GMST angle out of range: {} at days={}",
+                angle_rad,
                 days
             );
         }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -114,6 +114,10 @@ pub fn ephemeris_update_system(
     };
     let tdb_jd = sim_time.tdb_julian_date();
     for (ephem_body, mut source_pos, source_vel, trans_state) in &mut query {
+        // Phase 1 (#103): the `DVec3` accessor is deprecated; migration
+        // to `get_state_typed` happens in Phase 3+ once downstream state
+        // storage is typed.
+        #[allow(deprecated)]
         let (pos, vel) = eph
             .get_state(ephem_body.target, ephem_body.observer, tdb_jd)
             .unwrap_or_else(|e| {

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -442,6 +442,8 @@ fn tier3_bevy_mars_dawn() {
     };
 
     let eph_init = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_rel_mars, _) = eph_init
         .get_state(EphemerisBody::Sun, EphemerisBody::Mars, J2000_JD)
         .expect("Sun wrt Mars at J2000");

--- a/tests/parity_helpers/mod.rs
+++ b/tests/parity_helpers/mod.rs
@@ -346,6 +346,8 @@ fn de421_ephemeris() -> &'static Ephemeris {
 
 /// Helper: load initial Sun position from DE421 at J2000 (cached ephemeris).
 pub fn sun_initial_pos() -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _vel) = de421_ephemeris()
         .get_earth_centered_state(EphemerisBody::Sun, J2000_JD)
         .expect("Sun state at J2000");
@@ -354,6 +356,8 @@ pub fn sun_initial_pos() -> DVec3 {
 
 /// Helper: load initial Moon position from DE421 at J2000 (cached ephemeris).
 pub fn moon_initial_pos() -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _vel) = de421_ephemeris()
         .get_earth_centered_state(EphemerisBody::Moon, J2000_JD)
         .expect("Moon state at J2000");


### PR DESCRIPTION
## Summary

Closes #103. Part of [#101](https://github.com/simnaut/bevy_jeod/issues/101).

Phase 1 of #101: each of the five leaf crates (no intra-workspace deps
on each other) gains typed `_typed` siblings to its existing `f64` /
`DVec3` accessors. Phase 1 is **additive** — every existing surface
remains intact and tests still pass — so callers in `jeod_math`,
`jeod_dynamics`, etc. compile unchanged. Phase 2 (#129 / #104) migrates
`jeod_math` against the retained f64 surfaces in parallel.

## Merged sub-PRs

| Commit | Sub-PR | Crate | Typed surface added |
|--------|--------|-------|---------------------|
| `7c99210` | (pre-fanout) | (all 5) | wire `jeod_quantities` dep + `pub use prelude` re-export |
| `c182287` | #130 | `jeod_planet` | `PlanetShape::{mu_typed, r_eq_typed, r_pol_typed}` (`GravParam`, `Length`) |
| `88bf9d9` | #131 | `jeod_atmosphere` | `AtmosphereState::{density_typed → MassDensity, temperature_typed → ThermodynamicTemperature, pressure_typed → Pressure, wind_typed → Velocity<Inertial>}` + typed `compute_corotation_wind` |
| `da5d9f0` | #132 | `jeod_test_data` | `ReferenceState::{position_typed → Position<Inertial>, velocity_typed → Velocity<Inertial>}`; `crossval.rs` typed assertion helpers |
| `97b9e21` | #133 | `jeod_time` | `SimulationTime::{tai, utc, ut1, tt, tdb, gps}() → SecondsSince<S>`; typed converter free functions; `TimeConverter<TAI, TT>` round-trip test |
| `9fea723` | #134 | `jeod_ephemeris` | `get_state_typed`, `get_earth_centered_state_typed`; old `DVec3` variants `#[doc(hidden)] #[deprecated]` |
| `d34f1b6` | (review) | `jeod_test_data` | replace `prelude::*` glob with explicit `F64Ext` import in `crossval.rs` (PR feedback) |

## Verification

- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --tests -- -D warnings`
- ✅ `cargo nextest run --workspace -E 'not test(tier3_)'` — 647 pass / 0 fail / 311 skipped
- ✅ Tier 3 baseline-invariance guard (#127) green; existing CSVs unchanged within tolerance.

## Depends on

- #127 (baseline-invariance CI guard) — merged.

## Test plan

- [x] CI `Lint & Format` passes
- [x] CI `Test (unit + tier 2)` passes
- [x] CI `Test (Tier 3 fast)` passes (each sub-PR ran the guard independently)
- [ ] CI `Test (Tier 3 full + earth_moon)` runs on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)