### PR TITLE
[Phase 5] Migrate jeod_sim public API + typestate VehicleBuilder (#107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,9 +2478,11 @@ dependencies = [
  "jeod_interactions",
  "jeod_math",
  "jeod_planet",
+ "jeod_quantities",
  "jeod_test_data",
  "jeod_time",
  "log",
+ "uom",
 ]
 
 [[package]]

--- a/crates/jeod_sim/Cargo.toml
+++ b/crates/jeod_sim/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+jeod_quantities = { path = "../jeod_quantities" }
 jeod_math = { path = "../jeod_math" }
 jeod_dynamics = { path = "../jeod_dynamics" }
 jeod_gravity = { path = "../jeod_gravity" }
@@ -15,6 +16,7 @@ jeod_ephemeris = { path = "../jeod_ephemeris" }
 jeod_planet = { path = "../jeod_planet" }
 glam = { workspace = true }
 log = { workspace = true }
+uom = { workspace = true }
 
 [dev-dependencies]
 jeod_test_data = { path = "../jeod_test_data" }

--- a/crates/jeod_sim/src/atmosphere.rs
+++ b/crates/jeod_sim/src/atmosphere.rs
@@ -4,6 +4,8 @@ use jeod_atmosphere::met::MetAtmosphere;
 use jeod_atmosphere::AtmosphereState;
 #[allow(deprecated)]
 use jeod_math::geodetic::cartesian_to_geodetic;
+use jeod_quantities::aliases::Position;
+use jeod_quantities::frame::Inertial;
 
 use crate::planet_config::PlanetConfig;
 
@@ -131,4 +133,20 @@ pub fn evaluate_atmosphere(
         pressure: result.pressure,
         wind,
     }
+}
+
+/// Typed sibling of [`evaluate_atmosphere`].
+///
+/// Identical kernel — accepts a typed `Position<Inertial>` for the
+/// vehicle position. The returned [`AtmosphereState`] keeps its raw
+/// fields (`density: f64`, `wind: DVec3`, …) since `AtmosphereState`
+/// itself exposes `_typed` accessors (`density_typed`, `wind_typed`,
+/// …) for callers who want quantity types at the consumption site.
+pub fn evaluate_atmosphere_typed(
+    config: &AtmosphereConfig,
+    position: Position<Inertial>,
+    t_inertial_pfix: Option<&DMat3>,
+    tai_tjt: Option<f64>,
+) -> AtmosphereState {
+    evaluate_atmosphere(config, position.raw_si(), t_inertial_pfix, tai_tjt)
 }

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -8,6 +8,9 @@ use glam::{DMat3, DQuat, DVec3};
 
 use crate::{EulerSequence, GeodeticState, LvlhFrame, OrbitalElements, RotationalState};
 use jeod_math::OrbitalError;
+use jeod_quantities::aliases::{Position, Velocity};
+use jeod_quantities::dims::GravParam;
+use jeod_quantities::frame::Inertial;
 
 /// Relative state between two bodies.
 ///
@@ -206,6 +209,20 @@ pub fn compute_lvlh_relative_state(
         position: pos_lvlh,
         velocity: vel_lvlh,
     }
+}
+
+/// Typed sibling of [`compute_orbital_elements`].
+///
+/// Delegates to [`OrbitalElements::from_cartesian_typed`] (the typed
+/// entry point added by Phase 2). Identical numerics — the typed
+/// kernel itself extracts SI base values and calls the same f64
+/// implementation.
+pub fn compute_orbital_elements_typed(
+    mu: GravParam,
+    position: Position<Inertial>,
+    velocity: Velocity<Inertial>,
+) -> Result<OrbitalElements, OrbitalError> {
+    OrbitalElements::from_cartesian_typed(mu, position, velocity)
 }
 
 #[cfg(test)]

--- a/crates/jeod_sim/src/forces.rs
+++ b/crates/jeod_sim/src/forces.rs
@@ -1,8 +1,10 @@
 use glam::{DMat3, DVec3};
+use jeod_dynamics::forces::{FrameDerivativesTyped, GravityAccelerationTyped, TotalForceTyped};
 use jeod_dynamics::{
     ForceContributions, FrameDerivatives, MassProperties, RotationalState, TotalForce,
 };
 use jeod_interactions::{AerodynamicForce, RadiationForce};
+use jeod_quantities::frame::{Inertial, Vehicle};
 
 /// Collect all interaction forces and torques, resolve frame transforms,
 /// and compute frame derivatives.
@@ -105,4 +107,42 @@ pub fn collect_and_resolve_forces(
     };
 
     (collected, derivs)
+}
+
+/// Typed sibling of [`collect_and_resolve_forces`].
+///
+/// Identical kernel — entry boundary takes
+/// [`GravityAccelerationTyped<Inertial>`] for the gravity
+/// acceleration, exit boundary returns
+/// [`TotalForceTyped<V, Inertial>`] / [`FrameDerivativesTyped<Inertial,
+/// V>`]. The aerodynamic / radiation / gravity-torque / rotation-state /
+/// mass inputs remain untyped because Phase 3 left those struct
+/// surfaces untyped at their `jeod_dynamics` / `jeod_interactions`
+/// home crates.
+#[allow(clippy::too_many_arguments)]
+pub fn collect_and_resolve_forces_typed<V: Vehicle>(
+    aero: Option<&AerodynamicForce>,
+    srp: Option<&RadiationForce>,
+    gravity_torque: Option<DVec3>,
+    rot_state: Option<&RotationalState>,
+    t_struct_body: DMat3,
+    mass: Option<&MassProperties>,
+    gravity_accel: GravityAccelerationTyped<Inertial>,
+) -> (
+    TotalForceTyped<V, Inertial>,
+    FrameDerivativesTyped<Inertial, V>,
+) {
+    let (force, derivs) = collect_and_resolve_forces(
+        aero,
+        srp,
+        gravity_torque,
+        rot_state,
+        t_struct_body,
+        mass,
+        gravity_accel.grav_accel.raw_si(),
+    );
+    (
+        TotalForceTyped::<V, Inertial>::from_untyped_unchecked(&force),
+        FrameDerivativesTyped::<Inertial, V>::from_untyped_unchecked(&derivs),
+    )
 }

