### PR TITLE
[Phase 1 #103] jeod_ephemeris: typed accessors

### DIFF
--- a/crates/jeod_ephemeris/src/ephemeris.rs
+++ b/crates/jeod_ephemeris/src/ephemeris.rs
@@ -5,6 +5,7 @@ use anise::constants::frames::*;
 use anise::constants::orientations::J2000;
 use anise::prelude::*;
 use glam::DVec3;
+use jeod_quantities::prelude::{Inertial, Position, Vec3Ext, Velocity};
 
 use crate::bodies::EphemerisBody;
 
@@ -51,6 +52,11 @@ impl Ephemeris {
     /// Get state of `target` relative to `observer` at a given TDB Julian Date.
     ///
     /// Returns `(position_m, velocity_m_per_s)` in J2000 ICRF.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.0-phase-1",
+        note = "use get_state_typed / get_earth_centered_state_typed; this f64 variant is removed in Phase 10"
+    )]
     pub fn get_state(
         &self,
         target: EphemerisBody,
@@ -89,12 +95,49 @@ impl Ephemeris {
     /// Get Earth-centered state of `target` at a given TDB Julian Date.
     ///
     /// Returns `(position_m, velocity_m_per_s)` relative to Earth center in J2000 ICRF.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.0-phase-1",
+        note = "use get_state_typed / get_earth_centered_state_typed; this f64 variant is removed in Phase 10"
+    )]
     pub fn get_earth_centered_state(
         &self,
         target: EphemerisBody,
         tdb_jd: f64,
     ) -> Result<(DVec3, DVec3), EphemerisError> {
+        #[allow(deprecated)]
         self.get_state(target, EphemerisBody::Earth, tdb_jd)
+    }
+
+    /// Get state of `target` relative to `observer` at a given TDB Julian Date,
+    /// returning frame-tagged, dimensioned quantities in the J2000 (ICRF-aligned)
+    /// inertial frame.
+    ///
+    /// This is the typed counterpart to [`Self::get_state`]; the underlying
+    /// ANISE translate call is unchanged, the returned values are simply wrapped
+    /// as `Position<Inertial>` / `Velocity<Inertial>` in SI base units
+    /// (meters, m/s).
+    pub fn get_state_typed(
+        &self,
+        target: EphemerisBody,
+        observer: EphemerisBody,
+        tdb_jd: f64,
+    ) -> Result<(Position<Inertial>, Velocity<Inertial>), EphemerisError> {
+        #[allow(deprecated)]
+        let (pos_m, vel_m_s) = self.get_state(target, observer, tdb_jd)?;
+        Ok((pos_m.m_at::<Inertial>(), vel_m_s.m_per_s_at::<Inertial>()))
+    }
+
+    /// Earth-centered variant of [`Self::get_state_typed`].
+    ///
+    /// Returns `(Position<Inertial>, Velocity<Inertial>)` relative to Earth
+    /// center in J2000 ICRF (meters, m/s).
+    pub fn get_earth_centered_state_typed(
+        &self,
+        target: EphemerisBody,
+        tdb_jd: f64,
+    ) -> Result<(Position<Inertial>, Velocity<Inertial>), EphemerisError> {
+        self.get_state_typed(target, EphemerisBody::Earth, tdb_jd)
     }
 
     /// Get the rotation matrix from J2000 inertial to a body's body-fixed frame.
