### PR TITLE
[Phase 3] Migrate jeod_frames + jeod_dynamics typed siblings (#105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
  "jeod_math",
+ "jeod_quantities",
  "jeod_test_data",
  "jeod_time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
  "jeod_gravity",
  "jeod_math",
  "jeod_planet",
+ "jeod_quantities",
  "jeod_test_data",
  "sha2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "jeod_quantities",
  "jeod_test_data",
  "sha2",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2021"
 [dependencies]
 jeod_frames = { path = "../jeod_frames" }
 jeod_math = { path = "../jeod_math" }
+jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 
 [dev-dependencies]
 jeod_math = { path = "../jeod_math", features = ["test-utils"] }
+jeod_quantities = { path = "../jeod_quantities", features = ["test-utils"] }
 jeod_test_data = { path = "../jeod_test_data" }
 jeod_gravity = { path = "../jeod_gravity" }
 jeod_planet = { path = "../jeod_planet" }

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -8,6 +8,7 @@ jeod_frames = { path = "../jeod_frames" }
 jeod_math = { path = "../jeod_math" }
 jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
+uom = { workspace = true }
 
 [dev-dependencies]
 jeod_math = { path = "../jeod_math", features = ["test-utils"] }

--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -7,7 +7,7 @@
 //! parameterizations: Keplerian orbital elements, LVLH-relative state, or
 //! NED (North-East-Down) relative state.
 
-use crate::state::TranslationalState;
+use crate::state::{TranslationalState, TranslationalStateTyped};
 use glam::{DMat3, DVec3};
 use jeod_math::OrbitalElements;
 use jeod_math::{mat3_from_rows, GeodeticState};
@@ -15,6 +15,11 @@ use jeod_math::{mat3_from_rows, GeodeticState};
 // Phase 3 migration of this module to the typed `_typed` APIs.
 #[allow(deprecated)]
 use jeod_math::{compute_lvlh_frame, geodetic_to_cartesian};
+use jeod_quantities::dims::GravParam;
+use jeod_quantities::frame::Inertial;
+use uom::si::angle::radian;
+use uom::si::f64::{Angle, Length};
+use uom::si::length::meter;
 
 /// Initialize translational state from Keplerian orbital elements (true anomaly).
 ///
@@ -71,6 +76,35 @@ pub fn init_from_orbital_elements(
         .expect("init_from_orbital_elements: to_cartesian failed");
 
     TranslationalState { position, velocity }
+}
+
+/// Typed sibling of [`init_from_orbital_elements`].
+///
+/// Returns a [`TranslationalStateTyped<Inertial>`] — Phase 3 callers
+/// can pipe the result directly into typed propagation paths without
+/// hand-wrapping with `from_untyped_unchecked`. Numerically
+/// bit-identical to the untyped variant: the typed entry unwraps
+/// inputs to f64 base SI, calls the existing implementation, and
+/// re-wraps the output.
+pub fn init_from_orbital_elements_typed(
+    semi_major_axis: Length,
+    eccentricity: f64,
+    inclination: Angle,
+    raan: Angle,
+    arg_periapsis: Angle,
+    true_anomaly: Angle,
+    mu: GravParam,
+) -> TranslationalStateTyped<Inertial> {
+    let untyped = init_from_orbital_elements(
+        semi_major_axis.get::<meter>(),
+        eccentricity,
+        inclination.get::<radian>(),
+        raan.get::<radian>(),
+        arg_periapsis.get::<radian>(),
+        true_anomaly.get::<radian>(),
+        mu.value, // base SI: m³/s²
+    );
+    TranslationalStateTyped::<Inertial>::from_untyped_unchecked(&untyped)
 }
 
 /// Initialize translational state from Keplerian orbital elements (mean anomaly).
@@ -797,5 +831,36 @@ mod tests {
             "Offset magnitude: expected 1000 m, got {} m",
             delta
         );
+    }
+
+    #[test]
+    fn typed_orbital_init_matches_untyped_bit_for_bit() {
+        use jeod_quantities::ext::F64Ext;
+        use uom::si::angle::radian;
+        use uom::si::f64::{Angle, Length};
+        use uom::si::length::meter;
+
+        let alt = 400_000.0;
+        let r = EARTH_R_EQ + alt;
+        let a = r;
+        let e = 0.0;
+        let inc = 0.0;
+        let raan = 0.0;
+        let argp = 0.0;
+        let nu = 0.0;
+
+        let untyped = init_from_orbital_elements(a, e, inc, raan, argp, nu, EARTH_MU);
+        let typed = init_from_orbital_elements_typed(
+            Length::new::<meter>(a),
+            e,
+            Angle::new::<radian>(inc),
+            Angle::new::<radian>(raan),
+            Angle::new::<radian>(argp),
+            Angle::new::<radian>(nu),
+            EARTH_MU.m3_per_s2(),
+        );
+
+        assert_eq!(typed.position.raw_si(), untyped.position);
+        assert_eq!(typed.velocity.raw_si(), untyped.velocity);
     }
 }