--- a/crates/jeod_sim/src/forces.rs
+++ b/crates/jeod_sim/src/forces.rs
@@ -116,9 +116,12 @@ pub fn collect_and_resolve_forces(
 /// acceleration, exit boundary returns
 /// [`TotalForceTyped<V, Inertial>`] / [`FrameDerivativesTyped<Inertial,
 /// V>`]. The aerodynamic / radiation / gravity-torque / rotation-state /
-/// mass inputs remain untyped because Phase 3 left those struct
-/// surfaces untyped at their `jeod_dynamics` / `jeod_interactions`
-/// home crates.
+/// mass inputs remain untyped here because this orchestration
+/// boundary has not yet been migrated to consume the typed
+/// interaction / state structs end-to-end (typed variants like
+/// `AerodynamicForceTyped`, `DragConfigTyped`,
+/// `RotationalStateTyped` already exist upstream from Phases 3–4 and
+/// will thread through in a follow-up).
 #[allow(clippy::too_many_arguments)]
 pub fn collect_and_resolve_forces_typed<V: Vehicle>(
     aero: Option<&AerodynamicForce>,

--- a/crates/jeod_sim/src/gravity.rs
+++ b/crates/jeod_sim/src/gravity.rs
@@ -1,6 +1,9 @@
 use glam::{DMat3, DVec3};
+use jeod_dynamics::forces::GravityAccelerationTyped;
 use jeod_dynamics::GravityAcceleration;
 use jeod_gravity::{GravityControls, GravitySource};
+use jeod_quantities::aliases::{Acceleration, Position};
+use jeod_quantities::frame::Inertial;
 
 /// Information about a gravity source resolved from a source identifier.
 ///
@@ -253,6 +256,48 @@ pub fn accumulate_relativistic_corrections<S: Copy + std::fmt::Debug + PartialEq
     }
 
     total_correction
+}
+
+/// Typed sibling of [`accumulate_gravity`].
+///
+/// Identical numerics — wraps the untyped kernel by extracting the SI
+/// values via [`Position::raw_si`] at entry and reconstructing the typed
+/// [`GravityAccelerationTyped<Inertial>`] at exit. The `source_lookup`
+/// closure still returns the existing untyped [`ResolvedSource`].
+// JEOD_INV: GV.12 — gravity source must exist for control
+pub fn accumulate_gravity_typed<'a, S: Copy + std::fmt::Debug>(
+    position: Position<Inertial>,
+    controls: &GravityControls<S>,
+    integration_origin: Position<Inertial>,
+    source_lookup: impl Fn(S) -> Option<ResolvedSource<'a>>,
+) -> GravityAccelerationTyped<Inertial> {
+    let raw = accumulate_gravity(
+        position.raw_si(),
+        controls,
+        integration_origin.raw_si(),
+        source_lookup,
+    );
+    GravityAccelerationTyped::<Inertial>::from_untyped_unchecked(&raw)
+}
+
+/// Typed sibling of [`accumulate_relativistic_corrections`].
+///
+/// Same kernel; entry/exit boundary types are
+/// [`Position<Inertial>`] / [`Velocity<Inertial>`] /
+/// [`Acceleration<Inertial>`].
+pub fn accumulate_relativistic_corrections_typed<S: Copy + std::fmt::Debug + PartialEq>(
+    body_position: Position<Inertial>,
+    body_velocity: jeod_quantities::aliases::Velocity<Inertial>,
+    controls: &GravityControls<S>,
+    source_lookup: impl Fn(S) -> Option<ResolvedRelativisticSource>,
+) -> Acceleration<Inertial> {
+    let raw = accumulate_relativistic_corrections(
+        body_position.raw_si(),
+        body_velocity.raw_si(),
+        controls,
+        source_lookup,
+    );
+    Acceleration::<Inertial>::from_raw_si(raw)
 }
 
 #[cfg(test)]

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -4,6 +4,9 @@ use jeod_dynamics::{
     TranslationalState,
 };
 use jeod_math::JeodQuat;
+use jeod_quantities::aliases::{Acceleration, Force, Position, Torque, Velocity};
+use jeod_quantities::frame::{BodyFrame, Inertial, Vehicle};
+use uom::si::f64::Time;
 
 use crate::integrable::IntegrableObject;
 use crate::interactions::FlatPlateState;
@@ -999,6 +1002,64 @@ fn integrate_coupled_sixdof(
         &k3_tdots,
         &eval4.temp_dots,
         integ_dyndt,
+    );
+}
+
+/// Typed sibling of [`integrate_body`].
+///
+/// Identical kernel — wraps the entry boundary so callers pass typed
+/// quantities. The `gravity_fn` closure is also typed: it receives an
+/// intermediate position / velocity in [`Inertial`] and returns an
+/// [`Acceleration<Inertial>`]. The wrapper translates raw `DVec3`
+/// inputs from the kernel into typed quantities for the closure and
+/// translates the typed result back into a raw `DVec3` for the kernel
+/// — no new arithmetic, just `.raw_si()` / `from_raw_si` at the
+/// edges.
+///
+/// `dt` becomes [`uom::si::f64::Time`]. The dimensionless
+/// `time_scale_factor` (JEOD's `TimeDyn::scale_factor`) stays an
+/// `f64` ratio per Phase 5's design note (#107).
+///
+/// Per-vehicle frame phantom `V` ties the torque to
+/// [`BodyFrame<V>`]; the body's translational state must be in
+/// [`Inertial`] (see [`TranslationalState`] / Phase 3 typing).
+#[allow(clippy::too_many_arguments)]
+pub fn integrate_body_typed<V: Vehicle>(
+    config: &DynamicsConfig,
+    trans: &mut TranslationalState,
+    rot: Option<&mut RotationalState>,
+    mass: Option<&MassProperties>,
+    gravity_fn: impl Fn(Position<Inertial>, Velocity<Inertial>, f64) -> Acceleration<Inertial>,
+    non_grav_force: Force<Inertial>,
+    torque: Torque<BodyFrame<V>>,
+    dt: Time,
+    time_scale_factor: f64,
+    integrator: IntegratorType,
+    gj_state: Option<&mut jeod_dynamics::GaussJacksonState>,
+    abm4_state: Option<&mut jeod_dynamics::Abm4State>,
+) {
+    use uom::si::time::second;
+    let raw_gravity_fn = |pos: DVec3, vel: DVec3, time_frac: f64| -> DVec3 {
+        gravity_fn(
+            Position::<Inertial>::from_raw_si(pos),
+            Velocity::<Inertial>::from_raw_si(vel),
+            time_frac,
+        )
+        .raw_si()
+    };
+    integrate_body(
+        config,
+        trans,
+        rot,
+        mass,
+        raw_gravity_fn,
+        non_grav_force.raw_si(),
+        torque.raw_si(),
+        dt.get::<second>(),
+        time_scale_factor,
+        integrator,
+        gj_state,
+        abm4_state,
     );
 }
 

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -1,4 +1,5 @@
 use glam::DVec3;
