### PR TITLE
[Phase 2 #104] euler_angles: typed variants

### DIFF
--- a/crates/jeod_math/src/euler_angles.rs
+++ b/crates/jeod_math/src/euler_angles.rs
@@ -447,8 +447,9 @@ pub fn compute_quaternion_from_euler_angles_typed(
         angles[2].get::<radian>(),
     ];
     let q = compute_quaternion_from_euler_angles_impl(radians, sequence);
-    NormalizedQuat::new(q)
-        .expect("compute_quaternion_from_euler_angles_impl returns a normalized quaternion")
+    NormalizedQuat::new(q).unwrap_or_else(|err| {
+        panic!("compute_quaternion_from_euler_angles_impl returns a normalized quaternion: {err}")
+    })
 }
 
 /// Typed sibling of [`compute_matrix_from_euler_angles`].
@@ -473,8 +474,11 @@ pub fn compute_matrix_from_euler_angles_typed(
 /// Returns a triple of `uom::si::f64::Angle` values carrying the radian
 /// results of the JEOD extraction algorithm. Bit-identical numerically to
 /// the bare-`f64` variant.
-pub fn compute_euler_angles_from_matrix_typed(trans: DMat3, sequence: EulerSequence) -> [Angle; 3] {
-    let [phi, theta, psi] = compute_euler_angles_from_matrix_impl(&trans, sequence);
+pub fn compute_euler_angles_from_matrix_typed(
+    trans: &DMat3,
+    sequence: EulerSequence,
+) -> [Angle; 3] {
+    let [phi, theta, psi] = compute_euler_angles_from_matrix_impl(trans, sequence);
     [
         Angle::new::<radian>(phi),
         Angle::new::<radian>(theta),
@@ -864,7 +868,7 @@ mod tests {
             let typed_in = angles_rad(raw[0], raw[1], raw[2]);
 
             let mat = compute_matrix_from_euler_angles_typed(typed_in, seq);
-            let extracted = compute_euler_angles_from_matrix_typed(mat, seq);
+            let extracted = compute_euler_angles_from_matrix_typed(&mat, seq);
 
             // Aero sequences recover the exact input angles; astro sequences
             // are allowed to drift as long as the matrix reconstructs.
@@ -933,7 +937,7 @@ mod tests {
             let raw = non_trivial_angles_for(seq);
             let mat = compute_matrix_from_euler_angles(raw, seq);
 
-            let from_typed = compute_euler_angles_from_matrix_typed(mat, seq);
+            let from_typed = compute_euler_angles_from_matrix_typed(&mat, seq);
             let from_f64 = compute_euler_angles_from_matrix(&mat, seq);
 
             for i in 0..3 {

--- a/crates/jeod_math/src/euler_angles.rs
+++ b/crates/jeod_math/src/euler_angles.rs
@@ -3,10 +3,22 @@
 //! Faithful port of JEOD `models/utils/orientation/src/euler_angles.cc`.
 //! Supports all 12 Euler rotation sequences (6 Tait-Bryan / aerodynamic,
 //! 6 proper Euler / astronomical).
+//!
+//! Two parallel surfaces are exposed:
+//! * the historical bare-`f64` entry points (radians, deprecated), and
+//! * the typed sibling APIs that accept/return `uom::si::f64::Angle` and
+//!   hand out a [`NormalizedQuat`] witness for the quaternion builder so
+//!   downstream code can bind the unit-norm precondition at the type level.
+//!
+//! The two surfaces share their numeric implementation, so the typed
+//! variants are bit-identical to the bare-`f64` ones at equal inputs.
 
 use crate::quaternion::JeodQuat;
 use crate::types::DMat3;
+use jeod_quantities::quat::{LeftTransform, NormalizedQuat, ScalarFirst};
 use std::f64::consts::{FRAC_PI_2, PI};
+use uom::si::angle::radian;
+use uom::si::f64::Angle;
 
 // ---------------------------------------------------------------------------
 // EulerSequence enum
@@ -174,15 +186,15 @@ fn t(trans: &DMat3, row: usize, col: usize) -> f64 {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Shared implementations (private). Both the bare-`f64` and typed public
+// entry points dispatch to these helpers so the two surfaces remain
+// bit-identical at equal numeric inputs.
 // ---------------------------------------------------------------------------
 
-/// Build a left-transformation quaternion from Euler angles.
-///
-/// Port of `euler_angles.cc:121-153`.
-/// Constructs three simple quaternions (one per rotation axis) and multiplies
-/// in reverse order: `result = q[2] * q[1] * q[0]`, then normalizes.
-pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> JeodQuat {
+fn compute_quaternion_from_euler_angles_impl(
+    angles: [f64; 3],
+    sequence: EulerSequence,
+) -> JeodQuat {
     let info = &EULER_INFO[sequence as usize];
     let axes = &info.indices;
 
@@ -208,12 +220,7 @@ pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSeq
     result
 }
 
-/// Build a left-transformation matrix from Euler angles.
-///
-/// Port of `euler_angles.cc:164-218`.
-/// Constructs three elementary rotation matrices and multiplies in reverse
-/// order: `result = m[2] * m[1] * m[0]`.
-pub fn compute_matrix_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> DMat3 {
+fn compute_matrix_from_euler_angles_impl(angles: [f64; 3], sequence: EulerSequence) -> DMat3 {
     let info = &EULER_INFO[sequence as usize];
     let axes = &info.indices;
 
@@ -270,11 +277,7 @@ pub fn compute_matrix_from_euler_angles(angles: [f64; 3], sequence: EulerSequenc
     m21 * m0
 }
 
-/// Extract Euler angles from a left-transformation matrix.
-///
-/// Port of `euler_angles.cc:297-464`.
-/// Returns `[phi, theta, psi]` in radians.
-pub fn compute_euler_angles_from_matrix(trans: &DMat3, sequence: EulerSequence) -> [f64; 3] {
+fn compute_euler_angles_from_matrix_impl(trans: &DMat3, sequence: EulerSequence) -> [f64; 3] {
     let info = &EULER_INFO[sequence as usize];
 
     // Extract theta_val: trans[info.indices[2]][info.indices[0]]
@@ -363,15 +366,148 @@ pub fn compute_euler_angles_from_matrix(trans: &DMat3, sequence: EulerSequence) 
     [phi, theta, psi]
 }
 
+// ---------------------------------------------------------------------------
+// Public API — bare-`f64` surface (deprecated, removed in Phase 10 of #101).
+// ---------------------------------------------------------------------------
+
+/// Build a left-transformation quaternion from Euler angles (radians).
+///
+/// Port of `euler_angles.cc:121-153`. Constructs three simple quaternions
+/// (one per rotation axis) and multiplies in reverse order:
+/// `result = q[2] * q[1] * q[0]`, then normalizes.
+///
+/// **Deprecated:** use [`compute_quaternion_from_euler_angles_typed`], which
+/// accepts `uom` `Angle`s and returns a [`NormalizedQuat`] witness.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_quaternion_from_euler_angles_typed; f64 variant removed in Phase 10"
+)]
+pub fn compute_quaternion_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> JeodQuat {
+    compute_quaternion_from_euler_angles_impl(angles, sequence)
+}
+
+/// Build a left-transformation matrix from Euler angles (radians).
+///
+/// Port of `euler_angles.cc:164-218`. Constructs three elementary rotation
+/// matrices and multiplies in reverse order: `result = m[2] * m[1] * m[0]`.
+///
+/// **Deprecated:** use [`compute_matrix_from_euler_angles_typed`], which
+/// accepts `uom` `Angle`s.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_matrix_from_euler_angles_typed; f64 variant removed in Phase 10"
+)]
+pub fn compute_matrix_from_euler_angles(angles: [f64; 3], sequence: EulerSequence) -> DMat3 {
+    compute_matrix_from_euler_angles_impl(angles, sequence)
+}
+
+/// Extract Euler angles (radians) from a left-transformation matrix.
+///
+/// Port of `euler_angles.cc:297-464`. Returns `[phi, theta, psi]` in radians.
+///
+/// **Deprecated:** use [`compute_euler_angles_from_matrix_typed`], which
+/// returns `uom` `Angle`s.
+#[doc(hidden)]
+#[deprecated(
+    since = "0.2.0-phase-3",
+    note = "use compute_euler_angles_from_matrix_typed; f64 variant removed in Phase 10"
+)]
+pub fn compute_euler_angles_from_matrix(trans: &DMat3, sequence: EulerSequence) -> [f64; 3] {
+    compute_euler_angles_from_matrix_impl(trans, sequence)
+}
+
+// ---------------------------------------------------------------------------
+// Public API — typed surface (uom `Angle`s + `NormalizedQuat` witness).
+// ---------------------------------------------------------------------------
+
+/// Typed sibling of [`compute_quaternion_from_euler_angles`].
+///
+/// Accepts a triple of `uom::si::f64::Angle` values and returns a
+/// [`NormalizedQuat`] witness of the resulting left-transformation
+/// quaternion. The inner [`JeodQuat`] is bit-identical to the value
+/// returned by the bare-`f64` variant when the same angles are supplied in
+/// radians, so both surfaces agree on every representable input.
+///
+/// The underlying `compute_quaternion_from_euler_angles_impl` applies
+/// JEOD's Padé-based `normalize()` before returning, so the witness is
+/// constructed via [`NormalizedQuat::new`]: the norm is checked against
+/// `NormalizedQuat::DEFAULT_TOLERANCE` (1e-12), which is comfortably
+/// wider than floating-point round-off on a post-normalization quaternion.
+/// Panics only if that tolerance is violated — i.e. if the underlying
+/// normalization routine is itself broken.
+pub fn compute_quaternion_from_euler_angles_typed(
+    angles: [Angle; 3],
+    sequence: EulerSequence,
+) -> NormalizedQuat<ScalarFirst, LeftTransform> {
+    let radians = [
+        angles[0].get::<radian>(),
+        angles[1].get::<radian>(),
+        angles[2].get::<radian>(),
+    ];
+    let q = compute_quaternion_from_euler_angles_impl(radians, sequence);
+    NormalizedQuat::new(q)
+        .expect("compute_quaternion_from_euler_angles_impl returns a normalized quaternion")
+}
+
+/// Typed sibling of [`compute_matrix_from_euler_angles`].
+///
+/// Accepts a triple of `uom::si::f64::Angle` values and returns the raw
+/// `DMat3` transformation matrix. Bit-identical to the bare-`f64` variant
+/// given the same angles (in radians).
+pub fn compute_matrix_from_euler_angles_typed(
+    angles: [Angle; 3],
+    sequence: EulerSequence,
+) -> DMat3 {
+    let radians = [
+        angles[0].get::<radian>(),
+        angles[1].get::<radian>(),
+        angles[2].get::<radian>(),
+    ];
+    compute_matrix_from_euler_angles_impl(radians, sequence)
+}
+
+/// Typed sibling of [`compute_euler_angles_from_matrix`].
+///
+/// Returns a triple of `uom::si::f64::Angle` values carrying the radian
+/// results of the JEOD extraction algorithm. Bit-identical numerically to
+/// the bare-`f64` variant.
+pub fn compute_euler_angles_from_matrix_typed(trans: DMat3, sequence: EulerSequence) -> [Angle; 3] {
+    let [phi, theta, psi] = compute_euler_angles_from_matrix_impl(&trans, sequence);
+    [
+        Angle::new::<radian>(phi),
+        Angle::new::<radian>(theta),
+        Angle::new::<radian>(psi),
+    ]
+}
+
+/// Build a left-transformation matrix from a witnessed unit-norm quaternion.
+///
+/// Preferred entry point for new callers: gates the unit-norm precondition
+/// at the type level instead of relying on callers remembering to
+/// renormalize after integration. Delegates to
+/// [`NormalizedQuat::left_quat_to_transformation`], which applies the JEOD
+/// `quaternion_to_matrix.cc` formula on the witnessed payload.
+pub fn quaternion_to_matrix_normalized(q: NormalizedQuat<ScalarFirst, LeftTransform>) -> DMat3 {
+    q.left_quat_to_transformation()
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
 
 #[cfg(test)]
 mod tests {
+    // Existing tests intentionally exercise the bare-`f64` public surface so
+    // the deprecated and typed entry points stay covered together through
+    // the Phase 10 removal.
+    #![allow(deprecated)]
+
     use super::*;
     use crate::test_utils::{approx_eq_f64, approx_eq_mat3};
     use glam::DVec3;
+    use uom::si::angle::radian;
 
     const TOL: f64 = 1e-14;
 
@@ -689,6 +825,168 @@ mod tests {
                 approx_eq_mat3(&t, &reconstructed, 1e-14),
                 "JEOD matrix round-trip for {seq:?} exceeds 1e-14: diff = {:.4e}",
                 max_mat_diff(&t, &reconstructed),
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Typed API (uom `Angle` + NormalizedQuat witness)
+    // -------------------------------------------------------------------
+
+    /// Build a `[Angle; 3]` from three radian values without cluttering
+    /// the assertion tests.
+    fn angles_rad(phi: f64, theta: f64, psi: f64) -> [Angle; 3] {
+        [
+            Angle::new::<radian>(phi),
+            Angle::new::<radian>(theta),
+            Angle::new::<radian>(psi),
+        ]
+    }
+
+    /// A non-trivial angle triple per `EulerSequence`. All chosen to stay
+    /// away from 0°, ±90°, ±180° so the extraction algorithm's gimbal-lock
+    /// branch is avoided and the raw radian angles round-trip cleanly.
+    fn non_trivial_angles_for(seq: EulerSequence) -> [f64; 3] {
+        if EULER_INFO[seq as usize].is_aerodynamics_sequence {
+            // Aero sequences fully round-trip angles for non-singular theta.
+            [0.3_f64, 0.4, 0.5]
+        } else {
+            // Astro (proper-Euler) sequences have theta in (0, pi). Pick
+            // angles well clear of both ends.
+            [0.3_f64, 0.9, 0.5]
+        }
+    }
+
+    #[test]
+    fn typed_roundtrip_all_sequences() {
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed_in = angles_rad(raw[0], raw[1], raw[2]);
+
+            let mat = compute_matrix_from_euler_angles_typed(typed_in, seq);
+            let extracted = compute_euler_angles_from_matrix_typed(mat, seq);
+
+            // Aero sequences recover the exact input angles; astro sequences
+            // are allowed to drift as long as the matrix reconstructs.
+            if EULER_INFO[seq as usize].is_aerodynamics_sequence {
+                for i in 0..3 {
+                    let err = (extracted[i] - typed_in[i]).get::<radian>().abs();
+                    assert!(
+                        err < 1e-13,
+                        "typed roundtrip {seq:?}: angle[{i}] err = {err:.4e} rad"
+                    );
+                }
+            }
+
+            let mat2 = compute_matrix_from_euler_angles_typed(extracted, seq);
+            assert!(
+                approx_eq_mat3(&mat, &mat2, 1e-13),
+                "typed roundtrip matrix mismatch for {seq:?}: diff = {:.4e}",
+                {
+                    let mut d = 0.0_f64;
+                    for c in 0..3 {
+                        for r in 0..3 {
+                            d = d.max((mat.col(c)[r] - mat2.col(c)[r]).abs());
+                        }
+                    }
+                    d
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn typed_matrix_bit_identical_to_f64() {
+        // The typed path must produce exactly the same DMat3 as the
+        // bare-`f64` path for every sequence, given equal numeric inputs.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed = angles_rad(raw[0], raw[1], raw[2]);
+
+            let mat_typed = compute_matrix_from_euler_angles_typed(typed, seq);
+            let mat_f64 = compute_matrix_from_euler_angles(
+                [
+                    typed[0].get::<radian>(),
+                    typed[1].get::<radian>(),
+                    typed[2].get::<radian>(),
+                ],
+                seq,
+            );
+
+            for c in 0..3 {
+                for r in 0..3 {
+                    assert_eq!(
+                        mat_typed.col(c)[r].to_bits(),
+                        mat_f64.col(c)[r].to_bits(),
+                        "{seq:?}: matrix element [{r}][{c}] differs bit-wise",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn typed_angles_bit_identical_to_f64() {
+        // Extract both via typed and f64 from the same matrix and check
+        // the resulting angle triples are bit-identical.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let mat = compute_matrix_from_euler_angles(raw, seq);
+
+            let from_typed = compute_euler_angles_from_matrix_typed(mat, seq);
+            let from_f64 = compute_euler_angles_from_matrix(&mat, seq);
+
+            for i in 0..3 {
+                assert_eq!(
+                    from_typed[i].get::<radian>().to_bits(),
+                    from_f64[i].to_bits(),
+                    "{seq:?}: angle[{i}] differs bit-wise",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn typed_quaternion_bit_identical_to_f64() {
+        // The typed quaternion builder must return a NormalizedQuat whose
+        // inner JeodQuat is bit-identical to the f64 variant's output.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed = angles_rad(raw[0], raw[1], raw[2]);
+
+            let q_typed = compute_quaternion_from_euler_angles_typed(typed, seq);
+            let q_f64 = compute_quaternion_from_euler_angles(raw, seq);
+
+            let inner = q_typed.inner();
+            for i in 0..4 {
+                assert_eq!(
+                    inner.data[i].to_bits(),
+                    q_f64.data[i].to_bits(),
+                    "{seq:?}: quaternion data[{i}] differs bit-wise",
+                );
+            }
+
+            // The NormalizedQuat witness implies unit norm; sanity-check
+            // this rather than leave it implicit.
+            assert!((inner.norm() - 1.0).abs() < 1e-14);
+        }
+    }
+
+    #[test]
+    fn quaternion_to_matrix_normalized_matches_f64_matrix() {
+        // The new matrix-conversion entry point gated on NormalizedQuat
+        // must agree with the bare-`f64` matrix constructor.
+        for &seq in &ALL_SEQUENCES {
+            let raw = non_trivial_angles_for(seq);
+            let typed = angles_rad(raw[0], raw[1], raw[2]);
+
+            let q = compute_quaternion_from_euler_angles_typed(typed, seq);
+            let mat_from_quat = quaternion_to_matrix_normalized(q);
+            let mat_direct = compute_matrix_from_euler_angles_typed(typed, seq);
+
+            assert!(
+                approx_eq_mat3(&mat_from_quat, &mat_direct, 1e-14),
+                "{seq:?}: NormalizedQuat-gated matrix disagrees with typed Euler->matrix",
             );
         }
     }

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -20,9 +20,15 @@ pub mod test_utils;
 pub mod types;
 
 pub use error::*;
+#[allow(deprecated)]
 pub use euler_angles::{
     compute_euler_angles_from_matrix, compute_matrix_from_euler_angles,
-    compute_quaternion_from_euler_angles, EulerSequence, ALL_SEQUENCES,
+    compute_quaternion_from_euler_angles,
+};
+pub use euler_angles::{
+    compute_euler_angles_from_matrix_typed, compute_matrix_from_euler_angles_typed,
+    compute_quaternion_from_euler_angles_typed, quaternion_to_matrix_normalized, EulerSequence,
+    ALL_SEQUENCES,
 };
 #[allow(deprecated)]
 pub use geodetic::{cartesian_to_geodetic, geodetic_to_cartesian, GeodeticState};

--- a/crates/jeod_math/tests/jeod_validation.rs
+++ b/crates/jeod_math/tests/jeod_validation.rs
@@ -451,6 +451,7 @@ fn validate_orbital_init_parser() {
 ///
 /// Exit criterion: 6/6 test vectors within 1e-12 rad.
 #[test]
+#[allow(deprecated)]
 fn validate_euler_angle_extraction_from_jeod_vectors() {
     use jeod_math::{compute_euler_angles_from_matrix, EulerSequence};
 

--- a/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
+++ b/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
@@ -26,6 +26,11 @@
 //! `crates/jeod_dynamics/tests/tier3_mass_attach_detach.rs` with direct
 //! JEOD cross-validation.
 
+// `compute_matrix_from_euler_angles` is deprecated in favor of its typed
+// sibling; this Tier 3 test is kept on the bare-`f64` surface until the
+// downstream mass-attach fixtures migrate to `uom` `Angle`s.
+#![allow(deprecated)]
+
 use glam::{DMat3, DVec3};
 use jeod_dynamics::{MassBodyId, MassProperties, MassTree};
 use jeod_math::euler_angles::{compute_matrix_from_euler_angles, EulerSequence};

--- a/crates/jeod_runner/tests/tier3_sim_euler.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler.rs
@@ -3,6 +3,11 @@
 //! Uses the RUN_2 point-mass 6-DOF trajectory (which has quaternion data)
 //! to validate Euler angle computation through the Simulation pipeline.
 
+// `compute_euler_angles_from_matrix` is deprecated in favor of its typed
+// sibling; this Tier 3 test reads from JEOD's raw-`f64` matrix and keeps
+// the bare variant until the derived-state consumers migrate.
+#![allow(deprecated)]
+
 mod sim_test_helpers;
 use sim_test_helpers::*;
 

--- a/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
@@ -7,6 +7,11 @@
 //! Both use point-mass Earth gravity, RK4 at the SIM_Euler S_define step size, 24h duration.
 //! Euler angles are validated against JEOD's logged quaternion data.
 
+// `compute_euler_angles_from_matrix` is deprecated in favor of its typed
+// sibling; this Tier 3 test keeps the bare variant while the derived-state
+// consumers migrate.
+#![allow(deprecated)]
+
 mod sim_test_helpers;
 use sim_test_helpers::*;
 

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -57,6 +57,7 @@ pub fn compute_orbital_elements(
 ///
 /// Converts the left-transformation quaternion to a rotation matrix, then
 /// decomposes it into Euler angles using the given sequence.
+#[allow(deprecated)]
 pub fn compute_body_euler_angles(rot: &RotationalState, sequence: EulerSequence) -> [f64; 3] {
     let t_parent_body = rot.quaternion.left_quat_to_transformation();
     jeod_math::compute_euler_angles_from_matrix(&t_parent_body, sequence)

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -140,9 +140,12 @@ pub use jeod_math::JeodQuat;
 
 // jeod_math: derived state types
 #[allow(deprecated)]
-pub use jeod_math::{cartesian_to_geodetic, compute_lvlh_frame, geodetic_to_cartesian};
 pub use jeod_math::{
-    cartesian_to_geodetic_typed, compute_euler_angles_from_matrix, compute_lvlh_frame_typed,
+    cartesian_to_geodetic, compute_euler_angles_from_matrix, compute_lvlh_frame,
+    geodetic_to_cartesian,
+};
+pub use jeod_math::{
+    cartesian_to_geodetic_typed, compute_euler_angles_from_matrix_typed, compute_lvlh_frame_typed,
     geodetic_to_cartesian_typed, solar_beta_angle, EulerSequence, GeodeticState,
     GeodeticStateTyped, LvlhFrame, OrbitalElements, OrbitalError,
 };


### PR DESCRIPTION
## Summary

Phase 2 follow-up (#104, Step 5) for `jeod_math::euler_angles`. Adds typed
sibling APIs over `uom::si::f64::Angle` and a `quaternion_to_matrix_normalized`
entry point gated on `NormalizedQuat<ScalarFirst, LeftTransform>`, so the
unit-norm precondition is now encoded in the type system rather than relying
on caller discipline. The bare-`f64` variants remain (deprecated,
`#[doc(hidden)]`) so downstream crates migrate incrementally; both surfaces
dispatch to shared private helpers and stay bit-identical at equal inputs.

- `compute_euler_angles_from_matrix_typed(DMat3, seq) -> [Angle; 3]`
- `compute_matrix_from_euler_angles_typed([Angle; 3], seq) -> DMat3`
- `compute_quaternion_from_euler_angles_typed([Angle; 3], seq) -> NormalizedQuat<ScalarFirst, LeftTransform>`
- `quaternion_to_matrix_normalized(NormalizedQuat<ScalarFirst, LeftTransform>) -> DMat3`

Downstream callers that still pass radian `f64` (three Tier 3 tests, the
`jeod_sim::derived::compute_body_euler_angles` wrapper, the `jeod_sim`
re-export, and the `jeod_validation` fixture test) get a targeted
`#[allow(deprecated)]` with no behavioral change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run -p jeod_math` — 79 tests pass (5 new)
  - `typed_roundtrip_all_sequences` — matrix round-trip for all 12
    `EulerSequence`s, with `<1e-13 rad` per-component angle error on
    aero sequences and matrix-diff `<1e-13` on astro sequences
  - `typed_matrix_bit_identical_to_f64` — `to_bits()` equality of the
    9 DMat3 elements vs the bare-`f64` variant, all 12 sequences
  - `typed_angles_bit_identical_to_f64` — `to_bits()` equality of the
    3-component `[Angle; 3]` vs the bare-`f64` extraction, all sequences
  - `typed_quaternion_bit_identical_to_f64` — `to_bits()` equality of the
    4-component `NormalizedQuat::inner().data` vs the bare-`f64`
    builder's `JeodQuat`, all sequences, plus `1e-14` unit-norm check
  - `quaternion_to_matrix_normalized_matches_f64_matrix` — agreement of
    the new `NormalizedQuat`-gated matrix conversion with the typed
    matrix constructor at `1e-14`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 633 tests pass
- [x] `cargo check --workspace`

No Tier 3 logic was modified.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>