--- a/crates/jeod_dynamics/src/forces.rs
+++ b/crates/jeod_dynamics/src/forces.rs
@@ -92,18 +92,21 @@ pub struct TotalForce {
 
 /// Typed sibling of [`TotalForce`].
 ///
-/// `force` carries the integration frame `F` (default `Inertial`);
-/// `torque` is in `BodyFrame<V>` (JEOD convention). The two type
-/// parameters are independent so a body integrating translation in
-/// one frame may carry torque about a separate body axis.
+/// `force` carries the integration frame `F` (defaults to `Inertial`
+/// to match the existing untyped struct's "force in integration
+/// frame" convention); `torque` is in `BodyFrame<V>` (JEOD
+/// convention). The two type parameters are independent so a body
+/// integrating translation in one frame may carry torque about a
+/// separate body axis. `V` has no default because no production
+/// vehicle marker exists yet (Phase 5 territory).
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct TotalForceTyped<F: Frame, V: Vehicle> {
+pub struct TotalForceTyped<V: Vehicle, F: Frame = Inertial> {
     pub force: Force<F>,
     pub torque: Torque<BodyFrame<V>>,
     _v: PhantomData<V>,
 }
 
-impl<F: Frame, V: Vehicle> Default for TotalForceTyped<F, V> {
+impl<V: Vehicle, F: Frame> Default for TotalForceTyped<V, F> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -114,7 +117,7 @@ impl<F: Frame, V: Vehicle> Default for TotalForceTyped<F, V> {
     }
 }
 
-impl<F: Frame, V: Vehicle> TotalForceTyped<F, V> {
+impl<V: Vehicle, F: Frame> TotalForceTyped<V, F> {
     /// Drop the phantoms and emit the untyped storage form.
     #[inline]
     pub fn to_untyped(&self) -> TotalForce {
@@ -565,22 +568,23 @@ mod tests {
 
     #[test]
     fn typed_total_force_round_trip() {
-        use jeod_quantities::frame::{Inertial, TestVehicle};
+        use jeod_quantities::frame::TestVehicle;
 
         let untyped = TotalForce {
             force: DVec3::new(100.0, 0.0, 0.0),
             torque: DVec3::new(0.0, 0.5, 0.0),
         };
-        let typed = TotalForceTyped::<Inertial, TestVehicle>::from_untyped_unchecked(&untyped);
+        // Use the F = Inertial default for the integration frame.
+        let typed = TotalForceTyped::<TestVehicle>::from_untyped_unchecked(&untyped);
         let back = typed.to_untyped();
         assert_eq!(back, untyped);
     }
 
     #[test]
     fn typed_total_force_default_is_zero() {
-        use jeod_quantities::frame::{Inertial, TestVehicle};
+        use jeod_quantities::frame::TestVehicle;
 
-        let typed = TotalForceTyped::<Inertial, TestVehicle>::default();
+        let typed = TotalForceTyped::<TestVehicle>::default();
         let back = typed.to_untyped();
         assert_eq!(back, TotalForce::default());
     }

--- a/crates/jeod_dynamics/src/forces.rs
+++ b/crates/jeod_dynamics/src/forces.rs
@@ -1,4 +1,8 @@
+use core::marker::PhantomData;
+
 use glam::{DMat3, DVec3};
+use jeod_quantities::aliases::{Acceleration, Force, Torque};
+use jeod_quantities::frame::{BodyFrame, Frame, Inertial, Vehicle};
 
 /// Gravitational acceleration, gradient tensor, and potential for a body.
 ///
@@ -32,10 +36,104 @@ impl Default for GravityAcceleration {
     }
 }
 
+/// Typed sibling of [`GravityAcceleration`].
+///
+/// Only `grav_accel` carries a frame phantom; `grav_grad` (1/s², a
+/// gradient tensor) and `grav_pot` (m²/s², a scalar) remain DMat3 / f64.
+/// Their dimensions are not exposed as typed aliases in
+/// `jeod_quantities` because they are evaluated within a single frame
+/// and never composed across frames in the dynamics layer.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GravityAccelerationTyped<F: Frame = Inertial> {
+    pub grav_accel: Acceleration<F>,
+    pub grav_grad: DMat3,
+    pub grav_pot: f64,
+}
+
+impl<F: Frame> Default for GravityAccelerationTyped<F> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            grav_accel: Acceleration::<F>::zero(),
+            grav_grad: DMat3::ZERO,
+            grav_pot: 0.0,
+        }
+    }
+}
+
+impl<F: Frame> GravityAccelerationTyped<F> {
+    /// Drop the phantom and emit the untyped storage form.
+    #[inline]
+    pub fn to_untyped(&self) -> GravityAcceleration {
+        GravityAcceleration {
+            grav_accel: self.grav_accel.raw_si(),
+            grav_grad: self.grav_grad,
+            grav_pot: self.grav_pot,
+        }
+    }
+
+    /// Wrap an untyped [`GravityAcceleration`] as typed. **The caller
+    /// asserts** the gravity acceleration is expressed in frame `F`.
+    #[inline]
+    pub fn from_untyped_unchecked(g: &GravityAcceleration) -> Self {
+        Self {
+            grav_accel: Acceleration::<F>::from_raw_si(g.grav_accel),
+            grav_grad: g.grav_grad,
+            grav_pot: g.grav_pot,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct TotalForce {
     pub force: DVec3,  // N, in integration frame
     pub torque: DVec3, // N*m, in body frame
+}
+
+/// Typed sibling of [`TotalForce`].
+///
+/// `force` carries the integration frame `F` (default `Inertial`);
+/// `torque` is in `BodyFrame<V>` (JEOD convention). The two type
+/// parameters are independent so a body integrating translation in
+/// one frame may carry torque about a separate body axis.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TotalForceTyped<F: Frame, V: Vehicle> {
+    pub force: Force<F>,
+    pub torque: Torque<BodyFrame<V>>,
+    _v: PhantomData<V>,
+}
+
+impl<F: Frame, V: Vehicle> Default for TotalForceTyped<F, V> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            force: Force::<F>::zero(),
+            torque: Torque::<BodyFrame<V>>::zero(),
+            _v: PhantomData,
+        }
+    }
+}
+
+impl<F: Frame, V: Vehicle> TotalForceTyped<F, V> {
+    /// Drop the phantoms and emit the untyped storage form.
+    #[inline]
+    pub fn to_untyped(&self) -> TotalForce {
+        TotalForce {
+            force: self.force.raw_si(),
+            torque: self.torque.raw_si(),
+        }
+    }
+
+    /// Wrap an untyped [`TotalForce`] as typed. **The caller asserts**
+    /// the force is in `F` and the torque in `BodyFrame<V>`.
+    #[inline]
+    pub fn from_untyped_unchecked(t: &TotalForce) -> Self {
+        Self {
+            force: Force::<F>::from_raw_si(t.force),
+            torque: Torque::<BodyFrame<V>>::from_raw_si(t.torque),
+            _v: PhantomData,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -52,34 +150,24 @@ pub struct FrameDerivatives {
 /// frame may carry rotational state about a body axis whose
 /// orientation is completely unrelated.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct FrameDerivativesTyped<
-    F: jeod_quantities::frame::Frame,
-    V: jeod_quantities::frame::Vehicle,
-> {
-    pub trans_accel: jeod_quantities::aliases::Acceleration<F>,
-    pub rot_accel:
-        jeod_quantities::aliases::AngularAcceleration<jeod_quantities::frame::BodyFrame<V>>,
-    _v: core::marker::PhantomData<V>,
+pub struct FrameDerivativesTyped<F: Frame, V: Vehicle> {
+    pub trans_accel: Acceleration<F>,
+    pub rot_accel: jeod_quantities::aliases::AngularAcceleration<BodyFrame<V>>,
+    _v: PhantomData<V>,
 }
 
-impl<F: jeod_quantities::frame::Frame, V: jeod_quantities::frame::Vehicle> Default
-    for FrameDerivativesTyped<F, V>
-{
+impl<F: Frame, V: Vehicle> Default for FrameDerivativesTyped<F, V> {
     #[inline]
     fn default() -> Self {
         Self {
-            trans_accel: jeod_quantities::aliases::Acceleration::<F>::zero(),
-            rot_accel: jeod_quantities::aliases::AngularAcceleration::<
-                jeod_quantities::frame::BodyFrame<V>,
-            >::zero(),
-            _v: core::marker::PhantomData,
+            trans_accel: Acceleration::<F>::zero(),
+            rot_accel: jeod_quantities::aliases::AngularAcceleration::<BodyFrame<V>>::zero(),
+            _v: PhantomData,
         }
     }
 }
 
-impl<F: jeod_quantities::frame::Frame, V: jeod_quantities::frame::Vehicle>
-    FrameDerivativesTyped<F, V>
-{
+impl<F: Frame, V: Vehicle> FrameDerivativesTyped<F, V> {
     /// Drop the frame phantoms and emit the untyped storage form.
     #[inline]
     pub fn to_untyped(&self) -> FrameDerivatives {
@@ -95,11 +183,11 @@ impl<F: jeod_quantities::frame::Frame, V: jeod_quantities::frame::Vehicle>
     #[inline]
     pub fn from_untyped_unchecked(d: &FrameDerivatives) -> Self {
         Self {
-            trans_accel: jeod_quantities::aliases::Acceleration::<F>::from_raw_si(d.trans_accel),
-            rot_accel: jeod_quantities::aliases::AngularAcceleration::<
-                jeod_quantities::frame::BodyFrame<V>,
-            >::from_raw_si(d.rot_accel),
-            _v: core::marker::PhantomData,
+            trans_accel: Acceleration::<F>::from_raw_si(d.trans_accel),
+            rot_accel: jeod_quantities::aliases::AngularAcceleration::<BodyFrame<V>>::from_raw_si(
+                d.rot_accel,
+            ),
+            _v: PhantomData,
         }
     }
 }
@@ -471,6 +559,42 @@ mod tests {
         };
         let typed =
             FrameDerivativesTyped::<Inertial, TestVehicle>::from_untyped_unchecked(&untyped);
+        let back = typed.to_untyped();
+        assert_eq!(back, untyped);
+    }
+
+    #[test]
+    fn typed_total_force_round_trip() {
+        use jeod_quantities::frame::{Inertial, TestVehicle};
+
+        let untyped = TotalForce {
+            force: DVec3::new(100.0, 0.0, 0.0),
+            torque: DVec3::new(0.0, 0.5, 0.0),
+        };
+        let typed = TotalForceTyped::<Inertial, TestVehicle>::from_untyped_unchecked(&untyped);
+        let back = typed.to_untyped();
+        assert_eq!(back, untyped);
+    }
+
+    #[test]
+    fn typed_total_force_default_is_zero() {
+        use jeod_quantities::frame::{Inertial, TestVehicle};
+
+        let typed = TotalForceTyped::<Inertial, TestVehicle>::default();
+        let back = typed.to_untyped();
+        assert_eq!(back, TotalForce::default());
+    }
+
+    #[test]
+    fn typed_gravity_acceleration_round_trip() {
+        use jeod_quantities::frame::Inertial;
+
+        let untyped = GravityAcceleration {
+            grav_accel: DVec3::new(0.0, 0.0, -9.81),
+            grav_grad: DMat3::IDENTITY * 1e-6,
+            grav_pot: 6.25e7,
+        };
+        let typed = GravityAccelerationTyped::<Inertial>::from_untyped_unchecked(&untyped);
         let back = typed.to_untyped();
         assert_eq!(back, untyped);
     }

--- a/crates/jeod_dynamics/src/forces.rs
+++ b/crates/jeod_dynamics/src/forces.rs
@@ -44,6 +44,66 @@ pub struct FrameDerivatives {
     pub rot_accel: DVec3,   // rad/s^2
 }
 
+/// Typed sibling of [`FrameDerivatives`].
+///
+/// `trans_accel` carries the integration frame `F`; `rot_accel`
+/// carries the body frame for vehicle `V`. The two type parameters
+/// are independent — a body integrating translational state in one
+/// frame may carry rotational state about a body axis whose
+/// orientation is completely unrelated.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FrameDerivativesTyped<
+    F: jeod_quantities::frame::Frame,
+    V: jeod_quantities::frame::Vehicle,
+> {
+    pub trans_accel: jeod_quantities::aliases::Acceleration<F>,
+    pub rot_accel:
+        jeod_quantities::aliases::AngularAcceleration<jeod_quantities::frame::BodyFrame<V>>,
+    _v: core::marker::PhantomData<V>,
+}
+
+impl<F: jeod_quantities::frame::Frame, V: jeod_quantities::frame::Vehicle> Default
+    for FrameDerivativesTyped<F, V>
+{
+    #[inline]
+    fn default() -> Self {
+        Self {
+            trans_accel: jeod_quantities::aliases::Acceleration::<F>::zero(),
+            rot_accel: jeod_quantities::aliases::AngularAcceleration::<
+                jeod_quantities::frame::BodyFrame<V>,
+            >::zero(),
+            _v: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<F: jeod_quantities::frame::Frame, V: jeod_quantities::frame::Vehicle>
+    FrameDerivativesTyped<F, V>
+{
+    /// Drop the frame phantoms and emit the untyped storage form.
+    #[inline]
+    pub fn to_untyped(&self) -> FrameDerivatives {
+        FrameDerivatives {
+            trans_accel: self.trans_accel.raw_si(),
+            rot_accel: self.rot_accel.raw_si(),
+        }
+    }
+
+    /// Wrap an untyped [`FrameDerivatives`] as typed. **The caller
+    /// asserts** the translational accel is in `F` and the rotational
+    /// accel is in `BodyFrame<V>`.
+    #[inline]
+    pub fn from_untyped_unchecked(d: &FrameDerivatives) -> Self {
+        Self {
+            trans_accel: jeod_quantities::aliases::Acceleration::<F>::from_raw_si(d.trans_accel),
+            rot_accel: jeod_quantities::aliases::AngularAcceleration::<
+                jeod_quantities::frame::BodyFrame<V>,
+            >::from_raw_si(d.rot_accel),
+            _v: core::marker::PhantomData,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DynamicsConfig {
     pub translational_dynamics: bool,
@@ -399,5 +459,19 @@ mod tests {
         );
         // non_grav_accel = 100 * (1/50) = 2.0 in x
         assert!((fd.trans_accel - DVec3::new(2.0, 0.0, -9.81)).length() < 1e-12);
+    }
+
+    #[test]
+    fn typed_frame_derivatives_round_trip() {
+        use jeod_quantities::frame::{Inertial, TestVehicle};
+
+        let untyped = FrameDerivatives {
+            trans_accel: DVec3::new(1.0, 2.0, 3.0),
+            rot_accel: DVec3::new(0.1, 0.2, 0.3),
+        };
+        let typed =
+            FrameDerivativesTyped::<Inertial, TestVehicle>::from_untyped_unchecked(&untyped);
+        let back = typed.to_untyped();
+        assert_eq!(back, untyped);
     }
 }

--- a/crates/jeod_dynamics/src/mass.rs
+++ b/crates/jeod_dynamics/src/mass.rs
@@ -1,4 +1,10 @@
+use core::marker::PhantomData;
+
 use glam::{DMat3, DVec3};
+use jeod_quantities::aliases::{InertiaTensor, Position};
+use jeod_quantities::frame::{BodyFrame, StructuralFrame, Vehicle};
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 /// Default tolerance for [`MassProperties::validate_consistency`].
 ///
@@ -127,6 +133,146 @@ impl MassProperties {
     }
 }
 
+/// Typed sibling of [`MassProperties`] parameterized by a vehicle marker
+/// `V`. Mass becomes a `uom::si::f64::Mass`, inertia is wrapped in
+/// [`InertiaTensor<BodyFrame<V>>`], and the center-of-mass position
+/// carries the `StructuralFrame<V>` phantom tag.
+///
+/// `inverse_mass` and `inverse_inertia` remain untyped (`f64` and
+/// `DMat3`): they are the integrator-hot-path caches for `F = m·a`
+/// resolution. The dimension is `1/M` and `1/(M·L²)` respectively —
+/// `jeod_quantities` does not expose a typed `Inverse<Mass>` alias and
+/// adding one would be churn for no enforced invariant beyond the f64
+/// path's own unit consistency.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MassPropertiesTyped<V: Vehicle> {
+    /// Total mass.
+    pub mass: Mass,
+    /// Precomputed `1 / mass` in `kg⁻¹` (caller maintains consistency
+    /// via [`Self::recompute_derived`]).
+    pub inverse_mass: f64,
+    /// Inertia tensor about the body-frame axes through the center of mass.
+    pub inertia: InertiaTensor<BodyFrame<V>>,
+    /// Precomputed `inertia⁻¹`. Maintained consistent with `inertia` via
+    /// [`Self::recompute_derived`].
+    pub inverse_inertia: DMat3,
+    /// Center of mass in the structural frame.
+    pub center_of_mass: Position<StructuralFrame<V>>,
+    /// See [`MassProperties::dirty`].
+    pub dirty: bool,
+    _v: PhantomData<V>,
+}
+
+impl<V: Vehicle> MassPropertiesTyped<V> {
+    /// Point-mass constructor with placeholder spherical inertia
+    /// (`I = m · I_{3×3}`) — see [`MassProperties::new`] for the same
+    /// caveat about translational-only validity.
+    // JEOD_INV: MA.02 — mass > 0 for meaningful dynamics
+    pub fn new(mass: Mass) -> Self {
+        let m = mass.get::<kilogram>();
+        assert!(m > 0.0, "mass must be positive, got {m}");
+        Self {
+            mass,
+            inverse_mass: 1.0 / m,
+            inertia: InertiaTensor::<BodyFrame<V>>::from_dmat3_unchecked(DMat3::IDENTITY * m),
+            inverse_inertia: DMat3::IDENTITY / m,
+            center_of_mass: Position::<StructuralFrame<V>>::zero(),
+            dirty: false,
+            _v: PhantomData,
+        }
+    }
+
+    /// Constructor with explicit inertia and center-of-mass position.
+    // JEOD_INV: MA.02 — mass > 0 for meaningful dynamics
+    // JEOD_INV: MA.04 — inverse_inertia computed from inertia
+    // JEOD_INV: DB.23 — inverse_inertia always computed
+    pub fn with_inertia(
+        mass: Mass,
+        inertia: InertiaTensor<BodyFrame<V>>,
+        center_of_mass: Position<StructuralFrame<V>>,
+    ) -> Self {
+        let m = mass.get::<kilogram>();
+        assert!(m > 0.0, "mass must be positive, got {m}");
+        let inertia_dmat = inertia.as_dmat3();
+        let det = inertia_dmat.determinant();
+        assert!(
+            det.abs() > 1e-30,
+            "inertia tensor is singular or near-singular (det={det:.2e}); \
+             inverse will produce inf/NaN"
+        );
+        Self {
+            mass,
+            inverse_mass: 1.0 / m,
+            inertia,
+            inverse_inertia: inertia_dmat.inverse(),
+            center_of_mass,
+            dirty: false,
+            _v: PhantomData,
+        }
+    }
+
+    /// Drop the phantoms and emit the untyped storage form. Numeric
+    /// values (kg, kg·m², m) are preserved exactly.
+    pub fn to_untyped(&self) -> MassProperties {
+        MassProperties {
+            mass: self.mass.get::<kilogram>(),
+            inverse_mass: self.inverse_mass,
+            inertia: self.inertia.as_dmat3(),
+            inverse_inertia: self.inverse_inertia,
+            position: self.center_of_mass.raw_si(),
+            dirty: self.dirty,
+        }
+    }
+
+    /// Wrap an untyped [`MassProperties`] as typed for vehicle `V`.
+    /// **The caller asserts** the inertia is in `BodyFrame<V>` and the
+    /// position is in `StructuralFrame<V>`.
+    pub fn from_untyped_unchecked(mp: &MassProperties) -> Self {
+        Self {
+            mass: Mass::new::<kilogram>(mp.mass),
+            inverse_mass: mp.inverse_mass,
+            inertia: InertiaTensor::<BodyFrame<V>>::from_dmat3_unchecked(mp.inertia),
+            inverse_inertia: mp.inverse_inertia,
+            center_of_mass: Position::<StructuralFrame<V>>::from_raw_si(mp.position),
+            dirty: mp.dirty,
+            _v: PhantomData,
+        }
+    }
+
+    /// Recompute `inverse_mass` and `inverse_inertia`.
+    // JEOD_INV: MA.03 — inverse_mass = 1/mass (recomputed)
+    // JEOD_INV: MA.04 — inverse_inertia consistent with inertia (recomputed)
+    // JEOD_INV: MA.07 — derived quantities recomputed after mutation
+    pub fn recompute_derived(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        self.dirty = false;
+        let m = self.mass.get::<kilogram>();
+        assert!(m > 0.0, "mass must be positive, got {m}");
+        self.inverse_mass = 1.0 / m;
+        let inertia_dmat = self.inertia.as_dmat3();
+        let det = inertia_dmat.determinant();
+        assert!(
+            det.abs() > 1e-30,
+            "inertia tensor is singular or near-singular (det={det:.2e}); \
+             inverse will produce inf/NaN"
+        );
+        self.inverse_inertia = inertia_dmat.inverse();
+    }
+
+    /// JEOD MA.04 invariant check: `inertia · inverse_inertia ≈ I`.
+    // JEOD_INV: MA.04 — inverse_inertia consistent with inertia
+    pub fn validate_consistency(&self, tol: f64) {
+        let product = self.inertia.as_dmat3() * self.inverse_inertia;
+        assert!(
+            (product - DMat3::IDENTITY).abs_diff_eq(DMat3::ZERO, tol),
+            "MassPropertiesTyped: inertia and inverse_inertia inconsistent \
+             (I·I⁻¹ != identity to {tol:.0e})"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,5 +364,68 @@ mod tests {
         // Verify consistency
         mp.validate_consistency(1e-6);
         assert!((mp.inverse_mass - 0.1).abs() < 1e-15);
+    }
+
+    // ---- typed MassPropertiesTyped<V> ----------------------------------
+
+    #[test]
+    fn typed_point_mass_round_trips_to_untyped() {
+        use jeod_quantities::frame::TestVehicle;
+
+        let typed = MassPropertiesTyped::<TestVehicle>::new(Mass::new::<kilogram>(10.0));
+        let untyped = typed.to_untyped();
+
+        assert_eq!(untyped.mass, 10.0);
+        assert_eq!(untyped.inverse_mass, 0.1);
+        assert_eq!(untyped.inertia, DMat3::IDENTITY * 10.0);
+        assert_eq!(untyped.inverse_inertia, DMat3::IDENTITY / 10.0);
+        assert_eq!(untyped.position, DVec3::ZERO);
+    }
+
+    #[test]
+    fn typed_with_inertia_matches_untyped() {
+        use jeod_quantities::frame::TestVehicle;
+
+        let m = 5.0;
+        let i = DMat3::from_diagonal(DVec3::new(50.0, 60.0, 70.0));
+        let pos = DVec3::new(0.1, 0.2, 0.3);
+
+        let typed = MassPropertiesTyped::<TestVehicle>::with_inertia(
+            Mass::new::<kilogram>(m),
+            InertiaTensor::<BodyFrame<TestVehicle>>::from_dmat3_unchecked(i),
+            Position::<StructuralFrame<TestVehicle>>::from_raw_si(pos),
+        );
+        let untyped = MassProperties::with_inertia(m, i, pos);
+
+        assert_eq!(typed.to_untyped(), untyped);
+    }
+
+    #[test]
+    fn typed_round_trip_through_from_untyped_unchecked() {
+        use jeod_quantities::frame::TestVehicle;
+
+        let untyped = MassProperties::with_inertia(
+            7.5,
+            DMat3::from_diagonal(DVec3::new(40.0, 50.0, 60.0)),
+            DVec3::new(0.0, 0.05, 0.0),
+        );
+        let typed = MassPropertiesTyped::<TestVehicle>::from_untyped_unchecked(&untyped);
+        let back = typed.to_untyped();
+
+        assert_eq!(back, untyped);
+    }
+
+    #[test]
+    fn typed_validate_consistency_passes() {
+        use jeod_quantities::frame::TestVehicle;
+
+        let typed = MassPropertiesTyped::<TestVehicle>::with_inertia(
+            Mass::new::<kilogram>(10.0),
+            InertiaTensor::<BodyFrame<TestVehicle>>::from_dmat3_unchecked(DMat3::from_diagonal(
+                DVec3::new(100.0, 200.0, 300.0),
+            )),
+            Position::<StructuralFrame<TestVehicle>>::zero(),
+        );
+        typed.validate_consistency(1e-6);
     }
 }

--- a/crates/jeod_dynamics/src/rotational.rs
+++ b/crates/jeod_dynamics/src/rotational.rs
@@ -78,7 +78,7 @@ impl<V: Vehicle> RotationalStateTyped<V> {
     }
 
     /// Drop the phantom and emit the untyped storage form. Numeric
-    /// values (radians for the quaternion, rad/s for the angular
+    /// values (unitless quaternion components, rad/s for the angular
     /// velocity) are preserved exactly.
     #[inline]
     pub fn to_untyped(&self) -> RotationalState {

--- a/crates/jeod_dynamics/src/rotational.rs
+++ b/crates/jeod_dynamics/src/rotational.rs
@@ -1,7 +1,12 @@
+use core::marker::PhantomData;
+
 use crate::state::TranslationalState;
 use glam::{DMat3, DVec3};
 use jeod_math::quaternion::NORM_LIMIT;
 use jeod_math::JeodQuat;
+use jeod_quantities::aliases::AngularVelocity;
+use jeod_quantities::frame::{BodyFrame, Vehicle};
+use jeod_quantities::quat::{LeftTransform, NormalizedQuat, ScalarFirst};
 
 /// Rotational state of a rigid body.
 ///
@@ -30,6 +35,74 @@ impl Default for RotationalState {
 pub struct SixDofState {
     pub trans: TranslationalState,
     pub rot: RotationalState,
+}
+
+/// Typed sibling of [`RotationalState`] parameterized by a vehicle marker
+/// `V`. The quaternion is a witnessed unit-norm
+/// [`NormalizedQuat<ScalarFirst, LeftTransform>`] (JEOD canonical), and
+/// angular velocity carries the `BodyFrame<V>` phantom tag.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RotationalStateTyped<V: Vehicle> {
+    /// Inertial → body left-transformation quaternion (witnessed unit-norm).
+    pub q_inertial_body: NormalizedQuat<ScalarFirst, LeftTransform>,
+    /// Angular velocity in `BodyFrame<V>`.
+    pub ang_vel_body: AngularVelocity<BodyFrame<V>>,
+    _v: PhantomData<V>,
+}
+
+impl<V: Vehicle> Default for RotationalStateTyped<V> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            q_inertial_body: NormalizedQuat::new(JeodQuat::identity())
+                .expect("identity quaternion is unit-norm"),
+            ang_vel_body: AngularVelocity::<BodyFrame<V>>::zero(),
+            _v: PhantomData,
+        }
+    }
+}
+
+impl<V: Vehicle> RotationalStateTyped<V> {
+    /// Construct from a witnessed unit-norm quaternion plus typed angular
+    /// velocity.
+    #[inline]
+    pub fn new(
+        q_inertial_body: NormalizedQuat<ScalarFirst, LeftTransform>,
+        ang_vel_body: AngularVelocity<BodyFrame<V>>,
+    ) -> Self {
+        Self {
+            q_inertial_body,
+            ang_vel_body,
+            _v: PhantomData,
+        }
+    }
+
+    /// Drop the phantom and emit the untyped storage form. Numeric
+    /// values (radians for the quaternion, rad/s for the angular
+    /// velocity) are preserved exactly.
+    #[inline]
+    pub fn to_untyped(&self) -> RotationalState {
+        RotationalState {
+            quaternion: self.q_inertial_body.inner(),
+            ang_vel_body: self.ang_vel_body.raw_si(),
+        }
+    }
+
+    /// Wrap an untyped [`RotationalState`] as typed for vehicle `V`.
+    /// **The caller asserts** the angular velocity is expressed in
+    /// `BodyFrame<V>`. The inner quaternion is checked against
+    /// [`NormalizedQuat::DEFAULT_TOLERANCE`]: panics if it has drifted
+    /// more than 1e-12 from unit norm, indicating an upstream
+    /// re-normalization was missed.
+    pub fn from_untyped_unchecked(s: &RotationalState) -> Self {
+        let q = NormalizedQuat::new(s.quaternion)
+            .unwrap_or_else(|err| panic!("RotationalState quaternion is not unit-norm: {err}"));
+        Self {
+            q_inertial_body: q,
+            ang_vel_body: AngularVelocity::<BodyFrame<V>>::from_raw_si(s.ang_vel_body),
+            _v: PhantomData,
+        }
+    }
 }
 
 /// Compute rotational acceleration from Euler's rigid-body equation.
@@ -383,5 +456,31 @@ mod tests {
             "vx should be 0.8, got {}",
             q.data[1],
         );
+    }
+
+    #[test]
+    fn typed_rotational_state_round_trips() {
+        use jeod_quantities::frame::TestVehicle;
+
+        let untyped = RotationalState {
+            quaternion: JeodQuat::left_quat_from_eigen_rotation(0.7, DVec3::Z),
+            ang_vel_body: DVec3::new(0.01, 0.02, 0.03),
+        };
+
+        let typed = RotationalStateTyped::<TestVehicle>::from_untyped_unchecked(&untyped);
+        let back = typed.to_untyped();
+
+        assert_eq!(back.quaternion, untyped.quaternion);
+        assert_eq!(back.ang_vel_body, untyped.ang_vel_body);
+    }
+
+    #[test]
+    fn typed_rotational_default_is_identity() {
+        use jeod_quantities::frame::TestVehicle;
+
+        let s = RotationalStateTyped::<TestVehicle>::default();
+        let untyped = s.to_untyped();
+        assert_eq!(untyped.quaternion, JeodQuat::identity());
+        assert_eq!(untyped.ang_vel_body, DVec3::ZERO);
     }
 }

--- a/crates/jeod_dynamics/src/state.rs
+++ b/crates/jeod_dynamics/src/state.rs
@@ -1,4 +1,6 @@
 use glam::DVec3;
+use jeod_quantities::aliases::{Position, Velocity};
+use jeod_quantities::frame::{Frame, Inertial};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct TranslationalState {
@@ -23,9 +25,66 @@ impl TranslationalState {
     }
 }
 
+/// Typed sibling of [`TranslationalState`] carrying a frame phantom on
+/// the position and velocity components. Defaults to the inertial frame
+/// to match the existing untyped storage convention; override with an
+/// explicit frame tag for non-inertial integrations.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TranslationalStateTyped<F: Frame = Inertial> {
+    /// Position in frame `F`.
+    pub position: Position<F>,
+    /// Velocity in frame `F`.
+    pub velocity: Velocity<F>,
+}
+
+impl<F: Frame> Default for TranslationalStateTyped<F> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            position: Position::<F>::zero(),
+            velocity: Velocity::<F>::zero(),
+        }
+    }
+}
+
+impl<F: Frame> TranslationalStateTyped<F> {
+    /// Drop the frame phantom and emit the untyped storage form. The
+    /// numeric values (in base SI units: m, m/s) are preserved exactly.
+    #[inline]
+    pub fn to_untyped(&self) -> TranslationalState {
+        TranslationalState {
+            position: self.position.raw_si(),
+            velocity: self.velocity.raw_si(),
+        }
+    }
+
+    /// Wrap an untyped [`TranslationalState`] as a typed one. **The
+    /// caller asserts** that the untyped state is expressed in frame
+    /// `F` — there is no runtime check.
+    #[inline]
+    pub fn from_untyped_unchecked(s: &TranslationalState) -> Self {
+        Self {
+            position: Position::<F>::from_raw_si(s.position),
+            velocity: Velocity::<F>::from_raw_si(s.velocity),
+        }
+    }
+
+    /// JEOD initialization heuristic — both position and velocity zero.
+    ///
+    /// Mirrors [`TranslationalState::is_likely_uninitialized`] for
+    /// downstream code holding the typed form.
+    // JEOD_INV: DM.05 — partial: detects zero translational state
+    // JEOD_INV: DB.11 — partial: zero-state heuristic only
+    #[inline]
+    pub fn is_likely_uninitialized(&self) -> bool {
+        self.position.raw_si() == DVec3::ZERO && self.velocity.raw_si() == DVec3::ZERO
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use jeod_quantities::frame::Ecef;
 
     #[test]
     fn default_is_likely_uninitialized() {
@@ -48,5 +107,33 @@ mod tests {
             velocity: DVec3::new(0.0, 7.5e3, 0.0),
         };
         assert!(!s.is_likely_uninitialized());
+    }
+
+    #[test]
+    fn typed_round_trips_through_untyped() {
+        let untyped = TranslationalState {
+            position: DVec3::new(7e6, 0.0, 0.0),
+            velocity: DVec3::new(0.0, 7500.0, 0.0),
+        };
+        let typed = TranslationalStateTyped::<Inertial>::from_untyped_unchecked(&untyped);
+        let back = typed.to_untyped();
+        assert_eq!(back, untyped);
+    }
+
+    #[test]
+    fn typed_default_is_likely_uninitialized() {
+        let s = TranslationalStateTyped::<Inertial>::default();
+        assert!(s.is_likely_uninitialized());
+    }
+
+    #[test]
+    fn typed_inertial_and_ecef_are_distinct_types() {
+        // Compile-time check that `TranslationalStateTyped<Inertial>` and
+        // `TranslationalStateTyped<Ecef>` are not assignable to one another;
+        // we only verify the same-frame case compiles here.
+        let s_inertial = TranslationalStateTyped::<Inertial>::default();
+        let s_ecef = TranslationalStateTyped::<Ecef>::default();
+        assert!(s_inertial.is_likely_uninitialized());
+        assert!(s_ecef.is_likely_uninitialized());
     }
 }

--- a/crates/jeod_frames/Cargo.toml
+++ b/crates/jeod_frames/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 jeod_math = { path = "../jeod_math" }
+jeod_quantities = { path = "../jeod_quantities" }
 glam = { workspace = true }
 
 [dev-dependencies]

--- a/crates/jeod_frames/src/frame_tree.rs
+++ b/crates/jeod_frames/src/frame_tree.rs
@@ -1290,9 +1290,9 @@ mod tests {
         let typed_out: RefFrameStateTyped<Inertial, Ecef> = tree.get_state_typed(child);
         assert_eq!(typed_out.trans.position.raw_si(), untyped.trans.position);
         assert_eq!(typed_out.trans.velocity.raw_si(), untyped.trans.velocity);
-        assert_eq!(typed_out.rot.t_parent_this, untyped.rot.t_parent_this);
+        assert_eq!(typed_out.rot.t_parent_this(), untyped.rot.t_parent_this);
         assert_eq!(
-            typed_out.rot.ang_vel_this.raw_si(),
+            typed_out.rot.ang_vel_this().raw_si(),
             untyped.rot.ang_vel_this
         );
     }

--- a/crates/jeod_frames/src/frame_tree.rs
+++ b/crates/jeod_frames/src/frame_tree.rs
@@ -7,7 +7,8 @@
 //!
 //! This module is pure Rust with zero Bevy dependency.
 
-use crate::ref_frame_state::{RefFrameKind, RefFrameState};
+use crate::ref_frame_state::{RefFrameKind, RefFrameState, RefFrameStateTyped};
+use jeod_quantities::frame::Frame;
 
 /// Handle into the [`FrameTree`] arena.
 pub type FrameId = usize;
@@ -80,6 +81,39 @@ impl FrameTree {
         self.children.push(Vec::new());
         self.children[parent_id].push(id);
         id
+    }
+
+    /// Typed sibling of [`Self::add_child`] taking a frame-tagged
+    /// [`RefFrameStateTyped<P, C>`]. The arena's storage stays
+    /// untyped — heterogeneous parent/child frames preclude a single
+    /// generic instantiation across a `Vec<FrameNode>` — so the typed
+    /// state is converted via [`RefFrameStateTyped::to_untyped`] at the
+    /// boundary. The numeric values are preserved exactly.
+    ///
+    /// `kind` is supplied separately because the runtime kind
+    /// discriminant is not derivable from the compile-time frame
+    /// markers in `jeod_quantities::frame` without a workspace-wide
+    /// trait extension.
+    pub fn add_child_typed<P: Frame, C: Frame>(
+        &mut self,
+        parent_id: FrameId,
+        name: String,
+        kind: RefFrameKind,
+        state: RefFrameStateTyped<P, C>,
+    ) -> FrameId {
+        self.add_child(parent_id, name, kind, state.to_untyped())
+    }
+
+    /// Read the state at `id` as a typed [`RefFrameStateTyped<P, C>`].
+    ///
+    /// **The caller asserts** the parent and child frame markers match
+    /// the runtime kind of the stored frame — there is no compile- or
+    /// run-time check. Used at the typed-API boundary in `jeod_dynamics`
+    /// and `jeod_sim`. The wrapped quaternion is checked against the
+    /// `NormalizedQuat::DEFAULT_TOLERANCE`; a missed renormalization
+    /// upstream surfaces immediately.
+    pub fn get_state_typed<P: Frame, C: Frame>(&self, id: FrameId) -> RefFrameStateTyped<P, C> {
+        RefFrameStateTyped::<P, C>::from_untyped_unchecked(&self.nodes[id].state)
     }
 
     // -- accessors ----------------------------------------------------------
@@ -1228,5 +1262,61 @@ mod tests {
             &non_panicking.rot.t_parent_this,
             TOL
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3: typed sugar over the untyped arena.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_child_typed_round_trips_through_storage() {
+        use jeod_quantities::frame::{Ecef, Inertial};
+
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("inertial".into(), RefFrameKind::Inertial);
+
+        let untyped = make_state(
+            0.5,
+            DVec3::new(1e6, 2e6, 3e6),
+            DVec3::new(10.0, 20.0, 30.0),
+            DVec3::new(0.001, 0.002, 0.003),
+        );
+        let typed_in = RefFrameStateTyped::<Inertial, Ecef>::from_untyped_unchecked(&untyped);
+
+        let child = tree.add_child_typed(root, "ecef".into(), RefFrameKind::PlanetFixed, typed_in);
+
+        // Read back via the typed accessor and assert the underlying
+        // raw_si values match the original untyped input bit-identically.
+        let typed_out: RefFrameStateTyped<Inertial, Ecef> = tree.get_state_typed(child);
+        assert_eq!(typed_out.trans.position.raw_si(), untyped.trans.position);
+        assert_eq!(typed_out.trans.velocity.raw_si(), untyped.trans.velocity);
+        assert_eq!(typed_out.rot.t_parent_this, untyped.rot.t_parent_this);
+        assert_eq!(
+            typed_out.rot.ang_vel_this.raw_si(),
+            untyped.rot.ang_vel_this
+        );
+    }
+
+    #[test]
+    fn add_child_typed_matches_untyped_storage() {
+        use jeod_quantities::frame::{Ecef, Inertial};
+
+        let mut tree_a = FrameTree::new();
+        let root_a = tree_a.add_root("inertial".into(), RefFrameKind::Inertial);
+        let mut tree_b = FrameTree::new();
+        let root_b = tree_b.add_root("inertial".into(), RefFrameKind::Inertial);
+
+        let untyped = make_state(
+            FRAC_PI_2,
+            DVec3::new(7e6, 0.0, 0.0),
+            DVec3::new(0.0, 7000.0, 0.0),
+            DVec3::new(0.0, 0.0, 7.292e-5),
+        );
+        let typed = RefFrameStateTyped::<Inertial, Ecef>::from_untyped_unchecked(&untyped);
+
+        let id_a = tree_a.add_child(root_a, "a".into(), RefFrameKind::PlanetFixed, untyped);
+        let id_b = tree_b.add_child_typed(root_b, "b".into(), RefFrameKind::PlanetFixed, typed);
+
+        assert_eq!(tree_a.get(id_a).state, tree_b.get(id_b).state);
     }
 }

--- a/crates/jeod_frames/src/ref_frame_state.rs
+++ b/crates/jeod_frames/src/ref_frame_state.rs
@@ -316,9 +316,20 @@ impl<P: Frame, C: Frame> RefFrameStateTyped<P, C> {
     /// [`NormalizedQuat::DEFAULT_TOLERANCE`]: panics if the source
     /// quaternion's norm has drifted past 1e-12, which would indicate
     /// a missing renormalization upstream.
+    ///
+    /// `t_parent_this` is **re-derived from `q_norm`** rather than
+    /// copied from the untyped state. JEOD's RF.04 invariant treats
+    /// the quaternion as the canonical source of truth and the matrix
+    /// as a cache; copying the cache without verification could
+    /// silently propagate a stale matrix into typed code if an
+    /// upstream caller mutated `q_parent_this` without recomputing
+    /// `t_parent_this`. The recompute cost is one
+    /// `left_quat_to_transformation` (a handful of FLOPs).
     pub fn from_untyped_unchecked(s: &RefFrameState) -> Self {
         let q_norm = NormalizedQuat::new(s.rot.q_parent_this)
             .unwrap_or_else(|err| panic!("RefFrameState quaternion is not unit-norm: {err}"));
+        // JEOD_INV: RF.04 — derive T from Q (canonical source of truth)
+        let t_parent_this = q_norm.inner().left_quat_to_transformation();
         Self {
             trans: RefFrameTransTyped {
                 position: Position::<P>::from_raw_si(s.trans.position),
@@ -326,7 +337,7 @@ impl<P: Frame, C: Frame> RefFrameStateTyped<P, C> {
             },
             rot: RefFrameRotTyped {
                 q_parent_this: q_norm,
-                t_parent_this: s.rot.t_parent_this,
+                t_parent_this,
                 ang_vel_this: AngularVelocity::<C>::from_raw_si(s.rot.ang_vel_this),
                 _p: PhantomData,
             },

--- a/crates/jeod_frames/src/ref_frame_state.rs
+++ b/crates/jeod_frames/src/ref_frame_state.rs
@@ -1,5 +1,10 @@
+use core::marker::PhantomData;
+
 use glam::{DMat3, DVec3};
 use jeod_math::JeodQuat;
+use jeod_quantities::aliases::{AngularVelocity, Position, Velocity};
+use jeod_quantities::frame::Frame;
+use jeod_quantities::quat::{LeftTransform, NormalizedQuat, ScalarFirst};
 
 // JEOD_INV: RF.06 — position/velocity in parent coordinates (structural convention)
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -162,6 +167,196 @@ impl RefFrameState {
     pub fn incr_left(&mut self, s_ab: &RefFrameState) {
         let result = s_ab.incr_right(self);
         *self = result;
+    }
+}
+
+// ===========================================================================
+// Phase 3: typed siblings — `RefFrameStateTyped<Parent, Child>`
+//
+// Frame-tagged variants of the structs above. These are the surface that
+// Phase 3 callers in `jeod_dynamics`, `jeod_sim` and downstream should
+// adopt. The untyped `RefFrameState` remains as the storage type for the
+// frame-tree arena (heterogeneous parents/children forbid a single
+// generic instantiation), with `to_untyped()` / `from_untyped_unchecked()`
+// bridging the typed and untyped surfaces.
+//
+// The typed types delegate their numeric operations (`negate`,
+// `incr_right`) to the untyped implementation so the f64 / DVec3 path is
+// the single source of truth — bit-identical results, no risk of drift
+// between the two surfaces.
+// ===========================================================================
+
+/// Typed translational state in parent frame `P`. Equivalent to
+/// [`RefFrameTrans`] but the `position` and `velocity` 3-vectors carry
+/// the parent-frame phantom tag.
+// JEOD_INV: RF.06 — position/velocity in parent coordinates (structural convention)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RefFrameTransTyped<P: Frame> {
+    /// Position of the child frame's origin in parent coordinates.
+    pub position: Position<P>,
+    /// Velocity of the child frame's origin in parent coordinates.
+    pub velocity: Velocity<P>,
+}
+
+impl<P: Frame> Default for RefFrameTransTyped<P> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            position: Position::<P>::zero(),
+            velocity: Velocity::<P>::zero(),
+        }
+    }
+}
+
+/// Typed rotational state for the `Parent → Child` axis transformation.
+///
+/// `q_parent_this` is witnessed unit-norm; `t_parent_this` is the cached
+/// 3×3 form, kept in sync at construction time. `ang_vel_this` is in
+/// child-frame coordinates (JEOD convention).
+// JEOD_INV: RF.07 — Q_parent_this is left-transformation quaternion (JEOD convention)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RefFrameRotTyped<P: Frame, C: Frame> {
+    /// Left-transformation quaternion taking vectors expressed in `P` to `C`.
+    pub q_parent_this: NormalizedQuat<ScalarFirst, LeftTransform>,
+    /// Cached 3×3 rotation form of `q_parent_this`.
+    pub t_parent_this: DMat3,
+    /// Angular velocity of `C` relative to `P`, expressed in `C` coordinates.
+    pub ang_vel_this: AngularVelocity<C>,
+    _p: PhantomData<P>,
+}
+
+impl<P: Frame, C: Frame> RefFrameRotTyped<P, C> {
+    /// Build from a JEOD-canonical quaternion plus angular velocity. The
+    /// 3×3 cached form is derived once at construction. The unit-norm
+    /// invariant is borne by `NormalizedQuat`.
+    #[inline]
+    pub fn new(
+        q_parent_this: NormalizedQuat<ScalarFirst, LeftTransform>,
+        ang_vel_this: AngularVelocity<C>,
+    ) -> Self {
+        // JEOD_INV: RF.04 — T_parent_this derived from quaternion (canonical source of truth)
+        let t_parent_this = q_parent_this.inner().left_quat_to_transformation();
+        Self {
+            q_parent_this,
+            t_parent_this,
+            ang_vel_this,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<F: Frame> Default for RefFrameRotTyped<F, F> {
+    /// Identity rotation (only defined when `Parent = Child`).
+    #[inline]
+    fn default() -> Self {
+        let q =
+            NormalizedQuat::new(JeodQuat::identity()).expect("identity quaternion is unit-norm");
+        Self {
+            q_parent_this: q,
+            t_parent_this: DMat3::IDENTITY,
+            ang_vel_this: AngularVelocity::<F>::zero(),
+            _p: PhantomData,
+        }
+    }
+}
+
+/// Typed reference-frame state: combined translation + rotation taking
+/// child frame `C` to its parent frame `P`. `negate()` returns the
+/// reversed transform `RefFrameStateTyped<C, P>`; `incr_right()` composes
+/// with another typed state whose parent matches `Self::Child` to produce
+/// a new state spanning the union.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RefFrameStateTyped<P: Frame, C: Frame> {
+    pub trans: RefFrameTransTyped<P>,
+    pub rot: RefFrameRotTyped<P, C>,
+}
+
+impl<F: Frame> Default for RefFrameStateTyped<F, F> {
+    /// Identity state. Only defined when `Parent = Child`.
+    #[inline]
+    fn default() -> Self {
+        Self {
+            trans: RefFrameTransTyped::<F>::default(),
+            rot: RefFrameRotTyped::<F, F>::default(),
+        }
+    }
+}
+
+impl<P: Frame, C: Frame> RefFrameStateTyped<P, C> {
+    /// Build from typed translation and rotation pieces.
+    #[inline]
+    pub fn new(trans: RefFrameTransTyped<P>, rot: RefFrameRotTyped<P, C>) -> Self {
+        Self { trans, rot }
+    }
+
+    /// Drop the frame phantoms and emit an untyped [`RefFrameState`] —
+    /// the storage type used by the frame-tree arena. Numeric values are
+    /// unchanged.
+    pub fn to_untyped(&self) -> RefFrameState {
+        RefFrameState {
+            trans: RefFrameTrans {
+                position: self.trans.position.raw_si(),
+                velocity: self.trans.velocity.raw_si(),
+            },
+            rot: RefFrameRot {
+                q_parent_this: self.rot.q_parent_this.inner(),
+                t_parent_this: self.rot.t_parent_this,
+                ang_vel_this: self.rot.ang_vel_this.raw_si(),
+            },
+        }
+    }
+
+    /// Wrap an untyped [`RefFrameState`] as a typed one. **The caller
+    /// asserts** that the untyped state's parent and child frames are
+    /// `P` and `C` respectively — there is no runtime check. Used at
+    /// the frame-tree arena boundary where `RefFrameKind` discriminates
+    /// the runtime kind separately.
+    ///
+    /// The wrapped quaternion is checked against
+    /// [`NormalizedQuat::DEFAULT_TOLERANCE`]: panics if the source
+    /// quaternion's norm has drifted past 1e-12, which would indicate
+    /// a missing renormalization upstream.
+    pub fn from_untyped_unchecked(s: &RefFrameState) -> Self {
+        let q_norm = NormalizedQuat::new(s.rot.q_parent_this)
+            .unwrap_or_else(|err| panic!("RefFrameState quaternion is not unit-norm: {err}"));
+        Self {
+            trans: RefFrameTransTyped {
+                position: Position::<P>::from_raw_si(s.trans.position),
+                velocity: Velocity::<P>::from_raw_si(s.trans.velocity),
+            },
+            rot: RefFrameRotTyped {
+                q_parent_this: q_norm,
+                t_parent_this: s.rot.t_parent_this,
+                ang_vel_this: AngularVelocity::<C>::from_raw_si(s.rot.ang_vel_this),
+                _p: PhantomData,
+            },
+        }
+    }
+
+    /// Negate (invert) the typed state: `S_{P:C}` → `S_{C:P}`.
+    ///
+    /// Delegates to the untyped [`RefFrameState::negate`] so the f64
+    /// path remains the single source of truth — typed and untyped
+    /// surfaces are bit-identical at equal numeric inputs.
+    pub fn negate(&self) -> RefFrameStateTyped<C, P> {
+        let untyped_neg = RefFrameState::negate(&self.to_untyped());
+        // SAFETY of the unchecked conversion: the negated state, by
+        // construction, takes child → parent. RF.03 holds because
+        // `RefFrameState::negate` re-normalizes the conjugate before
+        // emitting the result (see `q_new.normalize()` upstream).
+        RefFrameStateTyped::<C, P>::from_untyped_unchecked(&untyped_neg)
+    }
+
+    /// Compose `self` (P → C) with `s_cd` (C → D) to yield (P → D).
+    ///
+    /// Frame parameters are checked at compile time: the inner
+    /// "C" must match between `Self::Child` and `s_cd`'s parent.
+    pub fn incr_right<D: Frame>(
+        &self,
+        s_cd: &RefFrameStateTyped<C, D>,
+    ) -> RefFrameStateTyped<P, D> {
+        let composed_untyped = self.to_untyped().incr_right(&s_cd.to_untyped());
+        RefFrameStateTyped::<P, D>::from_untyped_unchecked(&composed_untyped)
     }
 }
 
@@ -712,5 +907,179 @@ mod tests {
             approx_eq_vec3(s.rot.q_parent_this.vector(), DVec3::ZERO, TOL),
             "Default quaternion vector"
         );
+    }
+}
+
+#[cfg(test)]
+mod typed_tests {
+    //! Phase 3: tests for the typed `RefFrameStateTyped<P, C>` surface.
+    //!
+    //! Each test compares the typed implementation against the untyped
+    //! one to assert bit-identical numeric results. The typed surface
+    //! adds compile-time frame checking on top of the same f64 path.
+
+    use super::*;
+    use glam::{DMat3, DVec3};
+    use jeod_math::test_utils::{approx_eq_mat3, approx_eq_vec3};
+    use jeod_math::JeodQuat;
+    use jeod_quantities::frame::{Ecef, Inertial};
+    use std::f64::consts::FRAC_PI_2;
+
+    const TOL: f64 = 1e-12;
+
+    fn make_state(angle_z: f64, pos: DVec3, vel: DVec3, ang_vel: DVec3) -> RefFrameState {
+        let q = JeodQuat::left_quat_from_eigen_rotation(angle_z, DVec3::Z);
+        let t = q.left_quat_to_transformation();
+        RefFrameState {
+            trans: RefFrameTrans {
+                position: pos,
+                velocity: vel,
+            },
+            rot: RefFrameRot {
+                q_parent_this: q,
+                t_parent_this: t,
+                ang_vel_this: ang_vel,
+            },
+        }
+    }
+
+    #[test]
+    fn untyped_to_typed_round_trip_is_identity() {
+        let s = make_state(
+            0.7,
+            DVec3::new(1e6, 2e6, 3e6),
+            DVec3::new(100.0, 200.0, 300.0),
+            DVec3::new(0.01, 0.02, 0.03),
+        );
+        let typed = RefFrameStateTyped::<Inertial, Ecef>::from_untyped_unchecked(&s);
+        let back = typed.to_untyped();
+
+        assert_eq!(back.trans.position, s.trans.position);
+        assert_eq!(back.trans.velocity, s.trans.velocity);
+        assert_eq!(back.rot.q_parent_this, s.rot.q_parent_this);
+        assert_eq!(back.rot.t_parent_this, s.rot.t_parent_this);
+        assert_eq!(back.rot.ang_vel_this, s.rot.ang_vel_this);
+    }
+
+    #[test]
+    fn typed_negate_matches_untyped() {
+        let s = make_state(
+            1.2,
+            DVec3::new(5e6, -3e6, 1e6),
+            DVec3::new(500.0, -300.0, 100.0),
+            DVec3::new(0.05, -0.02, 0.01),
+        );
+        let typed = RefFrameStateTyped::<Inertial, Ecef>::from_untyped_unchecked(&s);
+        let typed_neg: RefFrameStateTyped<Ecef, Inertial> = typed.negate();
+        let untyped_neg = RefFrameState::negate(&s);
+
+        assert!(approx_eq_vec3(
+            typed_neg.trans.position.raw_si(),
+            untyped_neg.trans.position,
+            TOL
+        ));
+        assert!(approx_eq_vec3(
+            typed_neg.trans.velocity.raw_si(),
+            untyped_neg.trans.velocity,
+            TOL
+        ));
+        assert!(approx_eq_mat3(
+            &typed_neg.rot.t_parent_this,
+            &untyped_neg.rot.t_parent_this,
+            TOL
+        ));
+        assert!(approx_eq_vec3(
+            typed_neg.rot.ang_vel_this.raw_si(),
+            untyped_neg.rot.ang_vel_this,
+            TOL
+        ));
+    }
+
+    #[test]
+    fn typed_incr_right_matches_untyped() {
+        // Frame chain: Inertial → Ecef → Inertial (round-trip via two
+        // composed typed states; the type system requires the inner
+        // frame to match.)
+        let s_ie = make_state(
+            FRAC_PI_2,
+            DVec3::new(1000.0, 0.0, 0.0),
+            DVec3::new(10.0, 0.0, 0.0),
+            DVec3::new(0.0, 0.0, 0.1),
+        );
+        let s_ei = make_state(
+            -0.4,
+            DVec3::new(0.0, 500.0, 0.0),
+            DVec3::new(0.0, 5.0, 0.0),
+            DVec3::new(0.001, 0.0, 0.0),
+        );
+
+        let typed_ie = RefFrameStateTyped::<Inertial, Ecef>::from_untyped_unchecked(&s_ie);
+        let typed_ei = RefFrameStateTyped::<Ecef, Inertial>::from_untyped_unchecked(&s_ei);
+
+        let composed_typed: RefFrameStateTyped<Inertial, Inertial> = typed_ie.incr_right(&typed_ei);
+        let composed_untyped = s_ie.incr_right(&s_ei);
+
+        assert!(approx_eq_vec3(
+            composed_typed.trans.position.raw_si(),
+            composed_untyped.trans.position,
+            TOL
+        ));
+        assert!(approx_eq_vec3(
+            composed_typed.trans.velocity.raw_si(),
+            composed_untyped.trans.velocity,
+            TOL
+        ));
+        assert!(approx_eq_mat3(
+            &composed_typed.rot.t_parent_this,
+            &composed_untyped.rot.t_parent_this,
+            TOL
+        ));
+        assert!(approx_eq_vec3(
+            composed_typed.rot.ang_vel_this.raw_si(),
+            composed_untyped.rot.ang_vel_this,
+            TOL
+        ));
+    }
+
+    #[test]
+    fn typed_default_for_same_frame_is_identity() {
+        let id = RefFrameStateTyped::<Inertial, Inertial>::default();
+        let untyped = id.to_untyped();
+        assert_eq!(untyped.trans.position, DVec3::ZERO);
+        assert_eq!(untyped.trans.velocity, DVec3::ZERO);
+        assert_eq!(untyped.rot.t_parent_this, DMat3::IDENTITY);
+        assert_eq!(untyped.rot.ang_vel_this, DVec3::ZERO);
+    }
+
+    #[test]
+    fn typed_round_trip_through_negate_recovers_original() {
+        let s = make_state(
+            0.9,
+            DVec3::new(2e6, -1e6, 5e5),
+            DVec3::new(50.0, -25.0, 12.5),
+            DVec3::new(0.01, 0.0, 0.005),
+        );
+        let typed = RefFrameStateTyped::<Inertial, Ecef>::from_untyped_unchecked(&s);
+        let twice_negated = typed.negate().negate();
+
+        // Compose s with negate(s) — should produce identity (within TOL).
+        // Equivalently, double-negate should recover s. Compare via the
+        // untyped projections.
+        let s_back = twice_negated.to_untyped();
+        assert!(approx_eq_vec3(
+            s_back.trans.position,
+            s.trans.position,
+            1e-6
+        ));
+        assert!(approx_eq_vec3(
+            s_back.trans.velocity,
+            s.trans.velocity,
+            1e-6
+        ));
+        assert!(approx_eq_mat3(
+            &s_back.rot.t_parent_this,
+            &s.rot.t_parent_this,
+            1e-10
+        ));
     }
 }

--- a/crates/jeod_frames/src/ref_frame_state.rs
+++ b/crates/jeod_frames/src/ref_frame_state.rs
@@ -208,40 +208,59 @@ impl<P: Frame> Default for RefFrameTransTyped<P> {
     }
 }
 
-/// Typed rotational state for the `Parent → Child` axis transformation.
+/// Typed rotational state for the `P → C` axis transformation.
 ///
-/// `q_parent_this` is witnessed unit-norm; `t_parent_this` is the cached
-/// 3×3 form, kept in sync at construction time. `ang_vel_this` is in
-/// child-frame coordinates (JEOD convention).
+/// Fields are private to enforce JEOD_INV RF.04 (`q_parent_this` is
+/// canonical, `t_parent_this` is a derived cache that must stay
+/// in sync). Construct via [`Self::new`] (the cache is derived once
+/// from the witnessed quaternion); read via the accessor methods.
 // JEOD_INV: RF.07 — Q_parent_this is left-transformation quaternion (JEOD convention)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RefFrameRotTyped<P: Frame, C: Frame> {
-    /// Left-transformation quaternion taking vectors expressed in `P` to `C`.
-    pub q_parent_this: NormalizedQuat<ScalarFirst, LeftTransform>,
-    /// Cached 3×3 rotation form of `q_parent_this`.
-    pub t_parent_this: DMat3,
-    /// Angular velocity of `C` relative to `P`, expressed in `C` coordinates.
-    pub ang_vel_this: AngularVelocity<C>,
+    q_parent_this: NormalizedQuat<ScalarFirst, LeftTransform>,
+    t_parent_this: DMat3,
+    ang_vel_this: AngularVelocity<C>,
     _p: PhantomData<P>,
 }
 
 impl<P: Frame, C: Frame> RefFrameRotTyped<P, C> {
     /// Build from a JEOD-canonical quaternion plus angular velocity. The
-    /// 3×3 cached form is derived once at construction. The unit-norm
-    /// invariant is borne by `NormalizedQuat`.
+    /// 3×3 cached form is derived once at construction via the
+    /// witness-gated [`NormalizedQuat::left_quat_to_transformation`].
+    /// The unit-norm invariant is borne by `NormalizedQuat`.
     #[inline]
     pub fn new(
         q_parent_this: NormalizedQuat<ScalarFirst, LeftTransform>,
         ang_vel_this: AngularVelocity<C>,
     ) -> Self {
         // JEOD_INV: RF.04 — T_parent_this derived from quaternion (canonical source of truth)
-        let t_parent_this = q_parent_this.inner().left_quat_to_transformation();
+        let t_parent_this = q_parent_this.left_quat_to_transformation();
         Self {
             q_parent_this,
             t_parent_this,
             ang_vel_this,
             _p: PhantomData,
         }
+    }
+
+    /// Witnessed unit-norm left quaternion taking vectors from `P` to `C`.
+    #[inline]
+    pub fn q_parent_this(&self) -> NormalizedQuat<ScalarFirst, LeftTransform> {
+        self.q_parent_this
+    }
+
+    /// Cached 3×3 rotation form of [`Self::q_parent_this`]. Always
+    /// consistent with the quaternion at construction time
+    /// (RF.04 invariant).
+    #[inline]
+    pub fn t_parent_this(&self) -> DMat3 {
+        self.t_parent_this
+    }
+
+    /// Angular velocity of `C` relative to `P`, expressed in `C` coordinates.
+    #[inline]
+    pub fn ang_vel_this(&self) -> AngularVelocity<C> {
+        self.ang_vel_this
     }
 }
 
@@ -260,11 +279,16 @@ impl<F: Frame> Default for RefFrameRotTyped<F, F> {
     }
 }
 
-/// Typed reference-frame state: combined translation + rotation taking
-/// child frame `C` to its parent frame `P`. `negate()` returns the
-/// reversed transform `RefFrameStateTyped<C, P>`; `incr_right()` composes
-/// with another typed state whose parent matches `Self::Child` to produce
-/// a new state spanning the union.
+/// Typed reference-frame state describing the state of child frame `C`
+/// relative to parent frame `P`: position/velocity of `C`'s origin
+/// expressed in `P`, plus the `P → C` axis rotation. This matches the
+/// JEOD convention (`q_parent_this` is the `P → C` rotation; vectors
+/// `r_PC` and `v_PC` live in `P` coordinates).
+///
+/// `negate()` returns the reversed-direction state
+/// `RefFrameStateTyped<C, P>`; `incr_right()` composes with another
+/// typed state whose parent matches `Self::Child` to produce a new
+/// state spanning the union.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RefFrameStateTyped<P: Frame, C: Frame> {
     pub trans: RefFrameTransTyped<P>,
@@ -323,24 +347,23 @@ impl<P: Frame, C: Frame> RefFrameStateTyped<P, C> {
     /// as a cache; copying the cache without verification could
     /// silently propagate a stale matrix into typed code if an
     /// upstream caller mutated `q_parent_this` without recomputing
-    /// `t_parent_this`. The recompute cost is one
+    /// `t_parent_this`. The recompute cost is one witness-gated
     /// `left_quat_to_transformation` (a handful of FLOPs).
     pub fn from_untyped_unchecked(s: &RefFrameState) -> Self {
         let q_norm = NormalizedQuat::new(s.rot.q_parent_this)
             .unwrap_or_else(|err| panic!("RefFrameState quaternion is not unit-norm: {err}"));
-        // JEOD_INV: RF.04 — derive T from Q (canonical source of truth)
-        let t_parent_this = q_norm.inner().left_quat_to_transformation();
         Self {
             trans: RefFrameTransTyped {
                 position: Position::<P>::from_raw_si(s.trans.position),
                 velocity: Velocity::<P>::from_raw_si(s.trans.velocity),
             },
-            rot: RefFrameRotTyped {
-                q_parent_this: q_norm,
-                t_parent_this,
-                ang_vel_this: AngularVelocity::<C>::from_raw_si(s.rot.ang_vel_this),
-                _p: PhantomData,
-            },
+            // RefFrameRotTyped::new derives `t_parent_this` from the
+            // witnessed quaternion via the witness-gated API
+            // (JEOD_INV: RF.04, canonical source of truth).
+            rot: RefFrameRotTyped::new(
+                q_norm,
+                AngularVelocity::<C>::from_raw_si(s.rot.ang_vel_this),
+            ),
         }
     }
 

--- a/crates/jeod_quantities/src/aliases.rs
+++ b/crates/jeod_quantities/src/aliases.rs
@@ -37,3 +37,8 @@ pub type AngularAcceleration<F = Inertial> = Qty3<angular_acceleration::Dimensio
 
 /// Angular momentum in frame `F`. Base SI unit: kg·m²/s.
 pub type AngularMomentum<F = Inertial> = Qty3<angular_momentum::Dimension, F>;
+
+// `InertiaTensor<F>` is a `DMat3` newtype rather than a `Qty3`, but it
+// belongs in the same conceptual namespace as the typed quantities — re-
+// export it here for `use jeod_quantities::aliases::*;` callers.
+pub use crate::inertia::InertiaTensor;

--- a/crates/jeod_quantities/src/inertia.rs
+++ b/crates/jeod_quantities/src/inertia.rs
@@ -4,8 +4,15 @@
 //! inertia (dimension `M·L²`, base SI unit `kg·m²`) about the mass body's
 //! axes. This module wraps that storage with a phantom frame parameter so
 //! `InertiaTensor<BodyFrame<V>>` and `InertiaTensor<StructuralFrame<V>>`
-//! are distinct types and cannot be combined without an explicit
-//! [`Self::transform`].
+//! are distinct types — `Add` requires both operands to share the same
+//! `F`, so cross-frame additions fail to compile.
+//!
+//! [`InertiaTensor::transform`] is the **numeric** similarity transform
+//! `T^T · I · T`; it does **not** change the frame phantom. To re-express
+//! an inertia tensor in a different frame, callers must explicitly retag
+//! after rotating: `InertiaTensor::<NewFrame>::from_dmat3_unchecked(
+//! original.transform(&rot).as_dmat3())`. A safer typed-`FrameTransform`
+//! wrapper is left for a follow-up phase.
 //!
 //! Storage is `DMat3` (no `uom` integration) — the dimension is a phantom
 //! annotation. Callers feed in / read out raw `DMat3` values whose entries
@@ -23,6 +30,20 @@ use crate::frame::Frame;
 /// Symmetric in physically-meaningful instances, but the type does not
 /// enforce symmetry — composition via [`Self::transform`] preserves it
 /// when the input is symmetric and the rotation is proper.
+///
+/// # Frame-mismatch is a compile error
+///
+/// Adding inertia tensors expressed in different compile-time frames
+/// fails to typecheck rather than silently mis-summing them:
+///
+/// ```compile_fail
+/// use jeod_quantities::frame::{Ecef, Inertial};
+/// use jeod_quantities::inertia::InertiaTensor;
+///
+/// let a = InertiaTensor::<Inertial>::from_principal(1.0, 1.0, 1.0);
+/// let b = InertiaTensor::<Ecef>::from_principal(1.0, 1.0, 1.0);
+/// let _bad = a + b; // Add is only impl'd for matching frames
+/// ```
 #[repr(transparent)]
 pub struct InertiaTensor<F: Frame> {
     value: DMat3,
@@ -84,18 +105,16 @@ impl<F: Frame> InertiaTensor<F> {
         Self::from_dmat3_unchecked(self.value.transpose())
     }
 
-    /// Re-express this inertia tensor in a sibling frame related to `F`
-    /// by the rotation matrix `rot` (interpreted as `T_parent_this`):
-    /// returns `T^T · I · T`.
+    /// Numeric similarity transform `T^T · I · T`. Matches JEOD's
+    /// `transpose_transform_matrix` usage in `mass_properties.cc` for
+    /// composing child inertia about a parent structural frame's axes.
     ///
-    /// Matches JEOD's `transpose_transform_matrix` usage in
-    /// `mass_properties.cc` for composing child inertia about a parent
-    /// structural frame.
-    ///
-    /// The frame parameter is intentionally unchanged — frame-changing
-    /// rotation must go through a higher-level wrapper (e.g. a typed
-    /// `FrameTransform`) so the tag is updated coherently. This method
-    /// is the kernel; callers in the dynamics layer wrap it.
+    /// **The frame phantom `F` is intentionally unchanged.** This is
+    /// the numeric kernel; frame-changing must go through an explicit
+    /// retag (`InertiaTensor::<NewFrame>::from_dmat3_unchecked(...)`)
+    /// or a future typed `FrameTransform`-style wrapper that updates
+    /// the phantom coherently. Calling `transform` alone does not
+    /// re-express the tensor in a different compile-time frame.
     #[inline]
     pub fn transform(&self, rot: &DMat3) -> Self {
         Self::from_dmat3_unchecked(rot.transpose() * self.value * *rot)

--- a/crates/jeod_quantities/src/inertia.rs
+++ b/crates/jeod_quantities/src/inertia.rs
@@ -1,0 +1,248 @@
+//! `InertiaTensor<F>` — a frame-tagged 3×3 inertia tensor.
+//!
+//! JEOD's `MassProperties::inertia` is a `DMat3` carrying mass moment of
+//! inertia (dimension `M·L²`, base SI unit `kg·m²`) about the mass body's
+//! axes. This module wraps that storage with a phantom frame parameter so
+//! `InertiaTensor<BodyFrame<V>>` and `InertiaTensor<StructuralFrame<V>>`
+//! are distinct types and cannot be combined without an explicit
+//! [`Self::transform`].
+//!
+//! Storage is `DMat3` (no `uom` integration) — the dimension is a phantom
+//! annotation. Callers feed in / read out raw `DMat3` values whose entries
+//! are interpreted as `kg·m²`.
+
+use core::marker::PhantomData;
+use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
+
+use glam::DMat3;
+
+use crate::frame::Frame;
+
+/// Mass moment of inertia tensor (`kg·m²`) expressed in frame `F`.
+///
+/// Symmetric in physically-meaningful instances, but the type does not
+/// enforce symmetry — composition via [`Self::transform`] preserves it
+/// when the input is symmetric and the rotation is proper.
+#[repr(transparent)]
+pub struct InertiaTensor<F: Frame> {
+    value: DMat3,
+    _f: PhantomData<F>,
+}
+
+impl<F: Frame> InertiaTensor<F> {
+    /// Wrap a raw `DMat3` whose entries are interpreted as `kg·m²` in
+    /// frame `F`. The caller is responsible for the unit and for any
+    /// symmetry / positive-definite invariants the downstream physics
+    /// expects.
+    #[inline]
+    pub const fn from_dmat3_unchecked(value: DMat3) -> Self {
+        Self {
+            value,
+            _f: PhantomData,
+        }
+    }
+
+    /// The zero tensor (useful as an accumulator seed).
+    #[inline]
+    pub fn zero() -> Self {
+        Self::from_dmat3_unchecked(DMat3::ZERO)
+    }
+
+    /// Diagonal tensor with the given principal moments
+    /// (`Ixx`, `Iyy`, `Izz`); off-diagonal products are zero.
+    #[inline]
+    pub fn from_principal(ixx: f64, iyy: f64, izz: f64) -> Self {
+        Self::from_dmat3_unchecked(DMat3::from_diagonal(glam::DVec3::new(ixx, iyy, izz)))
+    }
+
+    /// Symmetric tensor built from JEOD's six-component layout:
+    /// `Ixx, Iyy, Izz` on the diagonal; `Ixy, Ixz, Iyz` mirrored across.
+    ///
+    /// JEOD stores inertia products as `+Ixy = ∫ x·y dm` (no negation),
+    /// matching the convention used in
+    /// `models/dynamics/mass/src/mass_properties_inertia.cc`.
+    #[inline]
+    pub fn from_components(ixx: f64, iyy: f64, izz: f64, ixy: f64, ixz: f64, iyz: f64) -> Self {
+        // glam DMat3::from_cols is column-major: columns are x_axis, y_axis, z_axis.
+        let m = DMat3::from_cols(
+            glam::DVec3::new(ixx, ixy, ixz),
+            glam::DVec3::new(ixy, iyy, iyz),
+            glam::DVec3::new(ixz, iyz, izz),
+        );
+        Self::from_dmat3_unchecked(m)
+    }
+
+    /// Raw `DMat3` view in `kg·m²`. Value copy.
+    #[inline]
+    pub const fn as_dmat3(&self) -> DMat3 {
+        self.value
+    }
+
+    /// Transpose. For a symmetric inertia tensor this is the identity.
+    #[inline]
+    pub fn transpose(&self) -> Self {
+        Self::from_dmat3_unchecked(self.value.transpose())
+    }
+
+    /// Re-express this inertia tensor in a sibling frame related to `F`
+    /// by the rotation matrix `rot` (interpreted as `T_parent_this`):
+    /// returns `T^T · I · T`.
+    ///
+    /// Matches JEOD's `transpose_transform_matrix` usage in
+    /// `mass_properties.cc` for composing child inertia about a parent
+    /// structural frame.
+    ///
+    /// The frame parameter is intentionally unchanged — frame-changing
+    /// rotation must go through a higher-level wrapper (e.g. a typed
+    /// `FrameTransform`) so the tag is updated coherently. This method
+    /// is the kernel; callers in the dynamics layer wrap it.
+    #[inline]
+    pub fn transform(&self, rot: &DMat3) -> Self {
+        Self::from_dmat3_unchecked(rot.transpose() * self.value * *rot)
+    }
+}
+
+// Manual Copy/Clone/Debug/PartialEq mirroring `Qty3` style — derives would
+// otherwise demand `F: Copy + Debug + PartialEq` even though `PhantomData<F>`
+// is zero-sized regardless.
+
+impl<F: Frame> Copy for InertiaTensor<F> {}
+
+impl<F: Frame> Clone for InertiaTensor<F> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<F: Frame> core::fmt::Debug for InertiaTensor<F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "InertiaTensor<{}>({:?})",
+            core::any::type_name::<F>(),
+            self.value
+        )
+    }
+}
+
+impl<F: Frame> PartialEq for InertiaTensor<F> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<F: Frame> Default for InertiaTensor<F> {
+    #[inline]
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+// --- Arithmetic ----------------------------------------------------------
+
+/// Component-wise addition. Used by parallel-axis composition: the caller
+/// supplies the offset contribution (`m · ([d]² · I − d ⊗ d)`) as another
+/// `InertiaTensor<F>` in the same frame and adds it.
+impl<F: Frame> Add for InertiaTensor<F> {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self::from_dmat3_unchecked(self.value + rhs.value)
+    }
+}
+
+impl<F: Frame> AddAssign for InertiaTensor<F> {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.value += rhs.value;
+    }
+}
+
+impl<F: Frame> Sub for InertiaTensor<F> {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self::from_dmat3_unchecked(self.value - rhs.value)
+    }
+}
+
+impl<F: Frame> SubAssign for InertiaTensor<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.value -= rhs.value;
+    }
+}
+
+impl<F: Frame> Neg for InertiaTensor<F> {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self::from_dmat3_unchecked(-self.value)
+    }
+}
+
+/// Scalar multiply on the right (`tensor * f64`). The left form
+/// (`f64 * tensor`) is omitted — `Mul<InertiaTensor<F>> for f64` would
+/// require an `F`-generic foreign-impl that the orphan rules permit but
+/// which adds little ergonomic value for what's almost always a scalar
+/// in user code.
+impl<F: Frame> Mul<f64> for InertiaTensor<F> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, scalar: f64) -> Self {
+        Self::from_dmat3_unchecked(self.value * scalar)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::Inertial;
+
+    #[test]
+    fn principal_constructor_is_diagonal() {
+        let i = InertiaTensor::<Inertial>::from_principal(2.0, 3.0, 5.0);
+        let m = i.as_dmat3();
+        assert_eq!(m.x_axis, glam::DVec3::new(2.0, 0.0, 0.0));
+        assert_eq!(m.y_axis, glam::DVec3::new(0.0, 3.0, 0.0));
+        assert_eq!(m.z_axis, glam::DVec3::new(0.0, 0.0, 5.0));
+    }
+
+    #[test]
+    fn from_components_is_symmetric() {
+        let i = InertiaTensor::<Inertial>::from_components(1.0, 2.0, 3.0, 0.1, 0.2, 0.3);
+        let m = i.as_dmat3();
+        assert_eq!(m.col(0)[1], m.col(1)[0]);
+        assert_eq!(m.col(0)[2], m.col(2)[0]);
+        assert_eq!(m.col(1)[2], m.col(2)[1]);
+    }
+
+    #[test]
+    fn add_is_componentwise() {
+        let a = InertiaTensor::<Inertial>::from_principal(1.0, 1.0, 1.0);
+        let b = InertiaTensor::<Inertial>::from_principal(2.0, 3.0, 4.0);
+        assert_eq!(
+            (a + b).as_dmat3(),
+            DMat3::from_diagonal(glam::DVec3::new(3.0, 4.0, 5.0))
+        );
+    }
+
+    #[test]
+    fn scalar_mul_distributes() {
+        let i = InertiaTensor::<Inertial>::from_principal(1.0, 2.0, 3.0);
+        let scaled = i * 2.0;
+        assert_eq!(
+            scaled.as_dmat3(),
+            DMat3::from_diagonal(glam::DVec3::new(2.0, 4.0, 6.0))
+        );
+    }
+
+    #[test]
+    fn transform_with_identity_is_noop() {
+        let i = InertiaTensor::<Inertial>::from_components(1.0, 2.0, 3.0, 0.1, 0.2, 0.3);
+        let rotated = i.transform(&DMat3::IDENTITY);
+        assert_eq!(i, rotated);
+    }
+}

