### PR TITLE
[Phase 2 #104] lvlh: typed frame transform

### DIFF
--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -10,7 +10,11 @@
 use crate::state::TranslationalState;
 use glam::{DMat3, DVec3};
 use jeod_math::OrbitalElements;
-use jeod_math::{compute_lvlh_frame, geodetic_to_cartesian, mat3_from_rows, GeodeticState};
+use jeod_math::{geodetic_to_cartesian, mat3_from_rows, GeodeticState};
+// `compute_lvlh_frame` is deprecated pending Phase 3 migration of this module
+// to the typed `compute_lvlh_frame_typed` API.
+#[allow(deprecated)]
+use jeod_math::compute_lvlh_frame;
 
 /// Initialize translational state from Keplerian orbital elements (true anomaly).
 ///
@@ -205,6 +209,7 @@ pub fn init_from_lvlh(
     ref_position: DVec3,
     ref_velocity: DVec3,
 ) -> TranslationalState {
+    #[allow(deprecated)]
     let lvlh = compute_lvlh_frame(ref_position, ref_velocity);
 
     // t_parent_this transforms from inertial to LVLH.
@@ -458,6 +463,7 @@ mod tests {
         let state = init_from_lvlh(lvlh_offset_pos, lvlh_offset_vel, ref_pos, ref_vel);
 
         // Now compute the LVLH frame at the reference orbit and transform back
+        #[allow(deprecated)]
         let lvlh = compute_lvlh_frame(ref_pos, ref_vel);
         let t = lvlh.t_parent_this;
 

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -15,4 +15,7 @@ test-utils = []
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_ephemeris = { path = "../jeod_ephemeris" }
 jeod_planet = { path = "../jeod_planet" }
+# `test-utils` exposes `jeod_quantities::frame::TestVehicle` for inline tests
+# that need a phantom vehicle tag (Vehicle is sealed in production).
+jeod_quantities = { path = "../jeod_quantities", features = ["test-utils"] }
 

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -29,7 +29,9 @@ pub use jeod_quantities::{
     JeodQuat, Layout, LeftTransform, NormalizedQuat, Quat, RightTransform, ScalarFirst, ScalarLast,
     Transform,
 };
-pub use lvlh::{compute_lvlh_frame, LvlhFrame};
+#[allow(deprecated)]
+pub use lvlh::compute_lvlh_frame;
+pub use lvlh::{compute_lvlh_frame_typed, LvlhFrame};
 pub use orbital_elements::OrbitalElements;
 pub use solar_beta::solar_beta_angle;
 pub use types::*;

--- a/crates/jeod_math/src/lvlh.rs
+++ b/crates/jeod_math/src/lvlh.rs
@@ -11,6 +11,11 @@
 
 use glam::{DMat3, DVec3};
 
+use jeod_quantities::aliases::{Position, Velocity};
+use jeod_quantities::frame::{Inertial, Lvlh, Vehicle};
+use jeod_quantities::frame_transform::FrameTransform;
+use jeod_quantities::quat::{JeodQuat, NormalizedQuat};
+
 /// LVLH frame state: rotation matrix, angular velocity, and origin position/velocity.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LvlhFrame {
@@ -46,6 +51,11 @@ impl Default for LvlhFrame {
 ///
 /// # Panics
 /// Panics if position or angular momentum magnitude is zero.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_lvlh_frame_typed; f64 variant removed in Phase 10"
+)]
 pub fn compute_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     // Compute angular momentum vector: h = r × v
     let angmom = position.cross(velocity);
@@ -94,7 +104,50 @@ pub fn compute_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     }
 }
 
