### PR TITLE
[Phase 2 #104] orbital_elements: typed from_cartesian

### DIFF
--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -296,6 +296,9 @@ pub fn compute_ned_rotation(lat: f64, lon: f64) -> DMat3 {
 }
 
 #[cfg(test)]
+// Phase 2 #104: local tests call deprecated jeod_math OrbitalElements::from_cartesian.
+// Migration to from_cartesian_typed is deferred to Phase 3+.
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use std::f64::consts::PI;

--- a/crates/jeod_gravity/tests/j2_regression.rs
+++ b/crates/jeod_gravity/tests/j2_regression.rs
@@ -58,9 +58,12 @@ fn j2_nodal_regression_rate() {
     }
 
     // Compute RAAN at start and end
+    // Phase 2 #104: from_cartesian is deprecated; migration deferred to Phase 3+.
+    #[allow(deprecated)]
     let elems_start =
         OrbitalElements::from_cartesian(mu, state_initial.position, state_initial.velocity)
             .unwrap();
+    #[allow(deprecated)]
     let elems_end = OrbitalElements::from_cartesian(mu, state.position, state.velocity).unwrap();
 
     let raan_start = elems_start.long_asc_node;

--- a/crates/jeod_math/src/orbital_elements.rs
+++ b/crates/jeod_math/src/orbital_elements.rs
@@ -68,6 +68,11 @@ impl OrbitalElements {
     /// * `mu`  - gravitational parameter (units consistent with pos/vel, e.g. m^3/s^2)
     /// * `pos` - position vector
     /// * `vel` - velocity vector
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.2.0-phase-3",
+        note = "use from_cartesian_typed; f64 variant removed in Phase 10"
+    )]
     pub fn from_cartesian(
         mu: f64,
         pos: DVec3,
@@ -279,6 +284,25 @@ impl OrbitalElements {
         oe.nu_to_anomalies();
 
         Ok(oe)
+    }
+
+    /// Typed variant of [`from_cartesian`](Self::from_cartesian).
+    ///
+    /// Accepts dimensionally-typed inputs:
+    /// * `mu` — gravitational parameter in SI base units (m³/s²)
+    /// * `pos` — inertial-frame position in meters
+    /// * `vel` — inertial-frame velocity in m/s
+    ///
+    /// Output fields on [`OrbitalElements`] remain raw `f64` in SI base units
+    /// for this PR; typing the outputs is tracked separately in issue #104.
+    pub fn from_cartesian_typed(
+        mu: jeod_quantities::dims::GravParam,
+        pos: jeod_quantities::aliases::Position<jeod_quantities::frame::Inertial>,
+        vel: jeod_quantities::aliases::Velocity<jeod_quantities::frame::Inertial>,
+    ) -> Result<OrbitalElements, OrbitalError> {
+        // Extract SI base values and delegate to the existing f64 implementation.
+        #[allow(deprecated)]
+        Self::from_cartesian(mu.value, pos.raw_si(), vel.raw_si())
     }
 
     // ----------------------------------------------------------------
@@ -536,6 +560,7 @@ pub fn kep_eqtn_b(m: f64) -> f64 {
 // ====================================================================
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::types::DVec3;
@@ -1076,5 +1101,89 @@ mod tests {
             oe.true_anom,
             nu_diff
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Typed API: from_cartesian_typed
+    // ---------------------------------------------------------------
+    //
+    // These tests exercise the dimensionally-typed entry point. SI base
+    // units are required: m, m/s, m³/s². JEOD's Earth GM constant converted
+    // to SI from earth_GGM05C.cc:40 (398_600.441_50 km³/s² -> 3.986004415e14
+    // m³/s²).
+    #[test]
+    fn from_cartesian_typed_iss_like() {
+        use jeod_quantities::aliases::{Position, Velocity};
+        use jeod_quantities::ext::F64Ext;
+        use jeod_quantities::frame::Inertial;
+        use jeod_quantities::qty3::Qty3;
+
+        // ISS-ish: 408 km altitude circular orbit, SI units.
+        let mu_si: jeod_quantities::dims::GravParam = 3.986_004_415e14_f64.m3_per_s2();
+        let r = 6_779_000.0_f64; // m (~6371 + 408 km)
+        let v = (3.986_004_415e14_f64 / r).sqrt(); // m/s
+
+        // Qty3::from_raw_si wraps a DVec3 of SI-base-unit values in the
+        // typed frame-tagged envelope without any unit conversion.
+        let pos: Position<Inertial> = Qty3::from_raw_si(DVec3::new(r, 0.0, 0.0));
+        let vel: Velocity<Inertial> = Qty3::from_raw_si(DVec3::new(0.0, v, 0.0));
+
+        let oe = OrbitalElements::from_cartesian_typed(mu_si, pos, vel).unwrap();
+
+        // ISS-like semi-major axis falls in the 6.5e6 - 7.2e6 m band.
+        assert!(
+            oe.semi_major_axis > 6.5e6 && oe.semi_major_axis < 7.2e6,
+            "semi_major_axis {} out of ISS range [6.5e6, 7.2e6]",
+            oe.semi_major_axis
+        );
+        // Circular orbit has near-zero eccentricity.
+        assert!(
+            oe.e_mag < 1e-10,
+            "eccentricity should be ~0 for circular orbit, got {}",
+            oe.e_mag
+        );
+        // r_mag matches the input radius in meters.
+        assert!(
+            (oe.r_mag - r).abs() < 1e-6,
+            "r_mag should be ~{r}, got {}",
+            oe.r_mag
+        );
+    }
+
+    #[test]
+    fn from_cartesian_typed_matches_raw_bit_for_bit() {
+        use jeod_quantities::aliases::{Position, Velocity};
+        use jeod_quantities::ext::F64Ext;
+        use jeod_quantities::frame::Inertial;
+        use jeod_quantities::qty3::Qty3;
+
+        let mu_si: jeod_quantities::dims::GravParam = 3.986_004_415e14_f64.m3_per_s2();
+        // Mildly eccentric, slightly inclined ISS-ish state in SI units.
+        let pos_raw = DVec3::new(6_779_000.0, 0.0, 0.0);
+        let vel_raw = DVec3::new(0.0, 7_000.0, 1_500.0);
+
+        let pos: Position<Inertial> = Qty3::from_raw_si(pos_raw);
+        let vel: Velocity<Inertial> = Qty3::from_raw_si(vel_raw);
+
+        let oe_typed = OrbitalElements::from_cartesian_typed(mu_si, pos, vel).unwrap();
+        let oe_raw = OrbitalElements::from_cartesian(mu_si.value, pos_raw, vel_raw).unwrap();
+
+        // Bit-identical delegation: typed wrapper extracts SI values and calls
+        // the raw implementation — no intermediate arithmetic, so every field
+        // must match exactly.
+        assert_eq!(oe_typed.semi_major_axis, oe_raw.semi_major_axis);
+        assert_eq!(oe_typed.semiparam, oe_raw.semiparam);
+        assert_eq!(oe_typed.e_mag, oe_raw.e_mag);
+        assert_eq!(oe_typed.inclination, oe_raw.inclination);
+        assert_eq!(oe_typed.arg_periapsis, oe_raw.arg_periapsis);
+        assert_eq!(oe_typed.long_asc_node, oe_raw.long_asc_node);
+        assert_eq!(oe_typed.true_anom, oe_raw.true_anom);
+        assert_eq!(oe_typed.mean_anom, oe_raw.mean_anom);
+        assert_eq!(oe_typed.orbital_anom, oe_raw.orbital_anom);
+        assert_eq!(oe_typed.mean_motion, oe_raw.mean_motion);
+        assert_eq!(oe_typed.r_mag, oe_raw.r_mag);
+        assert_eq!(oe_typed.vel_mag, oe_raw.vel_mag);
+        assert_eq!(oe_typed.orb_energy, oe_raw.orb_energy);
+        assert_eq!(oe_typed.orb_ang_momentum, oe_raw.orb_ang_momentum);
     }
 }

--- a/crates/jeod_math/tests/jeod_validation.rs
+++ b/crates/jeod_math/tests/jeod_validation.rs
@@ -186,6 +186,8 @@ fn validate_orbital_roundtrip_5000_vectors() {
     let mut pass_count = 0;
 
     for (i, sv) in vectors.iter().enumerate() {
+        // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+        #[allow(deprecated)]
         let elems = match OrbitalElements::from_cartesian(MU_EARTH, sv.position, sv.velocity) {
             Ok(e) => e,
             Err(e) => {

--- a/crates/jeod_runner/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mercury.rs
@@ -108,6 +108,8 @@ fn propagate_mercury_periapses(
         let r_dot = r.dot(v) / r.length();
 
         if step > 0 && prev_rdot < 0.0 && r_dot >= 0.0 {
+            // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+            #[allow(deprecated)]
             if let Ok(e) = jeod_sim::OrbitalElements::from_cartesian(mu_sun, r, v) {
                 events.push(PeriapsisEvent {
                     time: sim_time,
@@ -211,6 +213,8 @@ fn detect_periapses_from_csv(path: &std::path::Path, mu: f64) -> Vec<PeriapsisEv
         let r_dot = pos.dot(vel) / pos.length();
 
         if prev_rdot < 0.0 && r_dot >= 0.0 {
+            // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+            #[allow(deprecated)]
             if let Ok(e) = jeod_sim::OrbitalElements::from_cartesian(mu, pos, vel) {
                 events.push(PeriapsisEvent {
                     time,

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
@@ -86,6 +86,8 @@ fn roundtrip_via_simulation(
     sim.step_n(n_steps);
 
     let body = sim.body(0);
+    // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+    #[allow(deprecated)]
     let oe_recovered =
         OrbitalElements::from_cartesian(MU_EARTH, body.trans.position, body.trans.velocity)
             .expect("from_cartesian failed after propagation");
@@ -217,6 +219,8 @@ fn tier3_orbinit_roundtrip_circular() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
+    // Phase 2 #104: from_cartesian deprecated; migration deferred to Phase 3+.
+    #[allow(deprecated)]
     let oe_recovered =
         OrbitalElements::from_cartesian(MU_EARTH, body.trans.position, body.trans.velocity)
             .expect("from_cartesian failed after propagation");

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -46,6 +46,10 @@ pub fn compute_orbital_elements(
     position: DVec3,
     velocity: DVec3,
 ) -> Result<OrbitalElements, OrbitalError> {
+    // Phase 2 #104: jeod_math::OrbitalElements::from_cartesian is deprecated in
+    // favor of from_cartesian_typed. Migration to the typed entry point is
+    // tracked for Phase 3+ — this call site retains the f64 API for now.
+    #[allow(deprecated)]
     OrbitalElements::from_cartesian(mu, position, velocity)
 }
 


### PR DESCRIPTION
## Summary

Step 2 of #104: add a dimensionally-typed `OrbitalElements::from_cartesian_typed` sibling to the existing `f64` entry point and deprecate the raw variant.

- New method: `OrbitalElements::from_cartesian_typed(mu: GravParam, pos: Position<Inertial>, vel: Velocity<Inertial>)` — extracts SI base values via `.value` and `raw_si()` and delegates to the existing f64 implementation. No physics changes.
- `OrbitalElements::from_cartesian` (f64) is now `#[doc(hidden)] #[deprecated(since = "0.2.0-phase-3", note = "use from_cartesian_typed; f64 variant removed in Phase 10")]`.
- Output fields on `OrbitalElements` stay `f64` for this PR per the #104 plan; typing outputs is deferred to a later, smaller-reviewable PR.

## Tests added (inline in `orbital_elements.rs`)

- `from_cartesian_typed_iss_like`: ISS-ish Cartesian state in SI base units (MU_EARTH = 3.986004415e14 m³/s², r = 6_779_000 m). Asserts recovered `semi_major_axis` is in `[6.5e6, 7.2e6]` m and `e_mag < 1e-10`.
- `from_cartesian_typed_matches_raw_bit_for_bit`: constructs `Position<Inertial>`/`Velocity<Inertial>` from raw `DVec3` values via `Qty3::from_raw_si`, asserts every output field is bit-identical between `from_cartesian_typed` and `from_cartesian` (delegation identity).

Existing km-based in-crate tests are unchanged — the raw API behaviour hasn't changed. They compile under a single `#[allow(deprecated)]` on the `tests` module.

## `#[allow(deprecated)]` propagation sites

Migration to the typed API is deferred to Phase 3+; these call sites keep the raw f64 API locally wrapped in `#[allow(deprecated)]`:

- `crates/jeod_sim/src/derived.rs` — `compute_orbital_elements`
- `crates/jeod_dynamics/src/body_init.rs` — `tests` module annotation (round-trip test)
- `crates/jeod_gravity/tests/j2_regression.rs` — two call sites (RAAN at start / end of propagation)
- `crates/jeod_math/tests/jeod_validation.rs` — `validate_orbital_roundtrip_5000_vectors`
- `crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs` — two call sites (round-trip + circular-LEO energy drift tests)
- `crates/jeod_runner/tests/tier3_sim_mercury.rs` — two call sites (our-sim periapsis detection + JEOD-reference CSV parser)

None of these propagation sites modify Tier 3 test logic — they are attribute-only edits.

## Test plan

- [x] `cargo fmt && cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run -p jeod_math` → 76 passed (including 2 new typed tests)
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` → 630 passed
- [x] `cargo check --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)