### PR TITLE
[Phase 2] Migrate jeod_math to typed jeod_quantities APIs (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,7 @@ dependencies = [
  "jeod_math",
  "jeod_planet",
  "jeod_test_data",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,7 @@ dependencies = [
  "jeod_quantities",
  "jeod_test_data",
  "thiserror 2.0.18",
+ "uom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,7 @@ dependencies = [
  "glam 0.30.10",
  "jeod_ephemeris",
  "jeod_planet",
+ "jeod_quantities",
  "jeod_test_data",
  "thiserror 2.0.18",
 ]

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -13,3 +13,4 @@ jeod_math = { path = "../jeod_math", features = ["test-utils"] }
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_gravity = { path = "../jeod_gravity" }
 jeod_planet = { path = "../jeod_planet" }
+sha2 = "0.10"

--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -10,7 +10,11 @@
 use crate::state::TranslationalState;
 use glam::{DMat3, DVec3};
 use jeod_math::OrbitalElements;
-use jeod_math::{compute_lvlh_frame, geodetic_to_cartesian, mat3_from_rows, GeodeticState};
+use jeod_math::{geodetic_to_cartesian, mat3_from_rows, GeodeticState};
+// `compute_lvlh_frame` is deprecated pending Phase 3 migration of this module
+// to the typed `compute_lvlh_frame_typed` API.
+#[allow(deprecated)]
+use jeod_math::compute_lvlh_frame;
 
 /// Initialize translational state from Keplerian orbital elements (true anomaly).
 ///
@@ -205,6 +209,7 @@ pub fn init_from_lvlh(
     ref_position: DVec3,
     ref_velocity: DVec3,
 ) -> TranslationalState {
+    #[allow(deprecated)]
     let lvlh = compute_lvlh_frame(ref_position, ref_velocity);
 
     // t_parent_this transforms from inertial to LVLH.
@@ -461,6 +466,7 @@ mod tests {
         let state = init_from_lvlh(lvlh_offset_pos, lvlh_offset_vel, ref_pos, ref_vel);
 
         // Now compute the LVLH frame at the reference orbit and transform back
+        #[allow(deprecated)]
         let lvlh = compute_lvlh_frame(ref_pos, ref_vel);
         let t = lvlh.t_parent_this;
 

--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -296,6 +296,9 @@ pub fn compute_ned_rotation(lat: f64, lon: f64) -> DMat3 {
 }
 
 #[cfg(test)]
+// Phase 2 #104: local tests call deprecated jeod_math OrbitalElements::from_cartesian.
+// Migration to from_cartesian_typed is deferred to Phase 3+.
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::f64::consts::PI;

--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -10,11 +10,11 @@
 use crate::state::TranslationalState;
 use glam::{DMat3, DVec3};
 use jeod_math::OrbitalElements;
-use jeod_math::{geodetic_to_cartesian, mat3_from_rows, GeodeticState};
-// `compute_lvlh_frame` is deprecated pending Phase 3 migration of this module
-// to the typed `compute_lvlh_frame_typed` API.
+use jeod_math::{mat3_from_rows, GeodeticState};
+// `compute_lvlh_frame` and `geodetic_to_cartesian` are deprecated pending
+// Phase 3 migration of this module to the typed `_typed` APIs.
 #[allow(deprecated)]
-use jeod_math::compute_lvlh_frame;
+use jeod_math::{compute_lvlh_frame, geodetic_to_cartesian};
 
 /// Initialize translational state from Keplerian orbital elements (true anomaly).
 ///
@@ -253,6 +253,7 @@ pub fn init_from_ned(
     omega_planet: DVec3,
 ) -> TranslationalState {
     // Convert geodetic to PCPF cartesian
+    #[allow(deprecated)]
     let pcpf_pos = geodetic_to_cartesian(geodetic, r_eq, r_pol);
 
     // Compute NED-to-PCPF rotation at this geodetic location.

--- a/crates/jeod_dynamics/tests/integrator_bit_match.rs
+++ b/crates/jeod_dynamics/tests/integrator_bit_match.rs
@@ -1,0 +1,89 @@
+//! Bit-identity regression test for the RK4 Kepler propagation path.
+//!
+//! Issue #101's type-system refactor wraps f64 computations in uom/typed
+//! newtypes. We expect these wrappers to be zero-cost — the compiler's
+//! IR should be byte-identical pre/post wrapping. This test pins a SHA-256
+//! of the integrator's output to catch any reordering that would shift
+//! downstream Tier 3 baselines.
+//!
+//! If this test fails after a refactor-only commit, investigate *before*
+//! refreezing the hash: the Tier 3 baselines.json is downstream of this.
+
+use glam::DVec3;
+use jeod_dynamics::{rk4_translational_step, TranslationalState};
+use sha2::{Digest, Sha256};
+
+/// Earth gravitational parameter (m^3/s^2), same literal used elsewhere in the
+/// workspace (e.g. `examples/kepler_orbit.rs`).
+const MU_EARTH: f64 = 3.986_004_415e14;
+
+/// Number of RK4 steps to take. 1000 steps at 60 s each = 60000 s ≈ 2.9 ISS
+/// orbits, exercising many integration rounds without being test-time costly.
+const NUM_STEPS: usize = 1000;
+
+/// Fixed integration step size (seconds).
+const DT: f64 = 60.0;
+
+/// Pinned SHA-256 of the canonical byte representation of the final state.
+/// See the module docstring: update only after verifying that an IR change is
+/// intentional.
+const PINNED_HASH: &str = "7b87ea77d0f00400664c6f9711375362e050346ad5a086fa7db59b44e0f0b037";
+
+/// Point-mass Earth gravity acceleration (two-body Kepler problem).
+fn kepler_accel(state: &TranslationalState, _time_frac: f64) -> DVec3 {
+    let r = state.position.length();
+    -MU_EARTH / (r * r * r) * state.position
+}
+
+/// Format a single f64 as a lossless decimal string. The `{:.17e}` format
+/// guarantees round-trip equality for finite f64 values, so the hash depends
+/// only on the numerical value, not on endianness or host-architecture
+/// in-memory layout.
+fn fmt(v: f64) -> String {
+    format!("{:.17e}", v)
+}
+
+#[test]
+fn rk4_kepler_bit_match() {
+    // ISS-like circular initial conditions (SI units). Chosen to match the
+    // profile used in `examples/kepler_orbit.rs`: a ~400 km altitude equatorial
+    // orbit.
+    let mut state = TranslationalState {
+        position: DVec3::new(6_778_137.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7_668.589_305_449_398, 0.0),
+    };
+
+    for _ in 0..NUM_STEPS {
+        state = rk4_translational_step(&state, kepler_accel, DT);
+    }
+
+    // Canonical byte representation: six f64 components in fixed order,
+    // each formatted as `{:.17e}` and newline-separated (trailing newline).
+    let mut canonical = String::with_capacity(6 * 25);
+    canonical.push_str(&fmt(state.position.x));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.position.y));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.position.z));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.velocity.x));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.velocity.y));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.velocity.z));
+    canonical.push('\n');
+
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let hash_bytes = hasher.finalize();
+    let hash_hex: String = hash_bytes.iter().map(|b| format!("{b:02x}")).collect();
+
+    assert_eq!(
+        hash_hex, PINNED_HASH,
+        "RK4 Kepler bit-identity regression: the integrator output changed.\n\
+         Canonical bytes follow — investigate *before* refreezing the hash.\n\
+         ----- BEGIN CANONICAL BYTES -----\n\
+         {canonical}\
+         ----- END CANONICAL BYTES -----",
+    );
+}

--- a/crates/jeod_gravity/tests/j2_regression.rs
+++ b/crates/jeod_gravity/tests/j2_regression.rs
@@ -58,9 +58,12 @@ fn j2_nodal_regression_rate() {
     }
 
     // Compute RAAN at start and end
+    // Phase 2 #104: from_cartesian is deprecated; migration deferred to Phase 3+.
+    #[allow(deprecated)]
     let elems_start =
         OrbitalElements::from_cartesian(mu, state_initial.position, state_initial.velocity)
             .unwrap();
+    #[allow(deprecated)]
     let elems_end = OrbitalElements::from_cartesian(mu, state.position, state.velocity).unwrap();
 
     let raan_start = elems_start.long_asc_node;

--- a/crates/jeod_interactions/tests/integration_physics.rs
+++ b/crates/jeod_interactions/tests/integration_physics.rs
@@ -15,6 +15,7 @@ use jeod_interactions::{
     compute_shadow_fraction, solar_flux_at_distance, DragConfig, FlatPlate, FlatPlateParams,
     FlatPlateThermal, SOLAR_RADIUS,
 };
+#[allow(deprecated)]
 use jeod_math::geodetic::cartesian_to_geodetic;
 use jeod_math::JeodQuat;
 
@@ -93,6 +94,7 @@ fn drag_causes_altitude_decay() {
                     -sin_g * s.position.x + cos_g * s.position.y,
                     s.position.z,
                 );
+                #[allow(deprecated)]
                 let geo = cartesian_to_geodetic(pfix, R_EARTH, R_EARTH_POL);
                 let atmos_state =
                     atmos.density(geo.altitude / 1000.0, geo.latitude, geo.longitude, tjt);

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 thiserror = { workspace = true }
+uom = { workspace = true }
 
 [features]
 test-utils = []

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -15,4 +15,7 @@ test-utils = []
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_ephemeris = { path = "../jeod_ephemeris" }
 jeod_planet = { path = "../jeod_planet" }
+# `test-utils` exposes `jeod_quantities::frame::TestVehicle` for inline tests
+# that need a phantom vehicle tag (Vehicle is sealed in production).
+jeod_quantities = { path = "../jeod_quantities", features = ["test-utils"] }
 

--- a/crates/jeod_math/src/euler_angles.rs
+++ b/crates/jeod_math/src/euler_angles.rs
@@ -198,7 +198,7 @@ pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSeq
         let mut data = [0.0_f64; 4];
         data[0] = cosht;
         data[1 + axes[ii]] = -sinht; // data[1..4] maps to vector[0..3]
-        q[ii] = JeodQuat { data };
+        q[ii] = JeodQuat::from_array(data);
     }
 
     // Reverse-order product: q[2] * q[1], then that * q[0].

--- a/crates/jeod_math/src/euler_angles.rs
+++ b/crates/jeod_math/src/euler_angles.rs
@@ -3,10 +3,22 @@
 //! Faithful port of JEOD `models/utils/orientation/src/euler_angles.cc`.
 //! Supports all 12 Euler rotation sequences (6 Tait-Bryan / aerodynamic,
 //! 6 proper Euler / astronomical).
+//!
+//! Two parallel surfaces are exposed:
+//! * the historical bare-`f64` entry points (radians, deprecated), and
+//! * the typed sibling APIs that accept/return `uom::si::f64::Angle` and
+//!   hand out a [`NormalizedQuat`] witness for the quaternion builder so
+//!   downstream code can bind the unit-norm precondition at the type level.
+//!
+//! The two surfaces share their numeric implementation, so the typed
+//! variants are bit-identical to the bare-`f64` ones at equal inputs.
 
 use crate::quaternion::JeodQuat;
 use crate::types::DMat3;
+use jeod_quantities::quat::{LeftTransform, NormalizedQuat, ScalarFirst};
 use std::f64::consts::{FRAC_PI_2, PI};
+use uom::si::angle::radian;
+use uom::si::f64::Angle;
 
 // ---------------------------------------------------------------------------
 // EulerSequence enum
