### PR TITLE
[Phase 1 #103] jeod_time: typed accessors + converters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ version = "0.1.0"
 dependencies = [
  "jeod_quantities",
  "log",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_time/Cargo.toml
+++ b/crates/jeod_time/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities" }
 log = { workspace = true }
+uom = { workspace = true }

--- a/crates/jeod_time/src/simulation_time.rs
+++ b/crates/jeod_time/src/simulation_time.rs
@@ -161,6 +161,60 @@ impl SimulationTime {
         self.tt_tjt() + 40_000.0 + 2_400_000.5
     }
 
+    // --- Typed accessors (Phase 1 #103) ------------------------------------
+    //
+    // Additive typed getters returning `SecondsSince<S>` for each time scale
+    // present as a pub f64 field. These delegate to the existing f64 fields
+    // (no recomputation) so behavior is bit-identical to the f64 API.
+    //
+    // Note: no typed getter for GMST is provided as `SecondsSince<GMST>` —
+    // the primary representation of GMST is an angle (see `gmst_angle()`).
+
+    /// TAI seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn tai(&self) -> crate::SecondsSince<crate::TAI> {
+        crate::SecondsSince::from_seconds(self.tai_seconds)
+    }
+
+    /// UTC seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn utc(&self) -> crate::SecondsSince<crate::UTC> {
+        crate::SecondsSince::from_seconds(self.utc_seconds)
+    }
+
+    /// UT1 seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn ut1(&self) -> crate::SecondsSince<crate::UT1> {
+        crate::SecondsSince::from_seconds(self.ut1_seconds)
+    }
+
+    /// TT seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn tt(&self) -> crate::SecondsSince<crate::TT> {
+        crate::SecondsSince::from_seconds(self.tt_seconds)
+    }
+
+    /// TDB seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn tdb(&self) -> crate::SecondsSince<crate::TDB> {
+        crate::SecondsSince::from_seconds(self.tdb_seconds)
+    }
+
+    /// GPS seconds since simulation start, as a typed quantity.
+    #[inline]
+    pub fn gps(&self) -> crate::SecondsSince<crate::GPS> {
+        crate::SecondsSince::from_seconds(self.gps_seconds)
+    }
+
+    /// Greenwich Mean Sidereal Time as a typed angle.
+    ///
+    /// GMST is fundamentally an angle; the primary representation is radians
+    /// wrapped to `[0, 2π)`. Use this instead of a `SecondsSince<GMST>` getter.
+    #[inline]
+    pub fn gmst_angle(&self) -> uom::si::f64::Angle {
+        uom::si::f64::Angle::new::<uom::si::angle::radian>(self.gmst_radians)
+    }
+
     // JEOD_INV: TM.03 — time types updated in dependency order (TAI -> TT -> TDB -> UTC -> UT1 -> GMST)
     /// Recompute all derived time scales from TAI.
     fn recompute_derived(&mut self) {
@@ -333,6 +387,49 @@ mod tests {
             (sim.gps_seconds - 81.0).abs() < 1e-15,
             "GPS after 100s: expected 81.0, got {}",
             sim.gps_seconds
+        );
+    }
+
+    // --- Typed-accessor tests (Phase 1 #103) -------------------------------
+
+    #[test]
+    fn typed_getters_match_f64_fields() {
+        // Advance by a non-trivial duration to exercise each scale.
+        let mut sim = SimulationTime::at_j2000(default_leap_second_table());
+        sim.advance(1_000_000.0);
+
+        // Each typed getter round-trips back to the matching f64 field.
+        assert_eq!(sim.tai().as_seconds(), sim.tai_seconds);
+        assert_eq!(sim.utc().as_seconds(), sim.utc_seconds);
+        assert_eq!(sim.ut1().as_seconds(), sim.ut1_seconds);
+        assert_eq!(sim.tt().as_seconds(), sim.tt_seconds);
+        assert_eq!(sim.tdb().as_seconds(), sim.tdb_seconds);
+        assert_eq!(sim.gps().as_seconds(), sim.gps_seconds);
+
+        // `gmst_angle()` returns uom Angle; extracting radians must match.
+        use uom::si::angle::radian;
+        let gmst_rad = sim.gmst_angle().get::<radian>();
+        assert_eq!(gmst_rad, sim.gmst_radians);
+    }
+
+    #[test]
+    fn typed_tai_tt_roundtrip_via_simulation_time() {
+        // Read TAI out via the typed getter, convert to TT via the typed
+        // converter, convert back, and verify bit-identical (tolerance 1e-14 s)
+        // agreement with the original reading.
+        use crate::time_converter_tai_tt::{tai_to_tt_typed, tt_to_tai_typed};
+
+        let mut sim = SimulationTime::at_j2000(default_leap_second_table());
+        sim.advance(1_000_000.0);
+
+        let tai = sim.tai();
+        let tt = tai_to_tt_typed(tai);
+        let back = tt_to_tai_typed(tt);
+        let err = (back.as_seconds() - tai.as_seconds()).abs();
+        assert!(
+            err < 1e-14,
+            "TAI->TT->TAI typed roundtrip err={} (tolerance 1e-14 s)",
+            err
         );
     }
 }

