### PR TITLE
[Phase 1 #103] jeod_test_data: typed accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
  "glam 0.30.10",
  "jeod_quantities",
  "regex",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_test_data/Cargo.toml
+++ b/crates/jeod_test_data/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 regex = "1"
+uom = { workspace = true }

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -6,8 +6,10 @@
 //! `target/tier3_crossval/<test_name>.json`.
 
 use glam::{DQuat, DVec3};
+use jeod_quantities::prelude::*;
 use std::io::Write;
 use std::path::PathBuf;
+use uom::si::f64::{Angle, AngularVelocity, Length, Velocity};
 
 fn output_dir() -> PathBuf {
     let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -180,6 +182,26 @@ impl CrossvalReport {
     /// Quaternion angle error in radians (rotation-invariant).
     pub fn max_quat_angle(&self) -> f64 {
         self.quat_angle.unwrap_or(0.0)
+    }
+
+    /// Worst-component position error as a typed [`Length`] (meters).
+    pub fn max_position_typed(&self) -> Length {
+        self.max_position_component().m()
+    }
+
+    /// Worst-component velocity error as a typed [`Velocity`] (m/s).
+    pub fn max_velocity_typed(&self) -> Velocity {
+        self.max_velocity_component().m_per_s()
+    }
+
+    /// Worst-component angular velocity error as a typed [`AngularVelocity`] (rad/s).
+    pub fn max_ang_vel_typed(&self) -> AngularVelocity {
+        self.max_ang_vel_component().rad_per_s()
+    }
+
+    /// Quaternion angle error as a typed [`Angle`] (radians).
+    pub fn max_quat_angle_typed(&self) -> Angle {
+        self.max_quat_angle().rad()
     }
 
     /// Assert each position component is within its tolerance.

--- a/crates/jeod_test_data/src/reference_state.rs
+++ b/crates/jeod_test_data/src/reference_state.rs
@@ -1,4 +1,5 @@
 use glam::DVec3;
+use jeod_quantities::prelude::*;
 use regex::Regex;
 
 /// ISS reference translational state from JEOD verification data.
@@ -11,10 +12,32 @@ use regex::Regex;
 ///   vehicle_reference.expected_state.trans.position  = [      1244540.53,   5655938.85,   3425643.22]
 ///   vehicle_reference.expected_state.trans.velocity  = [    -6003.833051, -1469.496044,  4590.511776]
 /// ```
+///
+/// Frame: inertial (ICRF) — JEOD's `reference_inertial_trans_state.py` files
+/// specify the state in the inertial frame. Use [`ReferenceState::position_typed`]
+/// and [`ReferenceState::velocity_typed`] to obtain frame-tagged typed views.
 #[derive(Debug, Clone)]
 pub struct ReferenceState {
     pub position: DVec3,
     pub velocity: DVec3,
+}
+
+impl ReferenceState {
+    /// Frame-tagged typed position in the inertial (ICRF) frame.
+    ///
+    /// This wraps the raw SI-unit `DVec3` (meters) without conversion.
+    #[inline]
+    pub fn position_typed(&self) -> Position<Inertial> {
+        self.position.m_at::<Inertial>()
+    }
+
+    /// Frame-tagged typed velocity in the inertial (ICRF) frame.
+    ///
+    /// This wraps the raw SI-unit `DVec3` (m/s) without conversion.
+    #[inline]
+    pub fn velocity_typed(&self) -> Velocity<Inertial> {
+        self.velocity.m_per_s_at::<Inertial>()
+    }
 }
 
 /// Load an ISS reference translational state from JEOD's verification data.
@@ -59,5 +82,57 @@ pub fn load_reference_state(
     ReferenceState {
         position: arrays[0],
         velocity: arrays[1],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uom::si::{length::meter, velocity::meter_per_second};
+
+    #[test]
+    fn position_typed_matches_raw_components_bit_identically() {
+        let pos = DVec3::new(1244540.53, 5655938.85, 3425643.22);
+        let vel = DVec3::new(-6003.833051, -1469.496044, 4590.511776);
+        let state = ReferenceState {
+            position: pos,
+            velocity: vel,
+        };
+
+        let typed = state.position_typed();
+        // Bit-identical per-component check.
+        assert_eq!(typed.x.get::<meter>().to_bits(), pos.x.to_bits());
+        assert_eq!(typed.y.get::<meter>().to_bits(), pos.y.to_bits());
+        assert_eq!(typed.z.get::<meter>().to_bits(), pos.z.to_bits());
+        // Raw-SI round-trip also bit-identical.
+        assert_eq!(typed.raw_si(), pos);
+    }
+
+    #[test]
+    fn velocity_typed_matches_raw_components_bit_identically() {
+        let pos = DVec3::new(1244540.53, 5655938.85, 3425643.22);
+        let vel = DVec3::new(-6003.833051, -1469.496044, 4590.511776);
+        let state = ReferenceState {
+            position: pos,
+            velocity: vel,
+        };
+
+        let typed = state.velocity_typed();
+        assert_eq!(typed.x.get::<meter_per_second>().to_bits(), vel.x.to_bits());
+        assert_eq!(typed.y.get::<meter_per_second>().to_bits(), vel.y.to_bits());
+        assert_eq!(typed.z.get::<meter_per_second>().to_bits(), vel.z.to_bits());
+        assert_eq!(typed.raw_si(), vel);
+    }
+
+    #[test]
+    fn typed_accessors_preserve_zero_and_negative_components() {
+        let state = ReferenceState {
+            position: DVec3::new(0.0, -1.5e7, 9.87654),
+            velocity: DVec3::new(-7123.456, 0.0, 42.0),
+        };
+        let p = state.position_typed();
+        let v = state.velocity_typed();
+        assert_eq!(p.raw_si(), state.position);
+        assert_eq!(v.raw_si(), state.velocity);
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 additive-typed-API migration for `jeod_test_data` (part of #101 / sub-issue #103).

- **`ReferenceState`** (`crates/jeod_test_data/src/reference_state.rs`): adds `position_typed() -> Position<Inertial>` and `velocity_typed() -> Velocity<Inertial>`. The existing `pub position: DVec3` and `pub velocity: DVec3` fields are kept as-is — callers migrate at their own pace.
- **`CrossvalReport`** (`crates/jeod_test_data/src/crossval.rs`): adds four one-line typed convenience accessors (`max_position_typed -> Length`, `max_velocity_typed -> Velocity`, `max_ang_vel_typed -> AngularVelocity`, `max_quat_angle_typed -> Angle`). The f64 / `[f64;3]` fields and the JSON serialization format are untouched.

### Wire format stability (intentional)

- Internal CSV parsing stays f64-internal. JEOD reference CSVs ship raw doubles and must round-trip unchanged.
- `baselines.json` — and therefore the binaries that write/diff it — must keep producing bit-identical JSON. For that reason:
  - `crates/jeod_test_data/src/bin/tier3_report.rs` is **unchanged**.
  - `crates/jeod_test_data/src/bin/tier3_baseline_diff.rs` is **unchanged**.
  - No `tests/tier3_*.rs` files were touched in any crate.

### Tests

Three inline unit tests in `reference_state.rs` assert bit-identical per-component equality (`.to_bits()`) between the DVec3 input and the typed accessor output, including negative and zero components.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run -p jeod_test_data` (19 passed)
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (630 passed)
- [x] `cargo check --workspace`