### PR TITLE
[Phase 2 #104] integrator_bit_match regression test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,6 +2356,7 @@ dependencies = [
  "jeod_math",
  "jeod_planet",
  "jeod_test_data",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -13,3 +13,4 @@ jeod_math = { path = "../jeod_math", features = ["test-utils"] }
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_gravity = { path = "../jeod_gravity" }
 jeod_planet = { path = "../jeod_planet" }
+sha2 = "0.10"

--- a/crates/jeod_dynamics/tests/integrator_bit_match.rs
+++ b/crates/jeod_dynamics/tests/integrator_bit_match.rs
@@ -1,0 +1,89 @@
+//! Bit-identity regression test for the RK4 Kepler propagation path.
+//!
+//! Issue #101's type-system refactor wraps f64 computations in uom/typed
+//! newtypes. We expect these wrappers to be zero-cost — the compiler's
+//! IR should be byte-identical pre/post wrapping. This test pins a SHA-256
+//! of the integrator's output to catch any reordering that would shift
+//! downstream Tier 3 baselines.
+//!
+//! If this test fails after a refactor-only commit, investigate *before*
+//! refreezing the hash: the Tier 3 baselines.json is downstream of this.
+
+use glam::DVec3;
+use jeod_dynamics::{rk4_translational_step, TranslationalState};
+use sha2::{Digest, Sha256};
+
+/// Earth gravitational parameter (m^3/s^2), same literal used elsewhere in the
+/// workspace (e.g. `examples/kepler_orbit.rs`).
+const MU_EARTH: f64 = 3.986_004_415e14;
+
+/// Number of RK4 steps to take. 1000 steps at 60 s each = 60000 s ≈ 2.9 ISS
+/// orbits, exercising many integration rounds without being test-time costly.
+const NUM_STEPS: usize = 1000;
+
+/// Fixed integration step size (seconds).
+const DT: f64 = 60.0;
+
+/// Pinned SHA-256 of the canonical byte representation of the final state.
+/// See the module docstring: update only after verifying that an IR change is
+/// intentional.
+const PINNED_HASH: &str = "7b87ea77d0f00400664c6f9711375362e050346ad5a086fa7db59b44e0f0b037";
+
+/// Point-mass Earth gravity acceleration (two-body Kepler problem).
+fn kepler_accel(state: &TranslationalState, _time_frac: f64) -> DVec3 {
+    let r = state.position.length();
+    -MU_EARTH / (r * r * r) * state.position
+}
+
+/// Format a single f64 as a lossless decimal string. The `{:.17e}` format
+/// guarantees round-trip equality for finite f64 values, so the hash depends
+/// only on the numerical value, not on endianness or host-architecture
+/// in-memory layout.
+fn fmt(v: f64) -> String {
+    format!("{:.17e}", v)
+}
+
+#[test]
+fn rk4_kepler_bit_match() {
+    // ISS-like circular initial conditions (SI units). Chosen to match the
+    // profile used in `examples/kepler_orbit.rs`: a ~400 km altitude equatorial
+    // orbit.
+    let mut state = TranslationalState {
+        position: DVec3::new(6_778_137.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7_668.589_305_449_398, 0.0),
+    };
+
+    for _ in 0..NUM_STEPS {
+        state = rk4_translational_step(&state, kepler_accel, DT);
+    }
+
+    // Canonical byte representation: six f64 components in fixed order,
+    // each formatted as `{:.17e}` and newline-separated (trailing newline).
+    let mut canonical = String::with_capacity(6 * 25);
+    canonical.push_str(&fmt(state.position.x));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.position.y));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.position.z));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.velocity.x));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.velocity.y));
+    canonical.push('\n');
+    canonical.push_str(&fmt(state.velocity.z));
+    canonical.push('\n');
+
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let hash_bytes = hasher.finalize();
+    let hash_hex: String = hash_bytes.iter().map(|b| format!("{b:02x}")).collect();
+
+    assert_eq!(
+        hash_hex, PINNED_HASH,
+        "RK4 Kepler bit-identity regression: the integrator output changed.\n\
+         Canonical bytes follow — investigate *before* refreezing the hash.\n\
+         ----- BEGIN CANONICAL BYTES -----\n\
+         {canonical}\
+         ----- END CANONICAL BYTES -----",
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `crates/jeod_dynamics/tests/integrator_bit_match.rs`, a SHA-256-pinned regression test for the RK4 Kepler propagation path.
- Catches compiler-IR-level drift introduced by the typed-wrapper refactors in issue #101 *before* Tier 3 baselines shift.
- Dev-dependency `sha2 = "0.10"` added, scoped to `jeod_dynamics` dev only.

## Details

- **Integrator entry point:** `jeod_dynamics::rk4_translational_step` (already `pub`; no API changes required).
- **Initial conditions:** ISS-like circular state, `r = 6_778_137.0 m`, `v = 7_668.589_305_449_398 m/s` tangential; `mu = 3.986_004_415e14 m^3/s^2` (the `MU_EARTH` literal used elsewhere in the workspace).
- **Propagation:** 1000 fixed RK4 steps at dt = 60 s (60_000 s total, ~2.9 ISS orbits).
- **Canonical bytes:** `[pos.x, pos.y, pos.z, vel.x, vel.y, vel.z]` each formatted `{:.17e}` (lossless for finite f64) and newline-separated. Independent of host endianness.
- **Pinned hash:** `7b87ea77d0f00400664c6f9711375362e050346ad5a086fa7db59b44e0f0b037`

## Rationale

Issue #101's type-system refactor wraps f64 in uom / typed newtypes. These wrappers should be zero-cost — the compiler's IR should be byte-identical pre/post wrapping. This test pins the integrator's final state so any accidental reordering or non-zero-cost abstraction is caught immediately, rather than surfacing later as a Tier 3 baseline drift.

On failure, the assertion message dumps the full canonical-byte block for diagnosis. The docstring warns reviewers to investigate *before* refreezing the hash.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run -p jeod_dynamics --test integrator_bit_match`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (629 passed)
- [x] `cargo check --workspace`