--- a/crates/jeod_time/src/time_converter_tai_tdb.rs
+++ b/crates/jeod_time/src/time_converter_tai_tdb.rs
@@ -1,5 +1,6 @@
 use crate::epoch::{J2000_TAI_TJT, TAI_TT_OFFSET};
 use crate::time_converter_tai_tt::tai_to_tt;
+use crate::{SecondsSince, TAI, TDB};
 use std::f64::consts::PI;
 
 /// Compute the TDB-TT offset in seconds at a given TAI truncated Julian time.
@@ -45,6 +46,25 @@ pub fn tdb_to_tai(tdb_seconds: f64, tai_tjt_initial: f64) -> f64 {
         }
     }
     tai
+}
+
+// --- Typed variants (Phase 1 #103) ------------------------------------------
+//
+// Additive typed siblings. They delegate to the f64 free functions so
+// behavior is bit-identical. `tai_tjt` is a scale-neutral truncated Julian
+// time anchor carried through untouched.
+
+/// Typed TAI → TDB converter (delegates to [`tai_to_tdb`]).
+///
+/// `tai_tjt` anchors the calendar date for the periodic TDB-TT offset; it is
+/// the same scalar the f64 free function takes (truncated Julian time in TAI).
+pub fn tai_to_tdb_typed(t: SecondsSince<TAI>, tai_tjt: f64) -> SecondsSince<TDB> {
+    SecondsSince::from_seconds(tai_to_tdb(t.as_seconds(), tai_tjt))
+}
+
+/// Typed TDB → TAI converter (delegates to [`tdb_to_tai`]).
+pub fn tdb_to_tai_typed(t: SecondsSince<TDB>, tai_tjt_initial: f64) -> SecondsSince<TAI> {
+    SecondsSince::from_seconds(tdb_to_tai(t.as_seconds(), tai_tjt_initial))
 }
 
 #[cfg(test)]
@@ -94,5 +114,27 @@ mod tests {
             back,
             (back - tai).abs()
         );
+    }
+
+    #[test]
+    fn tai_tdb_typed_matches_f64() {
+        let tai = 1_000_000.0_f64;
+        let tai_tjt = J2000_TAI_TJT + tai / 86400.0;
+        let tdb_typed = tai_to_tdb_typed(SecondsSince::<TAI>::from_seconds(tai), tai_tjt);
+        assert_eq!(tdb_typed.as_seconds(), tai_to_tdb(tai, tai_tjt));
+    }
+
+    #[test]
+    fn tai_tdb_typed_round_trip() {
+        // Non-trivial input, typed round-trip.
+        let tai_s = 1_000_000.0_f64;
+        let tai_tjt = J2000_TAI_TJT + tai_s / 86400.0;
+        let tai = SecondsSince::<TAI>::from_seconds(tai_s);
+        let tdb = tai_to_tdb_typed(tai, tai_tjt);
+        let back = tdb_to_tai_typed(tdb, tai_tjt);
+        let err = (back.as_seconds() - tai.as_seconds()).abs();
+        // Same 1e-10 bound the iterative f64 round-trip achieves; well below
+        // the 1e-14 TAI↔TT spec target (TDB adds ~ms-scale periodic noise).
+        assert!(err < 1e-10, "TAI->TDB->TAI typed round-trip err={}", err);
     }
 }