--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -25,6 +25,7 @@ pub mod dims;
 pub mod ext;
 pub mod frame;
 pub mod frame_transform;
+pub mod inertia;
 pub mod ops;
 pub mod prelude;
 pub mod qty3;
@@ -38,3 +39,4 @@ pub use frame_transform::*;
 pub use qty3::*;
 pub use quat::*;
 pub use time_scale::*;
+// `inertia::InertiaTensor` is re-exported via `aliases::*`.

--- a/crates/jeod_quantities/tests/inertia.rs
+++ b/crates/jeod_quantities/tests/inertia.rs
@@ -1,0 +1,136 @@
+//! Integration tests for `InertiaTensor<F>` — exercises the public surface
+//! (frame-tagged construction, rotational invariance, parallel-axis
+//! composition, frame-mismatch detection at the type level).
+
+use glam::{DMat3, DVec3};
+use jeod_quantities::prelude::*;
+
+const TOL: f64 = 1e-12;
+
+fn approx_mat_eq(a: DMat3, b: DMat3, tol: f64) -> bool {
+    for c in 0..3 {
+        for r in 0..3 {
+            if (a.col(c)[r] - b.col(c)[r]).abs() > tol {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn from_components_is_symmetric_and_diagonal_matches_principal() {
+    let i_full = InertiaTensor::<Inertial>::from_components(1.0, 2.0, 3.0, 0.0, 0.0, 0.0);
+    let i_diag = InertiaTensor::<Inertial>::from_principal(1.0, 2.0, 3.0);
+    assert_eq!(i_full, i_diag);
+}
+
+#[test]
+fn rotation_preserves_trace() {
+    // Trace of an inertia tensor is rotation-invariant. Cook a
+    // non-trivial rotation (45° about (1,1,1)/√3) and verify.
+    let i = InertiaTensor::<Inertial>::from_components(2.0, 3.0, 5.0, 0.1, 0.2, 0.3);
+    let axis = DVec3::new(1.0, 1.0, 1.0).normalize();
+    let rot = DMat3::from_axis_angle(axis, std::f64::consts::FRAC_PI_4);
+
+    let rotated = i.transform(&rot);
+
+    let original_trace = {
+        let m = i.as_dmat3();
+        m.col(0).x + m.col(1).y + m.col(2).z
+    };
+    let rotated_trace = {
+        let m = rotated.as_dmat3();
+        m.col(0).x + m.col(1).y + m.col(2).z
+    };
+    assert!(
+        (original_trace - rotated_trace).abs() < TOL,
+        "trace not preserved: {} vs {}",
+        original_trace,
+        rotated_trace
+    );
+}
+
+#[test]
+fn rotation_round_trip_recovers_original() {
+    let i = InertiaTensor::<Inertial>::from_components(2.0, 3.0, 5.0, 0.1, 0.2, 0.3);
+    let axis = DVec3::new(1.0, 0.5, -0.3).normalize();
+    let rot = DMat3::from_axis_angle(axis, 0.7);
+    let rot_inv = rot.transpose();
+
+    let i_rotated = i.transform(&rot);
+    let i_back = i_rotated.transform(&rot_inv);
+
+    assert!(
+        approx_mat_eq(i.as_dmat3(), i_back.as_dmat3(), 1e-13),
+        "round trip failed:\n  orig = {:?}\n  back = {:?}",
+        i.as_dmat3(),
+        i_back.as_dmat3()
+    );
+}
+
+#[test]
+fn parallel_axis_addition_matches_steiner() {
+    // Steiner: inertia about parent axis = inertia about CoM axis +
+    //   m * ([d]² · I − d ⊗ d). Build the offset contribution by
+    //   hand and verify InertiaTensor::add reproduces it.
+    let m = 5.0;
+    let d = DVec3::new(1.0, 2.0, -0.5);
+
+    let d_sq = d.length_squared();
+    let outer = DMat3::from_cols(
+        DVec3::new(d.x * d.x, d.y * d.x, d.z * d.x),
+        DVec3::new(d.x * d.y, d.y * d.y, d.z * d.y),
+        DVec3::new(d.x * d.z, d.y * d.z, d.z * d.z),
+    );
+    let offset_contribution =
+        InertiaTensor::<Inertial>::from_dmat3_unchecked(m * (DMat3::IDENTITY * d_sq - outer));
+
+    let i_com = InertiaTensor::<Inertial>::from_principal(2.0, 3.0, 4.0);
+    let i_about_parent = i_com + offset_contribution;
+
+    // Spot check: the (0,0) entry should be Ixx + m·(dy² + dz²).
+    let expected_xx = 2.0 + m * (d.y * d.y + d.z * d.z);
+    assert!(
+        (i_about_parent.as_dmat3().col(0).x - expected_xx).abs() < TOL,
+        "xx component: got {}, expected {}",
+        i_about_parent.as_dmat3().col(0).x,
+        expected_xx
+    );
+}
+
+#[test]
+fn scalar_mul_is_distributive() {
+    let a = InertiaTensor::<Inertial>::from_principal(1.0, 2.0, 3.0);
+    let b = InertiaTensor::<Inertial>::from_principal(4.0, 5.0, 6.0);
+    let lhs = (a + b) * 2.0;
+    let rhs = a * 2.0 + b * 2.0;
+    assert_eq!(lhs, rhs);
+}
+
+#[test]
+fn neg_then_add_is_zero() {
+    let i = InertiaTensor::<Inertial>::from_components(1.0, 2.0, 3.0, 0.4, 0.5, 0.6);
+    let z = i + (-i);
+    assert_eq!(z, InertiaTensor::<Inertial>::zero());
+}
+
+#[test]
+fn default_is_zero() {
+    let z: InertiaTensor<Inertial> = Default::default();
+    assert_eq!(z, InertiaTensor::<Inertial>::zero());
+}
+
+// `InertiaTensor<Ecef> + InertiaTensor<Inertial>` must NOT compile —
+// frame mismatch is a type error. We assert this via a `compile_fail`
+// pattern using a doctest in the inertia module rather than a separate
+// trybuild harness, to keep the integration test fast.
+//
+// Compile-fail surface is also covered by the `Frame` trait being
+// sealed; this test only confirms the same-frame happy path.
+#[test]
+fn add_within_same_frame_compiles() {
+    let a = InertiaTensor::<Ecef>::from_principal(1.0, 1.0, 1.0);
+    let b = InertiaTensor::<Ecef>::from_principal(2.0, 2.0, 2.0);
+    let _sum = a + b;
+}

--- a/crates/jeod_quantities/tests/inertia.rs
+++ b/crates/jeod_quantities/tests/inertia.rs
@@ -122,12 +122,10 @@ fn default_is_zero() {
 }
 
 // `InertiaTensor<Ecef> + InertiaTensor<Inertial>` must NOT compile —
-// frame mismatch is a type error. We assert this via a `compile_fail`
-// pattern using a doctest in the inertia module rather than a separate
-// trybuild harness, to keep the integration test fast.
-//
-// Compile-fail surface is also covered by the `Frame` trait being
-// sealed; this test only confirms the same-frame happy path.
+// frame mismatch is a type error. The compile-fail case is asserted
+// via a `compile_fail` doctest on `InertiaTensor` itself (see
+// `crates/jeod_quantities/src/inertia.rs`); this test confirms the
+// same-frame happy path.
 #[test]
 fn add_within_same_frame_compiles() {
     let a = InertiaTensor::<Ecef>::from_principal(1.0, 1.0, 1.0);


### PR DESCRIPTION
## Summary

Closes #105. Part of [#101](https://github.com/simnaut/bevy_jeod/issues/101).

Phase 3 of the type-system refactor. After this lands, every state
struct in the dynamics layer (RefFrameState, TranslationalState,
RotationalState, FrameDerivatives, MassProperties, TotalForce,
GravityAcceleration) has a frame-and-vehicle-tagged sibling alongside
the existing untyped form. The integrator hot path (rkf45, abm4,
gauss_jackson, lsode, propagation) keeps `f64`/`DVec3` interior — the
typed surface is a boundary skin only, by design.

## Step-by-step commits

| Commit | Step | Scope |
|--------|------|-------|
| `11864ac` | 0 | scaffolding: `InertiaTensor<F: Frame>` in `jeod_quantities::inertia` (newtype over `DMat3`, `M·L²` dimension), parallel-axis `Add`, `transform(&rot)` for `T^T·I·T` |
| `9f8fbd7` | 1 | `jeod_frames::ref_frame_state`: `RefFrameTransTyped<P>`, `RefFrameRotTyped<P, C>`, `RefFrameStateTyped<P, C>` with `negate()` / `incr_right()` delegating to the existing untyped impl for bit-identity |
| `939ebf7` | 2 | `jeod_frames::frame_tree`: `add_child_typed` / `get_state_typed` sugar — arena keeps `Vec<FrameNode>` (heterogeneous) |
| `3261590` | 3 | `jeod_dynamics`: `TranslationalStateTyped<F>`, `RotationalStateTyped<V>`, `FrameDerivativesTyped<F, V>` |
| `6399e01` | 4 | `jeod_dynamics::mass`: `MassPropertiesTyped<V>` adopting `InertiaTensor<BodyFrame<V>>` + typed `Mass` |
| `14e3474` | 5 | `jeod_dynamics::forces`: `TotalForceTyped<F, V>`, `GravityAccelerationTyped<F>` |
| `1299360` | 6 | `jeod_dynamics::body_init`: `init_from_orbital_elements_typed` returning `TranslationalStateTyped<Inertial>` |

All numeric operations on the typed surface delegate to the existing
untyped path — typed and untyped versions are **bit-identical** at equal
inputs. The RK4 Kepler bit-match regression (`integrator_bit_match.rs`)
continues to produce its pinned SHA-256 hash unchanged.

## Design choices

- **Additive, not replacing**. Existing untyped types/structs are
  preserved verbatim — this is a Phase-1-style boundary expansion, not
  a flag-day rewrite. Phase 7 (Tier 3 test rewrites, #109/#110)
  migrates downstream callers; Step 7 of this plan was a no-op since
  Phase 3 is purely additive.
- **Arena heterogeneity respected**. `FrameTree` keeps `FrameId(usize)`
  and `Vec<FrameNode>`. Per #105's "FrameId<F> ergonomics" risk note,
  the static-typed-FrameId option was rejected because it fights the
  arena. Typed reads use `from_untyped_unchecked` — caller asserts the
  frame markers, the wrapped quaternion is checked against
  `NormalizedQuat::DEFAULT_TOLERANCE`.
- **Inverse-mass / inverse-inertia stay untyped**. Those are
  integrator hot-path caches (`F = m⁻¹·force` resolution); the
  dimensions `1/M` and `1/(M·L²)` aren't exposed as typed aliases in
  `jeod_quantities` and adding them would be churn for no enforced
  invariant.
- **Body-frame torque uses `Torque<BodyFrame<V>>`**. The `TotalForceTyped`
  carries two phantoms (`F` for force, `V` for body-frame torque)
  reflecting the existing struct's frame split.

## JEOD invariants

All preserved. Tags `RF.03 / RF.04 / RF.06 / RF.07 / RF.09 / DM.05 /
DB.11 / DB.18 / DB.23 / MA.02 / MA.03 / MA.04 / MA.07 / FD.02 / DB.19
/ DB.20 / DB.05 / DB.06 / BA.05` propagated to typed siblings via
delegation to the untyped impl.

The structural promotion of `RF.07` (left-transformation quaternion)
to `structural` will be done in `docs/JEOD_invariants.md` in a
follow-up commit if reviewers want — the type system now enforces it
via the `LeftTransform` phantom in `NormalizedQuat<ScalarFirst,
LeftTransform>`, but the runtime tag is still informationally useful
on the untyped surface.

## Verification (per #105 exit criteria)

- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --tests -- -D warnings`
- ✅ `cargo nextest run -p jeod_frames -p jeod_dynamics`
- ✅ `cargo check --workspace`
- ✅ `cargo nextest run --workspace -E 'not test(tier3_)'` — 698 pass / 0 fail / 311 skipped
- ✅ Canaries: `tier3_sim_dyncomp_run2_3dof`, `tier3_sim_dyncomp_run2_6dof`, `tier3_apollo_mass_tree`, plus all 10 `tier3_mass_*` tests — 13/13 pass
- ✅ `cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing tier3_earth_moon_clem` — OK (76 matched, 0 violations, 1 informational new)
- ✅ `cargo nextest run -p jeod_dynamics --test integrator_bit_match` — RK4 hash unchanged

## Depends on

- #126 (`jeod_quantities` foundation, Phase 0)
- #128 (Phase 1 leaf crates)
- #129 (Phase 2 `jeod_math` typed APIs — quaternion unification, `NormalizedQuat`)

## Out of scope (per #105)

- Phase 4+ (`jeod_gravity`, `jeod_interactions`, `jeod_sim` typestate, `jeod_runner` recipes)
- Tier 3 test rewrites (Phases 7, 8 — issues #109, #110)
- Integrator interior typing (stays `f64`/`DVec3` by design)

## Test plan

- [x] CI `Lint & Format` passes
- [x] CI `Test (unit + tier 2)` passes
- [x] CI `Test (Tier 3 fast)` passes (baseline-invariance step green)
- [ ] CI `Test (Tier 3 full + earth_moon)` runs on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)