@@ -195,4 +238,65 @@ pub enum EphemerisError {
     LoadError(String),
     #[error("Ephemeris query failed: {0}")]
     QueryError(String),
+}
+
+#[cfg(test)]
+mod typed_accessor_tests {
+    //! Bit-identical equivalence between the deprecated `DVec3` accessors and
+    //! their typed siblings. Uses the committed `de421.bsp` kernel in
+    //! `test_data/`; the test will panic with a descriptive message if the
+    //! kernel is missing (no graceful skip — see project policy).
+    //!
+    //! We compare via `raw_si()` because the typed accessors return SI base
+    //! units (meters, m/s), so a matching `raw_si()` DVec3 is also bit-exact
+    //! in the intended unit.
+    use super::*;
+    use std::path::PathBuf;
+
+    const J2000_TDB_JD: f64 = 2_451_545.0;
+
+    fn load_de421() -> Ephemeris {
+        // crates/jeod_ephemeris -> workspace root -> test_data/de421.bsp
+        let path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("workspace root")
+            .join("test_data/de421.bsp");
+        assert!(
+            path.exists(),
+            "DE421.bsp not found at {}. Download with: curl -Lo test_data/de421.bsp https://public-data.nyxspace.com/anise/de421.bsp",
+            path.display(),
+        );
+        Ephemeris::from_bsp(&path).expect("load DE421.bsp")
+    }
+
+    #[test]
+    fn get_state_typed_is_bit_identical_to_get_state() {
+        let ephem = load_de421();
+        #[allow(deprecated)]
+        let (pos_dvec, vel_dvec) = ephem
+            .get_state(EphemerisBody::Moon, EphemerisBody::Earth, J2000_TDB_JD)
+            .expect("query Moon state");
+        let (pos_t, vel_t) = ephem
+            .get_state_typed(EphemerisBody::Moon, EphemerisBody::Earth, J2000_TDB_JD)
+            .expect("query Moon state (typed)");
+
+        assert_eq!(pos_t.raw_si(), pos_dvec);
+        assert_eq!(vel_t.raw_si(), vel_dvec);
+    }
+
+    #[test]
+    fn get_earth_centered_state_typed_is_bit_identical() {
+        let ephem = load_de421();
+        #[allow(deprecated)]
+        let (pos_dvec, vel_dvec) = ephem
+            .get_earth_centered_state(EphemerisBody::Sun, J2000_TDB_JD)
+            .expect("query Sun state");
+        let (pos_t, vel_t) = ephem
+            .get_earth_centered_state_typed(EphemerisBody::Sun, J2000_TDB_JD)
+            .expect("query Sun state (typed)");
+
+        assert_eq!(pos_t.raw_si(), pos_dvec);
+        assert_eq!(vel_t.raw_si(), vel_dvec);
+    }
 }

--- a/crates/jeod_ephemeris/tests/ephemeris_validation.rs
+++ b/crates/jeod_ephemeris/tests/ephemeris_validation.rs
@@ -3,6 +3,12 @@
 //! Requires `test_data/de421.bsp` to be present. Download with:
 //!   curl -Lo test_data/de421.bsp https://public-data.nyxspace.com/anise/de421.bsp
 