+/// Typed sibling of [`compute_lvlh_frame`]: returns a `FrameTransform` from
+/// the planet-centered inertial frame to the chief vehicle's LVLH frame.
+///
+/// Delegates to the f64-based computation, then wraps the resulting rotation
+/// matrix (`T_parent_this` — inertial → LVLH, rows are LVLH axes in the
+/// inertial frame) as a canonical JEOD scalar-first, left-transformation
+/// quaternion inside the `FrameTransform`.
+///
+/// Angular velocity, origin position, and origin velocity produced by the
+/// underlying LVLH computation are discarded here — this function returns
+/// only the frame orientation. Callers that need those auxiliary quantities
+/// should continue to use the (deprecated) f64 API until Phase 3+ migrates
+/// the full `LvlhFrame` struct to typed quantities.
+///
+/// # Arguments
+/// * `position` - Chief vehicle position in the planet-centered inertial frame.
+/// * `velocity` - Chief vehicle velocity in the planet-centered inertial frame.
+///
+/// # Panics
+/// Panics if position or angular momentum magnitude is zero (radial trajectory).
+pub fn compute_lvlh_frame_typed<Chief>(
+    position: Position<Inertial>,
+    velocity: Velocity<Inertial>,
+) -> FrameTransform<Inertial, Lvlh<Chief>>
+where
+    Chief: Vehicle,
+{
+    // Delegate to the f64-based port so physics stays in one place.
+    #[allow(deprecated)]
+    let lvlh = compute_lvlh_frame(position.raw_si(), velocity.raw_si());
+
+    // Convert the transformation matrix T_parent_this (inertial → LVLH) into
+    // a canonical JEOD left quaternion, then wrap in a `NormalizedQuat`
+    // witness. JEOD's `left_quat_from_transformation` extractor always returns
+    // a unit-norm result (it re-normalizes internally), but we renormalize
+    // defensively in case of rounding near the threshold.
+    let q: JeodQuat = JeodQuat::left_quat_from_transformation(&lvlh.t_parent_this);
+    let q_norm = NormalizedQuat::renormalize(q)
+        .expect("LVLH rotation matrix yields a finite, non-zero quaternion");
+    FrameTransform::<Inertial, Lvlh<Chief>>::from_quat(q_norm)
+}
+
 #[cfg(test)]
+#[allow(deprecated)] // existing f64 tests still exercise the deprecated API
 mod tests {
     use super::*;
 
@@ -217,5 +270,50 @@ mod tests {
         assert!(z_hat.x.abs() < 1e-14);
         assert!((z_hat.y + 1.0).abs() < 1e-14);
         assert!(z_hat.z.abs() < 1e-14);
+    }
+
+    // Re-alias the sealed-but-test-only chief marker from `jeod_quantities`.
+    // `Vehicle` is sealed, so we can't implement it here — the `test-utils`
+    // feature on `jeod_quantities` (dev-dep in our Cargo.toml) opens up
+    // `TestVehicle` specifically for tests like this.
+    use jeod_quantities::frame::TestVehicle as IssChief;
+
+    #[test]
+    fn typed_lvlh_matches_f64_port() {
+        // ISS-like inclined state in planet-centered inertial coordinates.
+        let r = 6_778_137.0; // ~ r_eq + 400 km
+        let v = (EARTH_MU / r).sqrt();
+        let inc = 51.6_f64.to_radians();
+
+        let position_raw = DVec3::new(r, 0.0, 0.0);
+        let velocity_raw = DVec3::new(0.0, v * inc.cos(), v * inc.sin());
+
+        // f64 baseline: derive the JEOD canonical quaternion from the old
+        // rotation-matrix output via the same extractor the typed variant uses.
+        let lvlh_f64 = compute_lvlh_frame(position_raw, velocity_raw);
+        let q_f64 = JeodQuat::left_quat_from_transformation(&lvlh_f64.t_parent_this);
+
+        // Typed sibling: build Position/Velocity and call compute_lvlh_frame_typed.
+        let position = Position::<Inertial>::from_raw_si(position_raw);
+        let velocity = Velocity::<Inertial>::from_raw_si(velocity_raw);
+        let xform = compute_lvlh_frame_typed::<IssChief>(position, velocity);
+
+        // Quaternion components must match bit-exactly — same extractor, same
+        // input matrix, same renormalization code path.
+        let q_typed = xform.quat().inner();
+        assert_eq!(
+            q_typed.data, q_f64.data,
+            "typed and f64 quaternion components must be bit-identical"
+        );
+
+        // Matrix cached inside the FrameTransform must round-trip through the
+        // quaternion → matrix derivation without drifting from orthonormality.
+        let m = xform.matrix();
+        let should_be_identity = m * m.transpose();
+        let diff = should_be_identity - DMat3::IDENTITY;
+        assert!(diff.x_axis.length() < 1e-14);
+        assert!(diff.y_axis.length() < 1e-14);
+        assert!(diff.z_axis.length() < 1e-14);
+        assert!((m.determinant() - 1.0).abs() < 1e-14);
     }
 }

--- a/crates/jeod_quantities/Cargo.toml
+++ b/crates/jeod_quantities/Cargo.toml
@@ -10,3 +10,9 @@ glam = { workspace = true }
 uom = { workspace = true }
 typenum = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+# Exposes test-only phantom markers (e.g. `TestVehicle`) so downstream crates
+# can write frame-composition tests without needing to implement sealed
+# marker traits. Never enabled in production builds.
+test-utils = []

--- a/crates/jeod_quantities/src/frame.rs
+++ b/crates/jeod_quantities/src/frame.rs
@@ -122,3 +122,24 @@ impl<C: Vehicle> Sealed for Ned<C> {}
 impl<C: Vehicle> Frame for Ned<C> {
     const NAME: &'static str = "Ned";
 }