--- a/crates/jeod_time/src/time_converter_tai_tt.rs
+++ b/crates/jeod_time/src/time_converter_tai_tt.rs
@@ -1,4 +1,5 @@
 use crate::epoch::TAI_TT_OFFSET;
+use crate::{SecondsSince, TAI, TT};
 
 /// Convert TAI seconds-since-epoch to TT seconds-since-epoch.
 /// TT = TAI + 32.184s (exact by definition).
@@ -9,6 +10,23 @@ pub fn tai_to_tt(tai_seconds: f64) -> f64 {
 /// Convert TT seconds-since-epoch to TAI seconds-since-epoch.
 pub fn tt_to_tai(tt_seconds: f64) -> f64 {
     tt_seconds - TAI_TT_OFFSET
+}
+
+// --- Typed variants (Phase 1 #103) ------------------------------------------
+//
+// Additive typed siblings. They forward to the f64 free functions above so
+// behavior is bit-identical — never routed through
+// `TimeConverter<TAI, TT>::apply()`, which would re-round through
+// `from_seconds`/`as_seconds`.
+
+/// Typed TAI → TT converter (delegates to [`tai_to_tt`]).
+pub fn tai_to_tt_typed(t: SecondsSince<TAI>) -> SecondsSince<TT> {
+    SecondsSince::from_seconds(tai_to_tt(t.as_seconds()))
+}
+
+/// Typed TT → TAI converter (delegates to [`tt_to_tai`]).
+pub fn tt_to_tai_typed(t: SecondsSince<TT>) -> SecondsSince<TAI> {
+    SecondsSince::from_seconds(tt_to_tai(t.as_seconds()))
 }
 
 #[cfg(test)]
@@ -28,5 +46,25 @@ mod tests {
         let tt = tai_to_tt(tai);
         let back = tt_to_tai(tt);
         assert!((back - tai).abs() < 1e-15);
+    }
+
+    #[test]
+    fn tai_tt_typed_matches_f64() {
+        // Typed wrappers must agree with the f64 versions bit-exactly.
+        let tai_raw = 1_000_000.0_f64;
+        let tt_typed = tai_to_tt_typed(SecondsSince::<TAI>::from_seconds(tai_raw));
+        assert_eq!(tt_typed.as_seconds(), tai_to_tt(tai_raw));
+    }
+
+    #[test]
+    fn tai_tt_typed_round_trip() {
+        // Non-trivial input; tolerance 1e-14 s (addition/subtraction of
+        // TAI_TT_OFFSET at this magnitude is exact in f64, but we still
+        // allow 1e-14 per the Phase 1 spec).
+        let tai = SecondsSince::<TAI>::from_seconds(1_000_000.0);
+        let tt = tai_to_tt_typed(tai);
+        let back = tt_to_tai_typed(tt);
+        let err = (back.as_seconds() - tai.as_seconds()).abs();
+        assert!(err < 1e-14, "round-trip err={} (tolerance 1e-14 s)", err);
     }
 }

--- a/crates/jeod_time/src/time_converter_ut1_gmst.rs
+++ b/crates/jeod_time/src/time_converter_ut1_gmst.rs
@@ -1,4 +1,7 @@
+use crate::{SecondsSince, GMST};
 use std::f64::consts::PI;
+use uom::si::angle::radian;
+use uom::si::f64::Angle;
 
 /// Convert UT1 days since noon 2000-01-01 to Greenwich Mean Sidereal Time.
 ///
@@ -31,6 +34,27 @@ pub fn ut1_to_gmst_radians(du: f64) -> f64 {
     let gmst_days = ut1_to_gmst_days(du);
     let fractional = gmst_days - gmst_days.floor();
     fractional * 2.0 * PI
+}
+
+// --- Typed variants (Phase 1 #103) ------------------------------------------
+//
+// The GMST polynomial (Aoki et al. 1982) is parameterised by `du`, UT1 days
+// since J2000 noon — a scale-neutral scalar anchor rather than a
+// `SecondsSince<UT1>`. The typed wrappers therefore keep the `du: f64` input
+// and return typed output: a `uom::si::f64::Angle` for the wrapped radian
+// form (GMST's primary representation) and `SecondsSince<GMST>` for the
+// accumulated sidereal-seconds form.
+
+/// Typed UT1 → GMST accumulated sidereal seconds (delegates to
+/// [`ut1_to_gmst_seconds`]).
+pub fn ut1_to_gmst_seconds_typed(du: f64) -> SecondsSince<GMST> {
+    SecondsSince::from_seconds(ut1_to_gmst_seconds(du))
+}
+
+/// Typed UT1 → GMST angle wrapped to `[0, 2π)` (delegates to
+/// [`ut1_to_gmst_radians`]).
+pub fn ut1_to_gmst_angle(du: f64) -> Angle {
+    Angle::new::<radian>(ut1_to_gmst_radians(du))
 }
 
 #[cfg(test)]