+// These validation tests still call the Phase-1-deprecated `DVec3` accessors
+// directly. Migrating them to the typed accessors is Phase 3+ work per
+// issue #101; keep the deprecated-lint suppression local so `-D warnings`
+// stays clean.
+#![allow(deprecated)]
+
 use jeod_ephemeris::{Ephemeris, EphemerisBody};
 use std::path::Path;
 

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -61,11 +61,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let epoch_tdb_jd = time.tdb_julian_date();
 
     // Get Moon and Sun positions at epoch
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (moon_pos, _) = ephemeris.get_state(
         jeod_sim::EphemerisBody::Moon,
         jeod_sim::EphemerisBody::Earth,
         epoch_tdb_jd,
     )?;
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris.get_state(
         jeod_sim::EphemerisBody::Sun,
         jeod_sim::EphemerisBody::Earth,

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -109,6 +109,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Earth: 3rd-body perturbation with per-step ephemeris
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (earth_pos, _) =
         ephemeris.get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)?;
     let earth = sim.add_source(
@@ -125,6 +127,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
 
     // Sun: 3rd-body + SRP source with per-step ephemeris
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) =
         ephemeris.get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)?;
     let sun = sim.add_source(

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -68,6 +68,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let time = SimulationTime::new(EPOCH_TAI_TJT, jeod_sim::default_leap_second_table());
     let epoch_tdb_jd = time.tdb_julian_date();
 
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris.get_state(
         jeod_sim::EphemerisBody::Sun,
         jeod_sim::EphemerisBody::Mars,

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1552,6 +1552,10 @@ impl Simulation {
             let tdb_jd = self.time.tdb_julian_date();
             for i in 0..self.source_ephem_bodies.len() {
                 if let Some(Some((target, observer))) = self.source_ephem_bodies.get(i) {
+                    // Phase 1 (#103): the `DVec3` accessor is deprecated; migration
+                    // to `get_state_typed` happens in Phase 3+ once downstream state
+                    // storage is typed.
+                    #[allow(deprecated)]
                     let (pos, vel) =
                         eph.get_state(*target, *observer, tdb_jd)
                             .unwrap_or_else(|e| {

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -65,6 +65,8 @@ fn pipeline_earth_lighting_smoke() {
 
     // Sun from DE421
     let j2000_jd = 2_451_545.0;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, j2000_jd)
         .expect("Sun position at J2000");
@@ -89,6 +91,8 @@ fn pipeline_earth_lighting_smoke() {
     sim.sun_source = Some(sun);
 
     // Moon from DE421
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_moon, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Moon, j2000_jd)
         .expect("Moon position at J2000");

--- a/crates/jeod_runner/tests/tier3_sim_battin.rs
+++ b/crates/jeod_runner/tests/tier3_sim_battin.rs
@@ -40,9 +40,12 @@ const LOG_INTERVAL: f64 = 60.0;
 
 /// Compute Earth-centered position and velocity of a body from DE421 ephemeris.
 fn earth_centered_state(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> (DVec3, DVec3) {
-    ephemeris
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
+    let out = ephemeris
         .get_earth_centered_state(body, tdb_jd)
-        .expect("ephemeris query failed")
+        .expect("ephemeris query failed");
+    out
 }
 
 /// Build a `Simulation` with ISS-like orbit, Earth central, Sun + Moon third-body.

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
@@ -33,6 +33,8 @@ const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 /// Compute Earth-centered position of a body from DE421 ephemeris.
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
@@ -34,6 +34,8 @@ use std::path::Path;
 const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -150,6 +150,8 @@ fn tier3_simulation_earth_moon_clem() {
 
     // Earth as 3rd-body with per-step ephemeris updates
     let epoch_tdb_jd = sim.time.tdb_julian_date();
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (earth_pos_from_moon, _earth_vel) = ephemeris
         .get_state(EphemerisBody::Earth, EphemerisBody::Moon, epoch_tdb_jd)
         .expect("Earth-Moon state from DE421");
@@ -168,6 +170,8 @@ fn tier3_simulation_earth_moon_clem() {
     sim.set_source_ephemeris(earth, EphemerisBody::Earth, EphemerisBody::Moon);
 
     // Sun as 3rd-body with per-step ephemeris updates (also SRP source)
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos_from_moon, _) = ephemeris
         .get_state(EphemerisBody::Sun, EphemerisBody::Moon, epoch_tdb_jd)
         .expect("Sun-Moon state from DE421");

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -101,6 +101,8 @@ fn tier3_simulation_mars_dawn() {
     let bsp_path = test_data_path("de421.bsp");
     let ephemeris = jeod_sim::Ephemeris::from_bsp(&bsp_path).expect("load DE421");
     let epoch_tdb_jd = time.tdb_julian_date();
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos_from_mars, _sun_vel) = ephemeris
         .get_state(
             jeod_sim::EphemerisBody::Sun,

--- a/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
+++ b/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
@@ -94,6 +94,8 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
 
     // Sun from DE421 (query in TDB JD, not TAI JD)
     let tdb_jd = sim.time.tdb_julian_date();
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position at epoch");

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
@@ -94,6 +94,8 @@ fn tier3_simulation_solar_beta() {
     // by tier3_sim_dyncomp_run4 and tier3_sim_torque_simple.
     // J2000.0 = JD 2451545.0
     let j2000_jd = 2_451_545.0;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, j2000_jd)
         .expect("Sun position at J2000");
@@ -144,6 +146,8 @@ fn tier3_simulation_solar_beta() {
     for record in &trajectory[1..] {
         // Update Sun position from ephemeris
         let tdb_jd = j2000_jd + record.time / 86_400.0;
+        // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+        #[allow(deprecated)]
         let (sun_pos, _) = ephemeris
             .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
             .expect("Sun position query");

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
@@ -137,6 +137,8 @@ fn run_solar_beta_test(
     );
 
     // Sun source — position from DE421 at epoch
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (initial_sun, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, EPOCH_TDB_JD)
         .expect("Sun position at epoch");

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -92,6 +92,8 @@ fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
 
 fn srp_sun_position(sim_time: f64, epoch_tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
     let tdb_jd = epoch_tdb_jd + sim_time / 86400.0;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position query failed");

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -100,6 +100,8 @@ fn srp_plates() -> Vec<(FlatPlate, FlatPlateParams, FlatPlateThermal)> {
 fn srp_sun_position(sim_time: f64, epoch_tai_tjt: f64, ephemeris: &Ephemeris) -> DVec3 {
     let sim_days = sim_time / 86400.0;
     let tdb_jd = (epoch_tai_tjt + sim_days) + 40000.0 + 2_400_000.5;
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_pos, _) = ephemeris
         .get_earth_centered_state(EphemerisBody::Sun, tdb_jd)
         .expect("Sun position query failed");

--- a/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
@@ -26,6 +26,8 @@ use std::path::Path;
 const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -110,6 +110,8 @@ struct RunConfig {
 
 /// Compute Earth-centered position of a body from DE421 ephemeris.
 fn earth_centered_position(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _) = ephemeris
         .get_earth_centered_state(body, tdb_jd)
         .expect("ephemeris query failed");

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -114,6 +114,10 @@ pub fn ephemeris_update_system(
     };
     let tdb_jd = sim_time.tdb_julian_date();
     for (ephem_body, mut source_pos, source_vel, trans_state) in &mut query {
+        // Phase 1 (#103): the `DVec3` accessor is deprecated; migration
+        // to `get_state_typed` happens in Phase 3+ once downstream state
+        // storage is typed.
+        #[allow(deprecated)]
         let (pos, vel) = eph
             .get_state(ephem_body.target, ephem_body.observer, tdb_jd)
             .unwrap_or_else(|e| {

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -442,6 +442,8 @@ fn tier3_bevy_mars_dawn() {
     };
 
     let eph_init = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (sun_rel_mars, _) = eph_init
         .get_state(EphemerisBody::Sun, EphemerisBody::Mars, J2000_JD)
         .expect("Sun wrt Mars at J2000");

--- a/tests/parity_helpers/mod.rs
+++ b/tests/parity_helpers/mod.rs
@@ -346,6 +346,8 @@ fn de421_ephemeris() -> &'static Ephemeris {
 
 /// Helper: load initial Sun position from DE421 at J2000 (cached ephemeris).
 pub fn sun_initial_pos() -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _vel) = de421_ephemeris()
         .get_earth_centered_state(EphemerisBody::Sun, J2000_JD)
         .expect("Sun state at J2000");
@@ -354,6 +356,8 @@ pub fn sun_initial_pos() -> DVec3 {
 
 /// Helper: load initial Moon position from DE421 at J2000 (cached ephemeris).
 pub fn moon_initial_pos() -> DVec3 {
+    // Phase 1 (#103): DVec3 accessor is deprecated; migration is Phase 3+ work.
+    #[allow(deprecated)]
     let (pos, _vel) = de421_ephemeris()
         .get_earth_centered_state(EphemerisBody::Moon, J2000_JD)
         .expect("Moon state at J2000");


### PR DESCRIPTION
## Summary

Phase 1 sub-PR for issue #101 (type-system refactor), scoped to `jeod_ephemeris`.
Adds dimensioned / frame-tagged sibling methods next to the existing
`DVec3`-returning ephemeris accessors:

- `Ephemeris::get_state_typed(target, observer, tdb_jd) -> (Position<Inertial>, Velocity<Inertial>)`
- `Ephemeris::get_earth_centered_state_typed(target, tdb_jd) -> (Position<Inertial>, Velocity<Inertial>)`

Implementation delegates to the existing ANISE translate call and wraps the
result via `Vec3Ext::{m_at, m_per_s_at}` — no behavior change, no new
numerical path.

The original `get_state` / `get_earth_centered_state` are now
`#[doc(hidden)] #[deprecated(since = "0.2.0-phase-1", ...)]`. They remain on
the API surface through Phase 10 so downstream crates can migrate piecewise.

## `#[allow(deprecated)]` propagation

The deprecation warnings fire in downstream crates. To keep CI's
`cargo clippy --workspace --tests -- -D warnings` green without migrating
those call sites (Phase 3+ work), the following locations got a localized,
single-call-site `#[allow(deprecated)]`:

**Production code**

- `crates/jeod_runner/src/lib.rs` (ephemeris-update loop, one call)
- `src/systems.rs` (Bevy adapter `ephemeris_update_system`, one call)

**Non-Tier-3 tests / helpers**

- `crates/jeod_runner/tests/pipeline_earth_lighting.rs`
- `tests/parity_helpers/mod.rs`
- `tests/bevy_parity_third_body.rs`
- `crates/jeod_ephemeris/tests/ephemeris_validation.rs` (module-level `#![allow(deprecated)]`)

**Tier 3 tests** — these files contain only lint-attribute additions; no
test logic, tolerance, or initial-condition changes. The baseline-invariance
CI guard compares trajectory numerics which are unaffected:

- `crates/jeod_runner/tests/tier3_sim_battin.rs`
- `crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs`
- `crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs`
- `crates/jeod_runner/tests/tier3_sim_earth_moon.rs`
- `crates/jeod_runner/tests/tier3_sim_mars_orbit.rs`
- `crates/jeod_runner/tests/tier3_sim_shadow_2a.rs`
- `crates/jeod_runner/tests/tier3_sim_solar_beta.rs`
- `crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs`
- `crates/jeod_runner/tests/tier3_sim_srp.rs`
- `crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs`
- `crates/jeod_runner/tests/tier3_sim_tide_verif.rs`
- `crates/jeod_runner/tests/tier3_sim_torque_simple.rs`

**Examples** (outside CI's `--tests` scope but kept consistent):

- `crates/jeod_runner/examples/apollo.rs`
- `crates/jeod_runner/examples/earth_moon.rs`
- `crates/jeod_runner/examples/mars_orbit.rs`

## Tests

New inline `#[cfg(test)] mod typed_accessor_tests` in `ephemeris.rs`:

- `get_state_typed_is_bit_identical_to_get_state` — Moon vs Earth, J2000 TDB
- `get_earth_centered_state_typed_is_bit_identical` — Sun vs Earth, J2000 TDB

Both compare via `Qty3::raw_si()` against the deprecated accessor's `DVec3`
return value using `assert_eq!` — bit-for-bit identity is required.

Tests use the committed `test_data/de421.bsp` kernel and panic with a
descriptive download command if it is missing (no graceful skip — per
project policy).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run -p jeod_ephemeris` (8/8 passing incl. 2 new)
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (629/629 passing)
- [x] `cargo check --workspace`
- [ ] Tier 3 baseline guard (expected to pass — no physics or numerical path changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)