### PR TITLE
[Phase 1 #103] jeod_atmosphere: typed accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,7 @@ version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
  "jeod_quantities",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_atmosphere/Cargo.toml
+++ b/crates/jeod_atmosphere/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
+uom = { workspace = true }

--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -4,6 +4,10 @@ pub mod exponential;
 pub mod met;
 
 use glam::DVec3;
+use uom::si::f64::{MassDensity, Pressure, ThermodynamicTemperature};
+use uom::si::mass_density::kilogram_per_cubic_meter;
+use uom::si::pressure::pascal;
+use uom::si::thermodynamic_temperature::kelvin;
 
 /// Atmospheric state at a given position.
 ///
@@ -31,6 +35,34 @@ impl Default for AtmosphereState {
     }
 }
 
+impl AtmosphereState {
+    /// Typed accessor: atmospheric density as `uom::si::f64::MassDensity` (kg/m^3).
+    #[inline]
+    pub fn density_typed(&self) -> MassDensity {
+        MassDensity::new::<kilogram_per_cubic_meter>(self.density)
+    }
+
+    /// Typed accessor: atmospheric temperature as
+    /// `uom::si::f64::ThermodynamicTemperature` (kelvin).
+    #[inline]
+    pub fn temperature_typed(&self) -> ThermodynamicTemperature {
+        ThermodynamicTemperature::new::<kelvin>(self.temperature)
+    }
+
+    /// Typed accessor: atmospheric pressure as `uom::si::f64::Pressure` (pascal).
+    #[inline]
+    pub fn pressure_typed(&self) -> Pressure {
+        Pressure::new::<pascal>(self.pressure)
+    }
+
+    /// Typed accessor: wind velocity as a frame-tagged
+    /// `Velocity<Inertial>` (m/s).
+    #[inline]
+    pub fn wind_typed(&self) -> Velocity<Inertial> {
+        self.wind.m_per_s_at::<Inertial>()
+    }
+}
+
 /// Compute atmospheric co-rotation wind velocity in the inertial frame.
 ///
 /// Port of JEOD `WindVelocity::update_wind()` with uniform omega scale.
@@ -46,6 +78,21 @@ impl Default for AtmosphereState {
 // JEOD_INV: AT.04 — wind velocity computed as omega × position (co-rotation)
 pub fn compute_corotation_wind(omega: f64, inertial_pos: DVec3) -> DVec3 {
     DVec3::new(-omega * inertial_pos.y, omega * inertial_pos.x, 0.0)
+}
+
+/// Typed variant of [`compute_corotation_wind`].
+///
+/// Wraps the same computation with dimension-typed inputs/outputs. Delegates
+/// to the raw f64/DVec3 implementation internally so behavior is bit-identical.
+#[inline]
+pub fn compute_corotation_wind_typed(
+    omega: uom::si::f64::AngularVelocity,
+    pos: Position<Inertial>,
+) -> Velocity<Inertial> {
+    use uom::si::angular_velocity::radian_per_second;
+    let w = omega.get::<radian_per_second>();
+    let p = pos.raw_si();
+    compute_corotation_wind(w, p).m_per_s_at::<Inertial>()
 }
 
 #[cfg(test)]
@@ -85,5 +132,54 @@ mod tests {
         let pos = DVec3::new(7e6, 3e6, 1e6);
         let wind = compute_corotation_wind(0.0, pos);
         assert_eq!(wind, DVec3::ZERO);
+    }
+
+    #[test]
+    fn typed_accessors_roundtrip_bit_identical() {
+        let state = AtmosphereState {
+            density: 1.225e-12,
+            temperature: 288.15,
+            pressure: 2.537e-10,
+            wind: DVec3::new(-359.7, 123.4, 0.5),
+        };
+
+        // Values extracted through typed accessors must equal the raw f64
+        // inputs bit-for-bit — no unit conversion or round-trip loss.
+        assert_eq!(
+            state.density_typed().get::<kilogram_per_cubic_meter>(),
+            state.density
+        );
+        assert_eq!(state.temperature_typed().get::<kelvin>(), state.temperature);
+        assert_eq!(state.pressure_typed().get::<pascal>(), state.pressure);
+        assert_eq!(state.wind_typed().raw_si(), state.wind);
+    }
+
+    #[test]
+    fn typed_accessors_default_state() {
+        let state = AtmosphereState::default();
+        assert_eq!(state.density_typed().get::<kilogram_per_cubic_meter>(), 0.0);
+        assert_eq!(state.temperature_typed().get::<kelvin>(), 0.0);
+        assert_eq!(state.pressure_typed().get::<pascal>(), 0.0);
+        assert_eq!(state.wind_typed().raw_si(), DVec3::ZERO);
+    }
+
+    #[test]
+    fn corotation_wind_typed_matches_raw() {
+        let omega_raw = 7.292115146706388e-5;
+        let pos_raw = DVec3::new(7.0e6, 3.0e6, 1.0e6);
+
+        let typed_out =
+            compute_corotation_wind_typed(omega_raw.rad_per_s(), pos_raw.m_at::<Inertial>());
+        let raw_out = compute_corotation_wind(omega_raw, pos_raw);
+
+        // Typed path must be bit-identical to the raw f64 path.
+        assert_eq!(typed_out.raw_si(), raw_out);
+    }
+
+    #[test]
+    fn corotation_wind_typed_zero_omega() {
+        let pos = DVec3::new(7e6, 3e6, 1e6).m_at::<Inertial>();
+        let wind = compute_corotation_wind_typed(0.0.rad_per_s(), pos);
+        assert_eq!(wind.raw_si(), DVec3::ZERO);
     }
 }


### PR DESCRIPTION
## Summary

Additive typed accessors for `jeod_atmosphere` as part of Phase 1 (#103) of the type-system refactor (#101).

- Adds `density_typed() -> MassDensity`, `temperature_typed() -> ThermodynamicTemperature`, `pressure_typed() -> Pressure`, and `wind_typed() -> Velocity<Inertial>` methods on `AtmosphereState`.
- Adds `compute_corotation_wind_typed(AngularVelocity, Position<Inertial>) -> Velocity<Inertial>` that delegates to the existing f64/DVec3 implementation for bit-identical behavior.
- All existing `pub f64`/`DVec3` fields and the raw `compute_corotation_wind` function are unchanged. Phase 10 handles full cleanup.
- Adds `uom` (workspace dep) to `jeod_atmosphere/Cargo.toml` so the scalar types can be named directly.

## Test plan

- [x] Inline tests assert bit-identical round-trips through the typed accessors (`get::<kilogram_per_cubic_meter>() == original f64`, etc.).
- [x] Inline test asserts typed corotation wind output exactly equals the raw DVec3 result for a non-trivial position.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --tests -- -D warnings` clean.
- [x] `cargo nextest run -p jeod_atmosphere` — 31/31 pass (4 new).
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 631/631 pass.
- [x] `cargo check --workspace` clean.

No Tier 3 test files were modified.

Ref: #101 (parent), #103 (this phase).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>