+
+// --- Test-only vehicle marker ------------------------------------------------
+//
+// `Vehicle` is sealed, so downstream crates cannot mint their own phantom
+// tags. Tests that exercise vehicle-parameterized frames (`Lvlh`, `Ned`,
+// `BodyFrame`, `StructuralFrame`) need *some* tag to instantiate, so we
+// expose a single test-only vehicle behind the `test-utils` feature. It is
+// never compiled into production builds.
+
+/// A no-op vehicle phantom marker for use in downstream test harnesses.
+///
+/// Available only when the crate is built with `--features test-utils`.
+#[cfg(feature = "test-utils")]
+#[derive(Debug, Clone, Copy)]
+pub struct TestVehicle;
+#[cfg(feature = "test-utils")]
+impl Sealed for TestVehicle {}
+#[cfg(feature = "test-utils")]
+impl Vehicle for TestVehicle {
+    const NAME: &'static str = "TestVehicle";
+}

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -60,7 +60,10 @@ pub fn compute_body_euler_angles(rot: &RotationalState, sequence: EulerSequence)
 
 /// Compute the LVLH (Local Vertical Local Horizontal) frame from translational state.
 ///
-/// Delegates to [`jeod_math::compute_lvlh_frame`].
+/// Delegates to [`jeod_math::compute_lvlh_frame`]. Phase 3+ will migrate this
+/// wrapper to the typed `compute_lvlh_frame_typed` API; for now we silence
+/// the local deprecation warning so Phase 2 stays scope-limited.
+#[allow(deprecated)]
 pub fn compute_body_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     jeod_math::compute_lvlh_frame(position, velocity)
 }

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -139,8 +139,10 @@ pub use jeod_planet::PlanetShape;
 pub use jeod_math::JeodQuat;
 
 // jeod_math: derived state types
+#[allow(deprecated)]
+pub use jeod_math::compute_lvlh_frame;
 pub use jeod_math::{
-    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame,
+    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame_typed,
     geodetic_to_cartesian, solar_beta_angle, EulerSequence, GeodeticState, LvlhFrame,
     OrbitalElements, OrbitalError,
 };


### PR DESCRIPTION
## Summary

Adds a typed sibling to `jeod_math::compute_lvlh_frame`:

```rust
pub fn compute_lvlh_frame_typed<Chief>(
    position: Position<Inertial>,
    velocity: Velocity<Inertial>,
) -> FrameTransform<Inertial, Lvlh<Chief>>
where
    Chief: Vehicle,
```

- Delegates to the existing f64 port, then wraps `T_parent_this`
  (inertial → LVLH) as a canonical JEOD scalar-first, left-transformation
  quaternion inside the `FrameTransform` cache.
- Auxiliary `ang_vel`, `position`, `velocity` fields of `LvlhFrame` are
  not surfaced through the typed API yet — Phase 3+ will migrate those.
- `compute_lvlh_frame` (f64) is now `#[doc(hidden)] #[deprecated(since = "0.2.0-phase-3")]`. The `LvlhFrame` struct is untouched.

## Test plan

- [x] `typed_lvlh_matches_f64_port` — ISS-like inclined inertial state;
      asserts the typed API's quaternion components are bit-identical to
      `JeodQuat::left_quat_from_transformation(&f64_port.t_parent_this)`,
      plus orthonormality and `det = 1` of the cached matrix.
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run -p jeod_math` — 75/75 pass
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 629/629 pass
- [ ] Tier 3 regression check (deferred; this PR has no physics change,
      only a new typed-sibling API)

## `#[allow(deprecated)]` propagation

The deprecation attribute fires at every remaining call site. To keep
this PR scope-limited, each is locally wrapped pending Phase 3+:

- `crates/jeod_math/src/lib.rs` — the pub re-export
- `crates/jeod_math/src/lvlh.rs` — inline f64 tests
- `crates/jeod_sim/src/derived.rs::compute_body_lvlh_frame`
- `crates/jeod_sim/src/lib.rs` — the re-export (alongside a new `compute_lvlh_frame_typed` re-export)
- `crates/jeod_dynamics/src/body_init.rs` — `init_from_lvlh` and its
  round-trip test

## `jeod_quantities` change

Adds a test-only `TestVehicle` phantom marker behind a new `test-utils`
feature, so inline tests can instantiate `Lvlh<Chief>` without
implementing the sealed `Vehicle` trait. The feature is pulled in as a
dev-dependency of `jeod_math` and is never compiled into production
builds.

---

Base branch: `phase-2-jeod-math` (Phase 2 of issue #101 / sub-issue #104).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>