@@ -174,15 +186,15 @@ fn t(trans: &DMat3, row: usize, col: usize) -> f64 {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Shared implementations (private). Both the bare-`f64` and typed public
+// entry points dispatch to these helpers so the two surfaces remain
+// bit-identical at equal numeric inputs.
 // ---------------------------------------------------------------------------
 
-/// Build a left-transformation quaternion from Euler angles.
-///
-/// Port of `euler_angles.cc:121-153`.
-/// Constructs three simple quaternions (one per rotation axis) and multiplies
-/// in reverse order: `result = q[2] * q[1] * q[0]`, then normalizes.
-pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> JeodQuat {
+fn compute_quaternion_from_euler_angles_impl(
+    angles: [f64; 3],
+    sequence: EulerSequence,
+) -> JeodQuat {
     let info = &EULER_INFO[sequence as usize];
     let axes = &info.indices;
 
@@ -208,12 +220,7 @@ pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSeq
     result
 }
 
-/// Build a left-transformation matrix from Euler angles.
-///
-/// Port of `euler_angles.cc:164-218`.
-/// Constructs three elementary rotation matrices and multiplies in reverse
-/// order: `result = m[2] * m[1] * m[0]`.
-pub fn compute_matrix_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> DMat3 {
+fn compute_matrix_from_euler_angles_impl(angles: [f64; 3], sequence: EulerSequence) -> DMat3 {
     let info = &EULER_INFO[sequence as usize];
     let axes = &info.indices;
 
@@ -270,11 +277,7 @@ pub fn compute_matrix_from_euler_angles(angles: [f64; 3], sequence: EulerSequenc
     m21 * m0
 }
 
-/// Extract Euler angles from a left-transformation matrix.
-///
-/// Port of `euler_angles.cc:297-464`.
-/// Returns `[phi, theta, psi]` in radians.
-pub fn compute_euler_angles_from_matrix(trans: &DMat3, sequence: EulerSequence) -> [f64; 3] {
+fn compute_euler_angles_from_matrix_impl(trans: &DMat3, sequence: EulerSequence) -> [f64; 3] {
     let info = &EULER_INFO[sequence as usize];
 
     // Extract theta_val: trans[info.indices[2]][info.indices[0]]
@@ -363,15 +366,152 @@ pub fn compute_euler_angles_from_matrix(trans: &DMat3, sequence: EulerSequence) 
     [phi, theta, psi]
 }
 
+// ---------------------------------------------------------------------------
+// Public API — bare-`f64` surface (deprecated, removed in Phase 10 of #101).
+// ---------------------------------------------------------------------------
+
+/// Build a left-transformation quaternion from Euler angles (radians).
+///
+/// Port of `euler_angles.cc:121-153`. Constructs three simple quaternions
+/// (one per rotation axis) and multiplies in reverse order:
+/// `result = q[2] * q[1] * q[0]`, then normalizes.
+///
+/// **Deprecated:** use [`compute_quaternion_from_euler_angles_typed`], which
+/// accepts `uom` `Angle`s and returns a [`NormalizedQuat`] witness.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_quaternion_from_euler_angles_typed; f64 variant removed in Phase 10"
+)]
+pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> JeodQuat {
+    compute_quaternion_from_euler_angles_impl(angles, sequence)
+}
+
+/// Build a left-transformation matrix from Euler angles (radians).
+///
+/// Port of `euler_angles.cc:164-218`. Constructs three elementary rotation
+/// matrices and multiplies in reverse order: `result = m[2] * m[1] * m[0]`.
+///
+/// **Deprecated:** use [`compute_matrix_from_euler_angles_typed`], which
+/// accepts `uom` `Angle`s.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_matrix_from_euler_angles_typed; f64 variant removed in Phase 10"
+)]
+pub fn compute_matrix_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> DMat3 {
+    compute_matrix_from_euler_angles_impl(angles, sequence)
+}
+
+/// Extract Euler angles (radians) from a left-transformation matrix.
+///
+/// Port of `euler_angles.cc:297-464`. Returns `[phi, theta, psi]` in radians.
+///
+/// **Deprecated:** use [`compute_euler_angles_from_matrix_typed`], which
+/// returns `uom` `Angle`s.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_euler_angles_from_matrix_typed; f64 variant removed in Phase 10"
+)]
+pub fn compute_euler_angles_from_matrix(trans: &DMat3, sequence: EulerSequence) -> [f64; 3] {
+    compute_euler_angles_from_matrix_impl(trans, sequence)
+}
+
+// ---------------------------------------------------------------------------
+// Public API — typed surface (uom `Angle`s + `NormalizedQuat` witness).
+// ---------------------------------------------------------------------------
+
+/// Typed sibling of [`compute_quaternion_from_euler_angles`].
+///
+/// Accepts a triple of `uom::si::f64::Angle` values and returns a
+/// [`NormalizedQuat`] witness of the resulting left-transformation
+/// quaternion. The inner [`JeodQuat`] is bit-identical to the value
+/// returned by the bare-`f64` variant when the same angles are supplied in
+/// radians, so both surfaces agree on every representable input.
+///
+/// The underlying `compute_quaternion_from_euler_angles_impl` applies
+/// JEOD's Padé-based `normalize()` before returning, so the witness is
+/// constructed via [`NormalizedQuat::new`]: the norm is checked against
+/// `NormalizedQuat::DEFAULT_TOLERANCE` (1e-12), which is comfortably
+/// wider than floating-point round-off on a post-normalization quaternion.
+/// Panics only if that tolerance is violated — i.e. if the underlying
+/// normalization routine is itself broken.
+pub fn compute_quaternion_from_euler_angles_typed(
+    angles: [Angle; 3],
+    sequence: EulerSequence,
+) -> NormalizedQuat<ScalarFirst, LeftTransform> {
+    let radians = [
+        angles[0].get::<radian>(),
+        angles[1].get::<radian>(),
+        angles[2].get::<radian>(),
+    ];
+    let q = compute_quaternion_from_euler_angles_impl(radians, sequence);
+    NormalizedQuat::new(q).unwrap_or_else(|err| {
+        panic!("compute_quaternion_from_euler_angles_impl returns a normalized quaternion: {err}")
+    })
+}
+
+/// Typed sibling of [`compute_matrix_from_euler_angles`].
+///
+/// Accepts a triple of `uom::si::f64::Angle` values and returns the raw
+/// `DMat3` transformation matrix. Bit-identical to the bare-`f64` variant
+/// given the same angles (in radians).
+pub fn compute_matrix_from_euler_angles_typed(
+    angles: [Angle; 3],
+    sequence: EulerSequence,
+) -> DMat3 {
+    let radians = [
+        angles[0].get::<radian>(),
+        angles[1].get::<radian>(),
+        angles[2].get::<radian>(),
+    ];
+    compute_matrix_from_euler_angles_impl(radians, sequence)
+}
+
+/// Typed sibling of [`compute_euler_angles_from_matrix`].
+///
+/// Returns a triple of `uom::si::f64::Angle` values carrying the radian
+/// results of the JEOD extraction algorithm. Bit-identical numerically to
+/// the bare-`f64` variant.
+pub fn compute_euler_angles_from_matrix_typed(
+    trans: &DMat3,
+    sequence: EulerSequence,
+) -> [Angle; 3] {
+    let [phi, theta, psi] = compute_euler_angles_from_matrix_impl(trans, sequence);
+    [
+        Angle::new::<radian>(phi),
+        Angle::new::<radian>(theta),
+        Angle::new::<radian>(psi),
+    ]
+}
+
+/// Build a left-transformation matrix from a witnessed unit-norm quaternion.
+///
+/// Preferred entry point for new callers: gates the unit-norm precondition
+/// at the type level instead of relying on callers remembering to
+/// renormalize after integration. Delegates to
+/// [`NormalizedQuat::left_quat_to_transformation`], which applies the JEOD
+/// `quaternion_to_matrix.cc` formula on the witnessed payload.
+pub fn quaternion_to_matrix_normalized(q: NormalizedQuat<ScalarFirst, LeftTransform>) -> DMat3 {
+    q.left_quat_to_transformation()
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
 
 #[cfg(test)]
 mod tests {
+    // Existing tests intentionally exercise the bare-`f64` public surface so
+    // the deprecated and typed entry points stay covered together through
+    // the Phase 10 removal.
+    #![allow(deprecated)]
+
     use super::*;
     use crate::test_utils::{approx_eq_f64, approx_eq_mat3};
     use glam::DVec3;
+    use uom::si::angle::radian;
 
     const TOL: f64 = 1e-14;
 
@@ -689,6 +829,168 @@ mod tests {
                 approx_eq_mat3(&t, &reconstructed, 1e-14),
                 "JEOD matrix round-trip for {seq:?} exceeds 1e-14: diff = {:.4e}",
                 max_mat_diff(&t, &reconstructed),
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Typed API (uom `Angle` + NormalizedQuat witness)
+    // -------------------------------------------------------------------
+
+    /// Build a `[Angle; 3]` from three radian values without cluttering
+    /// the assertion tests.
+    fn angles_rad(phi: f64, theta: f64, psi: f64) -> [Angle; 3] {
+        [
+            Angle::new::<radian>(phi),
+            Angle::new::<radian>(theta),
+            Angle::new::<radian>(psi),
+        ]
+    }
+
+    /// A non-trivial angle triple per `EulerSequence`. All chosen to stay
+    /// away from 0°, ±90°, ±180° so the extraction algorithm's gimbal-lock
+    /// branch is avoided and the raw radian angles round-trip cleanly.
+    fn non_trivial_angles_for(seq: EulerSequence) -> [f64; 3] {
+        if EULER_INFO[seq as usize].is_aerodynamics_sequence {
+            // Aero sequences fully round-trip angles for non-singular theta.
+            [0.3_f64, 0.4, 0.5]
+        } else {
+            // Astro (proper-Euler) sequences have theta in (0, pi). Pick
+            // angles well clear of both ends.
+            [0.3_f64, 0.9, 0.5]
+        }
+    }
+
+    #[test]
+    fn typed_roundtrip_all_sequences() {
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed_in = angles_rad(raw[0], raw[1], raw[2]);
+
+            let mat = compute_matrix_from_euler_angles_typed(typed_in, seq);
+            let extracted = compute_euler_angles_from_matrix_typed(&mat, seq);
+
+            // Aero sequences recover the exact input angles; astro sequences
+            // are allowed to drift as long as the matrix reconstructs.
+            if EULER_INFO[seq as usize].is_aerodynamics_sequence {
+                for i in 0..3 {
+                    let err = (extracted[i] - typed_in[i]).get::<radian>().abs();
+                    assert!(
+                        err < 1e-13,
+                        "typed roundtrip {seq:?}: angle[{i}] err = {err:.4e} rad"
+                    );
+                }
+            }
+
+            let mat2 = compute_matrix_from_euler_angles_typed(extracted, seq);
+            assert!(
+                approx_eq_mat3(&mat, &mat2, 1e-13),
+                "typed roundtrip matrix mismatch for {seq:?}: diff = {:.4e}",
+                {
+                    let mut d = 0.0_f64;
+                    for c in 0..3 {
+                        for r in 0..3 {
+                            d = d.max((mat.col(c)[r] - mat2.col(c)[r]).abs());
+                        }
+                    }
+                    d
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn typed_matrix_bit_identical_to_f64() {
+        // The typed path must produce exactly the same DMat3 as the
+        // bare-`f64` path for every sequence, given equal numeric inputs.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed = angles_rad(raw[0], raw[1], raw[2]);
+
+            let mat_typed = compute_matrix_from_euler_angles_typed(typed, seq);
+            let mat_f64 = compute_matrix_from_euler_angles(
+                [
+                    typed[0].get::<radian>(),
+                    typed[1].get::<radian>(),
+                    typed[2].get::<radian>(),
+                ],
+                seq,
+            );
+
+            for c in 0..3 {
+                for r in 0..3 {
+                    assert_eq!(
+                        mat_typed.col(c)[r].to_bits(),
+                        mat_f64.col(c)[r].to_bits(),
+                        "{seq:?}: matrix element [{r}][{c}] differs bit-wise",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn typed_angles_bit_identical_to_f64() {
+        // Extract both via typed and f64 from the same matrix and check
+        // the resulting angle triples are bit-identical.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let mat = compute_matrix_from_euler_angles(raw, seq);
+
+            let from_typed = compute_euler_angles_from_matrix_typed(&mat, seq);
+            let from_f64 = compute_euler_angles_from_matrix(&mat, seq);
+
+            for i in 0..3 {
+                assert_eq!(
+                    from_typed[i].get::<radian>().to_bits(),
+                    from_f64[i].to_bits(),
+                    "{seq:?}: angle[{i}] differs bit-wise",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn typed_quaternion_bit_identical_to_f64() {
+        // The typed quaternion builder must return a NormalizedQuat whose
+        // inner JeodQuat is bit-identical to the f64 variant's output.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed = angles_rad(raw[0], raw[1], raw[2]);
+
+            let q_typed = compute_quaternion_from_euler_angles_typed(typed, seq);
+            let q_f64 = compute_quaternion_from_euler_angles(raw, seq);
+
+            let inner = q_typed.inner();
+            for i in 0..4 {
+                assert_eq!(
+                    inner.data[i].to_bits(),
+                    q_f64.data[i].to_bits(),
+                    "{seq:?}: quaternion data[{i}] differs bit-wise",
+                );
+            }
+
+            // The NormalizedQuat witness implies unit norm; sanity-check
+            // this rather than leave it implicit.
+            assert!((inner.norm() - 1.0).abs() < 1e-14);
+        }
+    }
+
+    #[test]
+    fn quaternion_to_matrix_normalized_matches_f64_matrix() {
+        // The new matrix-conversion entry point gated on NormalizedQuat
+        // must agree with the bare-`f64` matrix constructor.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed = angles_rad(raw[0], raw[1], raw[2]);
+
+            let q = compute_quaternion_from_euler_angles_typed(typed, seq);
+            let mat_from_quat = quaternion_to_matrix_normalized(q);
+            let mat_direct = compute_matrix_from_euler_angles_typed(typed, seq);
+
+            assert!(
+                approx_eq_mat3(&mat_from_quat, &mat_direct, 1e-14),
+                "{seq:?}: NormalizedQuat-gated matrix disagrees with typed Euler->matrix",
             );
         }
     }

--- a/crates/jeod_math/src/geodetic.rs
+++ b/crates/jeod_math/src/geodetic.rs
@@ -5,8 +5,24 @@
 //! - Cartesian (PCPF) <-> spherical (latitude, longitude, altitude)
 //!
 //! All coordinates are in the planet-centered planet-fixed (PCPF) frame.
+//!
+//! Two API flavors are provided:
+//! - The original `f64` variants (`cartesian_to_geodetic`, `geodetic_to_cartesian`)
+//!   operate on raw `DVec3` / `f64` and are retained for backward compatibility.
+//!   They are deprecated and slated for removal in Phase 10 of the type-system
+//!   refactor (#101).
+//! - The typed sibling variants (`cartesian_to_geodetic_typed`,
+//!   `geodetic_to_cartesian_typed`) accept/return `jeod_quantities` typed
+//!   quantities (`Position<PlanetFixed<P>>`, `Length`, `Angle`), giving
+//!   frame-tagged, unit-safe signatures.
 
 use glam::DVec3;
+use jeod_quantities::aliases::Position;
+use jeod_quantities::frame::{Planet, PlanetFixed};
+use jeod_quantities::qty3::Qty3;
+use uom::si::angle::radian;
+use uom::si::f64::{Angle, Length};
+use uom::si::length::meter;
 
 /// Maximum iterations for Borkowski's geodetic latitude solver.
 /// Matches JEOD `PlanetFixedPosition::Max_iteration_limit` (class-level constant).
@@ -18,6 +34,43 @@ pub struct GeodeticState {
     pub latitude: f64,  // rad, geodetic latitude
     pub longitude: f64, // rad, geodetic longitude
     pub altitude: f64,  // m, height above reference ellipsoid
+}
+
+/// Typed geodetic coordinates on a reference ellipsoid.
+///
+/// Companion to [`GeodeticState`] carrying `uom` dimensioned scalars so
+/// signatures expressed with this type are unit-safe.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct GeodeticStateTyped {
+    /// Geodetic latitude (positive north, range ±π/2).
+    pub latitude: Angle,
+    /// Geodetic longitude (positive east).
+    pub longitude: Angle,
+    /// Height above the reference ellipsoid.
+    pub altitude: Length,
+}
+
+impl GeodeticStateTyped {
+    /// Construct a typed state from an untyped [`GeodeticState`] assuming the
+    /// stored components are in radians/meters (their documented base units).
+    #[inline]
+    pub fn from_raw(state: GeodeticState) -> Self {
+        Self {
+            latitude: Angle::new::<radian>(state.latitude),
+            longitude: Angle::new::<radian>(state.longitude),
+            altitude: Length::new::<meter>(state.altitude),
+        }
+    }
+
+    /// Lower a typed state back to the raw [`GeodeticState`] (radians/meters).
+    #[inline]
+    pub fn into_raw(self) -> GeodeticState {
+        GeodeticState {
+            latitude: self.latitude.get::<radian>(),
+            longitude: self.longitude.get::<radian>(),
+            altitude: self.altitude.get::<meter>(),
+        }
+    }
 }
 
 /// Spherical coordinates relative to a spherical planet.
@@ -78,6 +131,11 @@ pub fn spherical_to_cartesian(sph: &SphericalState, r_eq: f64) -> DVec3 {
 /// * `cart` - Cartesian position in PCPF frame (m)
 /// * `r_eq` - Equatorial radius (m)
 /// * `r_pol` - Polar radius (m)
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use cartesian_to_geodetic_typed; f64 variant removed in Phase 10"
+)]
 pub fn cartesian_to_geodetic(cart: DVec3, r_eq: f64, r_pol: f64) -> GeodeticState {
     // JEOD_INV: PF.02 — input must be NaN/Inf free
     // JEOD planet_fixed_posn.cc:155-162: check for NaN/Inf before proceeding.
@@ -184,6 +242,11 @@ fn get_elliptic_parameters(r: f64, z: f64, r_eq: f64, r_pol: f64) -> (f64, f64) 
 /// * `geo` - Geodetic coordinates (latitude rad, longitude rad, altitude m)
 /// * `r_eq` - Equatorial radius (m)
 /// * `r_pol` - Polar radius (m)
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use geodetic_to_cartesian_typed; f64 variant removed in Phase 10"
+)]
 pub fn geodetic_to_cartesian(geo: &GeodeticState, r_eq: f64, r_pol: f64) -> DVec3 {
     let sin_lat = geo.latitude.sin();
     let cos_lat = geo.latitude.cos();
@@ -204,9 +267,48 @@ pub fn geodetic_to_cartesian(geo: &GeodeticState, r_eq: f64, r_pol: f64) -> DVec
     )
 }
 
+/// Typed sibling of [`cartesian_to_geodetic`]. Accepts a planet-fixed
+/// position and returns a dimensionally-typed [`GeodeticStateTyped`].
+///
+/// Bit-identical to [`cartesian_to_geodetic`] — this is a thin wrapper that
+/// unwraps `Position<PlanetFixed<P>>` to its SI `DVec3` representation,
+/// delegates to the f64 implementation, and re-wraps the scalar outputs.
+///
+/// The planet is carried only as a compile-time phantom tag on the input
+/// frame; the ellipsoid dimensions are supplied numerically via `r_eq` /
+/// `r_pol` (matching the existing f64 API). The geodetic representation is
+/// defined with respect to the body-fixed frame of the named planet.
+pub fn cartesian_to_geodetic_typed<P: Planet>(
+    pos: Position<PlanetFixed<P>>,
+    r_eq: Length,
+    r_pol: Length,
+) -> GeodeticStateTyped {
+    #[allow(deprecated)]
+    let raw = cartesian_to_geodetic(pos.raw_si(), r_eq.get::<meter>(), r_pol.get::<meter>());
+    GeodeticStateTyped::from_raw(raw)
+}
+
+/// Typed sibling of [`geodetic_to_cartesian`]. Returns a planet-fixed
+/// position parameterized by the planet tag `P`.
+///
+/// Bit-identical to [`geodetic_to_cartesian`].
+pub fn geodetic_to_cartesian_typed<P: Planet>(
+    state: GeodeticStateTyped,
+    r_eq: Length,
+    r_pol: Length,
+) -> Position<PlanetFixed<P>> {
+    let raw_state = state.into_raw();
+    #[allow(deprecated)]
+    let cart = geodetic_to_cartesian(&raw_state, r_eq.get::<meter>(), r_pol.get::<meter>());
+    Qty3::from_raw_si(cart)
+}
+
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
+    use jeod_quantities::ext::F64Ext;
+    use jeod_quantities::frame::Earth;
     use std::f64::consts::PI;
 
     const EARTH_R_EQ: f64 = 6_378_137.0; // WGS84 equatorial radius (m)
@@ -403,5 +505,88 @@ mod tests {
             assert!(lon_err < 1e-10, "{label}: longitude error = {lon_err}");
             assert!(alt_err < 1e-6, "{label}: altitude error = {alt_err} m");
         }
+    }
+
+    // =================================================================
+    // Typed API tests
+    // =================================================================
+
+    /// ISS altitude landmark: typed round-trip (geodetic -> cartesian -> geodetic)
+    /// must close to <1e-14 rad / <1e-9 m.
+    #[test]
+    fn typed_round_trip_iss_landmark() {
+        // ISS-like: 51.6° N, 30° E, 408 km above WGS84 ellipsoid.
+        let original = GeodeticStateTyped {
+            latitude: 51.6.deg(),
+            longitude: 30.0.deg(),
+            altitude: 408_000.0.m(),
+        };
+        let r_eq = EARTH_R_EQ.m();
+        let r_pol = EARTH_R_POL.m();
+
+        let cart: Position<PlanetFixed<Earth>> = geodetic_to_cartesian_typed(original, r_eq, r_pol);
+        let recovered = cartesian_to_geodetic_typed(cart, r_eq, r_pol);
+
+        let lat_err =
+            (recovered.latitude.get::<radian>() - original.latitude.get::<radian>()).abs();
+        let lon_err =
+            (recovered.longitude.get::<radian>() - original.longitude.get::<radian>()).abs();
+        let alt_err = (recovered.altitude.get::<meter>() - original.altitude.get::<meter>()).abs();
+
+        assert!(lat_err < 1e-14, "lat err = {lat_err}");
+        assert!(lon_err < 1e-14, "lon err = {lon_err}");
+        assert!(alt_err < 1e-9, "alt err = {alt_err} m");
+    }
+
+    /// The typed and f64 entry points must be bit-identical for the
+    /// underlying scalar components.
+    #[test]
+    fn typed_matches_f64_cartesian_to_geodetic() {
+        // Non-trivial position to exercise non-zero lat/lon/alt components.
+        let raw_pos = DVec3::new(4_500_000.0, -2_800_000.0, 3_700_000.0);
+        let pos: Position<PlanetFixed<Earth>> = Qty3::from_raw_si(raw_pos);
+
+        let f64_result = cartesian_to_geodetic(raw_pos, EARTH_R_EQ, EARTH_R_POL);
+        let typed_result = cartesian_to_geodetic_typed(pos, EARTH_R_EQ.m(), EARTH_R_POL.m());
+
+        // Bit-identical: same numerical operation, just unit-wrapped.
+        assert_eq!(typed_result.latitude.get::<radian>(), f64_result.latitude);
+        assert_eq!(typed_result.longitude.get::<radian>(), f64_result.longitude);
+        assert_eq!(typed_result.altitude.get::<meter>(), f64_result.altitude);
+    }
+
+    /// Dual of the previous test for `geodetic_to_cartesian`.
+    #[test]
+    fn typed_matches_f64_geodetic_to_cartesian() {
+        let raw = GeodeticState {
+            latitude: 0.9,
+            longitude: -0.5,
+            altitude: 408_000.0,
+        };
+        let typed = GeodeticStateTyped::from_raw(raw);
+
+        let f64_cart = geodetic_to_cartesian(&raw, EARTH_R_EQ, EARTH_R_POL);
+        let typed_cart: Position<PlanetFixed<Earth>> =
+            geodetic_to_cartesian_typed(typed, EARTH_R_EQ.m(), EARTH_R_POL.m());
+
+        let typed_raw = typed_cart.raw_si();
+        assert_eq!(typed_raw.x, f64_cart.x);
+        assert_eq!(typed_raw.y, f64_cart.y);
+        assert_eq!(typed_raw.z, f64_cart.z);
+    }
+
+    /// `GeodeticStateTyped::from_raw` / `into_raw` must be inverses.
+    #[test]
+    fn typed_raw_conversion_round_trip() {
+        let raw = GeodeticState {
+            latitude: 0.123_456_789,
+            longitude: -1.987_654_321,
+            altitude: 12_345.678,
+        };
+        let typed = GeodeticStateTyped::from_raw(raw);
+        let back = typed.into_raw();
+        assert_eq!(raw.latitude, back.latitude);
+        assert_eq!(raw.longitude, back.longitude);
+        assert_eq!(raw.altitude, back.altitude);
     }
 }

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -24,7 +24,9 @@ pub use euler_angles::{
     compute_euler_angles_from_matrix, compute_matrix_from_euler_angles,
     compute_quaternion_from_euler_angles, EulerSequence, ALL_SEQUENCES,
 };
+#[allow(deprecated)]
 pub use geodetic::{cartesian_to_geodetic, geodetic_to_cartesian, GeodeticState};
+pub use geodetic::{cartesian_to_geodetic_typed, geodetic_to_cartesian_typed, GeodeticStateTyped};
 pub use jeod_quantities::{
     JeodQuat, Layout, LeftTransform, NormalizedQuat, Quat, RightTransform, ScalarFirst, ScalarLast,
     Transform,

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -1,3 +1,13 @@
+//! `jeod_math` — JEOD-faithful math kernels.
+//!
+//! Phase 2 of the type-system refactor (#104) unifies the quaternion type
+//! with [`jeod_quantities`]. `JeodQuat` is now a re-export of
+//! `jeod_quantities::JeodQuat` (the canonical `Quat<ScalarFirst,
+//! LeftTransform>` type alias), and all algebraic/conversion methods live
+//! on that unified type so there is only one quaternion in the workspace.
+
+pub use jeod_quantities::prelude::*;
+
 pub mod error;
 pub mod euler_angles;
 pub mod geodetic;
@@ -15,8 +25,11 @@ pub use euler_angles::{
     compute_quaternion_from_euler_angles, EulerSequence, ALL_SEQUENCES,
 };
 pub use geodetic::{cartesian_to_geodetic, geodetic_to_cartesian, GeodeticState};
+pub use jeod_quantities::{
+    JeodQuat, Layout, LeftTransform, NormalizedQuat, Quat, RightTransform, ScalarFirst, ScalarLast,
+    Transform,
+};
 pub use lvlh::{compute_lvlh_frame, LvlhFrame};
 pub use orbital_elements::OrbitalElements;
-pub use quaternion::JeodQuat;
 pub use solar_beta::solar_beta_angle;
 pub use types::*;

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -41,5 +41,7 @@ pub use jeod_quantities::{
 pub use lvlh::compute_lvlh_frame;
 pub use lvlh::{compute_lvlh_frame_typed, LvlhFrame};
 pub use orbital_elements::OrbitalElements;
+#[allow(deprecated)]
 pub use solar_beta::solar_beta_angle;
+pub use solar_beta::solar_beta_angle_typed;
 pub use types::*;

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -29,7 +29,9 @@ pub use jeod_quantities::{
     JeodQuat, Layout, LeftTransform, NormalizedQuat, Quat, RightTransform, ScalarFirst, ScalarLast,
     Transform,
 };
-pub use lvlh::{compute_lvlh_frame, LvlhFrame};
+#[allow(deprecated)]
+pub use lvlh::compute_lvlh_frame;
+pub use lvlh::{compute_lvlh_frame_typed, LvlhFrame};
 pub use orbital_elements::OrbitalElements;
 pub use solar_beta::solar_beta_angle;
 pub use types::*;

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -20,9 +20,15 @@ pub mod test_utils;
 pub mod types;
 
 pub use error::*;
+#[allow(deprecated)]
 pub use euler_angles::{
     compute_euler_angles_from_matrix, compute_matrix_from_euler_angles,
-    compute_quaternion_from_euler_angles, EulerSequence, ALL_SEQUENCES,
+    compute_quaternion_from_euler_angles,
+};
+pub use euler_angles::{
+    compute_euler_angles_from_matrix_typed, compute_matrix_from_euler_angles_typed,
+    compute_quaternion_from_euler_angles_typed, quaternion_to_matrix_normalized, EulerSequence,
+    ALL_SEQUENCES,
 };
 #[allow(deprecated)]
 pub use geodetic::{cartesian_to_geodetic, geodetic_to_cartesian, GeodeticState};

--- a/crates/jeod_math/src/lvlh.rs
+++ b/crates/jeod_math/src/lvlh.rs
@@ -136,13 +136,13 @@ where
     let lvlh = compute_lvlh_frame(position.raw_si(), velocity.raw_si());
 
     // Convert the transformation matrix T_parent_this (inertial → LVLH) into
-    // a canonical JEOD left quaternion, then wrap in a `NormalizedQuat`
-    // witness. JEOD's `left_quat_from_transformation` extractor always returns
-    // a unit-norm result (it re-normalizes internally), but we renormalize
-    // defensively in case of rounding near the threshold.
+    // a canonical JEOD left quaternion. JEOD's `left_quat_from_transformation`
+    // extractor already re-normalizes internally, so we wrap the result with
+    // `NormalizedQuat::new` — that witnesses the existing unit norm without
+    // re-dividing by `‖q‖`, preserving bit-identity with the f64 surface.
     let q: JeodQuat = JeodQuat::left_quat_from_transformation(&lvlh.t_parent_this);
-    let q_norm = NormalizedQuat::renormalize(q)
-        .expect("LVLH rotation matrix yields a finite, non-zero quaternion");
+    let q_norm = NormalizedQuat::new(q)
+        .unwrap_or_else(|err| panic!("left_quat_from_transformation guarantees unit norm: {err}"));
     FrameTransform::<Inertial, Lvlh<Chief>>::from_quat(q_norm)
 }
 

--- a/crates/jeod_math/src/lvlh.rs
+++ b/crates/jeod_math/src/lvlh.rs
@@ -11,6 +11,11 @@
 
 use glam::{DMat3, DVec3};
 
+use jeod_quantities::aliases::{Position, Velocity};
+use jeod_quantities::frame::{Inertial, Lvlh, Vehicle};
+use jeod_quantities::frame_transform::FrameTransform;
+use jeod_quantities::quat::{JeodQuat, NormalizedQuat};
+
 /// LVLH frame state: rotation matrix, angular velocity, and origin position/velocity.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LvlhFrame {
@@ -46,6 +51,11 @@ impl Default for LvlhFrame {
 ///
 /// # Panics
 /// Panics if position or angular momentum magnitude is zero.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_lvlh_frame_typed; f64 variant removed in Phase 10"
+)]
 pub fn compute_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     // Compute angular momentum vector: h = r × v
     let angmom = position.cross(velocity);
@@ -94,7 +104,50 @@ pub fn compute_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     }
 }
 
+/// Typed sibling of [`compute_lvlh_frame`]: returns a `FrameTransform` from
+/// the planet-centered inertial frame to the chief vehicle's LVLH frame.
+///
+/// Delegates to the f64-based computation, then wraps the resulting rotation
+/// matrix (`T_parent_this` — inertial → LVLH, rows are LVLH axes in the
+/// inertial frame) as a canonical JEOD scalar-first, left-transformation
+/// quaternion inside the `FrameTransform`.
+///
+/// Angular velocity, origin position, and origin velocity produced by the
+/// underlying LVLH computation are discarded here — this function returns
+/// only the frame orientation. Callers that need those auxiliary quantities
+/// should continue to use the (deprecated) f64 API until Phase 3+ migrates
+/// the full `LvlhFrame` struct to typed quantities.
+///
+/// # Arguments
+/// * `position` - Chief vehicle position in the planet-centered inertial frame.
+/// * `velocity` - Chief vehicle velocity in the planet-centered inertial frame.
+///
+/// # Panics
+/// Panics if position or angular momentum magnitude is zero (radial trajectory).
+pub fn compute_lvlh_frame_typed<Chief>(
+    position: Position<Inertial>,
+    velocity: Velocity<Inertial>,
+) -> FrameTransform<Inertial, Lvlh<Chief>>
+where
+    Chief: Vehicle,
+{
+    // Delegate to the f64-based port so physics stays in one place.
+    #[allow(deprecated)]
+    let lvlh = compute_lvlh_frame(position.raw_si(), velocity.raw_si());
+
+    // Convert the transformation matrix T_parent_this (inertial → LVLH) into
+    // a canonical JEOD left quaternion, then wrap in a `NormalizedQuat`
+    // witness. JEOD's `left_quat_from_transformation` extractor always returns
+    // a unit-norm result (it re-normalizes internally), but we renormalize
+    // defensively in case of rounding near the threshold.
+    let q: JeodQuat = JeodQuat::left_quat_from_transformation(&lvlh.t_parent_this);
+    let q_norm = NormalizedQuat::renormalize(q)
+        .expect("LVLH rotation matrix yields a finite, non-zero quaternion");
+    FrameTransform::<Inertial, Lvlh<Chief>>::from_quat(q_norm)
+}
+
 #[cfg(test)]
+#[allow(deprecated)] // existing f64 tests still exercise the deprecated API
 mod tests {
     use super::*;
 
@@ -217,5 +270,50 @@ mod tests {
         assert!(z_hat.x.abs() < 1e-14);
         assert!((z_hat.y + 1.0).abs() < 1e-14);
         assert!(z_hat.z.abs() < 1e-14);
+    }
+
+    // Re-alias the sealed-but-test-only chief marker from `jeod_quantities`.
+    // `Vehicle` is sealed, so we can't implement it here — the `test-utils`
+    // feature on `jeod_quantities` (dev-dep in our Cargo.toml) opens up
+    // `TestVehicle` specifically for tests like this.
+    use jeod_quantities::frame::TestVehicle as IssChief;
+
+    #[test]
+    fn typed_lvlh_matches_f64_port() {
+        // ISS-like inclined state in planet-centered inertial coordinates.
+        let r = 6_778_137.0; // ~ r_eq + 400 km
+        let v = (EARTH_MU / r).sqrt();
+        let inc = 51.6_f64.to_radians();
+
+        let position_raw = DVec3::new(r, 0.0, 0.0);
+        let velocity_raw = DVec3::new(0.0, v * inc.cos(), v * inc.sin());
+
+        // f64 baseline: derive the JEOD canonical quaternion from the old
+        // rotation-matrix output via the same extractor the typed variant uses.
+        let lvlh_f64 = compute_lvlh_frame(position_raw, velocity_raw);
+        let q_f64 = JeodQuat::left_quat_from_transformation(&lvlh_f64.t_parent_this);
+
+        // Typed sibling: build Position/Velocity and call compute_lvlh_frame_typed.
+        let position = Position::<Inertial>::from_raw_si(position_raw);
+        let velocity = Velocity::<Inertial>::from_raw_si(velocity_raw);
+        let xform = compute_lvlh_frame_typed::<IssChief>(position, velocity);
+
+        // Quaternion components must match bit-exactly — same extractor, same
+        // input matrix, same renormalization code path.
+        let q_typed = xform.quat().inner();
+        assert_eq!(
+            q_typed.data, q_f64.data,
+            "typed and f64 quaternion components must be bit-identical"
+        );
+
+        // Matrix cached inside the FrameTransform must round-trip through the
+        // quaternion → matrix derivation without drifting from orthonormality.
+        let m = xform.matrix();
+        let should_be_identity = m * m.transpose();
+        let diff = should_be_identity - DMat3::IDENTITY;
+        assert!(diff.x_axis.length() < 1e-14);
+        assert!(diff.y_axis.length() < 1e-14);
+        assert!(diff.z_axis.length() < 1e-14);
+        assert!((m.determinant() - 1.0).abs() < 1e-14);
     }
 }

--- a/crates/jeod_math/src/orbital_elements.rs
+++ b/crates/jeod_math/src/orbital_elements.rs
@@ -68,6 +68,11 @@ impl OrbitalElements {
     /// * `mu`  - gravitational parameter (units consistent with pos/vel, e.g. m^3/s^2)
     /// * `pos` - position vector
     /// * `vel` - velocity vector
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.0-phase-3",
+        note = "use from_cartesian_typed; f64 variant removed in Phase 10"
+    )]
     pub fn from_cartesian(
         mu: f64,
         pos: DVec3,
@@ -279,6 +284,25 @@ impl OrbitalElements {
         oe.nu_to_anomalies();
 
         Ok(oe)
+    }
+
+    /// Typed variant of [`from_cartesian`](Self::from_cartesian).
+    ///
+    /// Accepts dimensionally-typed inputs:
+    /// * `mu` — gravitational parameter in SI base units (m³/s²)
+    /// * `pos` — inertial-frame position in meters
+    /// * `vel` — inertial-frame velocity in m/s
+    ///
+    /// Output fields on [`OrbitalElements`] remain raw `f64` in SI base units
+    /// for this PR; typing the outputs is tracked separately in issue #104.
+    pub fn from_cartesian_typed(
+        mu: jeod_quantities::dims::GravParam,
+        pos: jeod_quantities::aliases::Position<jeod_quantities::frame::Inertial>,
+        vel: jeod_quantities::aliases::Velocity<jeod_quantities::frame::Inertial>,
+    ) -> Result<OrbitalElements, OrbitalError> {
+        // Extract SI base values and delegate to the existing f64 implementation.
+        #[allow(deprecated)]
+        Self::from_cartesian(mu.value, pos.raw_si(), vel.raw_si())
     }
 
     // ----------------------------------------------------------------
@@ -536,6 +560,7 @@ pub fn kep_eqtn_b(m: f64) -> f64 {
 // ====================================================================
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::types::DVec3;
@@ -1076,5 +1101,89 @@ mod tests {
             oe.true_anom,
             nu_diff
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Typed API: from_cartesian_typed
+    // ---------------------------------------------------------------
+    //
+    // These tests exercise the dimensionally-typed entry point. SI base
+    // units are required: m, m/s, m³/s². JEOD's Earth GM constant converted
+    // to SI from earth_GGM05C.cc:40 (398_600.441_50 km³/s² -> 3.986004415e14
+    // m³/s²).
+    #[test]
+    fn from_cartesian_typed_iss_like() {
+        use jeod_quantities::aliases::{Position, Velocity};
+        use jeod_quantities::ext::F64Ext;
+        use jeod_quantities::frame::Inertial;
+        use jeod_quantities::qty3::Qty3;
+
+        // ISS-ish: 408 km altitude circular orbit, SI units.
+        let mu_si: jeod_quantities::dims::GravParam = 3.986_004_415e14_f64.m3_per_s2();
+        let r = 6_779_000.0_f64; // m (~6371 + 408 km)
+        let v = (3.986_004_415e14_f64 / r).sqrt(); // m/s
+
+        // Qty3::from_raw_si wraps a DVec3 of SI-base-unit values in the
+        // typed frame-tagged envelope without any unit conversion.
+        let pos: Position<Inertial> = Qty3::from_raw_si(DVec3::new(r, 0.0, 0.0));
+        let vel: Velocity<Inertial> = Qty3::from_raw_si(DVec3::new(0.0, v, 0.0));
+
+        let oe = OrbitalElements::from_cartesian_typed(mu_si, pos, vel).unwrap();
+
+        // ISS-like semi-major axis falls in the 6.5e6 - 7.2e6 m band.
+        assert!(
+            oe.semi_major_axis > 6.5e6 && oe.semi_major_axis < 7.2e6,
+            "semi_major_axis {} out of ISS range [6.5e6, 7.2e6]",
+            oe.semi_major_axis
+        );
+        // Circular orbit has near-zero eccentricity.
+        assert!(
+            oe.e_mag < 1e-10,
+            "eccentricity should be ~0 for circular orbit, got {}",
+            oe.e_mag
+        );
+        // r_mag matches the input radius in meters.
+        assert!(
+            (oe.r_mag - r).abs() < 1e-6,
+            "r_mag should be ~{r}, got {}",
+            oe.r_mag
+        );
+    }
+
+    #[test]
+    fn from_cartesian_typed_matches_raw_bit_for_bit() {
+        use jeod_quantities::aliases::{Position, Velocity};
+        use jeod_quantities::ext::F64Ext;
+        use jeod_quantities::frame::Inertial;
+        use jeod_quantities::qty3::Qty3;
+
+        let mu_si: jeod_quantities::dims::GravParam = 3.986_004_415e14_f64.m3_per_s2();
+        // Mildly eccentric, slightly inclined ISS-ish state in SI units.
+        let pos_raw = DVec3::new(6_779_000.0, 0.0, 0.0);
+        let vel_raw = DVec3::new(0.0, 7_000.0, 1_500.0);
+
+        let pos: Position<Inertial> = Qty3::from_raw_si(pos_raw);
+        let vel: Velocity<Inertial> = Qty3::from_raw_si(vel_raw);
+
+        let oe_typed = OrbitalElements::from_cartesian_typed(mu_si, pos, vel).unwrap();
+        let oe_raw = OrbitalElements::from_cartesian(mu_si.value, pos_raw, vel_raw).unwrap();
+
+        // Bit-identical delegation: typed wrapper extracts SI values and calls
+        // the raw implementation — no intermediate arithmetic, so every field
+        // must match exactly.
+        assert_eq!(oe_typed.semi_major_axis, oe_raw.semi_major_axis);
+        assert_eq!(oe_typed.semiparam, oe_raw.semiparam);
+        assert_eq!(oe_typed.e_mag, oe_raw.e_mag);
+        assert_eq!(oe_typed.inclination, oe_raw.inclination);
+        assert_eq!(oe_typed.arg_periapsis, oe_raw.arg_periapsis);
+        assert_eq!(oe_typed.long_asc_node, oe_raw.long_asc_node);
+        assert_eq!(oe_typed.true_anom, oe_raw.true_anom);
+        assert_eq!(oe_typed.mean_anom, oe_raw.mean_anom);
+        assert_eq!(oe_typed.orbital_anom, oe_raw.orbital_anom);
+        assert_eq!(oe_typed.mean_motion, oe_raw.mean_motion);
+        assert_eq!(oe_typed.r_mag, oe_raw.r_mag);
+        assert_eq!(oe_typed.vel_mag, oe_raw.vel_mag);
+        assert_eq!(oe_typed.orb_energy, oe_raw.orb_energy);
+        assert_eq!(oe_typed.orb_ang_momentum, oe_raw.orb_ang_momentum);
     }
 }

--- a/crates/jeod_math/src/quaternion.rs
+++ b/crates/jeod_math/src/quaternion.rs
@@ -1,320 +1,45 @@
-use crate::types::{mat3_from_rows, DMat3, DQuat, DVec3};
+//! JEOD quaternion glue: re-exports the unified
+//! [`jeod_quantities::JeodQuat`] type and keeps JEOD-specific constants and
+//! free helpers that don't belong in the generic quantities crate.
+//!
+//! All algebraic and conversion methods (`identity`, `new`, `scalar`,
+//! `vector`, `conjugate`, `multiply`, `normalize`, glam round-trips,
+//! axis-angle construction, left-transform ↔ matrix conversions, Rodrigues
+//! vector transform) are inherent methods on
+//! [`Quat<ScalarFirst, LeftTransform>`] defined in
+//! `jeod_quantities::quat`. This module is intentionally small — it exists
+//! so downstream crates can continue to say `jeod_math::JeodQuat` and
+//! `jeod_math::quaternion::NORM_LIMIT` after the Phase 2 unification.
 
-/// Scalar-first, left-transformation quaternion matching JEOD convention.
-///
-/// Layout: `[scalar, vx, vy, vz]`
-///
-/// For a rotation of angle theta about unit axis u-hat:
-///   scalar = cos(theta/2)
-///   vector = -sin(theta/2) * u-hat
-///
-/// A "left quaternion" transforms a vector as: v' = q * v * q_conj
-/// which is equivalent to the rotation matrix produced by
-/// `left_quat_to_transformation`.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct JeodQuat {
-    pub data: [f64; 4], // [scalar, vx, vy, vz]
-}
+pub use jeod_quantities::{
+    JeodQuat, Layout, LeftTransform, NormalizedQuat, Quat, RightTransform, ScalarFirst, ScalarLast,
+    Transform,
+};
 
 /// Threshold below which the fast renormalization (Padé approximant) path is used.
 /// From JEOD `models/utils/quaternion/src/quaternion_normalize.cc`.
+///
+/// The canonical [`JeodQuat::normalize`] (inherent method in
+/// `jeod_quantities::quat`) uses this same numeric value internally. The
+/// constant is re-exported here so JEOD-specific consumers (e.g.
+/// `jeod_dynamics::normalize_integ`, which must *not* flip the scalar sign
+/// during integration) can reach it under the expected path.
 pub const NORM_LIMIT: f64 = 2.107_342e-8;
-
-impl JeodQuat {
-    /// Identity quaternion: no rotation.
-    pub fn identity() -> Self {
-        Self {
-            data: [1.0, 0.0, 0.0, 0.0],
-        }
-    }
-
-    /// Construct from explicit components.
-    pub fn new(scalar: f64, vx: f64, vy: f64, vz: f64) -> Self {
-        Self {
-            data: [scalar, vx, vy, vz],
-        }
-    }
-
-    /// Scalar (real) part.
-    #[inline]
-    pub fn scalar(&self) -> f64 {
-        self.data[0]
-    }
-
-    /// Vector (imaginary) part.
-    #[inline]
-    pub fn vector(&self) -> DVec3 {
-        DVec3::new(self.data[1], self.data[2], self.data[3])
-    }
-
-    // ----------------------------------------------------------------
-    // Conversions to/from glam
-    // ----------------------------------------------------------------
-
-    /// Convert to a glam `DQuat`.
-    ///
-    /// glam stores `(x, y, z, w)` where w is the scalar.
-    pub fn to_glam(&self) -> DQuat {
-        DQuat::from_xyzw(self.data[1], self.data[2], self.data[3], self.data[0])
-    }
-
-    /// Create from a glam `DQuat`.
-    pub fn from_glam(q: DQuat) -> Self {
-        Self {
-            data: [q.w, q.x, q.y, q.z],
-        }
-    }
-
-    // ----------------------------------------------------------------
-    // Norm helpers
-    // ----------------------------------------------------------------
-
-    /// Squared norm of the quaternion.
-    pub fn norm_sq(&self) -> f64 {
-        self.data[0] * self.data[0]
-            + self.data[1] * self.data[1]
-            + self.data[2] * self.data[2]
-            + self.data[3] * self.data[3]
-    }
-
-    /// Normalize the quaternion in place.
-    ///
-    /// Uses JEOD's fast two-step approximation when the quaternion is already
-    /// close to unit length.  Always forces scalar >= 0.
-    pub fn normalize(&mut self) {
-        let qmagsq = self.norm_sq();
-        // JEOD_INV: QT.03 — cannot normalize a zero quaternion
-        assert!(qmagsq > 0.0, "cannot normalize a zero quaternion");
-
-        // JEOD_INV: QT.01 — fast Padé path near unit magnitude, sqrt path otherwise
-        let fact = if (1.0 - qmagsq).abs() < NORM_LIMIT {
-            // Near-unit: first-order Padé approximant  2 / (1 + ||q||²)
-            2.0 / (1.0 + qmagsq)
-        } else {
-            1.0 / qmagsq.sqrt()
-        };
-
-        for d in self.data.iter_mut() {
-            *d *= fact;
-        }
-
-        // JEOD_INV: QT.02 — canonical hemisphere: force scalar non-negative
-        if self.data[0] < 0.0 {
-            for d in self.data.iter_mut() {
-                *d = -*d;
-            }
-        }
-    }
-
-    // ----------------------------------------------------------------
-    // Algebraic operations
-    // ----------------------------------------------------------------
-
-    /// Quaternion conjugate: `[s, -v]`.
-    pub fn conjugate(&self) -> Self {
-        Self {
-            data: [self.data[0], -self.data[1], -self.data[2], -self.data[3]],
-        }
-    }
-
-    /// Quaternion product `self * other`.
-    ///
-    /// ```text
-    /// prod.scalar = s1*s2 - v1 . v2
-    /// prod.vector = s1*v2 + s2*v1 + v1 x v2
-    /// ```
-    pub fn multiply(&self, other: &Self) -> Self {
-        let s1 = self.scalar();
-        let v1 = self.vector();
-        let s2 = other.scalar();
-        let v2 = other.vector();
-
-        let ps = s1 * s2 - v1.dot(v2);
-        let pv = v2 * s1 + v1 * s2 + v1.cross(v2);
-
-        Self {
-            data: [ps, pv.x, pv.y, pv.z],
-        }
-    }
-
-    // ----------------------------------------------------------------
-    // Matrix <-> quaternion (left-transformation convention)
-    // ----------------------------------------------------------------
-
-    // JEOD_INV: RF.09 — assumes quaternion is normalized (caller must normalize after integration)
-    /// Build the 3x3 rotation (transformation) matrix from a left quaternion.
-    ///
-    /// Uses the half-angle formula from JEOD
-    /// `models/utils/quaternion/src/quaternion_to_matrix.cc`.
-    ///
-    /// ```text
-    /// cost  = 2*qs^2 - 1
-    /// T[i][i] = cost + 2*qv[i]^2
-    /// T[i][j] = 2*(qv[i]*qv[j] -/+ qs*qv[k])
-    /// ```
-    pub fn left_quat_to_transformation(&self) -> DMat3 {
-        let qs = self.data[0];
-        let qv = [self.data[1], self.data[2], self.data[3]];
-
-        let cost = 2.0 * qs * qs - 1.0;
-
-        // Diagonal
-        let t00 = cost + 2.0 * qv[0] * qv[0];
-        let t11 = cost + 2.0 * qv[1] * qv[1];
-        let t22 = cost + 2.0 * qv[2] * qv[2];
-
-        // Off-diagonal:
-        //   T[0][1] = 2*(qv0*qv1 - qs*qv2)
-        //   T[1][0] = 2*(qv1*qv0 + qs*qv2)
-        //   T[0][2] = 2*(qv0*qv2 + qs*qv1)
-        //   T[2][0] = 2*(qv2*qv0 - qs*qv1)
-        //   T[1][2] = 2*(qv1*qv2 - qs*qv0)
-        //   T[2][1] = 2*(qv2*qv1 + qs*qv0)
-        let t01 = 2.0 * (qv[0] * qv[1] - qs * qv[2]);
-        let t10 = 2.0 * (qv[1] * qv[0] + qs * qv[2]);
-        let t02 = 2.0 * (qv[0] * qv[2] + qs * qv[1]);
-        let t20 = 2.0 * (qv[2] * qv[0] - qs * qv[1]);
-        let t12 = 2.0 * (qv[1] * qv[2] - qs * qv[0]);
-        let t21 = 2.0 * (qv[2] * qv[1] + qs * qv[0]);
-
-        mat3_from_rows(
-            DVec3::new(t00, t01, t02),
-            DVec3::new(t10, t11, t12),
-            DVec3::new(t20, t21, t22),
-        )
-    }
-
-    /// Build a left quaternion from a transformation matrix.
-    ///
-    /// Robust method from JEOD
-    /// `models/utils/quaternion/src/quaternion_from_matrix.cc`:
-    /// selects among 4 extraction branches based on which of
-    /// {trace, T\[0\]\[0\], T\[1\]\[1\], T\[2\]\[2\]} is largest.
-    ///
-    /// `mat` is a glam `DMat3` (column-major). Access element T\[row\]\[col\]
-    /// via `mat.col(col)[row]`.
-    pub fn left_quat_from_transformation(mat: &DMat3) -> Self {
-        // Convenience macro: T[i][j] = mat.col(j)[i]
-        let t = |r: usize, c: usize| -> f64 { mat.col(c)[r] };
-
-        let tr = t(0, 0) + t(1, 1) + t(2, 2);
-
-        // Find maximum of (tr, T00, T11, T22)
-        let vals = [tr, t(0, 0), t(1, 1), t(2, 2)];
-        let max_idx = vals
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .unwrap()
-            .0;
-
-        let mut q = [0.0_f64; 4];
-
-        // For the JEOD left-transformation matrix, the off-diagonal
-        // anti-symmetric part gives:
-        //   T[2][1] - T[1][2] =  4*qs*qv[0]
-        //   T[0][2] - T[2][0] =  4*qs*qv[1]
-        //   T[1][0] - T[0][1] =  4*qs*qv[2]
-        // The symmetric off-diagonal part gives:
-        //   T[0][1] + T[1][0] =  4*qv[0]*qv[1]
-        //   T[0][2] + T[2][0] =  4*qv[0]*qv[2]
-        //   T[1][2] + T[2][1] =  4*qv[1]*qv[2]
-        match max_idx {
-            0 => {
-                // tr dominates -> solve for qs first
-                q[0] = 0.5 * (1.0 + tr).sqrt();
-                let inv4qs = 0.25 / q[0];
-                q[1] = (t(2, 1) - t(1, 2)) * inv4qs;
-                q[2] = (t(0, 2) - t(2, 0)) * inv4qs;
-                q[3] = (t(1, 0) - t(0, 1)) * inv4qs;
-            }
-            1 => {
-                // T[0][0] dominates -> solve for qv[0] first
-                q[1] = 0.5 * (1.0 + 2.0 * t(0, 0) - tr).sqrt();
-                let inv4qv0 = 0.25 / q[1];
-                q[0] = (t(2, 1) - t(1, 2)) * inv4qv0;
-                q[2] = (t(0, 1) + t(1, 0)) * inv4qv0;
-                q[3] = (t(0, 2) + t(2, 0)) * inv4qv0;
-            }
-            2 => {
-                // T[1][1] dominates -> solve for qv[1] first
-                q[2] = 0.5 * (1.0 + 2.0 * t(1, 1) - tr).sqrt();
-                let inv4qv1 = 0.25 / q[2];
-                q[0] = (t(0, 2) - t(2, 0)) * inv4qv1;
-                q[1] = (t(0, 1) + t(1, 0)) * inv4qv1;
-                q[3] = (t(1, 2) + t(2, 1)) * inv4qv1;
-            }
-            3 => {
-                // T[2][2] dominates -> solve for qv[2] first
-                q[3] = 0.5 * (1.0 + 2.0 * t(2, 2) - tr).sqrt();
-                let inv4qv2 = 0.25 / q[3];
-                q[0] = (t(1, 0) - t(0, 1)) * inv4qv2;
-                q[1] = (t(0, 2) + t(2, 0)) * inv4qv2;
-                q[2] = (t(1, 2) + t(2, 1)) * inv4qv2;
-            }
-            _ => unreachable!(),
-        }
-
-        // Force scalar non-negative (canonical hemisphere)
-        if q[0] < 0.0 {
-            for v in q.iter_mut() {
-                *v = -*v;
-            }
-        }
-
-        let mut result = Self { data: q };
-        result.normalize();
-        result
-    }
-
-    // ----------------------------------------------------------------
-    // Vector transformation
-    // ----------------------------------------------------------------
-
-    /// Transform a vector using the quaternion without building a matrix.
-    ///
-    /// Rodrigues formula via quaternion:
-    /// ```text
-    /// t = 2 * (qv x v)
-    /// v' = v + qs*t + qv x t
-    /// ```
-    pub fn left_quat_transform(&self, v: DVec3) -> DVec3 {
-        let qs = self.scalar();
-        let qv = self.vector();
-
-        let qv_cross_v = qv.cross(v);
-        v + 2.0 * qs * qv_cross_v + 2.0 * qv.cross(qv_cross_v)
-    }
-
-    // ----------------------------------------------------------------
-    // Axis-angle construction
-    // ----------------------------------------------------------------
-
-    /// Construct a left-transform quaternion from an axis-angle rotation.
-    ///
-    /// JEOD convention: scalar = cos(theta/2),  vector = -sin(theta/2) * axis
-    ///
-    /// `axis` must be a unit vector.
-    pub fn left_quat_from_eigen_rotation(angle: f64, axis: DVec3) -> Self {
-        let half = angle * 0.5;
-        let s = half.cos();
-        let v = -half.sin() * axis;
-        let mut q = Self {
-            data: [s, v.x, v.y, v.z],
-        };
-        q.normalize();
-        q
-    }
-}
 
 // ====================================================================
 // Tests
 // ====================================================================
+//
+// These tests exercise the unified methods now defined in
+// `jeod_quantities::quat`. They stay here (rather than in jeod_quantities)
+// because they depend on `jeod_math::test_utils::approx_*` helpers and on
+// JEOD-parity edge cases that are owned by this crate.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_utils::{approx_eq_f64, approx_eq_mat3, approx_eq_vec3};
+    use crate::types::{mat3_from_rows, DMat3, DVec3};
     use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
 
     const TOL: f64 = 1e-12;
@@ -547,5 +272,14 @@ mod tests {
             q180_composed,
             q180_direct,
         );
+    }
+
+    // ---------------------------------------------------------------
+    // NORM_LIMIT parity: the jeod_math re-export must match the
+    // threshold the unified `normalize` uses internally.
+    // ---------------------------------------------------------------
+    #[test]
+    fn norm_limit_is_jeod_value() {
+        assert_eq!(NORM_LIMIT, 2.107_342e-8);
     }
 }

--- a/crates/jeod_math/src/quaternion.rs
+++ b/crates/jeod_math/src/quaternion.rs
@@ -11,20 +11,11 @@
 //! so downstream crates can continue to say `jeod_math::JeodQuat` and
 //! `jeod_math::quaternion::NORM_LIMIT` after the Phase 2 unification.
 
+pub use jeod_quantities::quat::NORM_LIMIT;
 pub use jeod_quantities::{
     JeodQuat, Layout, LeftTransform, NormalizedQuat, Quat, RightTransform, ScalarFirst, ScalarLast,
     Transform,
 };
-
-/// Threshold below which the fast renormalization (Padé approximant) path is used.
-/// From JEOD `models/utils/quaternion/src/quaternion_normalize.cc`.
-///
-/// The canonical [`JeodQuat::normalize`] (inherent method in
-/// `jeod_quantities::quat`) uses this same numeric value internally. The
-/// constant is re-exported here so JEOD-specific consumers (e.g.
-/// `jeod_dynamics::normalize_integ`, which must *not* flip the scalar sign
-/// during integration) can reach it under the expected path.
-pub const NORM_LIMIT: f64 = 2.107_342e-8;
 
 // ====================================================================
 // Tests
@@ -275,8 +266,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // NORM_LIMIT parity: the jeod_math re-export must match the
-    // threshold the unified `normalize` uses internally.
+    // Pin the JEOD-source threshold value as a regression guard.
     // ---------------------------------------------------------------
     #[test]
     fn norm_limit_is_jeod_value() {

--- a/crates/jeod_math/src/solar_beta.rs
+++ b/crates/jeod_math/src/solar_beta.rs
@@ -11,6 +11,10 @@
 //! When β = ±90°, the Sun is perpendicular to the orbital plane.
 
 use glam::DVec3;
+use jeod_quantities::dims::SpecificAngMomDim;
+use jeod_quantities::prelude::{Inertial, Position, Qty3};
+use uom::si::angle::radian;
+use uom::si::f64::Angle;
 
 /// Compute the solar beta angle.
 ///
@@ -21,6 +25,11 @@ use glam::DVec3;
 /// # Returns
 /// Solar beta angle in radians, in range [-π/2, π/2].
 /// Positive when the Sun is on the same side as the angular momentum vector.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use solar_beta_angle_typed; f64 variant removed in Phase 10"
+)]
 pub fn solar_beta_angle(orbit_ang_momentum: DVec3, sun_direction: DVec3) -> f64 {
     assert!(
         orbit_ang_momentum.length_squared() > 0.0,
@@ -41,9 +50,37 @@ pub fn solar_beta_angle(orbit_ang_momentum: DVec3, sun_direction: DVec3) -> f64 
     dot.asin()
 }
 
+/// Typed counterpart of [`solar_beta_angle`].
+///
+/// Computes the solar beta angle from a frame-tagged specific angular
+/// momentum vector (r × v, m²/s) and an inertial-frame sun direction
+/// vector (interpreted as meters; only direction matters, so a unit
+/// vector or a full position difference are both acceptable).
+///
+/// # Arguments
+/// * `orbit_ang_momentum` - Specific orbital angular momentum `h = r × v`
+///   in the inertial frame (does not need to be unit)
+/// * `sun_direction` - Direction toward the Sun in the inertial frame
+///   (does not need to be unit)
+///
+/// # Returns
+/// Solar beta angle as a typed `Angle`, in range [-π/2, π/2].
+/// Positive when the Sun is on the same side as the angular momentum
+/// vector.
+pub fn solar_beta_angle_typed(
+    orbit_ang_momentum: Qty3<SpecificAngMomDim, Inertial>,
+    sun_direction: Position<Inertial>,
+) -> Angle {
+    #[allow(deprecated)]
+    let beta = solar_beta_angle(orbit_ang_momentum.raw_si(), sun_direction.raw_si());
+    Angle::new::<radian>(beta)
+}
+
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
+    use jeod_quantities::prelude::Vec3Ext;
     use std::f64::consts::PI;
 
     #[test]
@@ -99,5 +136,79 @@ mod tests {
         let beta = solar_beta_angle(h, sun);
         // Beta should be small (sun nearly in orbit plane at equinox)
         assert!(beta.abs() < 1e-14);
+    }
+
+    // --- Typed-variant tests (Phase 2 #104) --------------------------------
+
+    /// Wrap a raw `DVec3` as a frame-tagged, dimensioned specific
+    /// angular-momentum vector in the inertial frame.
+    fn h_in<F: jeod_quantities::frame::Frame>(v: DVec3) -> Qty3<SpecificAngMomDim, F> {
+        Qty3::from_raw_si(v)
+    }
+
+    #[test]
+    fn typed_bounded_in_pi_over_two() {
+        // Beta is always in [-π/2, π/2]; sweep a handful of inertial sun
+        // directions around an ISS-like orbit normal and verify the
+        // returned typed angle stays within that bound (plus a small
+        // floating-point slop).
+        let inc = 51.6_f64.to_radians();
+        let h = h_in::<Inertial>(DVec3::new(0.0, -inc.sin(), inc.cos()));
+        for (sx, sy, sz) in [
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+            (1.0, 1.0, 1.0),
+            (-1.0, 2.0, -0.5),
+            (0.0, 0.0, -1.0),
+        ] {
+            let sun = DVec3::new(sx, sy, sz).m_at::<Inertial>();
+            let beta = solar_beta_angle_typed(h, sun);
+            let rad = beta.get::<radian>();
+            assert!(
+                rad.abs() <= PI / 2.0 + 1e-15,
+                "beta out of range: {rad} for sun=({sx},{sy},{sz})"
+            );
+        }
+    }
+
+    #[test]
+    fn typed_iss_like_orbit() {
+        // Mirror of `iss_like_orbit` but through the typed API. Tolerance
+        // matches the f64 test exactly.
+        let inc = 51.6_f64.to_radians();
+        let h_raw = DVec3::new(0.0, -inc.sin(), inc.cos());
+        let sun_raw = DVec3::new(1.0, 0.0, 0.0);
+
+        let beta = solar_beta_angle_typed(h_in::<Inertial>(h_raw), sun_raw.m_at::<Inertial>());
+        assert!(beta.get::<radian>().abs() < 1e-14);
+    }
+
+    #[test]
+    fn typed_bit_identical_to_f64() {
+        // The typed variant must delegate verbatim to the f64 variant.
+        // Check a range of non-trivial inputs (orthogonal, oblique, nearly
+        // aligned, negative, unnormalized) and assert bit-exact equality
+        // between `solar_beta_angle_typed(...).get::<radian>()` and
+        // `solar_beta_angle(...)`.
+        let cases: &[(DVec3, DVec3)] = &[
+            (DVec3::new(0.0, 0.0, 1.0), DVec3::new(1.0, 0.0, 0.0)),
+            (DVec3::new(0.0, 0.0, 1.0), DVec3::new(0.0, 0.0, 1.0)),
+            (DVec3::new(0.0, 0.0, 1.0), DVec3::new(0.0, 0.0, -1.0)),
+            (DVec3::new(0.0, 0.0, 1.0), DVec3::new(1.0, 0.0, 1.0)),
+            (DVec3::new(0.0, 0.0, 1e10), DVec3::new(1e8, 0.0, 0.0)),
+            (DVec3::new(1.0, 2.0, 3.0), DVec3::new(-0.5, 0.25, 0.75)),
+            (DVec3::new(-1.0, 4.0, -2.0), DVec3::new(7.0, -3.0, 1.0)),
+        ];
+
+        for &(h, sun) in cases {
+            let f64_result = solar_beta_angle(h, sun);
+            let typed_result = solar_beta_angle_typed(h_in::<Inertial>(h), sun.m_at::<Inertial>());
+            assert_eq!(
+                typed_result.get::<radian>(),
+                f64_result,
+                "typed != f64 for h={h:?} sun={sun:?}"
+            );
+        }
     }
 }