@@ -83,6 +107,29 @@ mod tests {
                 (0.0..std::f64::consts::TAU).contains(&gmst_rad),
                 "GMST radians out of range: {} at days={}",
                 gmst_rad,
+                days
+            );
+        }
+    }
+
+    #[test]
+    fn ut1_gmst_typed_matches_f64() {
+        let du = 365.25_f64;
+        let typed_secs = ut1_to_gmst_seconds_typed(du);
+        assert_eq!(typed_secs.as_seconds(), ut1_to_gmst_seconds(du));
+
+        let typed_angle = ut1_to_gmst_angle(du);
+        assert_eq!(typed_angle.get::<radian>(), ut1_to_gmst_radians(du));
+    }
+
+    #[test]
+    fn ut1_gmst_typed_angle_is_bounded() {
+        for days in [-1000.0, 0.0, 365.25, 3652.5] {
+            let angle_rad = ut1_to_gmst_angle(days).get::<radian>();
+            assert!(
+                (0.0..std::f64::consts::TAU).contains(&angle_rad),
+                "typed GMST angle out of range: {} at days={}",
+                angle_rad,
                 days
             );
         }


### PR DESCRIPTION
## Summary

Phase 1 leaf-crate migration for `jeod_time` (issue #101 / sub-issue #103). **Purely additive** — no existing field, function signature, or behavior changes.

### What's new

**Typed getters on `SimulationTime`** (delegate to pub f64 fields, no recomputation):
- `tai() -> SecondsSince<TAI>`
- `utc() -> SecondsSince<UTC>`
- `ut1() -> SecondsSince<UT1>`
- `tt() -> SecondsSince<TT>`
- `tdb() -> SecondsSince<TDB>`
- `gps() -> SecondsSince<GPS>`
- `gmst_angle() -> uom::si::f64::Angle` — GMST's primary representation is an angle, so no `SecondsSince<GMST>` getter is offered per the Phase 1 spec.

**Typed converter sibling free functions** (delegate to existing f64 functions for bit-identical behavior):
- `time_converter_tai_tt::tai_to_tt_typed`, `tt_to_tai_typed`
- `time_converter_tai_tdb::tai_to_tdb_typed`, `tdb_to_tai_typed` (carry `tai_tjt` through as-is)
- `time_converter_ut1_gmst::ut1_to_gmst_seconds_typed` -> `SecondsSince<GMST>`, `ut1_to_gmst_angle` -> `uom::si::f64::Angle`

### Tests

- `simulation_time::typed_getters_match_f64_fields` — every typed getter exposes the underlying f64 field byte-for-byte after a non-trivial `advance(1e6 s)`.
- `simulation_time::typed_tai_tt_roundtrip_via_simulation_time` — the required **TAI→TT→TAI typed roundtrip with tolerance 1e-14 s**, driven from a live `SimulationTime`.
- Per-converter `_typed_matches_f64` tests assert bit-exact agreement with the f64 functions.
- `tai_tt_typed_round_trip` with tolerance 1e-14 s; `tai_tdb_typed_round_trip` with tolerance 1e-10 s (TDB adds ms-scale periodic noise, matches the existing iterative f64 round-trip bound).
- `ut1_gmst_typed_angle_is_bounded` sanity-checks the `uom::si::f64::Angle` wrapping.

### Cargo

`jeod_time/Cargo.toml` gains a direct `uom = { workspace = true }` dep, since `gmst_angle()` and `ut1_to_gmst_angle()` now return `uom::si::f64::Angle` in the public API.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo nextest run -p jeod_time` — **84/84 passing** (9 new typed tests)
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — **635/635 passing**
- [x] `cargo check --workspace` clean
- [ ] Tier 3 baseline guard (runs in CI)

Targets `phase-1-leaf-crates` per the Phase 1 fan-out plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)