+use jeod_dynamics::state::TranslationalStateTyped;
 use jeod_dynamics::{
     DynamicsConfig, IntegratorType, MassProperties, RotationalState, SixDofState,
     TranslationalState,
@@ -1008,13 +1009,14 @@ fn integrate_coupled_sixdof(
 /// Typed sibling of [`integrate_body`].
 ///
 /// Identical kernel — wraps the entry boundary so callers pass typed
-/// quantities. The `gravity_fn` closure is also typed: it receives an
+/// quantities. The `trans` parameter takes a mutable
+/// [`TranslationalStateTyped<Inertial>`] so the inertial-frame
+/// constraint is enforced at compile time; the wrapper unwraps to the
+/// raw kernel storage on entry and writes the integrated state back
+/// at exit. The `gravity_fn` closure is also typed: it receives an
 /// intermediate position / velocity in [`Inertial`] and returns an
-/// [`Acceleration<Inertial>`]. The wrapper translates raw `DVec3`
-/// inputs from the kernel into typed quantities for the closure and
-/// translates the typed result back into a raw `DVec3` for the kernel
-/// — no new arithmetic, just `.raw_si()` / `from_raw_si` at the
-/// edges.
+/// [`Acceleration<Inertial>`]. No new arithmetic — only `.raw_si()` /
+/// `from_raw_si` at the edges.
 ///
 /// `dt` becomes [`uom::si::f64::Time`]. The dimensionless
 /// `time_scale_factor` (JEOD's `TimeDyn::scale_factor`) stays an
@@ -1022,11 +1024,12 @@ fn integrate_coupled_sixdof(
 ///
 /// Per-vehicle frame phantom `V` ties the torque to
 /// [`BodyFrame<V>`]; the body's translational state must be in
-/// [`Inertial`] (see [`TranslationalState`] / Phase 3 typing).
+/// [`Inertial`] (enforced by the [`TranslationalStateTyped<Inertial>`]
+/// parameter type).
 #[allow(clippy::too_many_arguments)]
 pub fn integrate_body_typed<V: Vehicle>(
     config: &DynamicsConfig,
-    trans: &mut TranslationalState,
+    trans: &mut TranslationalStateTyped<Inertial>,
     rot: Option<&mut RotationalState>,
     mass: Option<&MassProperties>,
     gravity_fn: impl Fn(Position<Inertial>, Velocity<Inertial>, f64) -> Acceleration<Inertial>,
@@ -1047,9 +1050,10 @@ pub fn integrate_body_typed<V: Vehicle>(
         )
         .raw_si()
     };
+    let mut raw_trans = trans.to_untyped();
     integrate_body(
         config,
-        trans,
+        &mut raw_trans,
         rot,
         mass,
         raw_gravity_fn,
@@ -1061,6 +1065,7 @@ pub fn integrate_body_typed<V: Vehicle>(
         gj_state,
         abm4_state,
     );
+    *trans = TranslationalStateTyped::<Inertial>::from_untyped_unchecked(&raw_trans);
 }
 
 /// Compute total translational acceleration from a stage evaluation.

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -1,9 +1,13 @@
 use glam::{DMat3, DVec3};
 use jeod_dynamics::{MassProperties, RotationalState, TranslationalState};
 use jeod_interactions::{
-    compute_contact_force_from_geometry, compute_contact_geometry, AerodynamicForce, ContactFacet,
-    DragConfig, FlatPlate, FlatPlateParams, FlatPlateThermal,
+    compute_contact_force_from_geometry, compute_contact_geometry, AerodynamicForce,
+    AerodynamicForceTyped, ContactFacet, DragConfig, DragConfigTyped, FlatPlate, FlatPlateParams,
+    FlatPlateThermal,
 };
+use jeod_quantities::aliases::{Force, InertiaTensor, Position, Torque, Velocity};
+use jeod_quantities::frame::{BodyFrame, Inertial, Vehicle};
+use uom::si::f64::{Area, Ratio};
 
 use crate::integrable::IntegrableObject;
 
@@ -513,6 +517,117 @@ pub fn evaluate_contact_pair(
         torque_a_body,
         torque_b_body,
     })
+}
+
+/// Typed sibling of [`compute_drag`].
+///
+/// Identical kernel — wraps with [`DragConfigTyped`] / typed
+/// [`Velocity<Inertial>`] inputs and returns
+/// [`AerodynamicForceTyped<V>`].
+pub fn compute_drag_typed<V: Vehicle>(
+    drag_config: &DragConfigTyped,
+    atmos: &jeod_atmosphere::AtmosphereState,
+    velocity: Velocity<Inertial>,
+    rot: Option<&RotationalState>,
+    t_struct_body: DMat3,
+) -> AerodynamicForceTyped<V> {
+    let raw = compute_drag(
+        &drag_config.to_untyped(),
+        atmos,
+        velocity.raw_si(),
+        rot,
+        t_struct_body,
+    );
+    AerodynamicForceTyped::<V>::from_untyped_unchecked(&raw)
+}
+
+/// Typed sibling of [`compute_gravity_torque`].
+///
+/// Returns the gravity gradient torque in [`BodyFrame<V>`].
+pub fn compute_gravity_torque_typed<V: Vehicle>(
+    grav_grad: &DMat3,
+    rot: &RotationalState,
+    inertia: InertiaTensor<BodyFrame<V>>,
+) -> Torque<BodyFrame<V>> {
+    let inertia_dmat = inertia.as_dmat3();
+    let raw = compute_gravity_torque(grav_grad, rot, &inertia_dmat);
+    Torque::<BodyFrame<V>>::from_raw_si(raw)
+}
+
+/// Typed sibling of [`compute_cannonball_srp`].
+///
+/// Identical kernel — wraps positions and uom dimensionless ratios.
+/// Returns the cannonball SRP force in [`Inertial`].
+pub fn compute_cannonball_srp_typed(
+    body_pos: Position<Inertial>,
+    sun_pos: Position<Inertial>,
+    cx_area: Area,
+    albedo: Ratio,
+    diffuse: Ratio,
+    illum_factor: Ratio,
+) -> Force<Inertial> {
+    use uom::si::area::square_meter;
+    use uom::si::ratio::ratio;
+    let raw = compute_cannonball_srp(
+        body_pos.raw_si(),
+        sun_pos.raw_si(),
+        cx_area.get::<square_meter>(),
+        albedo.get::<ratio>(),
+        diffuse.get::<ratio>(),
+        illum_factor.get::<ratio>(),
+    );
+    Force::<Inertial>::from_raw_si(raw)
+}
+
+/// Step-constant SRP inputs (typed sibling of [`FlatPlateStageInputs`]).
+///
+/// Same role and lifetime; sun position becomes [`Position<Inertial>`],
+/// the dimensionless illumination factor becomes [`Ratio`], and the
+/// structural-frame center of gravity stays [`DVec3`] (the structural
+/// frame is per-vehicle and `FlatPlateState` does not carry a `V`
+/// phantom).
+#[derive(Debug, Clone, Copy)]
+pub struct FlatPlateStageInputsTyped {
+    pub sun_position: Position<Inertial>,
+    pub illum_factor: Ratio,
+    pub center_grav: DVec3,
+}
+
+impl Default for FlatPlateStageInputsTyped {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            sun_position: Position::<Inertial>::zero(),
+            illum_factor: Ratio::default(),
+            center_grav: DVec3::ZERO,
+        }
+    }
+}
+
+impl FlatPlateStageInputsTyped {
+    /// Drop the wrappers and emit the existing untyped storage form.
+    #[inline]
+    pub fn to_untyped(&self) -> FlatPlateStageInputs {
+        use uom::si::ratio::ratio;
+        FlatPlateStageInputs {
+            sun_position: self.sun_position.raw_si(),
+            illum_factor: self.illum_factor.get::<ratio>(),
+            center_grav: self.center_grav,
+        }
+    }
+
+    /// Wrap an untyped [`FlatPlateStageInputs`] as typed. **The caller
+    /// asserts** the sun position is in `Inertial` and the illumination
+    /// factor is dimensionless.
+    #[inline]
+    pub fn from_untyped_unchecked(s: &FlatPlateStageInputs) -> Self {
+        use uom::si::ratio::ratio;
+        Self {
+            sun_position: Position::<Inertial>::from_raw_si(s.sun_position),
+            illum_factor: Ratio::new::<ratio>(s.illum_factor),
+            center_grav: s.center_grav,
+        }
+    }
 }
 
 /// Transform a contact facet's shape endpoints from structural to inertial

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -45,27 +45,31 @@ pub mod pipeline;
 pub mod planet_config;
 pub mod rotation_model;
 pub mod validation;