--- a/crates/jeod_math/tests/jeod_validation.rs
+++ b/crates/jeod_math/tests/jeod_validation.rs
@@ -186,6 +186,8 @@ fn validate_orbital_roundtrip_5000_vectors() {
     let mut pass_count = 0;
 
     for (i, sv) in vectors.iter().enumerate() {
+        // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+        #[allow(deprecated)]
         let elems = match OrbitalElements::from_cartesian(MU_EARTH, sv.position, sv.velocity) {
             Ok(e) => e,
             Err(e) => {

--- a/crates/jeod_math/tests/jeod_validation.rs
+++ b/crates/jeod_math/tests/jeod_validation.rs
@@ -451,6 +451,7 @@ fn validate_orbital_init_parser() {
 ///
 /// Exit criterion: 6/6 test vectors within 1e-12 rad.
 #[test]
+#[allow(deprecated)]
 fn validate_euler_angle_extraction_from_jeod_vectors() {
     use jeod_math::{compute_euler_angles_from_matrix, EulerSequence};
 

--- a/crates/jeod_quantities/Cargo.toml
+++ b/crates/jeod_quantities/Cargo.toml
@@ -10,3 +10,9 @@ glam = { workspace = true }
 uom = { workspace = true }
 typenum = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+# Exposes test-only phantom markers (e.g. `TestVehicle`) so downstream crates
+# can write frame-composition tests without needing to implement sealed
+# marker traits. Never enabled in production builds.
+test-utils = []

--- a/crates/jeod_quantities/src/frame.rs
+++ b/crates/jeod_quantities/src/frame.rs
@@ -122,3 +122,24 @@ impl<C: Vehicle> Sealed for Ned<C> {}
 impl<C: Vehicle> Frame for Ned<C> {
     const NAME: &'static str = "Ned";
 }
+
+// --- Test-only vehicle marker ------------------------------------------------
+//
+// `Vehicle` is sealed, so downstream crates cannot mint their own phantom
+// tags. Tests that exercise vehicle-parameterized frames (`Lvlh`, `Ned`,
+// `BodyFrame`, `StructuralFrame`) need *some* tag to instantiate, so we
+// expose a single test-only vehicle behind the `test-utils` feature. It is
+// never compiled into production builds.
+
+/// A no-op vehicle phantom marker for use in downstream test harnesses.
+///
+/// Available only when the crate is built with `--features test-utils`.
+#[cfg(feature = "test-utils")]
+#[derive(Debug, Clone, Copy)]
+pub struct TestVehicle;
+#[cfg(feature = "test-utils")]
+impl Sealed for TestVehicle {}
+#[cfg(feature = "test-utils")]
+impl Vehicle for TestVehicle {
+    const NAME: &'static str = "TestVehicle";
+}

--- a/crates/jeod_quantities/src/quat.rs
+++ b/crates/jeod_quantities/src/quat.rs
@@ -227,19 +227,18 @@ impl<L: Layout, T: Transform> NormalizedQuat<L, T> {
 //
 // These impls live here (rather than in `jeod_math::quaternion`) because
 // inherent impls may only appear in the defining crate. See
-// `jeod_math::quaternion` for the `NORM_LIMIT` constant and the
-// JEOD-specific `normalize_integ` variant that preserves the scalar sign.
+// `jeod_math::quaternion` for the JEOD-specific `normalize_integ` variant
+// that preserves the scalar sign.
 // ============================================================================
 
 /// Threshold (as a scalar difference `1 - ‖q‖²`) below which the fast Padé
 /// renormalization path is used. JEOD source:
 /// `models/utils/quaternion/src/quaternion_normalize.cc`.
 ///
-/// Prefer the re-export at `jeod_math::quaternion::NORM_LIMIT`; this copy
-/// exists only because the inherent [`JeodQuat::normalize`] method lives in
-/// the defining crate (`jeod_quantities`), which must not depend upward on
-/// `jeod_math`.
-const JEOD_NORM_LIMIT: f64 = 2.107_342e-8;
+/// Single source of truth: `jeod_math::quaternion::NORM_LIMIT` re-exports
+/// this constant so JEOD-specific consumers can reach it under their
+/// expected path without duplicating the literal.
+pub const NORM_LIMIT: f64 = 2.107_342e-8;
 
 impl JeodQuat {
     /// Identity quaternion `[1, 0, 0, 0]`: no rotation.
@@ -332,7 +331,7 @@ impl JeodQuat {
         assert!(qmagsq > 0.0, "cannot normalize a zero quaternion");
 
         // JEOD_INV: QT.01 — fast Padé path near unit magnitude, sqrt path otherwise
-        let fact = if (1.0 - qmagsq).abs() < JEOD_NORM_LIMIT {
+        let fact = if (1.0 - qmagsq).abs() < NORM_LIMIT {
             // Near-unit: first-order Padé approximant  2 / (1 + ||q||²)
             2.0 / (1.0 + qmagsq)
         } else {

--- a/crates/jeod_quantities/src/quat.rs
+++ b/crates/jeod_quantities/src/quat.rs
@@ -15,7 +15,7 @@
 
 use core::marker::PhantomData;
 
-use glam::DQuat;
+use glam::{DMat3, DQuat, DVec3};
 
 use crate::sealed::Sealed;
 
@@ -25,7 +25,7 @@ pub trait Layout: Sealed + 'static {
 }
 
 /// Storage layout `[q0, q1, q2, q3]` where `q0` is the scalar part (JEOD).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ScalarFirst;
 impl Sealed for ScalarFirst {}
 impl Layout for ScalarFirst {
@@ -33,7 +33,7 @@ impl Layout for ScalarFirst {
 }
 
 /// Storage layout `[x, y, z, w]` where `w` is the scalar part (glam).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ScalarLast;
 impl Sealed for ScalarLast {}
 impl Layout for ScalarLast {
@@ -46,7 +46,7 @@ pub trait Transform: Sealed + 'static {
 }
 
 /// `r' = q r q⁻¹` — the JEOD convention.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LeftTransform;
 impl Sealed for LeftTransform {}
 impl Transform for LeftTransform {
@@ -54,7 +54,7 @@ impl Transform for LeftTransform {
 }
 
 /// `r' = q⁻¹ r q` — the opposite of JEOD; common in many textbooks.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RightTransform;
 impl Sealed for RightTransform {}
 impl Transform for RightTransform {
@@ -219,4 +219,322 @@ impl<L: Layout, T: Transform> NormalizedQuat<L, T> {
     pub const fn inner(self) -> Quat<L, T> {
         self.0
     }
+}
+
+// ============================================================================
+// JEOD canonical (ScalarFirst, LeftTransform) algebra, matrix conversions,
+// axis-angle construction, vector transform.
+//
+// These impls live here (rather than in `jeod_math::quaternion`) because
+// inherent impls may only appear in the defining crate. See
+// `jeod_math::quaternion` for the `NORM_LIMIT` constant and the
+// JEOD-specific `normalize_integ` variant that preserves the scalar sign.
+// ============================================================================
+
+/// Threshold (as a scalar difference `1 - ‖q‖²`) below which the fast Padé
+/// renormalization path is used. JEOD source:
+/// `models/utils/quaternion/src/quaternion_normalize.cc`.
+///
+/// Prefer the re-export at `jeod_math::quaternion::NORM_LIMIT`; this copy
+/// exists only because the inherent [`JeodQuat::normalize`] method lives in
+/// the defining crate (`jeod_quantities`), which must not depend upward on
+/// `jeod_math`.
+const JEOD_NORM_LIMIT: f64 = 2.107_342e-8;
+
+impl JeodQuat {
+    /// Identity quaternion `[1, 0, 0, 0]`: no rotation.
+    #[inline]
+    pub const fn identity() -> Self {
+        Self::from_array([1.0, 0.0, 0.0, 0.0])
+    }
+
+    /// Construct from explicit scalar-first components.
+    #[inline]
+    pub const fn new(scalar: f64, vx: f64, vy: f64, vz: f64) -> Self {
+        Self::from_array([scalar, vx, vy, vz])
+    }
+
+    /// Scalar (real) part `q0`.
+    #[inline]
+    pub fn scalar(&self) -> f64 {
+        self.data[0]
+    }
+
+    /// Vector (imaginary) part `[q1, q2, q3]`.
+    #[inline]
+    pub fn vector(&self) -> DVec3 {
+        DVec3::new(self.data[1], self.data[2], self.data[3])
+    }
+
+    /// Squared norm (alias for [`Quat::norm_squared`] — kept for JEOD parity naming).
+    #[inline]
+    pub fn norm_sq(&self) -> f64 {
+        self.norm_squared()
+    }
+
+    // ----------------------------------------------------------------
+    // Conversions to/from glam::DQuat
+    // ----------------------------------------------------------------
+
+    /// Convert to a glam `DQuat`. glam stores `(x, y, z, w)` where `w` is the scalar.
+    #[inline]
+    pub fn to_glam(&self) -> DQuat {
+        DQuat::from_xyzw(self.data[1], self.data[2], self.data[3], self.data[0])
+    }
+
+    /// Create from a glam `DQuat` (which uses `[x, y, z, w]`).
+    #[inline]
+    pub fn from_glam(q: DQuat) -> Self {
+        Self::from_array([q.w, q.x, q.y, q.z])
+    }
+
+    // ----------------------------------------------------------------
+    // Algebraic operations
+    // ----------------------------------------------------------------
+
+    /// Quaternion conjugate: `[s, -v]`.
+    #[inline]
+    pub fn conjugate(&self) -> Self {
+        Self::from_array([self.data[0], -self.data[1], -self.data[2], -self.data[3]])
+    }
+
+    /// Quaternion product `self * other`.
+    ///
+    /// ```text
+    /// prod.scalar = s1*s2 - v1 . v2
+    /// prod.vector = s1*v2 + s2*v1 + v1 x v2
+    /// ```
+    pub fn multiply(&self, other: &Self) -> Self {
+        let s1 = self.scalar();
+        let v1 = self.vector();
+        let s2 = other.scalar();
+        let v2 = other.vector();
+
+        let ps = s1 * s2 - v1.dot(v2);
+        let pv = v2 * s1 + v1 * s2 + v1.cross(v2);
+
+        Self::from_array([ps, pv.x, pv.y, pv.z])
+    }
+
+    // ----------------------------------------------------------------
+    // Normalization (JEOD fast-path with canonical hemisphere)
+    // ----------------------------------------------------------------
+
+    /// Normalize the quaternion in place, forcing `scalar >= 0`
+    /// (canonical hemisphere).
+    ///
+    /// Uses JEOD's fast Padé approximation when the quaternion is already
+    /// close to unit length.  See
+    /// `models/utils/quaternion/src/quaternion_normalize.cc`.
+    pub fn normalize(&mut self) {
+        let qmagsq = self.norm_squared();
+        // JEOD_INV: QT.03 — cannot normalize a zero quaternion
+        assert!(qmagsq > 0.0, "cannot normalize a zero quaternion");
+
+        // JEOD_INV: QT.01 — fast Padé path near unit magnitude, sqrt path otherwise
+        let fact = if (1.0 - qmagsq).abs() < JEOD_NORM_LIMIT {
+            // Near-unit: first-order Padé approximant  2 / (1 + ||q||²)
+            2.0 / (1.0 + qmagsq)
+        } else {
+            1.0 / qmagsq.sqrt()
+        };
+
+        for d in self.data.iter_mut() {
+            *d *= fact;
+        }
+
+        // JEOD_INV: QT.02 — canonical hemisphere: force scalar non-negative
+        if self.data[0] < 0.0 {
+            for d in self.data.iter_mut() {
+                *d = -*d;
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Axis-angle construction
+    // ----------------------------------------------------------------
+
+    /// Construct a left-transform quaternion from an axis-angle rotation.
+    ///
+    /// JEOD convention: `scalar = cos(θ/2)`, `vector = -sin(θ/2) · axis`.
+    /// `axis` must be a unit vector.
+    pub fn left_quat_from_eigen_rotation(angle: f64, axis: DVec3) -> Self {
+        let half = angle * 0.5;
+        let s = half.cos();
+        let v = -half.sin() * axis;
+        let mut q = Self::from_array([s, v.x, v.y, v.z]);
+        q.normalize();
+        q
+    }
+
+    // ----------------------------------------------------------------
+    // Matrix <-> quaternion (left-transformation convention)
+    // ----------------------------------------------------------------
+
+    // JEOD_INV: RF.09 — assumes quaternion is normalized (caller must normalize after integration)
+    /// Build the 3x3 rotation (transformation) matrix from a left quaternion,
+    /// **without** verifying unit norm.
+    ///
+    /// This is the historical JEOD-parity signature retained for migration
+    /// purposes. New callers should prefer the [`NormalizedQuat`] witness
+    /// version (see module docs of `jeod_math::quaternion`).
+    ///
+    /// Formula from JEOD `models/utils/quaternion/src/quaternion_to_matrix.cc`.
+    ///
+    /// ```text
+    /// cost  = 2·qs² − 1
+    /// T[i][i] = cost + 2·qv[i]²
+    /// T[i][j] = 2·(qv[i]·qv[j] ∓ qs·qv[k])
+    /// ```
+    pub fn left_quat_to_transformation(&self) -> DMat3 {
+        left_quat_to_transformation_impl(self)
+    }
+
+    /// Build a left quaternion from a transformation matrix.
+    ///
+    /// Robust method from JEOD
+    /// `models/utils/quaternion/src/quaternion_from_matrix.cc`: selects
+    /// among four extraction branches based on which of
+    /// `{trace, T[0][0], T[1][1], T[2][2]}` is largest.
+    pub fn left_quat_from_transformation(mat: &DMat3) -> Self {
+        // Convenience accessor: T[i][j] = mat.col(j)[i]
+        let t = |r: usize, c: usize| -> f64 { mat.col(c)[r] };
+
+        let tr = t(0, 0) + t(1, 1) + t(2, 2);
+
+        // Find maximum of (tr, T00, T11, T22)
+        let vals = [tr, t(0, 0), t(1, 1), t(2, 2)];
+        let max_idx = vals
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(core::cmp::Ordering::Equal))
+            .unwrap()
+            .0;
+
+        let mut q = [0.0_f64; 4];
+
+        match max_idx {
+            0 => {
+                // tr dominates -> solve for qs first
+                q[0] = 0.5 * (1.0 + tr).sqrt();
+                let inv4qs = 0.25 / q[0];
+                q[1] = (t(2, 1) - t(1, 2)) * inv4qs;
+                q[2] = (t(0, 2) - t(2, 0)) * inv4qs;
+                q[3] = (t(1, 0) - t(0, 1)) * inv4qs;
+            }
+            1 => {
+                // T[0][0] dominates -> solve for qv[0] first
+                q[1] = 0.5 * (1.0 + 2.0 * t(0, 0) - tr).sqrt();
+                let inv4qv0 = 0.25 / q[1];
+                q[0] = (t(2, 1) - t(1, 2)) * inv4qv0;
+                q[2] = (t(0, 1) + t(1, 0)) * inv4qv0;
+                q[3] = (t(0, 2) + t(2, 0)) * inv4qv0;
+            }
+            2 => {
+                // T[1][1] dominates -> solve for qv[1] first
+                q[2] = 0.5 * (1.0 + 2.0 * t(1, 1) - tr).sqrt();
+                let inv4qv1 = 0.25 / q[2];
+                q[0] = (t(0, 2) - t(2, 0)) * inv4qv1;
+                q[1] = (t(0, 1) + t(1, 0)) * inv4qv1;
+                q[3] = (t(1, 2) + t(2, 1)) * inv4qv1;
+            }
+            3 => {
+                // T[2][2] dominates -> solve for qv[2] first
+                q[3] = 0.5 * (1.0 + 2.0 * t(2, 2) - tr).sqrt();
+                let inv4qv2 = 0.25 / q[3];
+                q[0] = (t(1, 0) - t(0, 1)) * inv4qv2;
+                q[1] = (t(0, 2) + t(2, 0)) * inv4qv2;
+                q[2] = (t(1, 2) + t(2, 1)) * inv4qv2;
+            }
+            _ => unreachable!(),
+        }
+
+        // Force scalar non-negative (canonical hemisphere)
+        if q[0] < 0.0 {
+            for v in q.iter_mut() {
+                *v = -*v;
+            }
+        }
+
+        let mut result = Self::from_array(q);
+        result.normalize();
+        result
+    }
+
+    // ----------------------------------------------------------------
+    // Vector transformation (Rodrigues via quaternion)
+    // ----------------------------------------------------------------
+
+    /// Transform a vector using the quaternion without building a matrix.
+    ///
+    /// ```text
+    /// t  = 2 · (qv × v)
+    /// v' = v + qs·t + qv × t
+    /// ```
+    pub fn left_quat_transform(&self, v: DVec3) -> DVec3 {
+        let qs = self.scalar();
+        let qv = self.vector();
+
+        let qv_cross_v = qv.cross(v);
+        v + 2.0 * qs * qv_cross_v + 2.0 * qv.cross(qv_cross_v)
+    }
+}
+
+// ----------------------------------------------------------------
+// NormalizedQuat: JEOD witness-gated operations
+// ----------------------------------------------------------------
+
+impl NormalizedQuat<ScalarFirst, LeftTransform> {
+    /// Build the 3x3 rotation (transformation) matrix from a witnessed
+    /// unit-norm left quaternion.
+    ///
+    /// Preferred over `JeodQuat::left_quat_to_transformation` because the
+    /// witness proves the unit-norm precondition at the type level.
+    #[inline]
+    pub fn left_quat_to_transformation(&self) -> DMat3 {
+        left_quat_to_transformation_impl(&self.inner())
+    }
+
+    /// Transform a vector using a witnessed unit-norm left quaternion.
+    #[inline]
+    pub fn left_quat_transform(&self, v: DVec3) -> DVec3 {
+        self.inner().left_quat_transform(v)
+    }
+}
+
+// Shared inner implementation used by both the raw-`JeodQuat` and the
+// witness-gated `NormalizedQuat<ScalarFirst, LeftTransform>` call sites.
+#[inline]
+fn left_quat_to_transformation_impl(q: &JeodQuat) -> DMat3 {
+    let qs = q.data[0];
+    let qv = [q.data[1], q.data[2], q.data[3]];
+
+    let cost = 2.0 * qs * qs - 1.0;
+
+    // Diagonal
+    let t00 = cost + 2.0 * qv[0] * qv[0];
+    let t11 = cost + 2.0 * qv[1] * qv[1];
+    let t22 = cost + 2.0 * qv[2] * qv[2];
+
+    // Off-diagonal:
+    //   T[0][1] = 2·(qv0·qv1 − qs·qv2)
+    //   T[1][0] = 2·(qv1·qv0 + qs·qv2)
+    //   T[0][2] = 2·(qv0·qv2 + qs·qv1)
+    //   T[2][0] = 2·(qv2·qv0 − qs·qv1)
+    //   T[1][2] = 2·(qv1·qv2 − qs·qv0)
+    //   T[2][1] = 2·(qv2·qv1 + qs·qv0)
+    let t01 = 2.0 * (qv[0] * qv[1] - qs * qv[2]);
+    let t10 = 2.0 * (qv[1] * qv[0] + qs * qv[2]);
+    let t02 = 2.0 * (qv[0] * qv[2] + qs * qv[1]);
+    let t20 = 2.0 * (qv[2] * qv[0] - qs * qv[1]);
+    let t12 = 2.0 * (qv[1] * qv[2] - qs * qv[0]);
+    let t21 = 2.0 * (qv[2] * qv[1] + qs * qv[0]);
+
+    // glam stores column-major. Build columns from our row-indexed T.
+    DMat3::from_cols(
+        DVec3::new(t00, t10, t20), // col 0 -> T[0..3][0]
+        DVec3::new(t01, t11, t21), // col 1 -> T[0..3][1]
+        DVec3::new(t02, t12, t22), // col 2 -> T[0..3][2]
+    )
 }

--- a/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
+++ b/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
@@ -26,6 +26,11 @@
 //! `crates/jeod_dynamics/tests/tier3_mass_attach_detach.rs` with direct
 //! JEOD cross-validation.
 
+// `compute_matrix_from_euler_angles` is deprecated in favor of its typed
+// sibling; this Tier 3 test is kept on the bare-`f64` surface until the
+// downstream mass-attach fixtures migrate to `uom` `Angle`s.
+#![allow(deprecated)]
+
 use glam::{DMat3, DVec3};
 use jeod_dynamics::{MassBodyId, MassProperties, MassTree};
 use jeod_math::euler_angles::{compute_matrix_from_euler_angles, EulerSequence};

--- a/crates/jeod_runner/tests/tier3_sim_euler.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler.rs
@@ -3,6 +3,11 @@
 //! Uses the RUN_2 point-mass 6-DOF trajectory (which has quaternion data)
 //! to validate Euler angle computation through the Simulation pipeline.
 
+// `compute_euler_angles_from_matrix` is deprecated in favor of its typed
+// sibling; this Tier 3 test reads from JEOD's raw-`f64` matrix and keeps
+// the bare variant until the derived-state consumers migrate.
+#![allow(deprecated)]
+
 mod sim_test_helpers;
 use sim_test_helpers::*;
 

--- a/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
@@ -7,6 +7,11 @@
 //! Both use point-mass Earth gravity, RK4 at the SIM_Euler S_define step size, 24h duration.
 //! Euler angles are validated against JEOD's logged quaternion data.
 
+// `compute_euler_angles_from_matrix` is deprecated in favor of its typed
+// sibling; this Tier 3 test keeps the bare variant while the derived-state
+// consumers migrate.
+#![allow(deprecated)]
+
 mod sim_test_helpers;
 use sim_test_helpers::*;
 

--- a/crates/jeod_runner/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mercury.rs
@@ -108,6 +108,8 @@ fn propagate_mercury_periapses(
         let r_dot = r.dot(v) / r.length();
 
         if step > 0 && prev_rdot < 0.0 && r_dot >= 0.0 {
+            // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+            #[allow(deprecated)]
             if let Ok(e) = jeod_sim::OrbitalElements::from_cartesian(mu_sun, r, v) {
                 events.push(PeriapsisEvent {
                     time: sim_time,
@@ -211,6 +213,8 @@ fn detect_periapses_from_csv(path: &std::path::Path, mu: f64) -> Vec<PeriapsisEv
         let r_dot = pos.dot(vel) / pos.length();
 
         if prev_rdot < 0.0 && r_dot >= 0.0 {
+            // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+            #[allow(deprecated)]
             if let Ok(e) = jeod_sim::OrbitalElements::from_cartesian(mu, pos, vel) {
                 events.push(PeriapsisEvent {
                     time,

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
@@ -86,6 +86,8 @@ fn roundtrip_via_simulation(
     sim.step_n(n_steps);
 
     let body = sim.body(0);
+    // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+    #[allow(deprecated)]
     let oe_recovered =
         OrbitalElements::from_cartesian(MU_EARTH, body.trans.position, body.trans.velocity)
             .expect("from_cartesian failed after propagation");
@@ -217,6 +219,8 @@ fn tier3_orbinit_roundtrip_circular() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
+    // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+    #[allow(deprecated)]
     let oe_recovered =
         OrbitalElements::from_cartesian(MU_EARTH, body.trans.position, body.trans.velocity)
             .expect("from_cartesian failed after propagation");

--- a/crates/jeod_sim/src/atmosphere.rs
+++ b/crates/jeod_sim/src/atmosphere.rs
@@ -2,6 +2,7 @@ use glam::{DMat3, DVec3};
 use jeod_atmosphere::exponential::ExponentialAtmosphere;
 use jeod_atmosphere::met::MetAtmosphere;
 use jeod_atmosphere::AtmosphereState;
+#[allow(deprecated)]
 use jeod_math::geodetic::cartesian_to_geodetic;
 
 use crate::planet_config::PlanetConfig;
@@ -96,6 +97,7 @@ pub fn evaluate_atmosphere(
     };
 
     // Convert to geodetic coordinates
+    #[allow(deprecated)]
     let geodetic = cartesian_to_geodetic(pos_pfix, config.r_eq, config.r_pol);
 
     // Evaluate atmosphere model

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -115,6 +115,7 @@ pub fn compute_body_solar_beta(position: DVec3, velocity: DVec3, sun_position: D
     );
 
     let sun_dir = rel_sun.normalize();
+    #[allow(deprecated)]
     jeod_math::solar_beta_angle(h, sun_dir)
 }
 

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -57,6 +57,7 @@ pub fn compute_orbital_elements(
 ///
 /// Converts the left-transformation quaternion to a rotation matrix, then
 /// decomposes it into Euler angles using the given sequence.
+#[allow(deprecated)]
 pub fn compute_body_euler_angles(rot: &RotationalState, sequence: EulerSequence) -> [f64; 3] {
     let t_parent_body = rot.quaternion.left_quat_to_transformation();
     jeod_math::compute_euler_angles_from_matrix(&t_parent_body, sequence)

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -46,6 +46,10 @@ pub fn compute_orbital_elements(
     position: DVec3,
     velocity: DVec3,
 ) -> Result<OrbitalElements, OrbitalError> {
+    // Phase 2 #104: jeod_math::OrbitalElements::from_cartesian is deprecated in
+    // favor of from_cartesian_typed. Migration to the typed entry point is
+    // tracked for Phase 3+ — this call site retains the f64 API for now.
+    #[allow(deprecated)]
     OrbitalElements::from_cartesian(mu, position, velocity)
 }
 

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -85,6 +85,7 @@ pub fn compute_body_geodetic(
 ) -> GeodeticState {
     // Rotate inertial position to planet-fixed frame
     let pos_pfix = *t_inertial_pfix * position;
+    #[allow(deprecated)]
     jeod_math::cartesian_to_geodetic(pos_pfix, r_eq, r_pol)
 }
 
@@ -262,6 +263,7 @@ mod tests {
 
         // Verify against direct computation to lock down the convention
         let pos_pfix = t_inertial_pfix * pos_inertial;
+        #[allow(deprecated)]
         let expected = jeod_math::cartesian_to_geodetic(pos_pfix, R_EQ, R_POL);
         assert_eq!(geo, expected);
     }

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -64,7 +64,10 @@ pub fn compute_body_euler_angles(rot: &RotationalState, sequence: EulerSequence)
 
 /// Compute the LVLH (Local Vertical Local Horizontal) frame from translational state.
 ///
-/// Delegates to [`jeod_math::compute_lvlh_frame`].
+/// Delegates to [`jeod_math::compute_lvlh_frame`]. Phase 3+ will migrate this
+/// wrapper to the typed `compute_lvlh_frame_typed` API; for now we silence
+/// the local deprecation warning so Phase 2 stays scope-limited.
+#[allow(deprecated)]
 pub fn compute_body_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     jeod_math::compute_lvlh_frame(position, velocity)
 }

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -139,8 +139,10 @@ pub use jeod_planet::PlanetShape;
 pub use jeod_math::JeodQuat;
 
 // jeod_math: derived state types
+#[allow(deprecated)]
+pub use jeod_math::compute_lvlh_frame;
 pub use jeod_math::{
-    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame,
+    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame_typed,
     geodetic_to_cartesian, solar_beta_angle, EulerSequence, GeodeticState, LvlhFrame,
     OrbitalElements, OrbitalError,
 };

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -140,9 +140,9 @@ pub use jeod_math::JeodQuat;
 
 // jeod_math: derived state types
 #[allow(deprecated)]
-pub use jeod_math::compute_lvlh_frame;
+pub use jeod_math::{cartesian_to_geodetic, compute_lvlh_frame, geodetic_to_cartesian};
 pub use jeod_math::{
-    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame_typed,
-    geodetic_to_cartesian, solar_beta_angle, EulerSequence, GeodeticState, LvlhFrame,
-    OrbitalElements, OrbitalError,
+    cartesian_to_geodetic_typed, compute_euler_angles_from_matrix, compute_lvlh_frame_typed,
+    geodetic_to_cartesian_typed, solar_beta_angle, EulerSequence, GeodeticState,
+    GeodeticStateTyped, LvlhFrame, OrbitalElements, OrbitalError,
 };

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -142,10 +142,10 @@ pub use jeod_math::JeodQuat;
 #[allow(deprecated)]
 pub use jeod_math::{
     cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame,
-    geodetic_to_cartesian,
+    geodetic_to_cartesian, solar_beta_angle,
 };
 pub use jeod_math::{
     cartesian_to_geodetic_typed, compute_euler_angles_from_matrix_typed, compute_lvlh_frame_typed,
-    geodetic_to_cartesian_typed, solar_beta_angle, EulerSequence, GeodeticState,
+    geodetic_to_cartesian_typed, solar_beta_angle_typed, EulerSequence, GeodeticState,
     GeodeticStateTyped, LvlhFrame, OrbitalElements, OrbitalError,
 };

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -140,9 +140,12 @@ pub use jeod_math::JeodQuat;
 
 // jeod_math: derived state types
 #[allow(deprecated)]
-pub use jeod_math::{cartesian_to_geodetic, compute_lvlh_frame, geodetic_to_cartesian};
 pub use jeod_math::{
-    cartesian_to_geodetic_typed, compute_euler_angles_from_matrix, compute_lvlh_frame_typed,
+    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame,
+    geodetic_to_cartesian,
+};
+pub use jeod_math::{
+    cartesian_to_geodetic_typed, compute_euler_angles_from_matrix_typed, compute_lvlh_frame_typed,
     geodetic_to_cartesian_typed, solar_beta_angle, EulerSequence, GeodeticState,
     GeodeticStateTyped, LvlhFrame, OrbitalElements, OrbitalError,
 };


### PR DESCRIPTION
## Summary

Closes #104. Part of [#101](https://github.com/simnaut/bevy_jeod/issues/101).

This is the **#101 commitment-point branch**. All 7 sub-PRs have landed
into the integration branch — `jeod_math` now exposes typed sibling APIs
in parallel with the retained bare-`f64` / `DVec3` surfaces. Phase 1
(#103 / #128) lands independently per the parallelization policy.

## Merged sub-PRs (in landing order)

| Commit | Sub-PR | Scope |
|--------|--------|-------|
| `80f9df0` | (prep) | wire `jeod_quantities` dep into `jeod_math` |
| `3064711` | (prep) | unify `jeod_math::JeodQuat` ⇄ `jeod_quantities::JeodQuat` |
| `b7f583d` | #135 | `integrator_bit_match` RK4 Kepler SHA-256 regression test |
| `3673608` | #138 | `orbital_elements::from_cartesian_typed` (typed `GravParam`/`Position`/`Velocity` in, typed `OrbitalElements` out); deprecate f64 variant |
| `8559f67` | #137 | `lvlh::compute_lvlh_frame_typed` returns `FrameTransform<Inertial, Lvlh<Chief>>` |
| `893d7c7` | #139 | `GeodeticStateTyped { latitude/longitude: Angle, altitude: Length }` + `cartesian_to_geodetic_typed` / `geodetic_to_cartesian_typed` |
| `3d26ac5` | #140 | `euler_angles_*_typed` variants; `NormalizedQuat`-gated quaternion construction; matrix conversions take `&DMat3` |
| `3ebe15b` | #136 | `solar_beta_angle_typed`; deprecate f64 sibling |

## Phase 2 deliverables (per #104)

- ✅ `Quat<L, T>` generic + `JeodQuat` alias + `NormalizedQuat<L, T>` witness — all in `jeod_quantities`, `jeod_math` re-exports.
- ✅ `OrbitalElements::from_cartesian_typed(GravParam, Position<Inertial>, Velocity<Inertial>) -> Result<...>` with typed output fields.
- ✅ `LvlhFrame<Chief: Vehicle>`; functions return `FrameTransform<Inertial, Lvlh<Chief>>`.
- ✅ `GeodeticStateTyped { latitude: Angle, longitude: Angle, altitude: Length }`.
- ✅ Euler angles typed; matrix conversions take `NormalizedQuat`.
- ✅ Beta angle typed.
- ✅ Escape hatches: `Position::<F>::from_dvec3_unchecked`, `From<Qty3> for DVec3`, `From<Length> for f64`, `tag_as_inertial!` macro — all `#[doc(hidden)] #[deprecated(since = "0.2.0-phase-3")]`.
- ✅ `crates/jeod_dynamics/tests/integrator_bit_match.rs` — RK4 Kepler SHA-256 vs pinned hash.

The bare-`f64` / `DVec3` surfaces remain intact and `#[allow(deprecated)]`-gated where used internally, so Phase 1 callers compile unchanged.

## Depends on

- #127 (Tier 3 baseline-invariance CI guard) — merged.

## Commitment-gate checks (per #104)

- ✅ `cargo check --workspace` — clean.
- ✅ `cargo nextest run --workspace -E 'not test(tier3_)'` — 644 pass / 0 fail / 311 skipped.
- ✅ `cargo nextest run -p jeod_runner --test tier3_sim_dyncomp_run2` — 2 / 2 pass.
- ✅ `cargo nextest run -p jeod_dynamics --test integrator_bit_match` — pass.
- ✅ `cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing tier3_earth_moon_clem` — OK (76 matched, 0 violations).
- 5 intentionally-wrong type samples produce `on_unimplemented` errors < 30 lines each — verified in #126 / `jeod_quantities` diagnostics module; gates remain in effect.

## Verification

- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --tests -- -D warnings`
- ✅ Tier 3 trajectory unchanged within baseline tolerance (`max_error_new ≤ max(baseline + 1e-12·|baseline|, 1e-12)`).

## Test plan

- [x] CI `Lint & Format` passes
- [x] CI `Test (unit + tier 2)` passes
- [x] CI `Test (Tier 3 fast)` passes (baseline-invariance step green)
- [ ] CI `Test (Tier 3 full + earth_moon)` runs on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)