### PR TITLE
[Phase 1 #103] jeod_planet: typed accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ name = "jeod_planet"
 version = "0.1.0"
 dependencies = [
  "jeod_quantities",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_planet/Cargo.toml
+++ b/crates/jeod_planet/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities" }
+uom = { workspace = true }

--- a/crates/jeod_planet/src/planet.rs
+++ b/crates/jeod_planet/src/planet.rs
@@ -34,11 +34,62 @@ impl PlanetShape {
         let f = self.flat_coeff;
         2.0 * f - f * f
     }
+
+    /// Gravitational parameter as a typed `GravParam` (m³/s²).
+    ///
+    /// Additive typed accessor introduced by Phase 1 of the type-system
+    /// refactor (issue #101). Wraps the existing `mu` f64 field; the
+    /// underlying field is unchanged.
+    pub fn mu_typed(&self) -> jeod_quantities::dims::GravParam {
+        use jeod_quantities::ext::F64Ext;
+        self.mu.m3_per_s2()
+    }
+
+    /// Equatorial radius as a typed `uom::si::f64::Length` (meters).
+    ///
+    /// Additive typed accessor introduced by Phase 1 of the type-system
+    /// refactor (issue #101). Wraps the existing `r_eq` f64 field; the
+    /// underlying field is unchanged.
+    pub fn r_eq_typed(&self) -> uom::si::f64::Length {
+        use jeod_quantities::ext::F64Ext;
+        self.r_eq.m()
+    }
+
+    /// Polar radius as a typed `uom::si::f64::Length` (meters).
+    ///
+    /// Additive typed accessor introduced by Phase 1 of the type-system
+    /// refactor (issue #101). Wraps the existing `r_pol` f64 field; the
+    /// underlying field is unchanged.
+    pub fn r_pol_typed(&self) -> uom::si::f64::Length {
+        use jeod_quantities::ext::F64Ext;
+        self.r_pol.m()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::presets::*;
+
+    #[test]
+    fn earth_mu_typed_matches_f64_field() {
+        // `GravParam` stores value in base SI (m³/s²) via `.value`.
+        let mu = EARTH.mu_typed();
+        assert_eq!(mu.value, EARTH.mu);
+    }
+
+    #[test]
+    fn earth_r_eq_typed_matches_f64_field() {
+        use uom::si::length::meter;
+        let r_eq = EARTH.r_eq_typed();
+        assert_eq!(r_eq.get::<meter>(), EARTH.r_eq);
+    }
+
+    #[test]
+    fn earth_r_pol_typed_matches_f64_field() {
+        use uom::si::length::meter;
+        let r_pol = EARTH.r_pol_typed();
+        assert_eq!(r_pol.get::<meter>(), EARTH.r_pol);
+    }
 
     #[test]
     fn polar_radius_consistent_with_flattening() {


### PR DESCRIPTION
## Summary

Phase 1 sub-PR of #103 / #101 — adds typed accessors on `PlanetShape` **additively**. All existing `pub` f64 fields stay intact; this is a zero-breaking-change surface extension.

## What was added

On `crates/jeod_planet/src/planet.rs`:

- `PlanetShape::mu_typed(&self) -> jeod_quantities::dims::GravParam` (m³/s²)
- `PlanetShape::r_eq_typed(&self) -> uom::si::f64::Length` (meters)
- `PlanetShape::r_pol_typed(&self) -> uom::si::f64::Length` (meters)

Plus three inline unit tests asserting exact f64 round-trip equality against the `EARTH` preset.

`flat_coeff` is unitless (a ratio) and needs no typed variant.

## Build setup

Added `uom = { workspace = true }` to `crates/jeod_planet/Cargo.toml` so the `uom::si::f64::Length` return type resolves directly rather than via transitive re-export.

## What was NOT changed

- `pub name`, `pub mu`, `pub r_eq`, `pub r_pol`, `pub flat_coeff` — left AS-IS. (Rust has no field-level deprecation on `pub` struct fields; Phase 10 handles the cleanup.)
- Zero Tier 3 test changes; zero physics behaviour changes. Baseline guard in CI should be unaffected.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo nextest run -p jeod_planet` — 7/7 pass (3 new + 4 existing)
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 630/630 pass
- [x] `cargo check --workspace` — clean

## Refs

- Parent refactor: #101
- Phase 1 integration: #103
- Targets branch: `phase-1-leaf-crates`