+pub mod vehicle_builder;
 
 // ── Orchestration functions ──
-pub use atmosphere::{evaluate_atmosphere, AtmosphereConfig, AtmosphereModel};
+pub use atmosphere::{
+    evaluate_atmosphere, evaluate_atmosphere_typed, AtmosphereConfig, AtmosphereModel,
+};
 pub use derived::{
     compute_body_euler_angles, compute_body_geodetic, compute_body_lvlh_frame,
     compute_body_solar_beta, compute_lvlh_relative_state, compute_orbital_elements,
-    compute_relative_state, LvlhRelativeState, RelativeState,
+    compute_orbital_elements_typed, compute_relative_state, LvlhRelativeState, RelativeState,
 };
-pub use forces::collect_and_resolve_forces;
+pub use forces::{collect_and_resolve_forces, collect_and_resolve_forces_typed};
 pub use gravity::{
-    accumulate_gravity, accumulate_relativistic_corrections, ResolvedRelativisticSource,
-    ResolvedSource,
+    accumulate_gravity, accumulate_gravity_typed, accumulate_relativistic_corrections,
+    accumulate_relativistic_corrections_typed, ResolvedRelativisticSource, ResolvedSource,
 };
 pub use integrable::IntegrableObject;
 pub use integration::{
-    integrate_bodies_contact_coupled, integrate_body, integrate_body_coupled, CoupledBodyInput,
-    CoupledIntegScratch, CoupledStageEval,
+    integrate_bodies_contact_coupled, integrate_body, integrate_body_coupled, integrate_body_typed,
+    CoupledBodyInput, CoupledIntegScratch, CoupledStageEval,
 };
 pub use interactions::{
-    compute_cannonball_srp, compute_drag, compute_gravity_torque, evaluate_contact_pair,
-    ContactPairEval, FlatPlateStageInputs, FlatPlateState, ThermalIntegrationOrder,
+    compute_cannonball_srp, compute_cannonball_srp_typed, compute_drag, compute_drag_typed,
+    compute_gravity_torque, compute_gravity_torque_typed, evaluate_contact_pair, ContactPairEval,
+    FlatPlateStageInputs, FlatPlateStageInputsTyped, FlatPlateState, ThermalIntegrationOrder,
 };
 pub use jeod_dynamics::{
     Abm4State, GaussJacksonConfig, GaussJacksonState, IntegratorResult, IntegratorType,
@@ -74,6 +78,9 @@ pub use pipeline::{PipelineStage, PIPELINE_ORDER};
 pub use planet_config::{PlanetConfig, EARTH, MARS, MOON, SUN};
 pub use rotation_model::RotationModel;
 pub use validation::{validate_body, ValidationError};
+pub use vehicle_builder::{
+    BuildState, HasIntegrator, NeedsMass, NeedsState, Ready, TypedVehicleConfig, VehicleBuilder,
+};
 
 // ── Re-exports from jeod_* crates ──
 // ECS adapters depend only on jeod_sim — these re-exports provide all the

--- a/crates/jeod_sim/src/planet_config.rs
+++ b/crates/jeod_sim/src/planet_config.rs
@@ -6,6 +6,9 @@
 
 use crate::RotationModel;
 use jeod_planet::PlanetShape;
+use jeod_quantities::dims::GravParam;
+use jeod_quantities::ext::F64Ext;
+use uom::si::f64::{AngularVelocity, Length};
 
 /// Complete planet configuration for simulation setup.
 ///
@@ -27,6 +30,29 @@ pub struct PlanetConfig {
     /// Body radius (m) for SRP eclipse (shadow) computation.
     /// Typically the mean equatorial radius.
     pub shadow_radius: f64,
+}
+
+impl PlanetConfig {
+    /// Typed accessor: gravitational parameter as [`GravParam`]
+    /// (m³/s²). Same numeric value as `self.shape.mu`.
+    #[inline]
+    pub fn mu_typed(&self) -> GravParam {
+        self.shape.mu.m3_per_s2()
+    }
+
+    /// Typed accessor: sidereal angular velocity as
+    /// [`uom::si::f64::AngularVelocity`] (rad/s).
+    #[inline]
+    pub fn omega_typed(&self) -> AngularVelocity {
+        self.omega.rad_per_s()
+    }
+
+    /// Typed accessor: SRP shadow body radius as [`Length`] (meters).
+    #[inline]
+    pub fn shadow_radius_typed(&self) -> Length {
+        use uom::si::length::meter;
+        Length::new::<meter>(self.shadow_radius)
+    }
 }
 
 /// Earth — WGS84 ellipsoid, IAU 2000A precession-nutation rotation.

--- a/crates/jeod_sim/src/planet_config.rs
+++ b/crates/jeod_sim/src/planet_config.rs
@@ -34,10 +34,11 @@ pub struct PlanetConfig {
 
 impl PlanetConfig {
     /// Typed accessor: gravitational parameter as [`GravParam`]
-    /// (m³/s²). Same numeric value as `self.shape.mu`.
+    /// (m³/s²). Delegates to [`PlanetShape::mu_typed`] so the
+    /// unit-wrapping lives in one place.
     #[inline]
     pub fn mu_typed(&self) -> GravParam {
-        self.shape.mu.m3_per_s2()
+        self.shape.mu_typed()
     }
 
     /// Typed accessor: sidereal angular velocity as

--- a/crates/jeod_sim/src/vehicle_builder.rs
+++ b/crates/jeod_sim/src/vehicle_builder.rs
@@ -10,7 +10,9 @@
 //! will add the conversion from [`TypedVehicleConfig`] into the
 //! `jeod_runner` simulation pipeline; until then the typestate builder
 //! exists alongside the existing runtime `jeod_runner::VehicleBuilder`,
-//! which remains the way to construct a [`Simulation`](`jeod_runner`).
+//! which remains the way to construct a `jeod_runner::Simulation`
+//! (no rustdoc intra-link — `jeod_sim` does not depend on
+//! `jeod_runner`, so the path can't be resolved here).
 //!
 //! # Compile-time gating
 //!

--- a/crates/jeod_sim/src/vehicle_builder.rs
+++ b/crates/jeod_sim/src/vehicle_builder.rs
@@ -107,11 +107,16 @@ impl BuildState for Ready {}
 pub struct TypedVehicleConfig {
     /// Translational state in the inertial frame.
     pub trans: TranslationalStateTyped<Inertial>,
-    /// Optional rotational state (6-DOF when present).
+    /// Optional rotational state (6-DOF when present, `None` for 3-DOF
+    /// point-mass bodies).
     pub rot: Option<RotationalState>,
-    /// Optional mass properties (required for any non-zero force).
-    pub mass: Option<MassProperties>,
-    /// Selected integrator (default: RK4).
+    /// Mass properties. Always populated — the typestate path through
+    /// either [`VehicleBuilder::three_dof_point_mass`] or
+    /// [`VehicleBuilder::sixdof`] sets it before
+    /// [`VehicleBuilder::build`] is reachable.
+    pub mass: MassProperties,
+    /// Selected integrator (chosen explicitly via the typestate
+    /// transition through [`HasIntegrator`]).
     pub integrator: IntegratorType,
     /// Per-body gravity controls.
     pub gravity_controls: GravityControls<usize>,
@@ -312,7 +317,7 @@ impl VehicleBuilder<Ready> {
                 .trans
                 .expect("typestate guarantees translational state"),
             rot: self.rot,
-            mass: self.mass,
+            mass: self.mass.expect("typestate guarantees mass"),
             integrator: self.integrator.expect("typestate guarantees integrator"),
             gravity_controls: self.gravity_controls,
             drag: self.drag,
@@ -352,7 +357,7 @@ mod tests {
             .rk4()
             .build();
         assert_eq!(cfg.integrator, IntegratorType::Rk4);
-        assert!(cfg.mass.is_some());
+        assert_eq!(cfg.mass.mass, 420_000.0);
         assert!(cfg.rot.is_none());
     }
 
@@ -378,6 +383,6 @@ mod tests {
             .rk4()
             .build();
         assert!(cfg.rot.is_some());
-        assert!(cfg.mass.is_some());
+        assert_eq!(cfg.mass.mass, 420_000.0);
     }
 }

--- a/crates/jeod_sim/src/vehicle_builder.rs
+++ b/crates/jeod_sim/src/vehicle_builder.rs
@@ -1,0 +1,381 @@
+//! Typestate vehicle builder for the typed pipeline.
+//!
+//! [`VehicleBuilder`] gates configuration via four phantom states —
+//! [`NeedsState`] → [`NeedsMass`] → [`HasIntegrator`] → [`Ready`] — so
+//! that "forgot to set translational state" or "forgot to choose an
+//! integrator" become **compile errors** instead of runtime panics.
+//!
+//! The output of [`VehicleBuilder::build`] is a [`TypedVehicleConfig`],
+//! a typed companion of `jeod_runner::VehicleConfig`. Phase 6 of #101
+//! will add the conversion from [`TypedVehicleConfig`] into the
+//! `jeod_runner` simulation pipeline; until then the typestate builder
+//! exists alongside the existing runtime `jeod_runner::VehicleBuilder`,
+//! which remains the way to construct a [`Simulation`](`jeod_runner`).
+//!
+//! # Compile-time gating
+//!
+//! ```compile_fail
+//! use jeod_sim::vehicle_builder::VehicleBuilder;
+//! // `.rk4()` is only available on `VehicleBuilder<HasIntegrator>` —
+//! // calling it before `.with_translational()` and `.three_dof_point_mass()`
+//! // is a compile error, not a runtime panic.
+//! let _ = VehicleBuilder::new().rk4();
+//! ```
+//!
+//! # Happy path
+//!
+//! ```ignore
+//! use jeod_sim::vehicle_builder::VehicleBuilder;
+//! use jeod_sim::EARTH;
+//! use jeod_quantities::ext::F64Ext;
+//!
+//! let cfg = VehicleBuilder::new()
+//!     .from_orbital_elements(elems, EARTH.mu_typed())
+//!     .three_dof_point_mass(420_000.0.kg())
+//!     .rk4()
+//!     .build();
+//! ```
+
+use core::marker::PhantomData;
+
+use jeod_dynamics::body_init::init_from_orbital_elements_typed;
+use jeod_dynamics::state::TranslationalStateTyped;
+use jeod_dynamics::{
+    GaussJacksonConfig, IntegratorType, MassProperties, RotationalState, TranslationalState,
+};
+use jeod_gravity::{GravityControl, GravityControls};
+use jeod_interactions::DragConfigTyped;
+use jeod_math::OrbitalElements;
+use jeod_quantities::dims::GravParam;
+use jeod_quantities::frame::Inertial;
+use uom::si::f64::{Angle, Length, Mass};
+
+use crate::interactions::FlatPlateState;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker trait for the four states of the typestate
+/// [`VehicleBuilder`]. Sealed downstream — implementors are limited to
+/// [`NeedsState`], [`NeedsMass`], [`HasIntegrator`], [`Ready`].
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid `VehicleBuilder` state. Use \
+        `NeedsState`, `NeedsMass`, `HasIntegrator`, or `Ready`.",
+    label = "not a `BuildState`"
+)]
+pub trait BuildState: sealed::Sealed {}
+
+/// Stage 0: nothing configured yet. Call
+/// [`VehicleBuilder::with_translational`] or
+/// [`VehicleBuilder::from_orbital_elements`] to advance.
+pub struct NeedsState;
+/// Stage 1: translational state set. Call
+/// [`VehicleBuilder::three_dof_point_mass`] or
+/// [`VehicleBuilder::sixdof`] to advance.
+pub struct NeedsMass;
+/// Stage 2: state and mass set. Choose an integrator with
+/// [`VehicleBuilder::rk4`], [`VehicleBuilder::rkf45`],
+/// [`VehicleBuilder::gauss_jackson`], or
+/// [`VehicleBuilder::with_integrator`].
+pub struct HasIntegrator;
+/// Stage 3: fully configured. Optional features (gravity, drag, SRP)
+/// can be added; [`VehicleBuilder::build`] is available.
+pub struct Ready;
+
+impl sealed::Sealed for NeedsState {}
+impl sealed::Sealed for NeedsMass {}
+impl sealed::Sealed for HasIntegrator {}
+impl sealed::Sealed for Ready {}
+impl BuildState for NeedsState {}
+impl BuildState for NeedsMass {}
+impl BuildState for HasIntegrator {}
+impl BuildState for Ready {}
+
+/// Typed companion of `jeod_runner::VehicleConfig` produced by
+/// [`VehicleBuilder::build`].
+///
+/// Phase 5 deliverable. Phase 6 (#108) will provide the conversion
+/// into the existing `jeod_runner` pipeline. The fields below cover
+/// only the typestate-tracked configuration; mission features that
+/// stayed in `jeod_runner` (shadow body, frame switches, mass tree,
+/// derived states, earth lighting, …) are still configured through
+/// `jeod_runner::VehicleBuilder`.
+#[derive(Clone, Debug)]
+pub struct TypedVehicleConfig {
+    /// Translational state in the inertial frame.
+    pub trans: TranslationalStateTyped<Inertial>,
+    /// Optional rotational state (6-DOF when present).
+    pub rot: Option<RotationalState>,
+    /// Optional mass properties (required for any non-zero force).
+    pub mass: Option<MassProperties>,
+    /// Selected integrator (default: RK4).
+    pub integrator: IntegratorType,
+    /// Per-body gravity controls.
+    pub gravity_controls: GravityControls<usize>,
+    /// Optional aerodynamic drag configuration (typed).
+    pub drag: Option<DragConfigTyped>,
+    /// Optional flat-plate solar-radiation-pressure state.
+    pub flat_plate_srp: Option<FlatPlateState>,
+}
+
+/// Typestate vehicle builder. The `S: BuildState` parameter advances
+/// through [`NeedsState`] → [`NeedsMass`] → [`HasIntegrator`] →
+/// [`Ready`] as required configuration is supplied. Methods that
+/// require a particular state are only in-scope for that state's
+/// `impl` block, so missing-step calls are compile errors.
+///
+/// The order is `with_translational`/`from_orbital_elements` →
+/// `three_dof_point_mass`/`sixdof` →
+/// `rk4`/`rkf45`/`gauss_jackson`/`with_integrator` → `build`. See
+/// module-level docs for examples.
+pub struct VehicleBuilder<S: BuildState = NeedsState> {
+    trans: Option<TranslationalStateTyped<Inertial>>,
+    rot: Option<RotationalState>,
+    mass: Option<MassProperties>,
+    integrator: Option<IntegratorType>,
+    gravity_controls: GravityControls<usize>,
+    drag: Option<DragConfigTyped>,
+    flat_plate_srp: Option<FlatPlateState>,
+    _state: PhantomData<S>,
+}
+
+impl Default for VehicleBuilder<NeedsState> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VehicleBuilder<NeedsState> {
+    /// Create a fresh builder. The compiler will require
+    /// `.with_translational(...)` or `.from_orbital_elements(...)`
+    /// before any mass / integrator method becomes available.
+    pub fn new() -> Self {
+        Self {
+            trans: None,
+            rot: None,
+            mass: None,
+            integrator: None,
+            gravity_controls: GravityControls::default(),
+            drag: None,
+            flat_plate_srp: None,
+            _state: PhantomData,
+        }
+    }
+
+    /// Set the initial translational state (typed).
+    pub fn with_translational(
+        self,
+        s: TranslationalStateTyped<Inertial>,
+    ) -> VehicleBuilder<NeedsMass> {
+        VehicleBuilder {
+            trans: Some(s),
+            rot: self.rot,
+            mass: self.mass,
+            integrator: self.integrator,
+            gravity_controls: self.gravity_controls,
+            drag: self.drag,
+            flat_plate_srp: self.flat_plate_srp,
+            _state: PhantomData,
+        }
+    }
+
+    /// Set the initial translational state from Keplerian orbital
+    /// elements and the central-body gravitational parameter.
+    ///
+    /// Delegates to
+    /// [`init_from_orbital_elements_typed`](jeod_dynamics::body_init::init_from_orbital_elements_typed).
+    /// The angles in `oe` are interpreted in radians, the semi-major
+    /// axis in meters, and `mu` carries its `GravParam` dimension.
+    pub fn from_orbital_elements(
+        self,
+        oe: OrbitalElements,
+        mu: GravParam,
+    ) -> VehicleBuilder<NeedsMass> {
+        use uom::si::angle::radian;
+        use uom::si::length::meter;
+        let trans = init_from_orbital_elements_typed(
+            Length::new::<meter>(oe.semi_major_axis),
+            oe.e_mag,
+            Angle::new::<radian>(oe.inclination),
+            Angle::new::<radian>(oe.long_asc_node),
+            Angle::new::<radian>(oe.arg_periapsis),
+            Angle::new::<radian>(oe.true_anom),
+            mu,
+        );
+        self.with_translational(trans)
+    }
+}
+
+impl VehicleBuilder<NeedsMass> {
+    /// Configure as 3-DoF point mass with the given total mass. No
+    /// rotational state, no inertia tensor — the most common
+    /// translational-only orbital case.
+    pub fn three_dof_point_mass(self, mass: Mass) -> VehicleBuilder<HasIntegrator> {
+        use uom::si::mass::kilogram;
+        let mass_props = MassProperties::new(mass.get::<kilogram>());
+        VehicleBuilder {
+            trans: self.trans,
+            rot: self.rot,
+            mass: Some(mass_props),
+            integrator: self.integrator,
+            gravity_controls: self.gravity_controls,
+            drag: self.drag,
+            flat_plate_srp: self.flat_plate_srp,
+            _state: PhantomData,
+        }
+    }
+
+    /// Configure as full 6-DoF body with the given rotational state and
+    /// mass properties (including inertia tensor).
+    pub fn sixdof(
+        self,
+        rot: RotationalState,
+        mass: MassProperties,
+    ) -> VehicleBuilder<HasIntegrator> {
+        VehicleBuilder {
+            trans: self.trans,
+            rot: Some(rot),
+            mass: Some(mass),
+            integrator: self.integrator,
+            gravity_controls: self.gravity_controls,
+            drag: self.drag,
+            flat_plate_srp: self.flat_plate_srp,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl VehicleBuilder<HasIntegrator> {
+    /// Use the standard 4-stage Runge-Kutta integrator.
+    pub fn rk4(self) -> VehicleBuilder<Ready> {
+        self.with_integrator(IntegratorType::Rk4)
+    }
+
+    /// Use the Runge-Kutta-Fehlberg 4(5) adaptive integrator.
+    pub fn rkf45(self) -> VehicleBuilder<Ready> {
+        self.with_integrator(IntegratorType::Rkf45)
+    }
+
+    /// Use the Gauss-Jackson predictor-corrector integrator.
+    pub fn gauss_jackson(self, cfg: GaussJacksonConfig) -> VehicleBuilder<Ready> {
+        self.with_integrator(IntegratorType::GaussJackson(cfg))
+    }
+
+    /// Use a caller-supplied integrator (Adams-Bashforth-Moulton,
+    /// Gauss-Jackson with custom config, etc.).
+    pub fn with_integrator(self, integrator: IntegratorType) -> VehicleBuilder<Ready> {
+        VehicleBuilder {
+            trans: self.trans,
+            rot: self.rot,
+            mass: self.mass,
+            integrator: Some(integrator),
+            gravity_controls: self.gravity_controls,
+            drag: self.drag,
+            flat_plate_srp: self.flat_plate_srp,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl VehicleBuilder<Ready> {
+    /// Append a gravity control. May be called multiple times to add
+    /// additional sources (point-mass third bodies, spherical-harmonics
+    /// central body, …).
+    pub fn gravity(mut self, control: GravityControl<usize>) -> Self {
+        self.gravity_controls.controls.push(control);
+        self
+    }
+
+    /// Configure aerodynamic drag (typed: Cd, area, optional density override).
+    pub fn drag(mut self, cfg: DragConfigTyped) -> Self {
+        self.drag = Some(cfg);
+        self
+    }
+
+    /// Configure flat-plate solar radiation pressure with the given
+    /// per-plate state (geometry, optical, thermal).
+    pub fn flat_plate_srp(mut self, state: FlatPlateState) -> Self {
+        self.flat_plate_srp = Some(state);
+        self
+    }
+
+    /// Build the typed vehicle configuration. The unwraps below are
+    /// safe because every required field was set during a state
+    /// transition; if any required field is `None` the typestate
+    /// would not have advanced to [`Ready`].
+    pub fn build(self) -> TypedVehicleConfig {
+        TypedVehicleConfig {
+            trans: self
+                .trans
+                .expect("typestate guarantees translational state"),
+            rot: self.rot,
+            mass: self.mass,
+            integrator: self.integrator.expect("typestate guarantees integrator"),
+            gravity_controls: self.gravity_controls,
+            drag: self.drag,
+            flat_plate_srp: self.flat_plate_srp,
+        }
+    }
+}
+
+impl TypedVehicleConfig {
+    /// Drop the frame phantoms and emit an untyped
+    /// [`TranslationalState`]. Convenience for callers that need to
+    /// hand the typed config to APIs not yet migrated to typed
+    /// states. **The caller asserts** the translational state is
+    /// expressed in `Inertial`.
+    pub fn trans_untyped(&self) -> TranslationalState {
+        self.trans.to_untyped()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jeod_quantities::ext::F64Ext;
+
+    /// Happy path: 3-DoF point mass advances through every stage and
+    /// `.build()` returns a populated [`TypedVehicleConfig`].
+    #[test]
+    fn three_dof_happy_path() {
+        let trans =
+            TranslationalStateTyped::<Inertial>::from_untyped_unchecked(&TranslationalState {
+                position: glam::DVec3::new(7_000_000.0, 0.0, 0.0),
+                velocity: glam::DVec3::new(0.0, 7_500.0, 0.0),
+            });
+        let cfg = VehicleBuilder::new()
+            .with_translational(trans)
+            .three_dof_point_mass(420_000.0.kg())
+            .rk4()
+            .build();
+        assert_eq!(cfg.integrator, IntegratorType::Rk4);
+        assert!(cfg.mass.is_some());
+        assert!(cfg.rot.is_none());
+    }
+
+    /// 6-DoF path produces a config with both rotational state and
+    /// mass populated.
+    #[test]
+    fn six_dof_happy_path() {
+        use jeod_math::JeodQuat;
+        let trans =
+            TranslationalStateTyped::<Inertial>::from_untyped_unchecked(&TranslationalState {
+                position: glam::DVec3::new(7_000_000.0, 0.0, 0.0),
+                velocity: glam::DVec3::new(0.0, 7_500.0, 0.0),
+            });
+        let rot = RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: glam::DVec3::ZERO,
+        };
+        let inertia = glam::DMat3::IDENTITY * 100.0;
+        let mass = MassProperties::with_inertia(420_000.0, inertia, glam::DVec3::ZERO);
+        let cfg = VehicleBuilder::new()
+            .with_translational(trans)
+            .sixdof(rot, mass)
+            .rk4()
+            .build();
+        assert!(cfg.rot.is_some());
+        assert!(cfg.mass.is_some());
+    }
+}

--- a/crates/jeod_sim/tests/vehicle_builder_typestate.rs
+++ b/crates/jeod_sim/tests/vehicle_builder_typestate.rs
@@ -1,0 +1,111 @@
+//! Runtime cover for the typestate `VehicleBuilder`.
+//!
+//! Compile-fail gating is locked in via `compile_fail` doctests on the
+//! [`vehicle_builder`](jeod_sim::vehicle_builder) module — those run via
+//! `cargo test --doc -p jeod_sim` and prove that out-of-order calls
+//! produce a compile error rather than a runtime panic.
+//!
+//! This file exercises the **happy paths** at runtime:
+//!
+//! - `with_translational` → `three_dof_point_mass` → `rk4` → `build`
+//! - `with_translational` → `sixdof` → `rkf45` → `build` with optional
+//!   gravity / drag / SRP additions in the `Ready` state
+//! - `from_orbital_elements` → … round-trips an ISS-class state through
+//!   the typed entry path
+
+use glam::{DMat3, DVec3};
+use jeod_dynamics::state::TranslationalStateTyped;
+use jeod_dynamics::{
+    GaussJacksonConfig, IntegratorType, MassProperties, RotationalState, TranslationalState,
+};
+use jeod_gravity::GravityControl;
+use jeod_interactions::DragConfigTyped;
+use jeod_math::{JeodQuat, OrbitalElements};
+use jeod_quantities::ext::F64Ext;
+use jeod_quantities::frame::Inertial;
+use jeod_sim::vehicle_builder::{TypedVehicleConfig, VehicleBuilder};
+use uom::si::area::square_meter;
+use uom::si::f64::Area;
+use uom::si::ratio::ratio;
+
+fn iss_trans() -> TranslationalStateTyped<Inertial> {
+    TranslationalStateTyped::<Inertial>::from_untyped_unchecked(&TranslationalState {
+        position: DVec3::new(6_778_000.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7_672.0, 0.0),
+    })
+}
+
+#[test]
+fn three_dof_rk4_round_trip() {
+    let cfg: TypedVehicleConfig = VehicleBuilder::new()
+        .with_translational(iss_trans())
+        .three_dof_point_mass(420_000.0.kg())
+        .rk4()
+        .build();
+    assert_eq!(cfg.integrator, IntegratorType::Rk4);
+    assert!(cfg.mass.is_some());
+    assert!(cfg.rot.is_none());
+    assert!(cfg.drag.is_none());
+}
+
+#[test]
+fn six_dof_rkf45_with_options() {
+    let rot = RotationalState {
+        quaternion: JeodQuat::identity(),
+        ang_vel_body: DVec3::ZERO,
+    };
+    let mass = MassProperties::with_inertia(420_000.0, DMat3::IDENTITY * 1.0e6, DVec3::ZERO);
+    let drag = DragConfigTyped {
+        cd: 2.2.unitless(),
+        area: Area::new::<square_meter>(40.0),
+        constant_density: None,
+    };
+    let cfg = VehicleBuilder::new()
+        .with_translational(iss_trans())
+        .sixdof(rot, mass)
+        .rkf45()
+        .gravity(GravityControl::new_spherical(0, false))
+        .drag(drag)
+        .build();
+    assert_eq!(cfg.integrator, IntegratorType::Rkf45);
+    assert!(cfg.rot.is_some());
+    assert_eq!(cfg.gravity_controls.controls.len(), 1);
+    assert!(cfg.drag.is_some());
+    assert_eq!(
+        cfg.drag.as_ref().unwrap().cd.get::<ratio>(),
+        drag.cd.get::<ratio>()
+    );
+}
+
+#[test]
+fn gauss_jackson_integrator_selection() {
+    let cfg = VehicleBuilder::new()
+        .with_translational(iss_trans())
+        .three_dof_point_mass(1_000.0.kg())
+        .gauss_jackson(GaussJacksonConfig::default())
+        .build();
+    assert!(matches!(cfg.integrator, IntegratorType::GaussJackson(_)));
+}
+
+#[test]
+fn from_orbital_elements_round_trip() {
+    let earth_mu = 3.986_004_415e14_f64.m3_per_s2();
+    let oe =
+        OrbitalElements::from_cartesian_typed(earth_mu, iss_trans().position, iss_trans().velocity)
+            .expect("ISS-class state has well-defined orbital elements");
+
+    let cfg = VehicleBuilder::new()
+        .from_orbital_elements(oe.clone(), earth_mu)
+        .three_dof_point_mass(420_000.0.kg())
+        .rk4()
+        .build();
+
+    // The reconstructed translational state must round-trip the
+    // original to within numerical tolerance — `from_orbital_elements`
+    // delegates to `init_from_orbital_elements_typed` which itself
+    // delegates to the bit-identical f64 implementation.
+    let pos_err = (cfg.trans_untyped().position - iss_trans().position.raw_si()).length();
+    let vel_err = (cfg.trans_untyped().velocity - iss_trans().velocity.raw_si()).length();
+    assert!(pos_err < 1.0e-6, "position round-trip error: {pos_err}");
+    assert!(vel_err < 1.0e-9, "velocity round-trip error: {vel_err}");
+}

--- a/crates/jeod_sim/tests/vehicle_builder_typestate.rs
+++ b/crates/jeod_sim/tests/vehicle_builder_typestate.rs
@@ -43,7 +43,7 @@ fn three_dof_rk4_round_trip() {
         .rk4()
         .build();
     assert_eq!(cfg.integrator, IntegratorType::Rk4);
-    assert!(cfg.mass.is_some());
+    assert_eq!(cfg.mass.mass, 420_000.0);
     assert!(cfg.rot.is_none());
     assert!(cfg.drag.is_none());
 }


### PR DESCRIPTION
## Summary

Closes #107. Part of [#101](https://github.com/simnaut/bevy_jeod/issues/101).

Phase 5 of the type-system refactor. Extends the boundary skin from
Phase 4 into `jeod_sim`'s orchestration crate: gravity, atmosphere,
force collection, integration, drag/SRP/torque interactions, derived
states, and planet-config presets now expose typed sibling APIs
(`_typed` suffix on functions, `Typed` suffix on structs) alongside
the existing untyped surfaces. Hot-path kernels (Gottlieb SH, RK4
loop, Battin's method) keep their `f64`/`DVec3` interior — typing is
boundary-only by design.

Phase 5 also introduces a new typestate `VehicleBuilder` in
`crates/jeod_sim/src/vehicle_builder.rs`. The four phantom states
`NeedsState → NeedsMass → HasIntegrator → Ready` turn previous
runtime panics for half-configured vehicles into compile errors:
`.new().rk4()` no longer compiles. The existing runtime
`jeod_runner::VehicleBuilder` is untouched in this phase — Phase 6
(#108) reconciles them.

## Step-by-step commits

| Step | Scope |
|------|-------|
| 0 | Typed siblings: `accumulate_gravity_typed`, `accumulate_relativistic_corrections_typed`, `evaluate_atmosphere_typed`, `compute_orbital_elements_typed`, `collect_and_resolve_forces_typed`, `compute_drag_typed`, `compute_gravity_torque_typed`, `compute_cannonball_srp_typed`, `integrate_body_typed`, `FlatPlateStageInputsTyped`, `PlanetConfig::{mu,omega,shadow_radius}_typed` |
| 1 | New `crates/jeod_sim/src/vehicle_builder.rs` with sealed `BuildState` typestate, `TypedVehicleConfig`, fluent methods (`with_translational`, `from_orbital_elements`, `three_dof_point_mass`, `sixdof`, `rk4`/`rkf45`/`gauss_jackson`/`with_integrator`, `gravity`, `drag`, `flat_plate_srp`, `build`) |
| 2 | `crates/jeod_sim/tests/vehicle_builder_typestate.rs` runtime cover (4 tests) + `compile_fail` doctest in module docs |
| 3 | `pub use` for every new typed sibling and the `vehicle_builder` module in `crates/jeod_sim/src/lib.rs` |

(Step 4 is verification — see below.)

## Design choices

- **Additive, not replacing**. Same Phase-4-style boundary expansion:
  every `*_typed` is a thin wrapper that does `.raw_si()` on entry,
  calls the existing untyped function unchanged, and re-wraps the
  output via `from_raw_si` / `from_untyped_unchecked`. **No new
  arithmetic** in the wrappers — kernels are bit-identical (J2 hash
  and RK4 Kepler hash regressions both pass unchanged).
- **`jeod_runner` untouched**. Phase 6 (#108) wires the runtime
  `jeod_runner::VehicleBuilder` / `VehicleConfig` to consume the
  new typestate. Workspace stays green at both ends because the
  typed siblings live alongside the untyped surfaces.
- **Sealed typestate**. `BuildState` lives in a private `mod sealed`
  trait; the four marker structs (`NeedsState`, `NeedsMass`,
  `HasIntegrator`, `Ready`) are the only implementors. Out-of-order
  method calls (e.g., `.new().rk4()`) are compile errors, not
  runtime panics. A `compile_fail` doctest in `vehicle_builder.rs`
  locks this guarantee.
- **Boundary stayed boundary**. Per #107 notes: validation,
  `IntegrableObject` trait, pipeline ordering, and rotation-model
  algebra remain untyped — typing the trait surface or returning a
  `FrameTransform` from `RotationModel` would require generic-over-
  `Planet` plumbing that does not buy the typestate any new
  compile-time guarantees today.
- **Mission-author API surface**. The example from #101 —
  `VehicleBuilder::new().from_orbital_elements(oe, EARTH.mu_typed())
  .three_dof_point_mass(420_000.0.kg()).rk4().build()` — works
  end-to-end through the new typed `mu_typed()` accessor on
  `PlanetConfig` plus the typestate builder.

## JEOD invariants

All preserved on the untyped surface; typed siblings inherit them
by delegation. No `JEOD_INV` catalog updates needed in this phase.

## Verification (per #107 exit criteria)

- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --tests -- -D warnings`
- ✅ `cargo nextest run -p jeod_sim` (incl. new typestate tests)
- ✅ `cargo test --doc -p jeod_sim` — `compile_fail` doctest passes
- ✅ `cargo check --workspace` — `jeod_runner` and root package
  compile unchanged
- ✅ `cargo nextest run --workspace -E 'not test(tier3_)'` —
  722 pass / 0 fail / 311 skipped
- ✅ `cargo nextest run -p jeod_runner --test tier3_sim_dyncomp_run2
  --test tier3_sim_dyncomp_run3` — 4/4 pass (3-DoF spherical canary,
  3-DoF + 6-DoF run2, 4×4 SH run3a, 8×8 SH run3b)
- ✅ `cargo run -p jeod_test_data --bin tier3_baseline_diff --
  --allow-missing tier3_earth_moon_clem` — OK (76 matched, 0
  violations)
- ✅ `j2_regression` + `integrator_bit_match` — hashes unchanged

## Depends on

- #126 (Phase 0: `jeod_quantities` foundation)
- #128 (Phase 1: typed leaf crates)
- #129 (Phase 2: typed `jeod_math`)
- #141 (Phase 3: typed `jeod_frames` + `jeod_dynamics`)
- #142 (Phase 4: typed `jeod_gravity` + `jeod_interactions`)

## Out of scope (per #107)

- Migration of `jeod_runner::VehicleBuilder` / `VehicleConfig` to
  consume the new typestate — Phase 6 (#108).
- `jeod_sim::recipes` module — Phase 6.
- Tier 3 rewrite to `VerificationCase` one-liners — Phases 7/8
  (#109, #110).
- Bevy `.spawn(&mut Commands) -> Entity` on the typestate builder —
  Phase 9 (#111).
- Removal of untyped surfaces — Phase 10 (#112).

## Test plan

- [x] CI \`Lint & Format\` passes
- [x] CI \`Test (unit + tier 2)\` passes
- [x] CI \`Test (Tier 3 fast)\` passes (baseline-invariance step green)
- [ ] CI \`Test (Tier 3 full + earth_moon)\` runs on push to \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)