### PR TITLE
[Phase 8] Tier 3 wave B: archetype-B classification + recipes::helpers infrastructure (#110)

### DIFF
--- a/crates/jeod_runner/tests/sim_test_helpers/mod.rs
+++ b/crates/jeod_runner/tests/sim_test_helpers/mod.rs
@@ -1,17 +1,39 @@
 //! Shared helpers for jeod_sim Tier 3 tests.
 //!
-//! Provides CSV parsing for SIM_dyncomp and derived-state trajectory data,
-//! quaternion error computation, and test data path resolution.
+//! Phase 8 of #101 hoisted the propagation utilities (state-error
+//! metrics, energy conservation, periapsis detection, integrator
+//! agreement, attach/detach scheduling, force/torque profiles, custom
+//! CSV reader, parametric orbinit cases) into
+//! [`jeod_sim::recipes::helpers`]. Phase 7 owns the typed CSV loaders
+//! in `jeod_sim::recipes::verification::csv_loader`. What remains in
+//! this file is:
+//!
+//! - Tests-only glue that depends on `jeod_test_data` types
+//!   ([`mass_props_from_init`]).
+//! - Schema-specific CSV loaders not yet absorbed by either Phase
+//!   (`load_orbelem_csv`, `load_lvlh_csv`, `load_ned_csv`,
+//!   `load_srp_trajectory`, …) — these stay until Phase 7's loader
+//!   catalogue lands or until Phase 10's cleanup.
+//! - The `test_data_path` resolver and `OMEGA_EARTH` re-export.
+//!
+//! Most tests will eventually import directly from
+//! `jeod_sim::recipes::helpers::*`; for backward compatibility this
+//! module re-exports the hoisted helpers under their original names so
+//! the migration can proceed file-by-file without flag-day churn.
 
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use glam::{DMat3, DVec3};
-use jeod_math::OrbitalElements;
-use jeod_sim::{JeodQuat, MassProperties, TranslationalState};
+use jeod_sim::{JeodQuat, MassProperties};
 use std::path::Path;
 
 #[allow(unused_imports)] // Not all test binaries use dyncomp CSV loading
 pub use jeod_test_data::dyncomp_csv::{load_dyncomp_csv, DyncompRecord};
+
+// Re-exports from the recipes layer (Phase 8 hoist).
+pub use jeod_sim::recipes::helpers::state_helpers::{
+    angle_diff, dquat_angle_error, max_mat_diff, state_from_elements,
+};
 
 /// Earth rotation rate (JEOD RNPJ2000 default), sourced from
 /// `jeod_sim::planet_config::EARTH.omega`.
@@ -21,6 +43,10 @@ pub const OMEGA_EARTH: f64 = jeod_sim::planet_config::EARTH.omega;
 ///
 /// Converts the row-major `[[f64; 3]; 3]` inertia tensor to glam `DMat3`
 /// (column-major) and passes through mass and CoM position.
+///
+/// Stays here (rather than `recipes::helpers`) because it depends on
+/// `jeod_test_data::mass_data::MassInitData`, which is test-data
+/// plumbing — not a recipe.
 pub fn mass_props_from_init(init: &jeod_test_data::mass_data::MassInitData) -> MassProperties {
     let inertia = DMat3::from_cols(
         DVec3::new(init.inertia[0][0], init.inertia[1][0], init.inertia[2][0]),
@@ -30,13 +56,10 @@ pub fn mass_props_from_init(init: &jeod_test_data::mass_data::MassInitData) -> M
     MassProperties::with_inertia(init.mass, inertia, DVec3::from_slice(&init.position))
 }
 
+/// Quaternion angular error (back-compat alias for callers that
+/// haven't migrated to `recipes::helpers::state_helpers::jeodquat_angle_error`).
 pub fn quaternion_angle_error(q1: &JeodQuat, q2: &JeodQuat) -> f64 {
-    let dot = (q1.scalar() * q2.scalar()
-        + q1.vector().x * q2.vector().x
-        + q1.vector().y * q2.vector().y
-        + q1.vector().z * q2.vector().z)
-        .abs();
-    2.0 * dot.min(1.0).acos()
+    jeod_sim::recipes::helpers::state_helpers::jeodquat_angle_error(q1, q2)
 }
 
 pub fn test_data_path(filename: &str) -> std::path::PathBuf {
@@ -136,61 +159,9 @@ pub fn load_torque_simple_csv(path: &Path) -> Vec<TorqueSimpleRecord> {
     records
 }
 
-/// Initialize a [`TranslationalState`] from classical orbital elements.
-/// Works for all eccentricities including e >= 1 (hyperbolic).
-pub fn state_from_elements(
-    a: f64,
-    e: f64,
-    i: f64,
-    raan: f64,
-    argp: f64,
-    nu: f64,
-    mu: f64,
-) -> TranslationalState {
-    let mut oe = OrbitalElements::default();
-    oe.semi_major_axis = a;
-    oe.e_mag = e;
-    oe.inclination = i;
-    oe.long_asc_node = raan;
-    oe.arg_periapsis = argp;
-    oe.true_anom = nu;
-
-    if e < 1.0 {
-        oe.semiparam = a * (1.0 - e * e);
-    } else {
-        // Hyperbolic: a is negative, p = a(1 - e^2) = |a|(e^2 - 1)
-        oe.semiparam = a.abs() * (e * e - 1.0);
-    }
-    oe.nu_to_anomalies();
-
-    let (position, velocity) = oe.to_cartesian(mu).expect("to_cartesian failed");
-    TranslationalState { position, velocity }
-}
-
-/// Compute angular difference accounting for wraparound at 2π.
-pub fn angle_diff(a: f64, b: f64) -> f64 {
-    let tau = 2.0 * std::f64::consts::PI;
-    let mut d = (a - b) % tau;
-    if d > std::f64::consts::PI {
-        d -= tau;
-    }
-    if d < -std::f64::consts::PI {
-        d += tau;
-    }
-    d.abs()
-}
-
-/// Max absolute element-wise difference between two 3×3 matrices.
-pub fn max_mat_diff(a: &DMat3, b: &DMat3) -> f64 {
-    let mut max_d = 0.0_f64;
-    for c in 0..3 {
-        for r in 0..3 {
-            let d = (a.col(c)[r] - b.col(c)[r]).abs();
-            max_d = max_d.max(d);
-        }
-    }
-    max_d
-}
+// Phase 8 #110: `state_from_elements`, `angle_diff`, and `max_mat_diff`
+// moved to `jeod_sim::recipes::helpers::state_helpers` and are re-
+// exported from this module's preamble.
 
 // ── SIM_VER_DRAG CSV loader (11 columns) ──
 

--- a/crates/jeod_runner/tests/sim_test_helpers/mod.rs
+++ b/crates/jeod_runner/tests/sim_test_helpers/mod.rs
@@ -5,8 +5,8 @@
 //! agreement, attach/detach scheduling, force/torque profiles, custom
 //! CSV reader, parametric orbinit cases) into
 //! [`jeod_sim::recipes::helpers`]. Phase 7 owns the typed CSV loaders
-//! in `jeod_sim::recipes::verification::csv_loader`. What remains in
-//! this file is:
+//! in [`jeod_test_data::tier3_csv`] (with `jeod_test_data::dyncomp_csv`
+//! as its initial entry). What remains in this file is:
 //!
 //! - Tests-only glue that depends on `jeod_test_data` types
 //!   ([`mass_props_from_init`]).

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -261,6 +261,11 @@ fn load_reference_sixdof(filename: &str) -> Vec<RefState> {
     states
 }
 
+// non-recipe: SIM_verif_frame_switch uses the Apollo 8 trans-lunar-coast
+// state vector (Dec 23 1968 19:38 UTC) with vehicle.py-specific inertia in
+// slug-ft² and CoM offset in inches. This is materially different from
+// `scenarios::apollo_translunar()` (J2000 epoch, 200 km parking orbit,
+// generic CSM mass) — substituting would change what's being verified.
 #[test]
 fn tier3_apollo8_eci_integ() {
     let (mut sim, body_idx, _moon) = build_apollo8_sim(false);
@@ -310,6 +315,9 @@ fn tier3_apollo8_eci_integ() {
 /// Cross-validate the frame-switch simulation against JEOD's reference data.
 /// JEOD logs position in the current integration frame: ECI before the switch,
 /// Moon-centered after.
+// non-recipe: same Apollo 8 trans-lunar coast state as
+// `tier3_apollo8_eci_integ`; setup is identical except for
+// `enable_frame_switch=true`.
 #[test]
 fn tier3_apollo8_frame_switch() {
     let (mut sim, body_idx, _moon) = build_apollo8_sim(true);

--- a/crates/jeod_runner/tests/tier3_sim_attach_detach.rs
+++ b/crates/jeod_runner/tests/tier3_sim_attach_detach.rs
@@ -160,6 +160,10 @@ fn assert_masses(row: &MassRow, v1: f64, v2: f64, v3: f64) -> f64 {
 const SIMPLE_ATTACH_TIME: f64 = 10.0;
 const SIMPLE_DETACH_TIME: f64 = 20.0;
 
+// non-recipe: SIM_verif_attach_detach exercises a placeholder mass-tree
+// (1/2/3 kg) directly through `MassTree::{attach,detach}`, not the full
+// simulation pipeline. Apollo masses don't apply; the event count is two,
+// so a one-shot flag pair is shorter than `EventSchedule`.
 #[test]
 fn tier3_sim_attach_detach_simple() {
     let rows = load_csv("attach_detach_simple_attach_detach.csv");
@@ -233,6 +237,8 @@ fn tier3_sim_attach_detach_simple() {
 /// Verify the CSV for the complex run is present and has correct t=0 state.
 /// Full mass-tree validation is deferred — `attach_to` auto-reroots the
 /// attaching body's root, which our `MassTree::attach` does not yet model.
+// non-recipe: t=0 sanity check on the same placeholder mass tree as
+// `tier3_sim_attach_detach_simple`.
 #[test]
 fn tier3_sim_attach_detach_complex_t0() {
     let rows = load_csv("attach_detach_complex_attach_detach.csv");
@@ -240,6 +246,7 @@ fn tier3_sim_attach_detach_complex_t0() {
 }
 
 /// Same sanity check for the compute_child_derivative run.
+// non-recipe: same placeholder mass tree as the simple/complex runs.
 #[test]
 fn tier3_sim_attach_detach_child_derivative_t0() {
     let rows = load_csv("attach_detach_child_deriv_attach_detach.csv");

--- a/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
+++ b/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
@@ -623,6 +623,10 @@ fn validate_run<S: AsRef<str>>(
 // Tier 3 test: iterates every run, asserts tolerances, emits report
 // ════════════════════════════════════════════════════════════════════
 
+// non-recipe: SIM_verif_attach_mass uses 1 kg JEOD test-fixture bodies
+// (parent_default/child{1,2,3}_default) ported from
+// `Modified_data/*.py`; not Apollo-class. The whole test runs against
+// `MassTree::print_tree` parity, not the full simulation pipeline.
 #[test]
 fn tier3_sim_attach_mass() {
     let mut errors = MaxErrors::new();

--- a/crates/jeod_runner/tests/tier3_sim_contact.rs
+++ b/crates/jeod_runner/tests/tier3_sim_contact.rs
@@ -401,6 +401,10 @@ fn assert_contact_force_torque(
 
 // ── Tier 3 tests ────────────────────────────────────────────────────
 
+// non-recipe (all 6 contact tests): SIM_contact uses 1 m / 100 kg test
+// spheres, lines, and ground geometries with bespoke contact pairs and
+// initial velocities. The geometries themselves are the test content; no
+// recipe vehicle preset matches.
 /// RUN_point: two 1 m radius spheres, 100 kg each. veh2 at (12,0,0) with
 /// v=(-2,0,0). Contact starts when the centers are 2 m apart (t ≈ 5 s).
 #[test]

--- a/crates/jeod_runner/tests/tier3_sim_contact.rs
+++ b/crates/jeod_runner/tests/tier3_sim_contact.rs
@@ -401,7 +401,7 @@ fn assert_contact_force_torque(
 
 // ── Tier 3 tests ────────────────────────────────────────────────────
 
-// non-recipe (all 6 contact tests): SIM_contact uses 1 m / 100 kg test
+// non-recipe: all 6 contact tests run SIM_contact with 1 m / 100 kg test
 // spheres, lines, and ground geometries with bespoke contact pairs and
 // initial velocities. The geometries themselves are the test content; no
 // recipe vehicle preset matches.

--- a/crates/jeod_runner/tests/tier3_sim_drag_6dof.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_6dof.rs
@@ -4,10 +4,9 @@
 //! `Simulation::step()`, verifying that drag interacts correctly with the
 //! attitude state. All tests use analytical verification.
 
-mod sim_test_helpers;
-
 use glam::{DMat3, DVec3};
 use jeod_runner::{GravitySourceEntry, Simulation, VehicleConfig};
+use jeod_sim::recipes::helpers::energy_conservation::specific_orbital_energy;
 use jeod_sim::{
     AtmosphereConfig, AtmosphereModel, DragConfig, ExponentialAtmosphere, GravityControl,
     GravityControls, GravityModel, GravitySource, JeodQuat, MassProperties, RotationalState,
@@ -19,11 +18,6 @@ const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
 /// Earth mean equatorial radius (m) — JEOD `earth.cc`.
 const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
-
-/// Compute specific orbital energy: E = v^2/2 - mu/r
-fn orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {
-    0.5 * vel.length_squared() - mu / pos.length()
-}
 
 /// Create a 6-DOF simulation with point-mass gravity and constant-density drag.
 #[allow(clippy::too_many_arguments)]
@@ -111,6 +105,9 @@ fn make_6dof_drag_sim(
 /// the drag magnitude. The force always opposes the relative velocity
 /// regardless of body orientation. This test verifies that a spinning body
 /// still experiences proper orbital energy dissipation.
+// non-recipe: 1 t mass + ballistic Cd·A on a 400 km equatorial circular
+// orbit; the geometry is bespoke and the drag config (Cd=2.2, area=10,
+// constant density 1e-12) drives the assertion content.
 #[test]
 fn tier3_drag_with_rotation_energy_loss() {
     let r = R_EARTH + 400_000.0;
@@ -138,7 +135,7 @@ fn tier3_drag_with_rotation_energy_loss() {
         pos, vel, mass, inertia, quat, ang_vel, cd, area, density, dt,
     );
 
-    let e_initial = orbital_energy(pos, vel, MU_EARTH);
+    let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
 
     // Propagate for 1 orbit
     let period = 2.0 * std::f64::consts::PI * (r.powi(3) / MU_EARTH).sqrt();
@@ -146,7 +143,7 @@ fn tier3_drag_with_rotation_energy_loss() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
-    let e_final = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let e_final = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
 
     println!("  Initial energy: {e_initial:.6e} J/kg");
     println!("  Final energy:   {e_final:.6e} J/kg");
@@ -189,6 +186,8 @@ fn tier3_drag_with_rotation_energy_loss() {
 /// attitudes but same translational state should experience the same
 /// translational trajectory. The force direction changes in the body frame,
 /// but in the inertial frame it is always anti-velocity.
+// non-recipe: same drag setup as `tier3_drag_with_rotation_energy_loss`,
+// run twice with different attitudes to verify ballistic-drag invariance.
 #[test]
 fn tier3_drag_attitude_invariance_ballistic() {
     let r = R_EARTH + 400_000.0;

--- a/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
@@ -181,7 +181,8 @@ fn tier3_drag_altitude_decay() {
 
     let mut sim = make_drag_sim(pos, vel, mass, cd, area, density, dt);
 
-    let a_initial = semi_major_axis_from_energy(specific_orbital_energy(pos, vel, MU_EARTH), MU_EARTH);
+    let a_initial =
+        semi_major_axis_from_energy(specific_orbital_energy(pos, vel, MU_EARTH), MU_EARTH);
 
     // Propagate for 2 orbits
     let period = 2.0 * std::f64::consts::PI * (a_initial.powi(3) / MU_EARTH).sqrt();
@@ -242,16 +243,16 @@ fn tier3_drag_higher_density_faster_decay() {
     let mut sim_low = make_drag_sim(pos, vel, mass, cd, area, density_low, dt);
     sim_low.step_n(n_steps);
     let body_low = sim_low.body(0);
-    let e_loss_low =
-        e_initial - specific_orbital_energy(body_low.trans.position, body_low.trans.velocity, MU_EARTH);
+    let e_loss_low = e_initial
+        - specific_orbital_energy(body_low.trans.position, body_low.trans.velocity, MU_EARTH);
 
     // Case 2: high density (10x)
     let density_high = 1e-11;
     let mut sim_high = make_drag_sim(pos, vel, mass, cd, area, density_high, dt);
     sim_high.step_n(n_steps);
     let body_high = sim_high.body(0);
-    let e_loss_high =
-        e_initial - specific_orbital_energy(body_high.trans.position, body_high.trans.velocity, MU_EARTH);
+    let e_loss_high = e_initial
+        - specific_orbital_energy(body_high.trans.position, body_high.trans.velocity, MU_EARTH);
 
     let density_ratio = density_high / density_low;
     let loss_ratio = e_loss_high / e_loss_low;
@@ -396,7 +397,8 @@ fn tier3_drag_corotation_wind_effect() {
     // Use ExponentialAtmosphere with a density that we'll override via
     // constant_density anyway.
 
-    let e_initial = specific_orbital_energy(DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0), MU_EARTH);
+    let e_initial =
+        specific_orbital_energy(DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0), MU_EARTH);
 
     // Prograde: velocity in +Y when position is +X (same as Earth rotation)
     let pos = DVec3::new(r, 0.0, 0.0);
@@ -410,8 +412,8 @@ fn tier3_drag_corotation_wind_effect() {
     let mut sim_pro = make_drag_sim_with_wind(pos, vel_prograde, mass, cd, area, density, dt);
     sim_pro.step_n(n_steps);
     let body_pro = sim_pro.body(0);
-    let e_loss_pro =
-        e_initial - specific_orbital_energy(body_pro.trans.position, body_pro.trans.velocity, MU_EARTH);
+    let e_loss_pro = e_initial
+        - specific_orbital_energy(body_pro.trans.position, body_pro.trans.velocity, MU_EARTH);
 
     // Retrograde orbit with co-rotation wind
     let mut sim_retro = make_drag_sim_with_wind(pos, vel_retrograde, mass, cd, area, density, dt);

--- a/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
@@ -7,27 +7,24 @@
 //! All tests use point-mass gravity with constant atmospheric density to isolate
 //! drag effects from atmosphere model complexity.
 
-mod sim_test_helpers;
-use sim_test_helpers::*;
-
 use glam::DVec3;
 use jeod_runner::{GravitySourceEntry, Simulation, VehicleConfig};
+use jeod_sim::recipes::helpers::energy_conservation::specific_orbital_energy;
 use jeod_sim::{
     AtmosphereConfig, AtmosphereModel, DragConfig, ExponentialAtmosphere, GravityControl,
     GravityControls, GravityModel, GravitySource, JeodQuat, MassProperties, RotationalState,
     SimulationTime, TranslationalState,
 };
 
+/// Earth rotation rate (JEOD RNPJ2000 default), sourced from
+/// `jeod_sim::planet_config::EARTH.omega`.
+const OMEGA_EARTH: f64 = jeod_sim::planet_config::EARTH.omega;
+
 /// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
 const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
 
 /// Earth mean equatorial radius (m) — JEOD `earth.cc`.
 const R_EARTH: f64 = jeod_sim::EARTH.shape.r_eq;
-
-/// Compute specific orbital energy: E = v^2/2 - mu/r
-fn orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {
-    0.5 * vel.length_squared() - mu / pos.length()
-}
 
 /// Compute semi-major axis from specific energy: a = -mu / (2*E)
 fn semi_major_axis_from_energy(energy: f64, mu: f64) -> f64 {
@@ -121,6 +118,11 @@ fn iss_circular_state() -> (DVec3, DVec3) {
 /// Drag removes kinetic energy from the orbit, causing the total specific
 /// energy to become more negative. This is the most fundamental property
 /// of atmospheric drag.
+// non-recipe (all 6 tests in this file): equatorial 400 km circular orbit
+// with various Cd / area / density combinations to verify analytical drag
+// laws (energy loss, altitude decay, density scaling, area scaling, no-drag
+// at zero density, corotation wind). Geometry and drag parameters are the
+// assertion content, not a recipe input.
 #[test]
 fn tier3_drag_constant_density_energy_loss() {
     let (pos, vel) = iss_circular_state();
@@ -132,7 +134,7 @@ fn tier3_drag_constant_density_energy_loss() {
 
     let mut sim = make_drag_sim(pos, vel, mass, cd, area, density, dt);
 
-    let e_initial = orbital_energy(pos, vel, MU_EARTH);
+    let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
 
     // Propagate for 1 orbit (~92 min at 400 km)
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
@@ -140,7 +142,7 @@ fn tier3_drag_constant_density_energy_loss() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
-    let e_final = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let e_final = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
 
     println!("  Initial energy: {e_initial:.6e} J/kg");
     println!("  Final energy:   {e_final:.6e} J/kg");
@@ -179,7 +181,7 @@ fn tier3_drag_altitude_decay() {
 
     let mut sim = make_drag_sim(pos, vel, mass, cd, area, density, dt);
 
-    let a_initial = semi_major_axis_from_energy(orbital_energy(pos, vel, MU_EARTH), MU_EARTH);
+    let a_initial = semi_major_axis_from_energy(specific_orbital_energy(pos, vel, MU_EARTH), MU_EARTH);
 
     // Propagate for 2 orbits
     let period = 2.0 * std::f64::consts::PI * (a_initial.powi(3) / MU_EARTH).sqrt();
@@ -188,7 +190,7 @@ fn tier3_drag_altitude_decay() {
 
     let body = sim.body(0);
     let a_final = semi_major_axis_from_energy(
-        orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH),
+        specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH),
         MU_EARTH,
     );
 
@@ -231,7 +233,7 @@ fn tier3_drag_higher_density_faster_decay() {
     let area = 10.0;
     let dt = 10.0;
 
-    let e_initial = orbital_energy(pos, vel, MU_EARTH);
+    let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
 
@@ -241,7 +243,7 @@ fn tier3_drag_higher_density_faster_decay() {
     sim_low.step_n(n_steps);
     let body_low = sim_low.body(0);
     let e_loss_low =
-        e_initial - orbital_energy(body_low.trans.position, body_low.trans.velocity, MU_EARTH);
+        e_initial - specific_orbital_energy(body_low.trans.position, body_low.trans.velocity, MU_EARTH);
 
     // Case 2: high density (10x)
     let density_high = 1e-11;
@@ -249,7 +251,7 @@ fn tier3_drag_higher_density_faster_decay() {
     sim_high.step_n(n_steps);
     let body_high = sim_high.body(0);
     let e_loss_high =
-        e_initial - orbital_energy(body_high.trans.position, body_high.trans.velocity, MU_EARTH);
+        e_initial - specific_orbital_energy(body_high.trans.position, body_high.trans.velocity, MU_EARTH);
 
     let density_ratio = density_high / density_low;
     let loss_ratio = e_loss_high / e_loss_low;
@@ -279,7 +281,7 @@ fn tier3_drag_larger_area_faster_decay() {
     let density = 1e-12;
     let dt = 10.0;
 
-    let e_initial = orbital_energy(pos, vel, MU_EARTH);
+    let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
 
@@ -289,7 +291,7 @@ fn tier3_drag_larger_area_faster_decay() {
     sim_small.step_n(n_steps);
     let body_small = sim_small.body(0);
     let e_loss_small = e_initial
-        - orbital_energy(
+        - specific_orbital_energy(
             body_small.trans.position,
             body_small.trans.velocity,
             MU_EARTH,
@@ -301,7 +303,7 @@ fn tier3_drag_larger_area_faster_decay() {
     sim_large.step_n(n_steps);
     let body_large = sim_large.body(0);
     let e_loss_large = e_initial
-        - orbital_energy(
+        - specific_orbital_energy(
             body_large.trans.position,
             body_large.trans.velocity,
             MU_EARTH,
@@ -335,7 +337,7 @@ fn tier3_drag_no_drag_at_zero_density() {
 
     let mut sim = make_drag_sim(pos, vel, mass, cd, area, density, dt);
 
-    let e_initial = orbital_energy(pos, vel, MU_EARTH);
+    let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
     let h_initial = pos.cross(vel).length(); // specific angular momentum
 
     // Propagate for 1 orbit
@@ -344,7 +346,7 @@ fn tier3_drag_no_drag_at_zero_density() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
-    let e_final = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let e_final = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
     let h_final = body.trans.position.cross(body.trans.velocity).length();
 
     let de = (e_final - e_initial).abs();
@@ -394,7 +396,7 @@ fn tier3_drag_corotation_wind_effect() {
     // Use ExponentialAtmosphere with a density that we'll override via
     // constant_density anyway.
 
-    let e_initial = orbital_energy(DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0), MU_EARTH);
+    let e_initial = specific_orbital_energy(DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0), MU_EARTH);
 
     // Prograde: velocity in +Y when position is +X (same as Earth rotation)
     let pos = DVec3::new(r, 0.0, 0.0);
@@ -409,7 +411,7 @@ fn tier3_drag_corotation_wind_effect() {
     sim_pro.step_n(n_steps);
     let body_pro = sim_pro.body(0);
     let e_loss_pro =
-        e_initial - orbital_energy(body_pro.trans.position, body_pro.trans.velocity, MU_EARTH);
+        e_initial - specific_orbital_energy(body_pro.trans.position, body_pro.trans.velocity, MU_EARTH);
 
     // Retrograde orbit with co-rotation wind
     let mut sim_retro = make_drag_sim_with_wind(pos, vel_retrograde, mass, cd, area, density, dt);
@@ -417,7 +419,7 @@ fn tier3_drag_corotation_wind_effect() {
     let body_retro = sim_retro.body(0);
     // For retrograde, initial energy is the same magnitude
     let e_loss_retro = e_initial
-        - orbital_energy(
+        - specific_orbital_energy(
             body_retro.trans.position,
             body_retro.trans.velocity,
             MU_EARTH,

--- a/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
@@ -118,7 +118,7 @@ fn iss_circular_state() -> (DVec3, DVec3) {
 /// Drag removes kinetic energy from the orbit, causing the total specific
 /// energy to become more negative. This is the most fundamental property
 /// of atmospheric drag.
-// non-recipe (all 6 tests in this file): equatorial 400 km circular orbit
+// non-recipe: all 6 tests in this file run an equatorial 400 km circular orbit
 // with various Cd / area / density combinations to verify analytical drag
 // laws (energy loss, altitude decay, density scaling, area scaling, no-drag
 // at zero density, corotation wind). Geometry and drag parameters are the

--- a/crates/jeod_runner/tests/tier3_sim_drag_flatplate_ver.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_flatplate_ver.rs
@@ -199,6 +199,10 @@ fn run_flat_plate_case(case: &FlatPlateCase) -> (f64, f64, f64) {
 
 // ── Specular (ε=1.0, `coef_method=Specular`) ──
 
+// non-recipe (all 8 tests in this file): SIM_VER_DRAG flatplate scenarios
+// drive bespoke Cd/area/incidence/epsilon parameters from JEOD's input.py
+// fixtures and compare via `load_drag_csv`. The setups are the assertion
+// content, not a recipe input.
 #[test]
 fn tier3_sim_drag_ver_flatplate_specular() {
     let case = FlatPlateCase {

--- a/crates/jeod_runner/tests/tier3_sim_drag_flatplate_ver.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_flatplate_ver.rs
@@ -199,8 +199,8 @@ fn run_flat_plate_case(case: &FlatPlateCase) -> (f64, f64, f64) {
 
 // ── Specular (ε=1.0, `coef_method=Specular`) ──
 
-// non-recipe (all 8 tests in this file): SIM_VER_DRAG flatplate scenarios
-// drive bespoke Cd/area/incidence/epsilon parameters from JEOD's input.py
+// non-recipe: all 8 tests in this file drive SIM_VER_DRAG flatplate scenarios
+// with bespoke Cd/area/incidence/epsilon parameters from JEOD's input.py
 // fixtures and compare via `load_drag_csv`. The setups are the assertion
 // content, not a recipe input.
 #[test]

--- a/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
@@ -13,6 +13,8 @@
 use jeod_runner::prelude::*;
 use jeod_runner::run_verification::sim_dyncomp;
 
+// non-recipe: SIM_dyncomp RUN_6B with structural-to-body rotation; the test
+// content is the rotation-frame invariance, not a recipe vehicle.
 #[test]
 fn tier3_simulation_drag_run6b_rotated() {
     sim_dyncomp::run6b_drag_rotated_struct().run_and_assert();

--- a/crates/jeod_runner/tests/tier3_sim_drag_ver.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_ver.rs
@@ -145,6 +145,8 @@ fn run_ballistic_case(
 /// JEOD computes `force = -0.5·ρ·v²·Cd·A · v̂_rel` in the structural frame.
 /// With identity T_inertial_struct, density 1e-12 kg/m³, and |v|=7500 m/s:
 ///   |force| = 0.5·1e-12·7500²·2·100 = 0.005625 N (accel_mag at t=0).
+// non-recipe: SIM_VER_DRAG bit-exact match — Cd=2, area=100 sphere, no
+// recipe preset matches the JEOD-injection geometry.
 #[test]
 fn tier3_sim_drag_ver_cd() {
     let drag = DragConfig {
@@ -182,6 +184,8 @@ fn tier3_sim_drag_ver_cd() {
 ///
 /// The two JEOD CSVs (`drag_cd_drag.csv`, `drag_bc_drag.csv`) differ only at
 /// the ~16th significant digit, confirming this equivalence.
+// non-recipe: same as `tier3_sim_drag_ver_cd` but using BC instead of CD —
+// algebraic equivalence is the test content.
 #[test]
 fn tier3_sim_drag_ver_bc() {
     let drag = DragConfig {

--- a/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
@@ -9,6 +9,8 @@
 use jeod_runner::prelude::*;
 use jeod_runner::run_verification::sim_dyncomp;
 
+// non-recipe: SIM_dyncomp RUN_6B — 1 kg sphere, Cd=0.02, MET atmosphere on
+// elliptical orbit; reproduces JEOD's verification fixture exactly.
 #[test]
 fn tier3_simulation_drag_run6b() {
     sim_dyncomp::run6b_drag_aero_traj().run_and_assert();

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
@@ -30,10 +30,9 @@
 //!   Related to RUN_8B (LVLH rate) attitude propagation: spin about the
 //!   major principal axis is stable (intermediate-axis theorem).
 
-mod sim_test_helpers;
-
 use glam::{DMat3, DVec3};
 use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::recipes::helpers::energy_conservation::specific_orbital_energy;
 use jeod_sim::{
     GravityControl, GravityControls, GravityModel, GravitySource, JeodQuat, MassProperties,
     RotationalState, SimulationTime, TranslationalState,
@@ -80,11 +79,6 @@ fn iss_circular_state() -> (DVec3, DVec3) {
     (DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0))
 }
 
-/// Specific orbital energy: v^2/2 - mu/r.
-fn orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {
-    0.5 * vel.length_squared() - mu / pos.length()
-}
-
 /// Build a 3-DOF point-mass orbit simulation (pure Kepler).
 fn make_kepler_sim(pos: DVec3, vel: DVec3, mass: f64, dt: f64) -> Simulation {
     let mut sim = Simulation::new(
@@ -121,7 +115,7 @@ fn tier3_dyncomp_point_mass_3dof_conservation() {
     let dt = 10.0;
     let mut sim = make_kepler_sim(pos, vel, 1000.0, dt);
 
-    let e0 = orbital_energy(pos, vel, MU_EARTH);
+    let e0 = specific_orbital_energy(pos, vel, MU_EARTH);
     let h0 = pos.cross(vel);
 
     // Propagate for 3 orbits.
@@ -130,7 +124,7 @@ fn tier3_dyncomp_point_mass_3dof_conservation() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
-    let e1 = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let e1 = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
     let h1 = body.trans.position.cross(body.trans.velocity);
 
     let de = (e1 - e0).abs() / e0.abs();
@@ -227,7 +221,7 @@ fn tier3_dyncomp_point_mass_plus_thirdbody_conservation() {
 
     sim.validate().unwrap();
 
-    let e0 = orbital_energy(pos, vel, MU_EARTH);
+    let e0 = specific_orbital_energy(pos, vel, MU_EARTH);
     let h0 = pos.cross(vel);
 
     // Integrate for one orbit.
@@ -236,7 +230,7 @@ fn tier3_dyncomp_point_mass_plus_thirdbody_conservation() {
     sim.step_n(n_steps);
 
     let body = sim.body(0);
-    let e1 = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+    let e1 = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
     let h1 = body.trans.position.cross(body.trans.velocity);
 
     // Orbital energy about Earth should remain bounded (~third-body magnitude
@@ -332,7 +326,7 @@ fn tier3_dyncomp_drag_point_mass_monotonic_decay() {
     for _ in 0..5 {
         sim.step_n(steps_per_orbit);
         let body = sim.body(0);
-        let e = orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
+        let e = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
         let a = -MU_EARTH / (2.0 * e);
         sma_samples.push(a);
     }

--- a/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
+++ b/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
@@ -108,6 +108,11 @@ fn make_free_body_6dof(mass: f64, inertia: DMat3, dt: f64) -> Simulation {
 /// After applying F for T seconds starting from rest:
 ///   v(T) = F*T/m
 ///   x(T) = 0.5 * F*T^2/m
+// non-recipe: SIM_force_torque uses 100 kg test masses and diag(10,20,20)
+// inertia for closed-form verification of F=m·a and τ=I·α. Analytical
+// constants don't match any recipe vehicle preset, and the constant-input
+// pattern is shorter than `force_torque_profiles::step_input` because
+// the on/off times here are step-count expressions, not test parameters.
 #[test]
 fn tier3_force_constant_acceleration() {
     let mass = 100.0; // kg
@@ -151,6 +156,7 @@ fn tier3_force_constant_acceleration() {
 ///   theta(T) = 0.5 * tau*T^2/I
 /// For an initially aligned body, after 10 s with tau_x=1 N·m and I_x=10:
 ///   omega_x = 1 rad/s, theta_x = 5 rad.
+// non-recipe: same analytical-mass setup as `tier3_force_constant_acceleration`.
 #[test]
 fn tier3_torque_constant_angular_acceleration() {
     let mass = 100.0;
@@ -203,6 +209,7 @@ fn tier3_torque_constant_angular_acceleration() {
 /// torque is applied on the body, translation and rotation are decoupled:
 ///   linear motion follows v = F*t/m regardless of torque
 ///   angular motion follows omega = tau*t/I regardless of force
+// non-recipe: same analytical-mass setup as `tier3_force_constant_acceleration`.
 #[test]
 fn tier3_force_and_torque_decoupled() {
     let mass = 100.0;
@@ -289,6 +296,9 @@ fn tier3_force_and_torque_decoupled() {
 /// decelerating; analytically, the final displacement is twice the position
 /// reached at `t = half_duration`. A symmetric triangle of acceleration is
 /// enough to assert that the body behaves linearly.
+// non-recipe: symmetric ±F impulse sequence verifies linearity; the
+// schedule is two `set_body_external_force` calls bracketing a
+// `step_n` count, simpler than instantiating a profile struct.
 #[test]
 fn tier3_force_symmetric_impulse_returns_to_rest() {
     let mass = 100.0;

--- a/crates/jeod_runner/tests/tier3_sim_gj.rs
+++ b/crates/jeod_runner/tests/tier3_sim_gj.rs
@@ -145,6 +145,9 @@ fn run_gj_test(
     report.assert_velocity(vel_tol);
 }
 
+// non-recipe: SIM_GJ_test uses an artificial μ (5.76e14) and CSV t=0 initial
+// conditions; no `recipes::*` building block matches. Helper math for
+// integrator agreement / state error is owned by `CrossvalReport`.
 #[test]
 fn tier3_simulation_gj_order8() {
     // Baseline: GJ order 8, dt=1s.
@@ -160,6 +163,7 @@ fn tier3_simulation_gj_order8() {
     );
 }
 
+// non-recipe: same artificial μ as `tier3_simulation_gj_order8`.
 #[test]
 fn tier3_simulation_gj_order4() {
     // GJ order 4, dt=1s.
@@ -175,6 +179,7 @@ fn tier3_simulation_gj_order4() {
     );
 }
 
+// non-recipe: same artificial μ as `tier3_simulation_gj_order8`.
 #[test]
 fn tier3_simulation_gj_order12() {
     // GJ order 12, dt=1s.
@@ -190,6 +195,8 @@ fn tier3_simulation_gj_order12() {
     );
 }
 
+// non-recipe: same artificial μ as `tier3_simulation_gj_order8`; effective
+// dt scaled via `time_scale_factor`.
 #[test]
 fn tier3_simulation_gj_dt10() {
     // GJ order 8, effective dt=10s. Coarser timestep → larger truncation error.

--- a/crates/jeod_runner/tests/tier3_sim_integ_comparison.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_comparison.rs
@@ -5,9 +5,19 @@
 //!
 //! Scenario: ISS-like circular orbit (a = 6778 km), point-mass Earth gravity,
 //! dt = 10s, propagate for 1 orbit (~5550s, ~92.5 min). 3-DOF (translational only).
+//!
+//! Phase 8 #110 migrated the energy bookkeeping to
+//! `recipes::helpers::energy_conservation` and the integrator-agreement
+//! summary to `recipes::helpers::integrator_agreement`. The custom
+//! propagation loop is unchanged — only setup constants and metric
+//! helpers move into the recipes layer.
 
 use glam::DVec3;
 use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::recipes::helpers::energy_conservation::{
+    specific_orbital_energy, KeplerEnergyMonitor,
+};
+use jeod_sim::recipes::helpers::integrator_agreement::integrator_divergence;
 use jeod_sim::{
     GaussJacksonConfig, GravityControl, GravityControls, GravityModel, GravitySource,
     IntegratorType, SimulationTime, TranslationalState,
@@ -37,11 +47,6 @@ fn init_position() -> DVec3 {
 /// Initial velocity: [0, v_circ, 0] m/s.
 fn init_velocity() -> DVec3 {
     DVec3::new(0.0, circular_velocity(), 0.0)
-}
-
-/// Compute specific orbital energy: E = v^2/2 - mu/r.
-fn specific_energy(pos: DVec3, vel: DVec3) -> f64 {
-    0.5 * vel.length_squared() - MU_EARTH / pos.length()
 }
 
 /// Create a simulation with a single body using the given integrator type.
@@ -97,21 +102,24 @@ fn propagate_one_orbit(integrator: IntegratorType, dt: f64) -> (DVec3, DVec3, f6
          steps = {n_steps}"
     );
     let mut sim = make_sim(integrator, adjusted_dt);
-    let e0 = specific_energy(init_position(), init_velocity());
-
-    let mut max_rel_energy_err = 0.0_f64;
+    let mut monitor = KeplerEnergyMonitor::new(init_position(), init_velocity(), MU_EARTH);
+    // Sanity: the monitor's initial energy must match the inlined formula.
+    let e0 = specific_orbital_energy(init_position(), init_velocity(), MU_EARTH);
+    debug_assert!((monitor.initial_energy() - e0).abs() < 1e-12);
 
     for i in 1..=n_steps {
         let t = (i as f64) * adjusted_dt;
         sim.step_until(t);
         let body = sim.body(0);
-        let e = specific_energy(body.trans.position, body.trans.velocity);
-        let rel_err = ((e - e0) / e0).abs();
-        max_rel_energy_err = max_rel_energy_err.max(rel_err);
+        monitor.observe(body.trans.position, body.trans.velocity);
     }
 
     let body = sim.body(0);
-    (body.trans.position, body.trans.velocity, max_rel_energy_err)
+    (
+        body.trans.position,
+        body.trans.velocity,
+        monitor.max_relative_error(),
+    )
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -169,8 +177,7 @@ fn tier3_integ_rk4_vs_rkf45_agreement() {
     let (pos_rk4, vel_rk4, _) = propagate_one_orbit(IntegratorType::Rk4, dt);
     let (pos_rkf, vel_rkf, _) = propagate_one_orbit(IntegratorType::Rkf45, dt);
 
-    let pos_diff = (pos_rk4 - pos_rkf).length();
-    let vel_diff = (vel_rk4 - vel_rkf).length();
+    let (pos_diff, vel_diff) = integrator_divergence(pos_rk4, vel_rk4, pos_rkf, vel_rkf);
     println!("RK4 vs RKF45 after 1 orbit: pos_diff={pos_diff:.6e} m, vel_diff={vel_diff:.6e} m/s");
 
     // Both are single-step Runge-Kutta methods with dt=10s on a smooth orbit.
@@ -194,8 +201,7 @@ fn tier3_integ_rk4_vs_gj_agreement() {
         dt,
     );
 
-    let pos_diff = (pos_rk4 - pos_gj).length();
-    let vel_diff = (vel_rk4 - vel_gj).length();
+    let (pos_diff, vel_diff) = integrator_divergence(pos_rk4, vel_rk4, pos_gj, vel_gj);
     println!("RK4 vs GJ-8 after 1 orbit: pos_diff={pos_diff:.6e} m, vel_diff={vel_diff:.6e} m/s");
 
     // RK4 and GJ-8 should agree reasonably well for smooth circular orbit.

--- a/crates/jeod_runner/tests/tier3_sim_lsode.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lsode.rs
@@ -255,6 +255,10 @@ fn run_integ_test(
 /// on both sides, the trajectories agree to sub-millimeter scale — any
 /// drift reflects floating-point reduction order differences, not algorithm
 /// divergence.
+// non-recipe: SIM_integ_test derives μ from sma/mean-motion (computed in
+// `compute_mu`), uses CSV t=0 prop_integ_state as IC (deterministically
+// rotated), and applies `time_scale_factor`. None of these match a recipe
+// preset; cross-validation math is owned by `CrossvalReport`.
 #[test]
 fn tier3_simulation_lsode_abm4() {
     // Observed max-component errors over 14 orbits (80000 s sim time):
@@ -281,6 +285,7 @@ fn tier3_simulation_lsode_abm4() {
 /// which is the expected order-4 vs order-~12 truncation difference. This
 /// test documents that drift rather than asserting agreement between
 /// dissimilar integrators.
+// non-recipe: same derived μ + CSV-rotated IC as `tier3_simulation_lsode_abm4`.
 #[test]
 fn tier3_simulation_lsode_default() {
     // Observed max-component errors (ABM4 vs LSODE reference, 14 orbits):

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
@@ -14,13 +14,11 @@
 //!
 //! No Docker reference data required.
 
-mod sim_test_helpers;
-use sim_test_helpers::*;
-
 use glam::DVec3;
 use jeod_runner::{
     DerivedStateConfig, GravitySourceEntry, RotationModel, Simulation, VehicleConfig,
 };
+use jeod_sim::recipes::helpers::state_helpers::max_mat_diff;
 use jeod_sim::{
     GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime,
     TranslationalState,

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_relative.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_relative.rs
@@ -147,11 +147,15 @@ fn run_lvlhrel_scenario(label: &str, csv_name: &str) {
     );
 }
 
+// non-recipe: SIM_LvlhRelative seeds two bodies from JEOD CSV t=0 records;
+// no `recipes::*` preset matches the bespoke 19-column schema. LVLH error
+// metric is `(a - b).length()`, too small to abstract.
 #[test]
 fn tier3_simulation_lvlhrel_test0() {
     run_lvlhrel_scenario("lvlhrel_test0", "lvlhrel_test0_lvlhrel.csv");
 }
 
+// non-recipe: same shape as `tier3_simulation_lvlhrel_test0`.
 #[test]
 fn tier3_simulation_lvlhrel_test1() {
     run_lvlhrel_scenario("lvlhrel_test1", "lvlhrel_test1_lvlhrel.csv");

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_families.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_families.rs
@@ -10,15 +10,14 @@
 //! - Radius constancy for circular orbits
 //! - Periapsis/apoapsis radius bounds for elliptic orbits
 
-mod sim_test_helpers;
-
 use glam::DVec3;
 use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::recipes::helpers::energy_conservation::specific_orbital_energy;
+use jeod_sim::recipes::helpers::state_helpers::state_from_elements;
 use jeod_sim::{
     GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime,
     TranslationalState,
 };
-use sim_test_helpers::state_from_elements;
 
 /// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
 const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
@@ -62,9 +61,12 @@ fn build_sim(trans: TranslationalState, dt: f64) -> Simulation {
     sim
 }
 
-/// Compute specific orbital energy: E = v^2/2 - mu/r.
+/// Specific orbital energy delegate that resolves to
+/// [`recipes::helpers::energy_conservation::specific_orbital_energy`]. Kept
+/// as a local alias so the bespoke conservation loop reads as it did
+/// pre-Phase 8.
 fn specific_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {
-    vel.length_squared() / 2.0 - mu / pos.length()
+    specific_orbital_energy(pos, vel, mu)
 }
 
 /// Compute specific angular momentum magnitude: |h| = |r x v|.

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
@@ -9,13 +9,11 @@
 //! Cartesian-to-element recovery -- ensuring no information is lost
 //! or corrupted through the pipeline.
 
-mod sim_test_helpers;
-
 use glam::DVec3;
 use jeod_math::OrbitalElements;
 use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
+use jeod_sim::recipes::helpers::state_helpers::state_from_elements;
 use jeod_sim::{GravityControl, GravityControls, GravityModel, GravitySource, SimulationTime};
-use sim_test_helpers::state_from_elements;
 
 /// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
 const MU_EARTH: f64 = jeod_sim::EARTH.shape.mu;
@@ -152,7 +150,7 @@ fn roundtrip_via_simulation(
     }
 }
 
-use sim_test_helpers::angle_diff;
+use jeod_sim::recipes::helpers::state_helpers::angle_diff;
 
 // ======================================================================
 // Circular LEO round-trip

--- a/crates/jeod_runner/tests/tier3_sim_relative.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative.rs
@@ -165,6 +165,9 @@ fn run_relative_scenario(label: &str, csv_name: &str) {
     );
 }
 
+// non-recipe: SIM_Relative seeds two bodies (rot+trans) from a 57-column
+// JEOD CSV with no equivalent recipe preset. Error metric is `(a-b).length()`,
+// too small to abstract.
 #[test]
 fn tier3_simulation_relative_ab_rot_ab_trans() {
     run_relative_scenario(
@@ -173,6 +176,7 @@ fn tier3_simulation_relative_ab_rot_ab_trans() {
     );
 }
 
+// non-recipe: same shape as `tier3_simulation_relative_ab_rot_ab_trans`.
 #[test]
 fn tier3_simulation_relative_no_rot_ab_trans() {
     run_relative_scenario(
@@ -181,6 +185,7 @@ fn tier3_simulation_relative_no_rot_ab_trans() {
     );
 }
 
+// non-recipe: same shape as `tier3_simulation_relative_ab_rot_ab_trans`.
 #[test]
 fn tier3_simulation_relative_a_rot_no_trans() {
     run_relative_scenario(

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -82,6 +82,8 @@ fn add_orbital_body(sim: &mut Simulation, earth: usize, trans: TranslationalStat
     });
 }
 
+// non-recipe: bespoke geometry — two vehicles on the same circular orbit
+// with a small along-track Δν offset. No recipe preset captures this pair.
 #[test]
 fn tier3_relative_two_coorbiting_vehicles() {
     // Two vehicles on the same 400 km circular equatorial orbit, separated by
@@ -174,6 +176,8 @@ fn tier3_relative_two_coorbiting_vehicles() {
     );
 }
 
+// non-recipe: chief circular + deputy ellipse with apoapsis at 1.05·r_chief;
+// hand-crafted Hohmann-shape geometry not in `recipes::orbital_elements`.
 #[test]
 fn tier3_relative_hohmann_transfer_geometry() {
     // Chief in circular orbit at 400 km; deputy in a coplanar ellipse whose
@@ -257,6 +261,7 @@ fn tier3_relative_hohmann_transfer_geometry() {
     );
 }
 
+// non-recipe: two-body 90° phase-difference geometry; setup is the assertion.
 #[test]
 fn tier3_relative_same_orbit_phase_difference() {
     // Two vehicles in the same circular orbit, 90° apart in true anomaly.
@@ -325,6 +330,8 @@ fn tier3_relative_same_orbit_phase_difference() {
     );
 }
 
+// non-recipe: chief equatorial vs deputy at +1° inclination — bespoke
+// cross-track geometry test.
 #[test]
 fn tier3_relative_different_inclinations() {
     // Chief on equatorial circular orbit; deputy on the same circular orbit
@@ -386,6 +393,8 @@ fn tier3_relative_different_inclinations() {
     );
 }
 
+// non-recipe: two orbits at different radii to verify r_AB = -r_BA symmetry;
+// the geometry is the test.
 #[test]
 fn tier3_relative_round_trip_frames() {
     // When neither body has a rotational state, the relative-state operator

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -108,6 +108,9 @@ fn srp_sun_position(sim_time: f64, epoch_tai_tjt: f64, ephemeris: &Ephemeris) ->
     sun_pos
 }
 
+// non-recipe: 1st-order SRP scenario loads JEOD reference trajectory from
+// the SIM_dyncomp SRP RUN and compares position. The Sun ephemeris and
+// surface model are bespoke to the JEOD setup.
 #[test]
 fn tier3_srp_1st_order_trajectory() {
     let jeod_root = jeod_test_data::jeod_path();

--- a/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
@@ -174,11 +174,14 @@ fn run_srp_basic_test(csv_filename: &str, label: &str) {
     );
 }
 
+// non-recipe: SIM_1_BASIC SRP scenarios load JEOD facet/surface fixtures
+// from the verification SIM and compare via `load_srp_basic_csv`.
 #[test]
 fn tier3_simulation_srp_basic_default() {
     run_srp_basic_test("srp_basic_srp_basic.csv", "RUN_basic (default surface)");
 }
 
+// non-recipe: same SRP setup, varied surface reflection coefficients.
 #[test]
 fn tier3_simulation_srp_basic_varied_cr() {
     run_srp_basic_test(

--- a/crates/jeod_runner/tests/tier3_sim_srp_rk4_thermal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_rk4_thermal.rs
@@ -105,6 +105,9 @@ fn run_with_order(order: ThermalIntegrationOrder) -> (f64, DVec3) {
     (t, pos)
 }
 
+// non-recipe: SRP thermal integration scenarios; the same orbit run three
+// times with `ThermalIntegrationOrder::{Scheduled,DerivativeFirstOrder,DerivativeRk4}`.
+// Test content is comparing the three modes, no recipe input applies.
 #[test]
 fn tier3_srp_rk4_thermal_differs_from_scheduled() {
     let (t_sched, p_sched) = run_with_order(ThermalIntegrationOrder::Scheduled);

--- a/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
@@ -72,6 +72,10 @@ fn load_reversal_csv(path: &std::path::Path) -> Vec<ReversalRecord> {
 
 /// RUN_1: spherical Earth gravity, forward 60,000 s + reverse 60,000 s.
 /// Validates both time and trajectory against JEOD reference.
+// non-recipe: SIM_7_time_reversal seeds from a JEOD CSV t=0 record (TAI TJT,
+// position, velocity, attitude derived from LVLH+pitch). The bespoke piece
+// is the negative-`time_scale_factor` flip at the reversal index — verified
+// here as part of the simulation pipeline.
 #[test]
 fn tier3_sim_time_reversal_run1() {
     let mu_earth_gemt1 = load_mu_earth_gemt1();
@@ -250,11 +254,13 @@ fn run_reversal_time_only(label: &str, csv_name: &str) {
     );
 }
 
+// non-recipe: time-only round trip; TAI seconds are read from CSV.
 #[test]
 fn tier3_sim_time_reversal_run3a() {
     run_reversal_time_only("reversal_run3a", "reversal_run3a_reversal.csv");
 }
 
+// non-recipe: time-only round trip; TAI seconds are read from CSV.
 #[test]
 fn tier3_sim_time_reversal_run8b() {
     run_reversal_time_only("reversal_run8b", "reversal_run8b_reversal.csv");

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -425,6 +425,13 @@ fn run_propagation_test(
 
 // -- Individual test functions --
 
+// non-recipe (all 6 runs): SIM_torque_compare_simple seeds ISS mass props
+// from JEOD `Modified_data/mass.py` (set_mass_iss) — a complete
+// non-diagonal inertia tensor with off-CoM offset that the
+// `recipes::vehicle::iss_mass()` scalar can't represent. CSV t=0 also
+// supplies position/velocity/quaternion/ang_vel. Helper math
+// (`quaternion_angle_error`) is hoisted via `sim_test_helpers`'s
+// re-export of `recipes::helpers::state_helpers::jeodquat_angle_error`.
 #[test]
 fn tier3_torque_simple_run01() {
     run_propagation_test(

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -430,8 +430,9 @@ fn run_propagation_test(
 // non-diagonal inertia tensor with off-CoM offset that the
 // `recipes::vehicle::iss_mass()` scalar can't represent. CSV t=0 also
 // supplies position/velocity/quaternion/ang_vel. Helper math
-// (`quaternion_angle_error`) is hoisted via `sim_test_helpers`'s
-// re-export of `recipes::helpers::state_helpers::jeodquat_angle_error`.
+// (`quaternion_angle_error`) is provided by `sim_test_helpers` as a
+// thin wrapper that delegates to
+// `recipes::helpers::state_helpers::jeodquat_angle_error`.
 #[test]
 fn tier3_torque_simple_run01() {
     run_propagation_test(

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -425,7 +425,7 @@ fn run_propagation_test(
 
 // -- Individual test functions --
 
-// non-recipe (all 6 runs): SIM_torque_compare_simple seeds ISS mass props
+// non-recipe: all 6 runs of SIM_torque_compare_simple seed ISS mass props
 // from JEOD `Modified_data/mass.py` (set_mass_iss) — a complete
 // non-diagonal inertia tensor with off-CoM offset that the
 // `recipes::vehicle::iss_mass()` scalar can't represent. CSV t=0 also

--- a/crates/jeod_sim/src/recipes/helpers/attach_detach_helpers.rs
+++ b/crates/jeod_sim/src/recipes/helpers/attach_detach_helpers.rs
@@ -1,0 +1,96 @@
+//! Time-stamped mass-tree event schedule for attach / detach tests.
+//!
+//! Phase 8 of #101: lifted from inlined `match step { ... }` patterns
+//! in the `tier3_sim_attach*.rs` family. The schedule lets a bespoke
+//! propagation loop ask "should I apply an event at time `t`?" without
+//! sprinkling step-count arithmetic through the test body.
+
+/// A single mass-tree event. The tag is opaque — tests interpret it
+/// through their own match.
+#[derive(Debug, Clone, Copy)]
+pub struct AttachDetachEvent<E> {
+    /// Simulation time (s) at which the event fires.
+    pub time: f64,
+    /// Test-specific event tag (typically `Attach` / `Detach`).
+    pub event: E,
+}
+
+impl<E> AttachDetachEvent<E> {
+    pub fn new(time: f64, event: E) -> Self {
+        Self { time, event }
+    }
+}
+
+/// Sorted-by-time queue of mass-tree events.
+///
+/// Tests typically build the schedule once at setup and call
+/// [`take_due`](Self::take_due) each step with the current sim time.
+#[derive(Debug, Clone, Default)]
+pub struct EventSchedule<E> {
+    pending: std::collections::VecDeque<AttachDetachEvent<E>>,
+}
+
+impl<E: Copy> EventSchedule<E> {
+    /// Build a schedule from a slice; sorts by ascending time.
+    pub fn new(events: &[AttachDetachEvent<E>]) -> Self {
+        let mut v: Vec<_> = events.to_vec();
+        v.sort_by(|a, b| {
+            a.time
+                .partial_cmp(&b.time)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        Self {
+            pending: v.into_iter().collect(),
+        }
+    }
+
+    /// Pop and return all events whose `time <= now`.
+    pub fn take_due(&mut self, now: f64) -> Vec<AttachDetachEvent<E>> {
+        let mut due = Vec::new();
+        while let Some(front) = self.pending.front() {
+            if front.time <= now {
+                due.push(self.pending.pop_front().unwrap());
+            } else {
+                break;
+            }
+        }
+        due
+    }
+
+    /// Number of events not yet fired.
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Returns `true` once every event has fired.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Ev {
+        Attach,
+        Detach,
+    }
+
+    #[test]
+    fn fires_in_time_order() {
+        let mut sched = EventSchedule::new(&[
+            AttachDetachEvent::new(20.0, Ev::Detach),
+            AttachDetachEvent::new(10.0, Ev::Attach),
+        ]);
+        assert_eq!(sched.pending_len(), 2);
+        let due = sched.take_due(15.0);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].event, Ev::Attach);
+        let due = sched.take_due(25.0);
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].event, Ev::Detach);
+        assert!(sched.is_empty());
+    }
+}

--- a/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
+++ b/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
@@ -48,9 +48,12 @@ pub fn read_lines(path: &Path, sim_label: &str) -> Vec<Vec<f64>> {
             .enumerate()
             .map(|(col, s)| {
                 let token = s.trim();
+                // 1-based column number to match editor / grep output
+                // conventions (`enumerate()` is 0-based).
+                let col_no = col + 1;
                 token.parse::<f64>().unwrap_or_else(|e| {
                     panic!(
-                        "CSV parse error at {path_display}:{line_no}:{col} \
+                        "CSV parse error at {path_display}:{line_no}:{col_no} \
                          (sim {sim_label}): {token:?} — {e}"
                     )
                 })

--- a/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
+++ b/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
@@ -1,0 +1,43 @@
+//! Schema-flexible CSV reader for ad-hoc test formats.
+//!
+//! Phase 7's [`recipes::verification::csv_loader`](super::super::verification)
+//! owns the typed CSV loaders for the standard JEOD reference logs
+//! (`SIM_dyncomp`, `SIM_LVLH`, etc.). This module provides the
+//! one-off / line-by-line escape hatch for archetype-B tests whose
+//! format is unique enough that defining a typed loader for them
+//! would have a single user.
+//!
+//! The function is intentionally minimal: read every line, skip
+//! blanks and the header, return parsed `Vec<Vec<f64>>`. Callers
+//! convert to their own record struct with field indices documented
+//! at the call site.
+
+use std::path::Path;
+
+/// Read a CSV file and return one `Vec<f64>` per non-empty data row,
+/// skipping the first line (header).
+///
+/// On read failure, panics with a helpful message that includes the
+/// command to regenerate test data via Docker.
+pub fn read_lines(path: &Path, sim_label: &str) -> Vec<Vec<f64>> {
+    let content = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        panic!(
+            "Failed to read {sim_label} CSV from {}: {e}\n\
+             Generate with: docker run --rm -v $(pwd)/test_data:/output \
+             -v $(pwd)/trick/generate_references.sh:/generate_references.sh:ro jeod-trick",
+            path.display()
+        )
+    });
+    let mut rows = Vec::new();
+    for (i, line) in content.lines().enumerate() {
+        if i == 0 || line.trim().is_empty() {
+            continue;
+        }
+        let row: Vec<f64> = line
+            .split(',')
+            .map(|s| s.trim().parse::<f64>().unwrap_or(f64::NAN))
+            .collect();
+        rows.push(row);
+    }
+    rows
+}

--- a/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
+++ b/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
@@ -1,16 +1,20 @@
 //! Schema-flexible CSV reader for ad-hoc test formats.
 //!
-//! Phase 7's [`recipes::verification::csv_loader`](super::super::verification)
-//! owns the typed CSV loaders for the standard JEOD reference logs
-//! (`SIM_dyncomp`, `SIM_LVLH`, etc.). This module provides the
-//! one-off / line-by-line escape hatch for archetype-B tests whose
-//! format is unique enough that defining a typed loader for them
-//! would have a single user.
+//! The typed CSV catalogue lives in [`jeod_test_data::tier3_csv`] (and
+//! its predecessor `jeod_test_data::dyncomp_csv`); those loaders own
+//! the standard JEOD reference logs (`SIM_dyncomp`, `SIM_LVLH`, …).
+//! This module provides the one-off / line-by-line escape hatch for
+//! archetype-B tests whose format is unique enough that defining a
+//! typed loader for them would have a single user.
 //!
 //! The function is intentionally minimal: read every line, skip
 //! blanks and the header, return parsed `Vec<Vec<f64>>`. Callers
 //! convert to their own record struct with field indices documented
 //! at the call site.
+//!
+//! Per the project's "no graceful skip" rule, malformed numeric
+//! fields panic with the exact `path:line:col` and offending token
+//! rather than silently turning into `f64::NAN`.
 
 use std::path::Path;
 
@@ -18,7 +22,9 @@ use std::path::Path;
 /// skipping the first line (header).
 ///
 /// On read failure, panics with a helpful message that includes the
-/// command to regenerate test data via Docker.
+/// command to regenerate test data via Docker. On parse failure of
+/// any field, panics with the offending `path:line:col` and the raw
+/// token so the malformed input is never silently coerced to `NaN`.
 pub fn read_lines(path: &Path, sim_label: &str) -> Vec<Vec<f64>> {
     let content = std::fs::read_to_string(path).unwrap_or_else(|e| {
         panic!(
@@ -28,14 +34,27 @@ pub fn read_lines(path: &Path, sim_label: &str) -> Vec<Vec<f64>> {
             path.display()
         )
     });
+    let path_display = path.display();
     let mut rows = Vec::new();
+    // 1-based line numbers in the panic message match what an editor
+    // jumps to. `i` here is 0-based over `lines()`, so add 1.
     for (i, line) in content.lines().enumerate() {
         if i == 0 || line.trim().is_empty() {
             continue;
         }
+        let line_no = i + 1;
         let row: Vec<f64> = line
             .split(',')
-            .map(|s| s.trim().parse::<f64>().unwrap_or(f64::NAN))
+            .enumerate()
+            .map(|(col, s)| {
+                let token = s.trim();
+                token.parse::<f64>().unwrap_or_else(|e| {
+                    panic!(
+                        "CSV parse error at {path_display}:{line_no}:{col} \
+                         (sim {sim_label}): {token:?} — {e}"
+                    )
+                })
+            })
             .collect();
         rows.push(row);
     }

--- a/crates/jeod_sim/src/recipes/helpers/energy_conservation.rs
+++ b/crates/jeod_sim/src/recipes/helpers/energy_conservation.rs
@@ -1,0 +1,93 @@
+//! Specific orbital energy bookkeeping for energy-conservation tests.
+//!
+//! Phase 8 of #101: extracted from inlined patterns in
+//! `tier3_sim_integ_comparison.rs`. These tests propagate a circular
+//! orbit and assert that `max |relative energy error|` against the
+//! initial energy stays below an integrator-specific threshold.
+
+use glam::DVec3;
+
+/// Two-body specific orbital energy `E = v²/2 − μ/r` (units: m²/s²).
+pub fn specific_orbital_energy(pos: DVec3, vel: DVec3, mu: f64) -> f64 {
+    0.5 * vel.length_squared() - mu / pos.length()
+}
+
+/// Streaming Kepler-energy monitor.
+///
+/// Records the energy at the t = 0 sample and tracks
+/// `max |E(t) − E(0)| / |E(0)|` across subsequent steps.
+///
+/// ```
+/// use glam::DVec3;
+/// use jeod_sim::recipes::helpers::energy_conservation::KeplerEnergyMonitor;
+/// let mu = 3.986_004_415e14_f64;
+/// let r = DVec3::new(7_000_000.0, 0.0, 0.0);
+/// let v = DVec3::new(0.0, (mu / 7_000_000.0_f64).sqrt(), 0.0);
+/// let mut mon = KeplerEnergyMonitor::new(r, v, mu);
+/// mon.observe(r, v);
+/// assert!(mon.max_relative_error() < 1e-15);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct KeplerEnergyMonitor {
+    mu: f64,
+    e0: f64,
+    max_rel_err: f64,
+}
+
+impl KeplerEnergyMonitor {
+    /// Construct from the t = 0 state.
+    pub fn new(pos0: DVec3, vel0: DVec3, mu: f64) -> Self {
+        Self {
+            mu,
+            e0: specific_orbital_energy(pos0, vel0, mu),
+            max_rel_err: 0.0,
+        }
+    }
+
+    /// Record a new state and update the running max.
+    pub fn observe(&mut self, pos: DVec3, vel: DVec3) {
+        let e = specific_orbital_energy(pos, vel, self.mu);
+        let rel = ((e - self.e0) / self.e0).abs();
+        if rel > self.max_rel_err {
+            self.max_rel_err = rel;
+        }
+    }
+
+    /// Initial energy E(0).
+    pub fn initial_energy(&self) -> f64 {
+        self.e0
+    }
+
+    /// `max |ΔE / E(0)|` across all observed states.
+    pub fn max_relative_error(&self) -> f64 {
+        self.max_rel_err
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circular_orbit_energy_matches_minus_mu_over_2a() {
+        let mu = 3.986_004_415e14;
+        let a = 7_000_000.0;
+        let r = DVec3::new(a, 0.0, 0.0);
+        let v = DVec3::new(0.0, (mu / a).sqrt(), 0.0);
+        let e = specific_orbital_energy(r, v, mu);
+        let expected = -mu / (2.0 * a);
+        assert!((e - expected).abs() < 1e-3);
+    }
+
+    #[test]
+    fn monitor_zero_for_identical_states() {
+        let mu = 3.986_004_415e14_f64;
+        let r = DVec3::new(7_000_000.0, 0.0, 0.0);
+        let v = DVec3::new(0.0, (mu / 7_000_000.0_f64).sqrt(), 0.0);
+        let mut mon = KeplerEnergyMonitor::new(r, v, mu);
+        for _ in 0..10 {
+            mon.observe(r, v);
+        }
+        assert!(mon.max_relative_error().abs() < 1e-15);
+    }
+}

--- a/crates/jeod_sim/src/recipes/helpers/force_torque_profiles.rs
+++ b/crates/jeod_sim/src/recipes/helpers/force_torque_profiles.rs
@@ -1,0 +1,100 @@
+//! Step / ramp / sinusoid input profiles for force–torque response
+//! tests.
+//!
+//! Phase 8 of #101: bespoke step/ramp inputs are a recurring pattern
+//! in the `tier3_sim_force_torque_response.rs` family. This module
+//! packages the patterns; it does not introduce new physics.
+
+use glam::DVec3;
+
+/// Constant input applied for `t >= t_on`, zero before.
+pub fn step_input(amplitude: DVec3, t_on: f64, t: f64) -> DVec3 {
+    if t >= t_on {
+        amplitude
+    } else {
+        DVec3::ZERO
+    }
+}
+
+/// Linear ramp: zero before `t_on`, `amplitude` from `t_on + duration`
+/// onwards, linear interpolation in between.
+#[derive(Debug, Clone, Copy)]
+pub struct RampInput {
+    pub amplitude: DVec3,
+    pub t_on: f64,
+    pub duration: f64,
+}
+
+impl RampInput {
+    pub fn evaluate(&self, t: f64) -> DVec3 {
+        if t < self.t_on {
+            DVec3::ZERO
+        } else if t >= self.t_on + self.duration {
+            self.amplitude
+        } else {
+            let alpha = (t - self.t_on) / self.duration;
+            self.amplitude * alpha
+        }
+    }
+}
+
+/// Sinusoidal input: `amplitude * sin(2π f (t − t_on))` for
+/// `t >= t_on`, zero before.
+#[derive(Debug, Clone, Copy)]
+pub struct SinusoidInput {
+    pub amplitude: DVec3,
+    pub frequency_hz: f64,
+    pub t_on: f64,
+}
+
+impl SinusoidInput {
+    pub fn evaluate(&self, t: f64) -> DVec3 {
+        if t < self.t_on {
+            return DVec3::ZERO;
+        }
+        let phase = 2.0 * std::f64::consts::PI * self.frequency_hz * (t - self.t_on);
+        self.amplitude * phase.sin()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_off_then_on() {
+        let amp = DVec3::new(1.0, 2.0, 3.0);
+        assert_eq!(step_input(amp, 1.0, 0.0), DVec3::ZERO);
+        assert_eq!(step_input(amp, 1.0, 1.0), amp);
+        assert_eq!(step_input(amp, 1.0, 5.0), amp);
+    }
+
+    #[test]
+    fn ramp_endpoints_and_midpoint() {
+        let r = RampInput {
+            amplitude: DVec3::new(1.0, 0.0, 0.0),
+            t_on: 0.0,
+            duration: 2.0,
+        };
+        assert_eq!(r.evaluate(-1.0), DVec3::ZERO);
+        assert_eq!(r.evaluate(0.0), DVec3::ZERO);
+        let mid = r.evaluate(1.0);
+        assert!((mid.x - 0.5).abs() < 1e-15);
+        assert_eq!(r.evaluate(2.0), DVec3::new(1.0, 0.0, 0.0));
+        assert_eq!(r.evaluate(3.0), DVec3::new(1.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn sinusoid_zero_at_phase_zero_and_pi() {
+        let s = SinusoidInput {
+            amplitude: DVec3::new(1.0, 0.0, 0.0),
+            frequency_hz: 1.0,
+            t_on: 0.0,
+        };
+        assert!(s.evaluate(0.0).length() < 1e-15);
+        assert!(s.evaluate(0.5).length() < 1e-15);
+        // Quarter cycle: amplitude.
+        let q = s.evaluate(0.25);
+        assert!((q.x - 1.0).abs() < 1e-12);
+    }
+}

--- a/crates/jeod_sim/src/recipes/helpers/integrator_agreement.rs
+++ b/crates/jeod_sim/src/recipes/helpers/integrator_agreement.rs
@@ -1,0 +1,63 @@
+//! Cross-integrator agreement bookkeeping.
+//!
+//! Phase 8 of #101: lifted from the inlined pattern in
+//! `tier3_sim_integ_comparison.rs`. Tests propagate the same scenario
+//! through two integrators (e.g. RK4 vs RKF45) and assert that the
+//! per-component divergence at the final time stays below a threshold.
+//!
+//! The actual propagation is left to the test's bespoke loop — this
+//! module is just a small struct that bundles the two final states and
+//! exposes their difference magnitudes.
+
+use glam::DVec3;
+
+/// Bundle of the two final states produced by two integrators on the
+/// same scenario.
+#[derive(Debug, Clone, Copy)]
+pub struct IntegratorAgreement {
+    /// Final position from integrator A.
+    pub pos_a: DVec3,
+    /// Final velocity from integrator A.
+    pub vel_a: DVec3,
+    /// Final position from integrator B.
+    pub pos_b: DVec3,
+    /// Final velocity from integrator B.
+    pub vel_b: DVec3,
+}
+
+impl IntegratorAgreement {
+    /// Magnitude of the position difference (m).
+    pub fn position_diff(&self) -> f64 {
+        (self.pos_a - self.pos_b).length()
+    }
+
+    /// Magnitude of the velocity difference (m/s).
+    pub fn velocity_diff(&self) -> f64 {
+        (self.vel_a - self.vel_b).length()
+    }
+}
+
+/// Convenience: return `(pos_diff, vel_diff)` magnitudes.
+pub fn integrator_divergence(pos_a: DVec3, vel_a: DVec3, pos_b: DVec3, vel_b: DVec3) -> (f64, f64) {
+    let agr = IntegratorAgreement {
+        pos_a,
+        vel_a,
+        pos_b,
+        vel_b,
+    };
+    (agr.position_diff(), agr.velocity_diff())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_diff_for_identical_states() {
+        let p = DVec3::new(1.0, 2.0, 3.0);
+        let v = DVec3::new(4.0, 5.0, 6.0);
+        let (dp, dv) = integrator_divergence(p, v, p, v);
+        assert!(dp.abs() < 1e-15);
+        assert!(dv.abs() < 1e-15);
+    }
+}

--- a/crates/jeod_sim/src/recipes/helpers/mod.rs
+++ b/crates/jeod_sim/src/recipes/helpers/mod.rs
@@ -1,0 +1,57 @@
+//! Tier 3 propagation helpers shared by `recipes` and Tier 3 tests.
+//!
+//! Phase 8 of #101 hoisted these utilities out of
+//! `crates/jeod_runner/tests/sim_test_helpers/mod.rs` so that
+//! archetype-B tests (those with bespoke per-step measurement loops:
+//! periapsis detection, energy conservation, integrator agreement,
+//! attach/detach event scheduling, etc.) can consume them through the
+//! same `recipes::*` namespace as their setup.
+//!
+//! These are **propagation utilities** only — schema-flexible CSV
+//! readers (which are reference-data plumbing, not propagation) live
+//! in [`recipes::verification::csv_loader`](super::verification) and
+//! are owned by Phase 7. Tests that don't fit a standard scenario but
+//! share these mid-loop bookkeeping patterns reach for the
+//! corresponding submodule below.
+//!
+//! Submodules:
+//!
+//! - [`state_helpers`]: quaternion / matrix angular-error metrics, the
+//!   2π-wraparound `angle_diff`, and a `state_from_elements` shortcut
+//!   that builds a [`TranslationalState`](crate::TranslationalState)
+//!   from raw Keplerian elements (handles e ≥ 1).
+//! - [`energy_conservation`]: extract specific orbital energy each
+//!   step, accumulate `max |relative error|` against the t = 0 value.
+//! - [`periapsis_detection`]: zero-crossing of radial velocity for
+//!   Kepler / GR perihelion-advance studies.
+//! - [`integrator_agreement`]: propagate the same scenario through two
+//!   integrators and report the per-component divergence.
+//! - [`force_torque_profiles`]: piecewise step / ramp / sinusoid input
+//!   shapes for force–torque response tests.
+//! - [`orbinit_case`]: bundle of (orbital elements, tolerance) for
+//!   parametric orbital-init roundtrip suites.
+//! - [`attach_detach_helpers`]: time-stamped mass-tree event schedule
+//!   wrapper for attach / detach tests.
+//! - [`custom_csv`]: schema-flexible CSV reader for ad-hoc test
+//!   formats that don't yet have a dedicated loader in
+//!   `verification::csv_loader`.
+
+pub mod attach_detach_helpers;
+pub mod custom_csv;
+pub mod energy_conservation;
+pub mod force_torque_profiles;
+pub mod integrator_agreement;
+pub mod orbinit_case;
+pub mod periapsis_detection;
+pub mod state_helpers;
+
+pub use attach_detach_helpers::{AttachDetachEvent, EventSchedule};
+pub use custom_csv::read_lines;
+pub use energy_conservation::{specific_orbital_energy, KeplerEnergyMonitor};
+pub use force_torque_profiles::{step_input, RampInput, SinusoidInput};
+pub use integrator_agreement::{integrator_divergence, IntegratorAgreement};
+pub use orbinit_case::OrbInitCase;
+pub use periapsis_detection::{detect_periapsis_passages, PeriapsisEvent};
+pub use state_helpers::{
+    angle_diff, dquat_angle_error, jeodquat_angle_error, max_mat_diff, state_from_elements,
+};

--- a/crates/jeod_sim/src/recipes/helpers/mod.rs
+++ b/crates/jeod_sim/src/recipes/helpers/mod.rs
@@ -9,10 +9,10 @@
 //!
 //! These are **propagation utilities** only — schema-flexible CSV
 //! readers (which are reference-data plumbing, not propagation) live
-//! in [`recipes::verification::csv_loader`](super::verification) and
-//! are owned by Phase 7. Tests that don't fit a standard scenario but
-//! share these mid-loop bookkeeping patterns reach for the
-//! corresponding submodule below.
+//! in [`jeod_test_data::tier3_csv`] (the typed Phase 7 catalogue, with
+//! `dyncomp_csv` as its current entry). Tests that don't fit a
+//! standard scenario but share these mid-loop bookkeeping patterns
+//! reach for the corresponding submodule below.
 //!
 //! Submodules:
 //!
@@ -33,8 +33,8 @@
 //! - [`attach_detach_helpers`]: time-stamped mass-tree event schedule
 //!   wrapper for attach / detach tests.
 //! - [`custom_csv`]: schema-flexible CSV reader for ad-hoc test
-//!   formats that don't yet have a dedicated loader in
-//!   `verification::csv_loader`.
+//!   formats that don't yet have a dedicated typed loader in
+//!   [`jeod_test_data::tier3_csv`].
 
 pub mod attach_detach_helpers;
 pub mod custom_csv;

--- a/crates/jeod_sim/src/recipes/helpers/orbinit_case.rs
+++ b/crates/jeod_sim/src/recipes/helpers/orbinit_case.rs
@@ -1,0 +1,30 @@
+//! Parametric orbital-init test-case bundle.
+//!
+//! Used by `tier3_sim_orbinit_*.rs` families that loop over many
+//! `(orbital elements, tolerance)` pairs and assert a roundtrip
+//! `state -> elements -> state` invariance.
+
+use jeod_math::OrbitalElements;
+
+/// A single orbital-init test case: a label, its starting orbital
+/// elements, and the position-roundtrip tolerance to assert. The
+/// tolerance is in meters and is consumed verbatim by the test asserts
+/// — see [the type-system refactor's Phase-0 baseline freeze
+/// policy](../../../../../CLAUDE.md#cross-validation-tolerances) for
+/// why test code (not this struct) owns tolerance values.
+#[derive(Debug, Clone)]
+pub struct OrbInitCase {
+    pub label: &'static str,
+    pub elements: OrbitalElements,
+    pub position_tol_m: f64,
+}
+
+impl OrbInitCase {
+    pub fn new(label: &'static str, elements: OrbitalElements, position_tol_m: f64) -> Self {
+        Self {
+            label,
+            elements,
+            position_tol_m,
+        }
+    }
+}

--- a/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
+++ b/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
@@ -1,0 +1,122 @@
+//! Periapsis-passage detection via radial-velocity zero crossing.
+//!
+//! Used by Mercury / GR perihelion-advance tests where the bespoke
+//! per-step loop captures an event each time `dr/dt` flips from
+//! negative to positive (the body has passed periapsis since the
+//! previous step).
+
+use glam::DVec3;
+
+/// A periapsis-passage event: the simulation time at the crossing
+/// (linear interpolation against the radial-velocity sign change is
+/// **not** performed here — callers that need sub-step precision
+/// should refit), and the longitude of perihelion
+/// `arg_periapsis + long_asc_node` (radians).
+#[derive(Debug, Clone, Copy)]
+pub struct PeriapsisEvent {
+    /// Time of detection (s, simulation epoch-relative).
+    pub time: f64,
+    /// Longitude of perihelion (rad), invariant to nodal regression.
+    pub long_perihelion: f64,
+}
+
+/// Streaming periapsis detector.
+///
+/// Feed each `(time, position, velocity)` sample; emits at most one
+/// event per call. Returns `Some(event)` when the radial velocity
+/// `r·v / |r|` transitions from negative to non-negative between the
+/// previous and current samples.
+#[derive(Debug, Clone, Copy)]
+pub struct PeriapsisDetector {
+    prev_rdot: f64,
+    initialized: bool,
+}
+
+impl Default for PeriapsisDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PeriapsisDetector {
+    pub fn new() -> Self {
+        Self {
+            prev_rdot: 0.0,
+            initialized: false,
+        }
+    }
+
+    /// Reset the detector so the next call seeds the previous radial
+    /// velocity without emitting an event.
+    pub fn reset(&mut self) {
+        self.initialized = false;
+        self.prev_rdot = 0.0;
+    }
+
+    /// Returns `true` if the previous-to-current sample contains a
+    /// periapsis crossing (radial velocity transitions from `< 0` to
+    /// `≥ 0`).
+    pub fn observe(&mut self, pos: DVec3, vel: DVec3) -> bool {
+        let r_dot = pos.dot(vel) / pos.length();
+        let crossed = self.initialized && self.prev_rdot < 0.0 && r_dot >= 0.0;
+        self.prev_rdot = r_dot;
+        self.initialized = true;
+        crossed
+    }
+}
+
+/// Sweep an iterator of `(time, position, velocity)` samples and
+/// return all detected periapsis events. The orbital elements are
+/// computed at the post-crossing sample via `OrbitalElements::from_cartesian`,
+/// giving longitude of perihelion `arg_periapsis + long_asc_node`.
+///
+/// Used by `tier3_sim_mercury` for both the in-memory sim trace and
+/// the JEOD CSV trace (they share this loop body).
+#[allow(deprecated)]
+pub fn detect_periapsis_passages<I>(samples: I, mu: f64) -> Vec<PeriapsisEvent>
+where
+    I: IntoIterator<Item = (f64, DVec3, DVec3)>,
+{
+    use jeod_math::OrbitalElements;
+    let mut det = PeriapsisDetector::new();
+    let mut events = Vec::new();
+    for (t, r, v) in samples {
+        if det.observe(r, v) {
+            // `from_cartesian` is the deprecated untyped path; the
+            // typed migration is tracked separately in #104. Honour
+            // existing call-site behaviour — we want bit-identical
+            // output across the refactor.
+            if let Ok(oe) = OrbitalElements::from_cartesian(mu, r, v) {
+                events.push(PeriapsisEvent {
+                    time: t,
+                    long_perihelion: oe.arg_periapsis + oe.long_asc_node,
+                });
+            }
+        }
+    }
+    events
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detector_emits_on_negative_to_positive_crossing() {
+        let mut det = PeriapsisDetector::new();
+        // Sample 1: r·v < 0 (approaching periapsis).
+        let crossed_1 = det.observe(DVec3::X, -DVec3::X);
+        assert!(!crossed_1, "first sample seeds prev_rdot, no event");
+        // Sample 2: r·v > 0 (post-periapsis).
+        let crossed_2 = det.observe(DVec3::X, DVec3::X);
+        assert!(crossed_2);
+    }
+
+    #[test]
+    fn detector_quiet_when_monotonic() {
+        let mut det = PeriapsisDetector::new();
+        det.observe(DVec3::X, DVec3::X); // seed
+        let crossed = det.observe(DVec3::X, DVec3::X);
+        assert!(!crossed);
+    }
+}

--- a/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
+++ b/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
@@ -67,26 +67,29 @@ impl PeriapsisDetector {
 
 /// Sweep an iterator of `(time, position, velocity)` samples and
 /// return all detected periapsis events. The orbital elements are
-/// computed at the post-crossing sample via `OrbitalElements::from_cartesian`,
-/// giving longitude of perihelion `arg_periapsis + long_asc_node`.
+/// computed at the post-crossing sample via
+/// `OrbitalElements::from_cartesian_typed`, giving longitude of
+/// perihelion `arg_periapsis + long_asc_node`.
 ///
 /// Used by `tier3_sim_mercury` for both the in-memory sim trace and
 /// the JEOD CSV trace (they share this loop body).
-#[allow(deprecated)]
 pub fn detect_periapsis_passages<I>(samples: I, mu: f64) -> Vec<PeriapsisEvent>
 where
     I: IntoIterator<Item = (f64, DVec3, DVec3)>,
 {
     use jeod_math::OrbitalElements;
+    use jeod_quantities::aliases::{Position, Velocity};
+    use jeod_quantities::ext::F64Ext;
+    use jeod_quantities::frame::Inertial;
+
+    let mu_typed = mu.m3_per_s2();
     let mut det = PeriapsisDetector::new();
     let mut events = Vec::new();
     for (t, r, v) in samples {
         if det.observe(r, v) {
-            // `from_cartesian` is the deprecated untyped path; the
-            // typed migration is tracked separately in #104. Honour
-            // existing call-site behaviour — we want bit-identical
-            // output across the refactor.
-            if let Ok(oe) = OrbitalElements::from_cartesian(mu, r, v) {
+            let pos_typed = Position::<Inertial>::from_raw_si(r);
+            let vel_typed = Velocity::<Inertial>::from_raw_si(v);
+            if let Ok(oe) = OrbitalElements::from_cartesian_typed(mu_typed, pos_typed, vel_typed) {
                 events.push(PeriapsisEvent {
                     time: t,
                     long_perihelion: oe.arg_periapsis + oe.long_asc_node,

--- a/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
+++ b/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
@@ -89,12 +89,17 @@ where
         if det.observe(r, v) {
             let pos_typed = Position::<Inertial>::from_raw_si(r);
             let vel_typed = Velocity::<Inertial>::from_raw_si(v);
-            if let Ok(oe) = OrbitalElements::from_cartesian_typed(mu_typed, pos_typed, vel_typed) {
-                events.push(PeriapsisEvent {
-                    time: t,
-                    long_perihelion: oe.arg_periapsis + oe.long_asc_node,
+            let oe = OrbitalElements::from_cartesian_typed(mu_typed, pos_typed, vel_typed)
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "periapsis_detection: from_cartesian_typed failed at t={t}, \
+                         position={r:?}, velocity={v:?}: {e:?}"
+                    )
                 });
-            }
+            events.push(PeriapsisEvent {
+                time: t,
+                long_perihelion: oe.arg_periapsis + oe.long_asc_node,
+            });
         }
     }
     events

--- a/crates/jeod_sim/src/recipes/helpers/state_helpers.rs
+++ b/crates/jeod_sim/src/recipes/helpers/state_helpers.rs
@@ -1,0 +1,156 @@
+//! Per-step state-error metrics used by archetype-B Tier 3 tests.
+//!
+//! Hoisted in Phase 8 of #101 from
+//! `crates/jeod_runner/tests/sim_test_helpers/mod.rs` (verbatim — only
+//! the location changes).
+
+use glam::{DMat3, DQuat};
+
+use crate::TranslationalState;
+use jeod_math::{JeodQuat, OrbitalElements};
+
+/// Smallest rotation angle (radians) between two scalar-first JEOD
+/// quaternions — `2 * acos(|<q1, q2>|)`.
+pub fn jeodquat_angle_error(q1: &JeodQuat, q2: &JeodQuat) -> f64 {
+    let dot = (q1.scalar() * q2.scalar()
+        + q1.vector().x * q2.vector().x
+        + q1.vector().y * q2.vector().y
+        + q1.vector().z * q2.vector().z)
+        .abs();
+    2.0 * dot.min(1.0).acos()
+}
+
+/// Smallest rotation angle (radians) between two `glam::DQuat` values.
+pub fn dquat_angle_error(a: DQuat, b: DQuat) -> f64 {
+    let dot = a.dot(b).abs();
+    2.0 * dot.min(1.0).acos()
+}
+
+/// Angular difference accounting for 2π wraparound. Returns the
+/// magnitude (≥ 0) in `[0, π]`.
+pub fn angle_diff(a: f64, b: f64) -> f64 {
+    let tau = 2.0 * std::f64::consts::PI;
+    let mut d = (a - b) % tau;
+    if d > std::f64::consts::PI {
+        d -= tau;
+    }
+    if d < -std::f64::consts::PI {
+        d += tau;
+    }
+    d.abs()
+}
+
+/// Max absolute element-wise difference between two 3×3 matrices.
+pub fn max_mat_diff(a: &DMat3, b: &DMat3) -> f64 {
+    let mut max_d = 0.0_f64;
+    for c in 0..3 {
+        for r in 0..3 {
+            let d = (a.col(c)[r] - b.col(c)[r]).abs();
+            max_d = max_d.max(d);
+        }
+    }
+    max_d
+}
+
+/// Initialize a [`TranslationalState`] from classical orbital elements.
+/// Works for all eccentricities including hyperbolic (e ≥ 1).
+///
+/// Mirrors `OrbitalElements::to_cartesian` but accepts loose scalar
+/// inputs for the parametric orbinit families that test edge cases
+/// across many eccentricities.
+pub fn state_from_elements(
+    a: f64,
+    e: f64,
+    i: f64,
+    raan: f64,
+    argp: f64,
+    nu: f64,
+    mu: f64,
+) -> TranslationalState {
+    let mut oe = OrbitalElements::default();
+    oe.semi_major_axis = a;
+    oe.e_mag = e;
+    oe.inclination = i;
+    oe.long_asc_node = raan;
+    oe.arg_periapsis = argp;
+    oe.true_anom = nu;
+
+    if e < 1.0 {
+        oe.semiparam = a * (1.0 - e * e);
+    } else {
+        // Hyperbolic: a is negative, p = a (1 - e²) = |a| (e² - 1).
+        oe.semiparam = a.abs() * (e * e - 1.0);
+    }
+    oe.nu_to_anomalies();
+
+    let (position, velocity) = oe.to_cartesian(mu).expect("to_cartesian failed");
+    TranslationalState { position, velocity }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dquat_angle_identity_zero() {
+        assert!(dquat_angle_error(DQuat::IDENTITY, DQuat::IDENTITY).abs() < 1e-15);
+    }
+
+    #[test]
+    fn jeodquat_angle_identity_zero() {
+        let q = JeodQuat::identity();
+        assert!(jeodquat_angle_error(&q, &q).abs() < 1e-15);
+    }
+
+    #[test]
+    fn angle_diff_wraparound() {
+        let tau = 2.0 * std::f64::consts::PI;
+        assert!(angle_diff(0.1, tau - 0.1) < 0.21);
+        assert!(angle_diff(0.0, 0.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn max_mat_diff_zero_for_identical() {
+        assert!(max_mat_diff(&DMat3::IDENTITY, &DMat3::IDENTITY).abs() < 1e-15);
+    }
+
+    #[test]
+    fn max_mat_diff_picks_largest_element() {
+        let mut b = DMat3::IDENTITY;
+        // Mutate the (1,2) element via column 2 of the matrix.
+        let mut col2 = b.col(2);
+        col2.y = 1.5; // off-diagonal element 1,2
+        b = DMat3::from_cols(b.col(0), b.col(1), col2);
+        let d = max_mat_diff(&DMat3::IDENTITY, &b);
+        assert!((d - 1.5).abs() < 1e-15);
+    }
+
+    #[test]
+    fn state_from_elements_circular() {
+        let mu = 3.986_004_415e14;
+        let a = 7_000_000.0;
+        let s = state_from_elements(a, 0.0, 0.0, 0.0, 0.0, 0.0, mu);
+        // Circular: |r| = a, |v| = sqrt(mu/a).
+        assert!((s.position.length() - a).abs() < 1.0);
+        assert!((s.velocity.length() - (mu / a).sqrt()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn state_from_elements_hyperbolic() {
+        let mu = 1.327e20;
+        let a = -1.0e12; // a < 0 for hyperbolic
+        let e = 1.5;
+        // Just check it produces something finite without panicking.
+        let s = state_from_elements(a, e, 0.0, 0.0, 0.0, 0.0, mu);
+        for v in [
+            s.position.x,
+            s.position.y,
+            s.position.z,
+            s.velocity.x,
+            s.velocity.y,
+            s.velocity.z,
+        ] {
+            assert!(v.is_finite());
+        }
+    }
+}

--- a/crates/jeod_sim/src/recipes/mod.rs
+++ b/crates/jeod_sim/src/recipes/mod.rs
@@ -40,6 +40,7 @@ pub mod atmosphere;
 pub mod constants;
 pub mod earth;
 pub mod epoch;
+pub mod helpers;
 pub mod mars;
 pub mod moon;
 pub mod orbital_elements;

--- a/crates/jeod_sim/src/recipes/orbital_elements.rs
+++ b/crates/jeod_sim/src/recipes/orbital_elements.rs
@@ -14,14 +14,22 @@
 
 use jeod_math::OrbitalElements;
 use jeod_quantities::aliases::{Position, Velocity};
+use jeod_quantities::dims::GravParam;
 use jeod_quantities::frame::Inertial;
 
-use super::constants::mu_ggm05c;
+use super::constants::{mu_ggm05c, mu_mars, mu_sun};
 
 fn from_pos_vel(pos: glam::DVec3, vel: glam::DVec3) -> OrbitalElements {
+    from_pos_vel_with_mu(pos, vel, mu_ggm05c())
+}
+
+/// Compute classical orbital elements for the given μ. Used by the
+/// non-geocentric presets ([`mercury_perihelion`], [`mars_dawn_orbit`])
+/// where Earth's μ is the wrong central body.
+fn from_pos_vel_with_mu(pos: glam::DVec3, vel: glam::DVec3, mu: GravParam) -> OrbitalElements {
     let p = Position::<Inertial>::from_raw_si(pos);
     let v = Velocity::<Inertial>::from_raw_si(vel);
-    OrbitalElements::from_cartesian_typed(mu_ggm05c(), p, v)
+    OrbitalElements::from_cartesian_typed(mu, p, v)
         .expect("preset state vector must produce well-defined orbital elements")
 }
 
@@ -72,4 +80,117 @@ pub fn leo_polar_600km() -> OrbitalElements {
         glam::DVec3::new(r, 0.0, 0.0),
         glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
     )
+}
+
+// ── Heliocentric / planetary presets ─────────────────────────────────
+
+/// Mercury at perihelion in a heliocentric inertial frame.
+///
+/// Position ~46 Gm Sun-ward (perihelion distance, scalar), velocity
+/// ~58.98 km/s perpendicular. Matches the inlined initial state used
+/// by the GR perihelion-advance test (`tier3_sim_mercury`) and the
+/// existing `scenarios::mercury_relativistic` setup.
+pub fn mercury_perihelion() -> OrbitalElements {
+    from_pos_vel_with_mu(
+        glam::DVec3::new(46.0e9, 0.0, 0.0),
+        glam::DVec3::new(0.0, 58_980.0, 0.0),
+        mu_sun(),
+    )
+}
+
+/// Dawn-class spacecraft initial state at Mars (Mars-centered
+/// inertial). Constants match `scenarios::mars_orbit` exactly so a
+/// custom-loop test can pull the same starting state without
+/// duplicating the literal vectors.
+pub fn mars_dawn_orbit() -> OrbitalElements {
+    from_pos_vel_with_mu(
+        glam::DVec3::new(11_563_355.680_2, -14_356_668.897_7, 6_293_704.616_9),
+        glam::DVec3::new(-2_273.107_8, 2_380.132_4, -22.911),
+        mu_mars(),
+    )
+}
+
+/// Apollo CSM parking orbit: 185 km circular at 32.5° inclination.
+///
+/// Used by Earth-orbit Apollo tests as the starting state before the
+/// trans-lunar burn.
+pub fn apollo_parking() -> OrbitalElements {
+    let r_eq = 6_378_137.0_f64;
+    let r = r_eq + 185_000.0;
+    let mu = 3.986_004_415e14_f64;
+    let v = (mu / r).sqrt();
+    let inc = 32.5_f64.to_radians();
+    from_pos_vel(
+        glam::DVec3::new(r, 0.0, 0.0),
+        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    )
+}
+
+/// Geostationary radius (42164 km) at non-zero inclination.
+///
+/// Specifically `geo_inclined(0.rad())` matches
+/// [`geostationary`](Self::geostationary). Pass the desired inclination
+/// (e.g. `0.1.rad()` for an inclined-GEO study) and the function
+/// returns the orbital elements of a circular orbit at that
+/// inclination, with the line of nodes along the +x axis.
+pub fn geo_inclined(inclination: uom::si::f64::Angle) -> OrbitalElements {
+    use uom::si::angle::radian;
+    let r = 42_164_172.0_f64;
+    let mu = 3.986_004_415e14_f64;
+    let v = (mu / r).sqrt();
+    let inc = inclination.get::<radian>();
+    from_pos_vel(
+        glam::DVec3::new(r, 0.0, 0.0),
+        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jeod_quantities::ext::F64Ext;
+
+    #[test]
+    fn mercury_perihelion_is_heliocentric_and_eccentric() {
+        let oe = mercury_perihelion();
+        // Mercury's semi-major axis is ~5.79e10 m.
+        assert!(oe.semi_major_axis > 5.5e10 && oe.semi_major_axis < 6.1e10);
+        // Eccentricity around 0.2 — definitely non-circular.
+        assert!(oe.e_mag > 0.1 && oe.e_mag < 0.3);
+    }
+
+    #[test]
+    fn mars_dawn_orbit_hyperbolic_at_arrival() {
+        let oe = mars_dawn_orbit();
+        // Dawn arrives at Mars on a hyperbolic flyby trajectory:
+        // semi-major axis < 0, eccentricity > 1.
+        assert!(oe.semi_major_axis < 0.0);
+        assert!(oe.e_mag > 1.0);
+    }
+
+    #[test]
+    fn apollo_parking_low_earth_orbit() {
+        let oe = apollo_parking();
+        // ~6563 km radius, near-circular.
+        assert!((oe.semi_major_axis - 6_563_137.0).abs() < 1.0);
+        assert!(oe.e_mag.abs() < 1e-10);
+        // Inclination 32.5° = 0.5672 rad.
+        assert!((oe.inclination - 32.5_f64.to_radians()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn geo_inclined_zero_matches_geostationary() {
+        let g0 = geo_inclined(0.0_f64.rad());
+        let g = geostationary();
+        assert!((g0.semi_major_axis - g.semi_major_axis).abs() < 1.0);
+        assert!(g0.inclination.abs() < 1e-12);
+    }
+
+    #[test]
+    fn geo_inclined_nonzero_carries_inclination() {
+        use uom::si::angle::radian;
+        let g = geo_inclined(uom::si::f64::Angle::new::<radian>(0.1));
+        assert!((g.inclination - 0.1).abs() < 1e-12);
+        assert!(g.semi_major_axis > 4.2e7 && g.semi_major_axis < 4.3e7);
+    }
 }

--- a/crates/jeod_sim/src/recipes/orbital_elements.rs
+++ b/crates/jeod_sim/src/recipes/orbital_elements.rs
@@ -19,13 +19,9 @@ use jeod_quantities::frame::Inertial;
 
 use super::constants::{mu_ggm05c, mu_mars, mu_sun};
 
-fn from_pos_vel(pos: glam::DVec3, vel: glam::DVec3) -> OrbitalElements {
-    from_pos_vel_with_mu(pos, vel, mu_ggm05c())
-}
-
-/// Compute classical orbital elements for the given μ. Used by the
-/// non-geocentric presets ([`mercury_perihelion`], [`mars_dawn_orbit`])
-/// where Earth's μ is the wrong central body.
+/// Compute classical orbital elements for the given μ. Every preset
+/// in this module funnels through here so the velocity computation
+/// (when present) and the conversion share a single μ value.
 fn from_pos_vel_with_mu(pos: glam::DVec3, vel: glam::DVec3, mu: GravParam) -> OrbitalElements {
     let p = Position::<Inertial>::from_raw_si(pos);
     let v = Velocity::<Inertial>::from_raw_si(vel);
@@ -46,12 +42,23 @@ pub fn iss() -> OrbitalElements {
     leo_400km_circular_iss_inclination()
 }
 
+/// Build a circular orbit of radius `r` and inclination `inc` (radians)
+/// for a body whose gravitational parameter is `mu`. Used by the
+/// circular-orbit presets so that the velocity computation and the
+/// `from_pos_vel_with_mu` call share a single source of truth for μ —
+/// mismatching them silently breaks the circular-orbit invariant.
+fn circular_orbit_with_mu(r: f64, inc: f64, mu: GravParam) -> OrbitalElements {
+    let v = (mu.value / r).sqrt();
+    from_pos_vel_with_mu(
+        glam::DVec3::new(r, 0.0, 0.0),
+        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+        mu,
+    )
+}
+
 /// Geostationary circular orbit at 42164 km, inclination 0°.
 pub fn geostationary() -> OrbitalElements {
-    let r = 42_164_172.0_f64;
-    let mu = 3.986_004_415e14_f64;
-    let v = (mu / r).sqrt();
-    from_pos_vel(glam::DVec3::new(r, 0.0, 0.0), glam::DVec3::new(0.0, v, 0.0))
+    circular_orbit_with_mu(42_164_172.0_f64, 0.0, mu_ggm05c())
 }
 
 /// 400 km circular LEO at 51.6° inclination — the simplest ISS-like
@@ -59,27 +66,13 @@ pub fn geostationary() -> OrbitalElements {
 /// reference state).
 pub fn leo_400km_circular_iss_inclination() -> OrbitalElements {
     let r_eq = 6_378_137.0_f64;
-    let r = r_eq + 400_000.0;
-    let mu = 3.986_004_415e14_f64;
-    let v = (mu / r).sqrt();
-    let inc = 51.6_f64.to_radians();
-    from_pos_vel(
-        glam::DVec3::new(r, 0.0, 0.0),
-        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    )
+    circular_orbit_with_mu(r_eq + 400_000.0, 51.6_f64.to_radians(), mu_ggm05c())
 }
 
 /// Polar circular LEO at 600 km altitude.
 pub fn leo_polar_600km() -> OrbitalElements {
     let r_eq = 6_378_137.0_f64;
-    let r = r_eq + 600_000.0;
-    let mu = 3.986_004_415e14_f64;
-    let v = (mu / r).sqrt();
-    let inc = 90.0_f64.to_radians();
-    from_pos_vel(
-        glam::DVec3::new(r, 0.0, 0.0),
-        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    )
+    circular_orbit_with_mu(r_eq + 600_000.0, 90.0_f64.to_radians(), mu_ggm05c())
 }
 
 // ── Heliocentric / planetary presets ─────────────────────────────────
@@ -116,14 +109,7 @@ pub fn mars_dawn_orbit() -> OrbitalElements {
 /// trans-lunar burn.
 pub fn apollo_parking() -> OrbitalElements {
     let r_eq = 6_378_137.0_f64;
-    let r = r_eq + 185_000.0;
-    let mu = 3.986_004_415e14_f64;
-    let v = (mu / r).sqrt();
-    let inc = 32.5_f64.to_radians();
-    from_pos_vel(
-        glam::DVec3::new(r, 0.0, 0.0),
-        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    )
+    circular_orbit_with_mu(r_eq + 185_000.0, 32.5_f64.to_radians(), mu_ggm05c())
 }
 
 /// Geostationary radius (42164 km) at non-zero inclination.
@@ -135,14 +121,7 @@ pub fn apollo_parking() -> OrbitalElements {
 /// inclination, with the line of nodes along the +x axis.
 pub fn geo_inclined(inclination: uom::si::f64::Angle) -> OrbitalElements {
     use uom::si::angle::radian;
-    let r = 42_164_172.0_f64;
-    let mu = 3.986_004_415e14_f64;
-    let v = (mu / r).sqrt();
-    let inc = inclination.get::<radian>();
-    from_pos_vel(
-        glam::DVec3::new(r, 0.0, 0.0),
-        glam::DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    )
+    circular_orbit_with_mu(42_164_172.0_f64, inclination.get::<radian>(), mu_ggm05c())
 }
 
 #[cfg(test)]

--- a/crates/jeod_sim/src/recipes/orbital_elements.rs
+++ b/crates/jeod_sim/src/recipes/orbital_elements.rs
@@ -115,7 +115,7 @@ pub fn apollo_parking() -> OrbitalElements {
 /// Geostationary radius (42164 km) at non-zero inclination.
 ///
 /// Specifically `geo_inclined(0.rad())` matches
-/// [`geostationary`](Self::geostationary). Pass the desired inclination
+/// [`geostationary`]. Pass the desired inclination
 /// (e.g. `0.1.rad()` for an inclined-GEO study) and the function
 /// returns the orbital elements of a circular orbit at that
 /// inclination, with the line of nodes along the +x axis.

--- a/crates/jeod_sim/src/recipes/vehicle.rs
+++ b/crates/jeod_sim/src/recipes/vehicle.rs
@@ -55,6 +55,12 @@ pub fn apollo_csm_mass() -> Mass {
     30_000.0.kg()
 }
 
+/// Apollo Lunar Module mass (~14.7 t fueled / lunar-descent
+/// configuration).
+pub fn apollo_lm_mass() -> Mass {
+    14_700.0.kg()
+}
+
 /// 6-DoF rigid sphere mass properties: total mass `mass`, uniform
 /// inertia `I = (2/5) m r²` along all body axes, CoM at structural
 /// origin. Inputs are typed so call sites stay unit-safe ergonomically:


### PR DESCRIPTION
## Summary

Closes #110. Part of [#101](https://github.com/simnaut/bevy_jeod/issues/101).

Phase 8 ships the **infrastructure layer** for Tier 3 wave B: a new `jeod_sim::recipes::helpers/` module tree (8 submodules of curated test-helper code), extended `recipes::orbital_elements` and `recipes::vehicle` building blocks, and a per-test classification pass over every archetype-B Tier 3 file. The archetype-B test corpus has been enumerated, classified, and either migrated (Cases A/B) or annotated `// non-recipe: <reason>` (Case C).

The headline finding: **0 Case A substitutions** were possible. Every archetype-B test inspected uses either JEOD-CSV-derived initial conditions (the test reads from JEOD source as cross-verification design), an artificial μ value (test-fixture choice), or hand-crafted analytical geometry. Substituting a `recipes::*` building block in any of these would either fork the test from JEOD's reference trajectory or change what the test exercises. The "production recipe path" and the "cross-verification path" are architecturally distinct, and archetype-B tests live firmly on the latter.

## Step-by-step commits

| Commit | Step | Scope |
|--------|------|-------|
| `9af7c2e` | 0 | New `crates/jeod_sim/src/recipes/helpers/` with 8 submodules: `state_helpers`, `energy_conservation`, `periapsis_detection`, `integrator_agreement`, `force_torque_profiles`, `orbinit_case`, `attach_detach_helpers`, `custom_csv`. Extends `recipes::orbital_elements` with `mercury_perihelion`, `mars_dawn_orbit`, `apollo_parking`, `geo_inclined`. Adds `recipes::vehicle::apollo_lm_mass`. |
| `f70e2a4` | — | Migrate `tier3_sim_integ_comparison` (7 tests) to consume `KeplerEnergyMonitor` + `integrator_divergence` from `recipes::helpers`. Custom propagation loops preserved verbatim. |
| `79f5b96` | — | Hoist propagation utilities (`state_from_elements`, `quaternion_angle_error`, `dquat_angle_error`, `angle_diff`, `max_mat_diff`) out of `sim_test_helpers/mod.rs` into `recipes::helpers::state_helpers`. Back-compat re-exports preserved (consumer migration is Phase 10 scope per #112). |
| `fa14a1f` | — | Migrate `tier3_sim_orbinit_families` and `tier3_sim_orbinit_roundtrip` to direct `recipes::helpers` imports. |
| `8799197` | — | Annotate `gj` (4 tests) and `lsode` (2 tests) families as Case C non-recipe. Reasons: artificial μ=5.76e14 (GJ test fixture) and CSV-rotated ICs (LSODE). |
| `354adac` | — | Migrate `lvlh_relative` (2 tests, Case C) and `lvlh_extended` (3 tests, Case B helper hoist for `max_mat_diff`). |
| `0e4ee78` | — | Annotate `relative` (3) + `relative_extended` (5) as Case C non-recipe (57-col CSV / bespoke geometric setups). |
| `b2c6bca` | — | Annotate `time_reversal` (3 tests) as Case C non-recipe (CSV-derived TAI/state, negative time-scale). |
| `a843bb2` | — | Migrate `dyncomp_combinations` (7 tests, Case B): hoist `orbital_energy` → `specific_orbital_energy` (5 sites). Setup remains bespoke (artificial circular/equatorial test states). |
| `5e8c6b7` | — | Annotate `attach_detach` (3) + `attach_mass` (1) as Case C non-recipe (placeholder `MassTree` fixtures, JEOD test-fixture bodies). |
| `b89f3af` | — | Annotate `apollo8_frame_switch` (2 tests) as Case C non-recipe (Apollo 8 vehicle.py state, slug-ft²/inches mass tensor). |
| `35f4c82` | — | Annotate `force_torque_response` (4) + `torque_simple` (6) as Case C non-recipe (analytical 100 kg test masses, ISS mass with non-diag inertia from JEOD `mass.py`). |
| `20f99e4` | — | Migrate `drag_6dof` (Case B, 2 tests), `drag_analytical` (Case B, 6 tests, 15 hoist sites), `drag_flatplate_ver` (8), `drag_rot_verif` (1), `drag_ver` (2), `drag_verif` (1), `srp_basic` (2), `srp_1st_order` (1), `srp_rk4_thermal` (1), `contact` (6) — most as Case C; helper math hoists where applicable. |
| `37ff2b8` | — | `cargo fmt` on `drag_analytical` `specific_orbital_energy` lines. |

## Migration policy (used by per-test classification)

For each archetype-B test:

- **Case A — substitutable**: inline `OrbitalElements`/`MassProperties` literals match a recipe building block byte-for-byte → substitute the recipe call. **0 instances found.**
- **Case B — helper hoist**: inline `state_from_elements`, `orbital_energy`, `quaternion_angle_error`, `max_mat_diff` etc. → replace with `recipes::helpers::*` imports. Initial conditions stay verbatim. **24 hoist sites across 6 families.**
- **Case C — non-recipe**: JEOD-CSV-derived ICs, artificial μ, hand-crafted analytical geometry → add `// non-recipe: <one-line reason>` and leave the setup. **51 tests across 18 families.**

## Architectural finding

`jeod_sim::recipes::*` is on the production code path. Its values are hardcoded literals; mission authors call them on a fresh laptop without `$JEOD_HOME`. Cross-verification tests use `jeod_test_data::s_define::parse_*` (and JEOD CSV reading) at test time, which is the right path for "given JEOD's literals from disk, does our propagator match JEOD's reference?" Substituting recipes into cross-verification tests would conflate the two paths and silently change numerics. The 51 Case C annotations document this distinction per test.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --workspace --tests -- -D warnings` ✓
- `cargo nextest run --workspace -E 'not test(tier3_simulation_earth_moon_clem)'` — **1051 pass / 0 fail / 4 skipped** (the 17-min `earth_moon` case is opt-in) ✓
- `cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing tier3_earth_moon_clem` — **75 matched, 0 violations, 1 allowed-missing, 1 new** (the "1 new" is `tier3_rnp_component_comparison`, a pre-existing label-string bug from #61, see #112) ✓
- `grep -rE "_unchecked\b|tag_as_inertial!" crates/jeod_runner/tests/` — **empty** (#110 escape-hatch exit criterion) ✓

## LoC delta

`39 files changed, +1101 / −150` (+951 net). Breakdown: ~+860 in new `recipes::helpers/` modules + extended `building_blocks`; ~+200 across migrated test files (Case C annotations + Case B import-line replacements); ~−110 in `sim_test_helpers/mod.rs` (utilities hoisted to recipes; re-export shims kept for the ~36 existing consumers).

## Out of scope / follow-on

The following items are tracked under #112 (Phase 10) per the [scope-expansion comment](https://github.com/simnaut/bevy_jeod/issues/112#issuecomment-4321099999):

- **`sim_test_helpers/mod.rs` consumer migration** (~36 test files migrate `use sim_test_helpers::*` → `use jeod_sim::recipes::helpers::state_helpers::*`); after that, the file shrinks to <100 LoC and deletes cleanly.
- **CSV-loader migration to Phase 7's `jeod_test_data::tier3_csv`** for archetype-B tests that load reference CSVs (orbinit, lvlh, ned, srp, torque_simple, drag, shadow_calc, gj, euler, solar_beta, atmos_traj, aero_traj). Not done in this PR because Phase 7 hadn't merged at the time of writing.
- **`tier3_rnp_component_comparison` label string bug** (#61 renamed the function but not the `CrossvalReport::compute()` label string); two-character fix candidate for the next baseline-touching PR.
- **Case C re-inspection for hidden Case A opportunities** — low ROI; the conservative classification preserves bit-identical numerics and the architectural distinction is real.

Per #101's parallelization policy, this phase depends only on Phase 6 (#108). #110's original "Depends on #109" text was stale.

## Test plan

- [x] CI \`Lint & Format\` passes
- [x] CI \`Test (unit + tier 2)\` passes
- [x] CI \`Test (Tier 3 fast)\` passes (baseline-invariance step green)
- [ ] CI \`Test (Tier 3 full + earth_moon)\` runs on push to \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)