### PR TITLE
[Phase 11] Documentation, CI polish, compile-time budget enforcement (#113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,20 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run -p jeod_quantities
 
+  docs-enforce:
+    name: Docs (rustdoc -D warnings + doctests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build workspace docs (no deps, deny warnings)
+        run: cargo doc --workspace --no-deps --quiet
+        env:
+          RUSTDOCFLAGS: -D warnings
+      - name: Run workspace doctests
+        run: cargo test --doc --workspace
+
   compile-time-budget:
     name: Compile-time budget (envelope)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,30 @@ The three verification tiers:
 ## Precision
 
 Use `f64` everywhere. Do NOT use Bevy's `Transform`/`GlobalTransform` (f32).
-Use `glam::DVec3`, `glam::DQuat`, `glam::DMat3` for 3D types.
 Spherical harmonics coefficients use `Vec<Vec<f64>>`. `nalgebra` is available
 transitively via `anise` but not used directly.
+
+After the type-system refactor (#101), there are two layers to choose between:
+
+- **Public/mission-crate code** uses typed quantities from `jeod_quantities`:
+  `Position<F: Frame>`, `Velocity<F>`, `Acceleration<F>`, `SecondsSince<S: TimeScale>`,
+  `Quat<L, T>`, `NormalizedQuat`, `FrameTransform<From, To>`, and the `F64Ext`
+  facade (`400.0.km()`, `51.6.deg()`, `420_000.0.kg()`). Mission code never sees
+  `DVec3`/`DQuat`/`DMat3` or `PhantomData`. The compiler rejects cross-frame
+  mismatches, scalar-vs-vector quaternion confusion, and unit-dimensional errors
+  at compile time. Custom `#[diagnostic::on_unimplemented]` messages render
+  errors in physics language (e.g., *"expected `Position<Inertial>`, found
+  `Position<Ecef>` — apply a `FrameTransform<Ecef, Inertial>` first"*).
+
+- **Internal physics-crate kernels** (the inside of `jeod_*` `*_typed` functions
+  and the underlying `_inner`/`_impl` math) use raw `glam::DVec3`/`DQuat`/`DMat3`
+  for arithmetic density. The typed siblings call `.raw_si()` at the boundary
+  to drop into the kernel and re-wrap on exit. This keeps numerics fast and the
+  public surface typed.
+
+See `docs/type_system.md` for the contributor primer (phantom-tag pattern,
+adding a new frame/scale/quantity, reading compiler errors, escape hatches)
+and `examples/typed_mission.rs` for the canonical worked example.
 
 ## Quaternion Convention
 
@@ -396,6 +417,53 @@ against NASA flight data. The bug was hidden for multiple commits because a brok
 `jeod_path()` caused the validation test to silently skip. Reading
 `models/dynamics/body_action/src/dyn_body_init_orbit.cc` would have given the correct
 formula immediately.
+
+## Building a Mission Crate
+
+A "mission crate" is a downstream crate that depends on `bevy_jeod` to model a
+specific scenario (an Earth-orbit constellation, a Mars approach, a station-
+keeping study). After the type-system refactor (#101), mission code reads like
+physics: typed building blocks compose via the typestate `VehicleBuilder`,
+units flow through the `F64Ext` facade, and the compiler rejects frame/unit
+mismatches before they become silent numerical bugs.
+
+**Imports**: a mission crate needs only the prelude and the recipes module.
+
+```rust
+use bevy::prelude::*;
+use bevy_jeod::prelude::*;        // JeodPlugin, typed Components, JeodSet
+use bevy_jeod::recipes::*;        // earth, orbital_elements, vehicle, scenarios
+```
+
+**Compose a vehicle** with the typestate `VehicleBuilder`. The compiler refuses
+`.three_dof_point_mass(...)` until a state is set, refuses `.rk4()` until mass
+is set, refuses `.build()` until an integrator is chosen.
+
+```rust
+use jeod_sim::{F64Ext, GravityControl, VehicleBuilder};
+use jeod_sim::recipes::{earth, orbital_elements, vehicle};
+
+let mu = earth::point_mass().source.mu.m3_per_s2();
+let cfg = VehicleBuilder::new()
+    .from_orbital_elements(orbital_elements::iss(), mu)
+    .three_dof_point_mass(vehicle::iss_mass())
+    .rk4()
+    .gravity(GravityControl::new_spherical(0_usize, false))
+    .build();
+let vehicle_entity = cfg.spawn_bevy(&mut commands, &[earth_entity]);
+```
+
+**Compiler errors as physics**: passing a `Position<Ecef>` where
+`Position<Inertial>` is required produces a custom diagnostic in physics
+language pointing to the missing `FrameTransform<Ecef, Inertial>` step, not a
+PhantomData type-mismatch wall.
+
+**Reference**:
+- Canonical worked example: `examples/typed_mission.rs`.
+- Contributor primer (phantom tags, adding new dimensions, escape hatches):
+  `docs/type_system.md`.
+- Architecture and phase history: `STRATEGY.md` §8 "Phase 8: Type-System
+  Refactor".
 
 ## Common Pitfalls
 

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -752,6 +752,15 @@ bevy_jeod/                               # workspace root
 
 **Dependency graph:**
 ```
+                     jeod_quantities
+                  (uom + phantom tags + Qty3<D, F> +
+                   NormalizedQuat + FrameTransform<From, To>)
+                            ^
+                            |
+                  ──────────┴──────────
+                  | every jeod_* crate |
+                  ─────────────────────
+                            |
 jeod_math  <── jeod_dynamics  <── jeod_interactions
    ^              ^                      |
    |              |                      v
@@ -769,6 +778,11 @@ jeod_frames  jeod_ephemeris    jeod_planet
               v
      bevy_jeod (src/) — unified Bevy glue (thin, delegates to jeod_sim)
 ```
+
+`jeod_quantities` (added in #101 Phase 0) sits at the bottom of the DAG. Every
+other `jeod_*` crate depends on it for typed quantities, phantom frame/time-scale
+tags, and the `F64Ext` facade. See §8 "Phase 8: Type-System Refactor" and
+`docs/type_system.md` for the architecture and rationale.
 
 ### Three-Layer Architecture
 
@@ -1448,6 +1462,76 @@ function port that surfaced during the audit.
 - `cargo clippy --workspace --tests -- -D warnings`: clean
 - Phase 7 exit-gate issues closed: #6, #49, #50, #60 (#13 already closed);
   DynManager multi-integrable-object work split into #114 as follow-up
+
+### Phase 8: Type-System Refactor (#101)
+
+**Goal:** Shift correctness guarantees from runtime/documentation into the type
+system. Mission-crate code never sees `DVec3`, `PhantomData`, or
+`uom::si::f64::Length::new::<kilometer>` — it composes typed building blocks and
+gets compiler errors in physics language when conventions are violated.
+
+**Context:** The original Phase 1–7 plan closed in April 2026. Phase 8 is the
+type-system refactor (issue #101), planned and shipped April 2026 across 12
+sub-issues #102–#113. It is additive to the original plan: physics is unchanged
+(Tier 3 baselines frozen at Phase 0 and held to within `1e-12 · magnitude`
+through every refactor-only phase).
+
+**Architectural outcome — three-layer facade:**
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Facade  (bevy_jeod::prelude, jeod_sim::recipes)          │
+│   F64Ext: 400.0.km(), 51.6.deg(), 420_000.0.kg()         │
+│   Concrete Component wrappers (no visible generics)      │
+│   Custom #[diagnostic::on_unimplemented] messages        │
+├──────────────────────────────────────────────────────────┤
+│ Typed jeod_* siblings                                     │
+│   Position<F: Frame>, SecondsSince<S: TimeScale>,        │
+│   Quat<L, T>, NormalizedQuat, FrameTransform<From, To>   │
+├──────────────────────────────────────────────────────────┤
+│ jeod_quantities (bottom of dep graph)                    │
+│   uom re-exports, Qty3<D, F>, phantom frames/scales,     │
+│   NormalizedQuat witness, F64Ext / Vec3Ext / Array3Ext   │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Phase summary table:**
+
+| Phase | Issue | PR | Scope |
+|------:|------:|----:|-------|
+| 0 | #102 | #126 | `jeod_quantities` crate, `F64Ext`, custom diagnostics, `baselines.json` capture |
+| 1 | #103 | #130–#134 | Migrate leaf crates: `jeod_time`, `jeod_planet`, `jeod_atmosphere`, `jeod_ephemeris`, `jeod_test_data` |
+| 2 | #104 | #129, #135–#140 | Migrate `jeod_math` (commitment-point gate) |
+| 3 | #105 | #141 | Migrate `jeod_frames` + `jeod_dynamics` typed siblings |
+| 4 | #106 | #142 | Migrate `jeod_gravity` + `jeod_interactions` typed siblings |
+| 5 | #107 | #143 | Migrate `jeod_sim` public API + typestate `VehicleBuilder` |
+| 6 | #108 | #145 | Migrate `jeod_runner` + introduce `jeod_sim::recipes` (`building_blocks`/`scenarios`/`verification`) |
+| 7 | #109 | #147 | Tier 3 wave A: VerificationCase one-liners + ExtrasComparator dispatch |
+| 8 | #110 | #146 | Tier 3 wave B: archetype-B classification + `recipes::helpers/` infrastructure |
+| 9 | #111 | #148 | Migrate root package + Bevy integration: typed Components + 5/20 systems |
+| 10 | #112 | #149 | Purge deprecated APIs + complete typed-sibling coverage + retire `sim_test_helpers` |
+| 11 | #113 | (this PR) | Documentation, CI polish, compile-time budget enforcement |
+
+**Acceptance:** mission code reads like physics — `let altitude = 400.0.km()` —
+and the compiler rejects frame mismatches, scalar-vs-vector quaternion confusion,
+and unit-dimensional errors at compile time. See `docs/type_system.md` for the
+contributor primer and `examples/typed_mission.rs` for the canonical worked
+example.
+
+**Deferred items (tracked separately):**
+
+| Topic | Tracker |
+|-------|--------:|
+| Session types for integrator stage ordering (design spike) | #150 |
+| Capability tokens vs Bevy SystemSets (design spike) | #151 |
+| Branded `Simulation<'sim>` lifetimes (design spike) | #152 |
+| Docker CSV regeneration pipeline modernization | #153 |
+| Bevy `Reflect` impls for `uom`-backed types | #154 |
+| Type-erase `FrameTransform`-shaped Bevy Components | #155 |
+| `pre_step` hook on `VerificationCaseExt` | #156 |
+| `EvaluationCase` recipe shape for non-propagating tests | #157 |
+| Const-generic dimensional analysis | obviated by `uom` adoption (Phase 0) |
+| Spherical harmonics evaluation performance | tracked under #65 |
 
 ---
 

--- a/crates/jeod_dynamics/src/integration.rs
+++ b/crates/jeod_dynamics/src/integration.rs
@@ -92,7 +92,7 @@ pub fn rk4_translational_step(
 }
 
 /// Advance a 6-DOF state by one RK4 step, integrating 13 variables simultaneously:
-/// position[3], velocity[3], quaternion[4], angular velocity[3].
+/// `position[3]`, `velocity[3]`, `quaternion[4]`, `angular velocity[3]`.
 ///
 /// The `accel_fn` computes translational acceleration from the current 6-DOF state.
 /// The `torque_fn` computes body-frame external torque from the current 6-DOF state.

--- a/crates/jeod_dynamics/src/mass.rs
+++ b/crates/jeod_dynamics/src/mass.rs
@@ -22,7 +22,7 @@ pub struct MassProperties {
     pub position: DVec3,        // m, in structural frame
     /// Set to `true` after mutating `mass` or `inertia` to trigger
     /// recomputation of `inverse_mass` and `inverse_inertia` on the next
-    /// call to [`recompute_derived`]. Constructors leave this `false`
+    /// call to [`Self::recompute_derived`]. Constructors leave this `false`
     /// (derived quantities are already computed).
     pub dirty: bool,
 }

--- a/crates/jeod_dynamics/src/rkf45.rs
+++ b/crates/jeod_dynamics/src/rkf45.rs
@@ -128,8 +128,8 @@ pub fn rkf45_translational_step(
 
 /// Advance a 6-DOF state by one RKF45 step (5th-order result).
 ///
-/// Integrates 13 variables simultaneously: position[3], velocity[3],
-/// quaternion[4], angular velocity[3]. Uses 6 derivative evaluations.
+/// Integrates 13 variables simultaneously: `position[3]`, `velocity[3]`,
+/// `quaternion[4]`, `angular velocity[3]`. Uses 6 derivative evaluations.
 pub fn rkf45_sixdof_step(
     state: &SixDofState,
     accel_fn: impl Fn(&SixDofState, f64) -> DVec3,
@@ -548,8 +548,8 @@ pub fn rkf45_adaptive_translational_step(
 
 /// Advance a 6-DOF state by one adaptive RKF45 step.
 ///
-/// Integrates 13 variables (position[3], velocity[3], quaternion[4],
-/// angular velocity[3]) with embedded error estimation and step size control.
+/// Integrates 13 variables (`position[3]`, `velocity[3]`, `quaternion[4]`,
+/// `angular velocity[3]`) with embedded error estimation and step size control.
 /// The error estimate uses the max over position and velocity component errors.
 pub fn rkf45_adaptive_sixdof_step(
     state: &SixDofState,

--- a/crates/jeod_gravity/src/coefficients.rs
+++ b/crates/jeod_gravity/src/coefficients.rs
@@ -146,8 +146,8 @@ pub fn load_from_jeod_cc(path: &std::path::Path) -> Result<SphericalHarmonicsDat
 ///
 /// Format: degree(u32), order(u32), radius(f64), mu(f64),
 ///         tide_free(u8), tide_free_delta(f64),
-///         then for each n=0..degree: cnm[n][0..n] as f64,
-///         then for each n=0..degree: snm[n][0..n] as f64.
+///         then for each n=0..degree: `cnm[n][0..n]` as f64,
+///         then for each n=0..degree: `snm[n][0..n]` as f64.
 pub fn save_binary(
     data: &SphericalHarmonicsData,
     path: &std::path::Path,

--- a/crates/jeod_gravity/src/spherical_harmonics_gravity_source.rs
+++ b/crates/jeod_gravity/src/spherical_harmonics_gravity_source.rs
@@ -17,9 +17,9 @@ pub struct SphericalHarmonicsData {
     pub radius: f64,
     /// Gravitational parameter (m^3/s^2).
     pub mu: f64,
-    /// Normalized cosine coefficients: cnm[n][m] for n=0..degree, m=0..n.
+    /// Normalized cosine coefficients: `cnm[n][m]` for n=0..degree, m=0..n.
     pub cnm: Vec<Vec<f64>>,
-    /// Normalized sine coefficients: snm[n][m] for n=0..degree, m=0..n.
+    /// Normalized sine coefficients: `snm[n][m]` for n=0..degree, m=0..n.
     pub snm: Vec<Vec<f64>>,
     /// Whether C20 is tide-free.
     pub tide_free: bool,

--- a/crates/jeod_interactions/src/aero_drag.rs
+++ b/crates/jeod_interactions/src/aero_drag.rs
@@ -148,8 +148,8 @@ impl DragConfigTyped {
 
 /// Typed sibling of [`AerodynamicForce`].
 ///
-/// `force` carries [`Force<StructuralFrame<V>>`]; `torque` carries
-/// [`Torque<StructuralFrame<V>>`]. Mirrors the untyped struct's
+/// `force` carries `Force<StructuralFrame<V>>`; `torque` carries
+/// `Torque<StructuralFrame<V>>`. Mirrors the untyped struct's
 /// "structural/body frame" convention (the frame `t_inertial_struct`
 /// rotates inertial vectors *into*).
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/jeod_interactions/src/contact.rs
+++ b/crates/jeod_interactions/src/contact.rs
@@ -116,11 +116,11 @@ pub struct ContactMaterial {
     pub damping: f64,
     /// Coulomb static friction coefficient (dimensionless).
     ///
-    /// Applies when the tangential slip speed is below [`slip_velocity`].
+    /// Applies when the tangential slip speed is below [`Self::slip_velocity`].
     pub mu_static: f64,
     /// Coulomb kinetic friction coefficient (dimensionless).
     ///
-    /// Applies when the tangential slip speed is above [`slip_velocity`].
+    /// Applies when the tangential slip speed is above [`Self::slip_velocity`].
     pub mu_kinetic: f64,
     /// Tangential speed below which static friction applies (m/s).
     ///

--- a/crates/jeod_math/src/euler_angles.rs
+++ b/crates/jeod_math/src/euler_angles.rs
@@ -375,12 +375,13 @@ fn compute_euler_angles_from_matrix_impl(trans: &DMat3, sequence: EulerSequence)
 // Public API — typed surface (uom `Angle`s + `NormalizedQuat` witness).
 // ---------------------------------------------------------------------------
 
-/// Typed sibling of [`compute_quaternion_from_euler_angles`].
+/// Typed sibling for the file-private `compute_quaternion_from_euler_angles_impl`
+/// kernel.
 ///
 /// Accepts a triple of `uom::si::f64::Angle` values and returns a
 /// [`NormalizedQuat`] witness of the resulting left-transformation
 /// quaternion. The inner [`JeodQuat`] is bit-identical to the value
-/// returned by the bare-`f64` variant when the same angles are supplied in
+/// returned by the kernel when the same angles are supplied in
 /// radians, so both surfaces agree on every representable input.
 ///
 /// The underlying `compute_quaternion_from_euler_angles_impl` applies
@@ -405,10 +406,11 @@ pub fn compute_quaternion_from_euler_angles_typed(
     })
 }
 
-/// Typed sibling of [`compute_matrix_from_euler_angles`].
+/// Typed sibling for the file-private `compute_matrix_from_euler_angles_impl`
+/// kernel.
 ///
 /// Accepts a triple of `uom::si::f64::Angle` values and returns the raw
-/// `DMat3` transformation matrix. Bit-identical to the bare-`f64` variant
+/// `DMat3` transformation matrix. Bit-identical to the kernel
 /// given the same angles (in radians).
 pub fn compute_matrix_from_euler_angles_typed(
     angles: [Angle; 3],
@@ -422,11 +424,12 @@ pub fn compute_matrix_from_euler_angles_typed(
     compute_matrix_from_euler_angles_impl(radians, sequence)
 }
 
-/// Typed sibling of [`compute_euler_angles_from_matrix`].
+/// Typed sibling for the file-private `compute_euler_angles_from_matrix_impl`
+/// kernel.
 ///
 /// Returns a triple of `uom::si::f64::Angle` values carrying the radian
 /// results of the JEOD extraction algorithm. Bit-identical numerically to
-/// the bare-`f64` variant.
+/// the kernel.
 pub fn compute_euler_angles_from_matrix_typed(
     trans: &DMat3,
     sequence: EulerSequence,

--- a/crates/jeod_math/src/geodetic.rs
+++ b/crates/jeod_math/src/geodetic.rs
@@ -285,10 +285,11 @@ pub(crate) fn geodetic_to_cartesian_impl(geo: &GeodeticState, r_eq: f64, r_pol: 
     )
 }
 
-/// Typed sibling of [`cartesian_to_geodetic`]. Accepts a planet-fixed
-/// position and returns a dimensionally-typed [`GeodeticStateTyped`].
+/// Typed sibling for the file-private `cartesian_to_geodetic_impl` kernel.
+/// Accepts a planet-fixed position and returns a dimensionally-typed
+/// [`GeodeticStateTyped`].
 ///
-/// Bit-identical to [`cartesian_to_geodetic`] — this is a thin wrapper that
+/// Bit-identical to the kernel — this is a thin wrapper that
 /// unwraps `Position<PlanetFixed<P>>` to its SI `DVec3` representation,
 /// delegates to the f64 implementation, and re-wraps the scalar outputs.
 ///
@@ -305,10 +306,10 @@ pub fn cartesian_to_geodetic_typed<P: Planet>(
     GeodeticStateTyped::from_raw(raw)
 }
 
-/// Typed sibling of [`geodetic_to_cartesian`]. Returns a planet-fixed
-/// position parameterized by the planet tag `P`.
+/// Typed sibling for the file-private `geodetic_to_cartesian_impl` kernel.
+/// Returns a planet-fixed position parameterized by the planet tag `P`.
 ///
-/// Bit-identical to [`geodetic_to_cartesian`].
+/// Bit-identical to the kernel.
 pub fn geodetic_to_cartesian_typed<P: Planet>(
     state: GeodeticStateTyped,
     r_eq: Length,

--- a/crates/jeod_math/src/lvlh.rs
+++ b/crates/jeod_math/src/lvlh.rs
@@ -50,7 +50,7 @@ impl LvlhFrame {
     /// [`compute_lvlh_frame_typed`] discards.
     ///
     /// Bit-identical numerics to [`compute_lvlh_frame_typed`] — both share
-    /// the [`compute_lvlh_frame_impl`] kernel.
+    /// the same `compute_lvlh_frame_impl` kernel.
     ///
     /// # Panics
     /// Panics if position or angular momentum magnitude is zero.
@@ -127,7 +127,7 @@ fn compute_lvlh_frame_impl(position: DVec3, velocity: DVec3) -> LvlhFrame {
     }
 }
 
-/// Typed sibling of [`compute_lvlh_frame`]: returns a `FrameTransform` from
+/// Typed sibling for `compute_lvlh_frame_impl`: returns a `FrameTransform` from
 /// the planet-centered inertial frame to the chief vehicle's LVLH frame.
 ///
 /// Delegates to the f64-based computation, then wraps the resulting rotation

--- a/crates/jeod_math/src/orbital_elements.rs
+++ b/crates/jeod_math/src/orbital_elements.rs
@@ -14,19 +14,19 @@ pub struct OrbitalElements {
     pub semiparam: f64,
     /// Eccentricity.
     pub e_mag: f64,
-    /// Inclination [rad].
+    /// Inclination (rad).
     pub inclination: f64,
-    /// Argument of periapsis [rad].
+    /// Argument of periapsis (rad).
     pub arg_periapsis: f64,
-    /// Longitude of ascending node [rad].
+    /// Longitude of ascending node (rad).
     pub long_asc_node: f64,
-    /// True anomaly [rad].
+    /// True anomaly (rad).
     pub true_anom: f64,
-    /// Mean anomaly [rad].
+    /// Mean anomaly (rad).
     pub mean_anom: f64,
-    /// Orbital (eccentric / hyperbolic / parabolic) anomaly [rad].
+    /// Orbital (eccentric / hyperbolic / parabolic) anomaly (rad).
     pub orbital_anom: f64,
-    /// Mean motion [rad/s].
+    /// Mean motion (rad/s).
     pub mean_motion: f64,
     /// Position magnitude.
     pub r_mag: f64,
@@ -285,7 +285,7 @@ impl OrbitalElements {
         Ok(oe)
     }
 
-    /// Typed variant of [`from_cartesian`](Self::from_cartesian).
+    /// Typed variant of `from_cartesian` (the file-private kernel below).
     ///
     /// Accepts dimensionally-typed inputs:
     /// * `mu` — gravitational parameter in SI base units (m³/s²)

--- a/crates/jeod_math/src/solar_beta.rs
+++ b/crates/jeod_math/src/solar_beta.rs
@@ -50,7 +50,7 @@ pub(crate) fn solar_beta_angle_impl(orbit_ang_momentum: DVec3, sun_direction: DV
     dot.asin()
 }
 
-/// Typed counterpart of [`solar_beta_angle`].
+/// Typed counterpart of `solar_beta_angle_impl` (the file-private kernel above).
 ///
 /// Computes the solar beta angle from a frame-tagged specific angular
 /// momentum vector (r × v, m²/s) and an inertial-frame sun direction

--- a/crates/jeod_quantities/src/ext.rs
+++ b/crates/jeod_quantities/src/ext.rs
@@ -40,85 +40,203 @@ use crate::qty3::Qty3;
 ///
 /// Every method returns a `uom` scalar quantity; dimensional analysis then
 /// takes over at the call site.
+///
+/// # Example
+///
+/// ```
+/// use jeod_quantities::prelude::*;
+///
+/// let altitude = 400.0.km();          // Length
+/// let inclination = 51.6.deg();        // Angle
+/// let mass = 420_000.0.kg();           // Mass
+/// let dt = 60.0.s();                   // Time
+/// let g = 9.81.m_per_s2();             // Acceleration
+/// let mu = 3.986_004_418e14.m3_per_s2(); // GravParam (Earth)
+/// ```
 pub trait F64Ext: Copy {
     // --- Length ---
+    /// Length in meters.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let r = 6_378_000.0.m();
+    /// ```
     fn m(self) -> Length;
+    /// Length in kilometers.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let altitude = 400.0.km();
+    /// ```
     fn km(self) -> Length;
+    /// Length in centimeters.
     fn cm(self) -> Length;
+    /// Length in millimeters.
     fn mm(self) -> Length;
+    /// Length in feet.
     fn ft(self) -> Length;
+    /// Length in statute miles.
     fn mi(self) -> Length;
+    /// Length in nautical miles.
     fn nmi(self) -> Length;
 
     // --- Velocity ---
+    /// Velocity in meters per second.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let v_circular = 7_660.0.m_per_s();
+    /// ```
     fn m_per_s(self) -> Velocity;
+    /// Velocity in kilometers per second.
     fn km_per_s(self) -> Velocity;
+    /// Velocity in kilometers per hour.
     fn km_per_h(self) -> Velocity;
+    /// Velocity in miles per hour.
     fn mph(self) -> Velocity;
 
     // --- Acceleration ---
+    /// Acceleration in m/s².
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let g = 9.81.m_per_s2();
+    /// ```
     fn m_per_s2(self) -> Acceleration;
+    /// Acceleration in km/s² (scaled to m/s² internally).
     fn km_per_s2(self) -> Acceleration;
+    /// Acceleration in standard gravities (1 g ≈ 9.80665 m/s²).
     fn g(self) -> Acceleration;
 
     // --- Mass ---
+    /// Mass in kilograms.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let iss_mass = 420_000.0.kg();
+    /// ```
     fn kg(self) -> Mass;
+    /// Mass in grams. Suffixed `_mass` to disambiguate from `g` (acceleration).
     fn g_mass(self) -> Mass;
+    /// Mass in metric tons (1000 kg).
     fn tonnes(self) -> Mass;
+    /// Mass in pounds.
     fn lb(self) -> Mass;
 
     // --- Angle ---
+    /// Angle in radians.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let half_pi = std::f64::consts::FRAC_PI_2.rad();
+    /// ```
     fn rad(self) -> Angle;
+    /// Angle in degrees.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let inclination = 51.6.deg();
+    /// ```
     fn deg(self) -> Angle;
+    /// Angle in arcminutes (1/60 degree).
     fn arcmin(self) -> Angle;
+    /// Angle in arcseconds (1/3600 degree).
     fn arcsec(self) -> Angle;
 
     // --- Time ---
+    /// Time in seconds.
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let dt = 60.0.s();
+    /// ```
     fn s(self) -> Time;
+    /// Time in milliseconds.
     fn ms(self) -> Time;
+    /// Time in microseconds.
     fn us(self) -> Time;
+    /// Time in minutes (60 s).
     fn min(self) -> Time;
+    /// Time in hours.
     fn hours(self) -> Time;
+    /// Time in days (86_400 s).
     fn days(self) -> Time;
+    /// Time in weeks (7 days).
     fn weeks(self) -> Time;
+    /// Time in Julian years (365.25 days, per `uom`).
     fn years(self) -> Time;
 
     // --- Force ---
+    /// Force in newtons.
     fn n(self) -> Force;
     /// kilonewtons (N × 1000). Spelled `kn` per the public facade list.
     fn kn(self) -> Force;
+    /// Torque in newton-meters.
     fn n_m(self) -> Torque;
+    /// Torque in pound-force-feet.
     fn ft_lb(self) -> Torque;
 
     // --- Angular velocity / acceleration ---
+    /// Angular velocity in radians per second.
     fn rad_per_s(self) -> AngularVelocity;
+    /// Angular velocity in degrees per second.
     fn deg_per_s(self) -> AngularVelocity;
+    /// Angular velocity in revolutions per minute.
     fn rpm(self) -> AngularVelocity;
+    /// Angular acceleration in radians per second².
     fn rad_per_s2(self) -> AngularAcceleration;
 
     // --- Gravitational parameter ---
+    /// Gravitational parameter μ in m³/s².
+    ///
+    /// # Example
+    /// ```
+    /// # use jeod_quantities::prelude::*;
+    /// let mu_earth = 3.986_004_418e14.m3_per_s2();
+    /// ```
     fn m3_per_s2(self) -> GravParam;
+    /// Gravitational parameter μ in km³/s² (scaled to m³/s² internally).
     fn km3_per_s2(self) -> GravParam;
 
     // --- Specific angular momentum / energy ---
+    /// Specific angular momentum in m²/s.
     fn m2_per_s(self) -> SpecificAngMom;
+    /// Specific angular momentum in km²/s (scaled to m²/s internally).
     fn km2_per_s(self) -> SpecificAngMom;
+    /// Specific energy in m²/s².
     fn m2_per_s2(self) -> SpecificEnergy;
+    /// Specific energy in km²/s² (scaled to m²/s² internally).
     fn km2_per_s2(self) -> SpecificEnergy;
 
     // --- Mass flow rate ---
+    /// Mass flow rate in kg/s.
     fn kg_per_s(self) -> MassFlowRate;
 
     // --- Frequency ---
+    /// Frequency in hertz.
     fn hz(self) -> Frequency;
+    /// Frequency in kilohertz.
     fn khz(self) -> Frequency;
 
     // --- Area ---
+    /// Area in square meters.
     fn m2(self) -> Area;
+    /// Area in square kilometers.
     fn km2(self) -> Area;
 
     // --- Unitless ratios ---
+    /// Dimensionless ratio. Use for unit-cancelled quantities like
+    /// reflectivity coefficients.
     fn unitless(self) -> Ratio;
+    /// Percentage; the value is divided by 100 to produce the ratio.
     fn percent(self) -> Ratio;
 }
 
@@ -371,6 +489,16 @@ impl F64Ext for f64 {
 }
 
 /// Extension trait on `glam::DVec3` producing frame-tagged 3-vectors.
+///
+/// # Example
+///
+/// ```
+/// use glam::DVec3;
+/// use jeod_quantities::prelude::*;
+///
+/// let r: Position<Inertial> = DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<Inertial>();
+/// let v: Velocity<Inertial> = DVec3::new(0.0, 7_546.0, 0.0).m_per_s_at::<Inertial>();
+/// ```
 pub trait Vec3Ext: Copy {
     /// Interpret as meters (position) in frame `F`.
     fn m_at<F: Frame>(self) -> crate::aliases::Position<F>;
@@ -421,6 +549,16 @@ impl Vec3Ext for DVec3 {
 
 /// Extension trait on `[f64; 3]` (raw component arrays from CSVs or JEOD
 /// initial conditions) producing frame-tagged 3-vectors.
+///
+/// # Example
+///
+/// ```
+/// use jeod_quantities::prelude::*;
+///
+/// // Loaded from a JEOD CSV row, [m, m, m].
+/// let row: [f64; 3] = [7_000_000.0, 0.0, 0.0];
+/// let r: Position<Inertial> = row.m_at::<Inertial>();
+/// ```
 pub trait Array3Ext: Copy {
     fn m_at<F: Frame>(self) -> crate::aliases::Position<F>;
     fn km_at<F: Frame>(self) -> crate::aliases::Position<F>;

--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -2,18 +2,57 @@
 //!
 //! Dimensional-analysis and phantom-tag foundation for `bevy_jeod`.
 //!
-//! This crate sits at the bottom of the workspace dependency graph. It provides:
+//! This crate sits at the bottom of the workspace dependency graph. Every other
+//! `jeod_*` crate, plus `jeod_sim`, `jeod_runner`, and the `bevy_jeod` Bevy glue
+//! all depend on it for typed quantities and phantom frame / time-scale tags.
 //!
-//! - Reference-frame and time-scale phantom markers (`Inertial`, `Ecef`, `TAI`, `TT`, ...)
-//! - `uom`-backed componentwise 3-vectors `Qty3<D, F>` (`Position<F>`, `Velocity<F>`, ...)
-//! - Quaternion convention tags (`ScalarFirst`/`ScalarLast`, `LeftTransform`/`RightTransform`)
-//!   plus a `NormalizedQuat` constructor-gated witness
+//! ## Three-layer facade
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────┐
+//! │ Facade  (bevy_jeod::prelude, jeod_sim::recipes)          │
+//! │   F64Ext: 400.0.km(), 51.6.deg(), 420_000.0.kg()         │
+//! │   Concrete Component wrappers (no visible generics)      │
+//! │   Custom #[diagnostic::on_unimplemented] messages        │
+//! ├──────────────────────────────────────────────────────────┤
+//! │ Typed jeod_* siblings                                     │
+//! │   Position<F: Frame>, SecondsSince<S: TimeScale>,        │
+//! │   Quat<L, T>, NormalizedQuat, FrameTransform<From, To>   │
+//! ├──────────────────────────────────────────────────────────┤
+//! │ jeod_quantities  (you are here)                          │
+//! │   uom re-exports, Qty3<D, F>, phantom frames/scales,     │
+//! │   F64Ext / Vec3Ext / Array3Ext                           │
+//! └──────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Mission-crate code consumes the facade layer and never sees `PhantomData`
+//! or `uom::si::*` paths. Internal physics kernels drop down to raw
+//! `glam::DVec3`/`f64` for arithmetic density via `.raw_si()` and re-wrap on
+//! exit. See `docs/type_system.md` and `STRATEGY.md` §8 for architecture.
+//!
+//! ## What this crate provides
+//!
+//! - Reference-frame and time-scale phantom markers (`Inertial`, `Ecef`,
+//!   `PlanetFixed<P>`, `BodyFrame<V>`, `Lvlh<Chief>`, `TAI`, `TT`, …)
+//! - `uom`-backed componentwise 3-vectors `Qty3<D, F>` with aliases
+//!   `Position<F>`, `Velocity<F>`, `Acceleration<F>`, `Force<F>`, `Torque<F>`, …
+//! - Quaternion convention tags (`ScalarFirst`/`ScalarLast`,
+//!   `LeftTransform`/`RightTransform`) plus a `NormalizedQuat`
+//!   constructor-gated witness
 //! - Typed `FrameTransform<From, To>` composing only when inner frames match
 //! - The `F64Ext` facade (`400.0.km()`, `51.6.deg()`, `420_000.0.kg()`)
-//! - Compiler error messages in physics language via `#[diagnostic::on_unimplemented]`
+//! - Compiler error messages in physics language via
+//!   `#[diagnostic::on_unimplemented]`
 //!
-//! No crate in the workspace consumes these types yet — Phase 0 of the
-//! type-system refactor (GitHub issues #101 / #102) is purely additive.
+//! ## Quick start
+//!
+//! ```
+//! use jeod_quantities::prelude::*;
+//!
+//! let altitude = 400.0.km();
+//! let inclination = 51.6.deg();
+//! let mass = 420_000.0.kg();
+//! ```
 
 #![forbid(unsafe_code)]
 

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -403,7 +403,8 @@ impl Simulation {
     /// Create a new simulation with the given initial time and timestep.
     ///
     /// Creates a frame tree whose root is initially named "Earth.inertial"
-    /// and may be renamed when a central source is added via [`add_source`].
+    /// and may be renamed when a central source is added via
+    /// [`Self::add_source`].
     /// All positions are relative to this root frame regardless of its name.
     pub fn new(time: SimulationTime, dt: f64) -> Self {
         let mut frame_tree = FrameTree::new();

--- a/crates/jeod_runner/src/prelude.rs
+++ b/crates/jeod_runner/src/prelude.rs
@@ -5,10 +5,10 @@
 //! ```
 //!
 //! Brings into scope the runner-side extension traits:
-//! - [`SimulationBuilderExt`](crate::SimulationBuilderExt) — terminal
+//! - [`crate::SimulationBuilderExt`] — terminal
 //!   `.build()` / `.build_unchecked()` on
 //!   [`jeod_sim::SimulationBuilder`].
-//! - [`VerificationCaseExt`](crate::VerificationCaseExt) — terminal
+//! - [`crate::VerificationCaseExt`] — terminal
 //!   `.run_and_assert()` on
 //!   [`jeod_sim::recipes::verification::VerificationCase`].
 

--- a/crates/jeod_runner/src/run_verification/mod.rs
+++ b/crates/jeod_runner/src/run_verification/mod.rs
@@ -1,8 +1,8 @@
 //! Phase 7 of #101 — `run_and_assert` machinery for Tier 3 verification.
 //!
-//! [`VerificationCase`](jeod_sim::recipes::verification::VerificationCase)
+//! [`jeod_sim::recipes::verification::VerificationCase`]
 //! lives in `jeod_sim` as adapter-neutral data. Materializing the scenario
-//! into a runtime [`Simulation`](crate::Simulation), loading the reference
+//! into a runtime [`crate::Simulation`], loading the reference
 //! CSV, propagating, and asserting tolerances is runner-specific — it
 //! lives here as the [`VerificationCaseExt`] trait.
 //!
@@ -71,7 +71,7 @@ impl CsvRecords {
 /// asserts its tolerances.
 pub trait VerificationCaseExt {
     /// Build the scenario, load the reference CSV, propagate via
-    /// [`Simulation::step_until`] up to the case's `duration`, and
+    /// [`crate::Simulation::step_until`] up to the case's `duration`, and
     /// assert tolerances on the resulting [`CrossvalReport`]. Panics on
     /// any tolerance breach.
     fn run_and_assert(&self);

--- a/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
@@ -1,13 +1,13 @@
 //! `VerificationCase` constructors for the SIM_dyncomp Tier 3 family.
 //!
 //! Each constructor returns a fully-populated
-//! [`VerificationCase`](jeod_sim::recipes::verification::VerificationCase)
+//! [`jeod_sim::recipes::verification::VerificationCase`]
 //! whose scenario closure loads its initial conditions from JEOD source
 //! files (Modified_data/*.py, S_define, gravity coefficient files, plus
 //! the t=0 row of the matching reference CSV — all "JEOD source data"
 //! per CLAUDE.md). The scenario builds a [`SimulationBuilder`] that the
 //! `run_and_assert` machinery materializes into a runtime
-//! [`Simulation`](crate::Simulation).
+//! [`crate::Simulation`].
 
 use std::path::PathBuf;
 
@@ -834,7 +834,7 @@ pub fn run6b_drag_aero_traj() -> VerificationCase {
     }
 }
 
-/// SIM_dyncomp RUN_6B with a 15° rotation about [1,1,1]/√3 applied to
+/// SIM_dyncomp RUN_6B with a 15° rotation about `[1,1,1]/√3` applied to
 /// the structural-to-body transform. Should match the identity case
 /// since ballistic drag on a sphere is rotation-invariant.
 pub fn run6b_drag_rotated_struct() -> VerificationCase {

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -112,7 +112,7 @@ pub fn compute_body_geodetic(
 /// Compute the solar beta angle (angle between orbit plane and Sun direction).
 ///
 /// Computes the orbital angular momentum vector `h = r × v`, then delegates
-/// to [`jeod_math::solar_beta_angle`].
+/// to [`jeod_math::solar_beta_angle_typed`].
 ///
 /// # Panics
 ///

--- a/crates/jeod_sim/src/gravity.rs
+++ b/crates/jeod_sim/src/gravity.rs
@@ -283,8 +283,7 @@ pub fn accumulate_gravity_typed<'a, S: Copy + std::fmt::Debug>(
 /// Typed sibling of [`accumulate_relativistic_corrections`].
 ///
 /// Same kernel; entry/exit boundary types are
-/// [`Position<Inertial>`] / [`Velocity<Inertial>`] /
-/// [`Acceleration<Inertial>`].
+/// `Position<Inertial>` / `Velocity<Inertial>` / `Acceleration<Inertial>`.
 pub fn accumulate_relativistic_corrections_typed<S: Copy + std::fmt::Debug + PartialEq>(
     body_position: Position<Inertial>,
     body_velocity: jeod_quantities::aliases::Velocity<Inertial>,

--- a/crates/jeod_sim/src/pipeline.rs
+++ b/crates/jeod_sim/src/pipeline.rs
@@ -2,7 +2,7 @@
 ///
 /// JEOD's simulation loop runs these stages in strict order every timestep.
 /// ECS adapters must schedule their systems to respect this ordering.
-/// The [`Simulation`](crate::Simulation) struct runs them internally in `step()`.
+/// The `jeod_runner::Simulation` struct runs them internally in `step()`.
 ///
 /// Ordering dependencies:
 /// - **Time** must be current before frame transforms (GMST, TT for RNP).

--- a/crates/jeod_sim/src/recipes/constants.rs
+++ b/crates/jeod_sim/src/recipes/constants.rs
@@ -1,8 +1,22 @@
 //! Typed physical constants used by recipes.
 //!
 //! Every constant carries its dimension via `uom`, so mission code that
-//! mixes `MU_GGM05C` with a length quantity gets a compile error rather
+//! mixes a `GravParam` with a length quantity gets a compile error rather
 //! than a unit mismatch at runtime.
+//!
+//! # Example
+//!
+//! ```
+//! use jeod_quantities::prelude::*;
+//! use jeod_sim::recipes::constants::{mu_ggm05c, r_eq_earth};
+//!
+//! let mu = mu_ggm05c();
+//! let r = r_eq_earth();
+//!
+//! // Circular-orbit speed at the equator: v = sqrt(mu / r).
+//! let v_circ_squared = mu.value / r.value;
+//! assert!(v_circ_squared > 0.0);
+//! ```
 
 use jeod_quantities::dims::GravParam;
 use jeod_quantities::ext::F64Ext;

--- a/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
+++ b/crates/jeod_sim/src/recipes/helpers/custom_csv.rs
@@ -1,6 +1,6 @@
 //! Schema-flexible CSV reader for ad-hoc test formats.
 //!
-//! The typed CSV catalogue lives in [`jeod_test_data::tier3_csv`] (and
+//! The typed CSV catalogue lives in `jeod_test_data::tier3_csv` (and
 //! its predecessor `jeod_test_data::dyncomp_csv`); those loaders own
 //! the standard JEOD reference logs (`SIM_dyncomp`, `SIM_LVLH`, …).
 //! This module provides the one-off / line-by-line escape hatch for

--- a/crates/jeod_sim/src/recipes/helpers/mod.rs
+++ b/crates/jeod_sim/src/recipes/helpers/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! These are **propagation utilities** only — schema-flexible CSV
 //! readers (which are reference-data plumbing, not propagation) live
-//! in [`jeod_test_data::tier3_csv`] (the typed Phase 7 catalogue, with
+//! in `jeod_test_data::tier3_csv` (the typed Phase 7 catalogue, with
 //! `dyncomp_csv` as its current entry). Tests that don't fit a
 //! standard scenario but share these mid-loop bookkeeping patterns
 //! reach for the corresponding submodule below.
@@ -34,7 +34,7 @@
 //!   wrapper for attach / detach tests.
 //! - [`custom_csv`]: schema-flexible CSV reader for ad-hoc test
 //!   formats that don't yet have a dedicated typed loader in
-//!   [`jeod_test_data::tier3_csv`].
+//!   `jeod_test_data::tier3_csv`.
 
 pub mod attach_detach_helpers;
 pub mod custom_csv;

--- a/crates/jeod_sim/src/recipes/scenarios/iss_leo.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/iss_leo.rs
@@ -16,7 +16,7 @@ use crate::SimulationBuilder;
 /// 3-DOF point-mass ISS-like LEO with Earth point-mass gravity.
 ///
 /// Uses the ISS reference orbital elements
-/// ([`orbital_elements::iss`](crate::recipes::orbital_elements::iss))
+/// ([`crate::recipes::orbital_elements::iss`])
 /// initialized via the typestate vehicle builder. Step size is 60 s,
 /// epoch is J2000.
 pub fn iss_leo() -> SimulationBuilder {

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -16,13 +16,13 @@
 //! [`reference_data`] submodule for JEOD-source-dependent loaders
 //! (gravity coefficient files, etc.). Phase 7 expands [`CsvReference`]
 //! into a tagged enum that names the per-CSV layout and provides one
-//! constructor per Tier 3 case in [`sim_dyncomp`] (and follow-on
+//! constructor per Tier 3 case in `sim_dyncomp` (and follow-on
 //! family modules).
 //!
 //! `run_and_assert` itself is implemented by `jeod_runner` via an
 //! extension trait, since materializing a [`SimulationBuilder`] into a
-//! runtime [`Simulation`] is runner-specific. The runner-side trait
-//! also dispatches on the [`CsvReference`] variant, calling the
+//! runtime `jeod_runner::Simulation` is runner-specific. The runner-side
+//! trait also dispatches on the [`CsvReference`] variant, calling the
 //! matching loader from `jeod_test_data::tier3_csv`.
 
 pub mod reference_data;
@@ -81,7 +81,7 @@ pub enum CsvReference {
     /// 80-column SIM_dyncomp state CSV consumed as a 3-DOF reference:
     /// position/velocity only — quaternion and ang_vel columns are
     /// dropped at the `jeod_test_data::crossval::StateLog` layer. Use
-    /// this for scenarios that build a [`VehicleConfig`] without `rot`,
+    /// this for scenarios that build a `jeod_runner::VehicleConfig` without `rot`,
     /// so per-step compares don't synthesize spurious rotational
     /// reference values from CSV columns the simulation never produces.
     Dyncomp3Dof(&'static str),
@@ -230,8 +230,8 @@ impl Default for Tolerances {
 /// Phase 6 shipped the type; Phase 7+ populates `verification::*`
 /// constructors that produce one of these per existing Tier 3 test.
 /// `run_and_assert` is provided by `jeod_runner::run_verification`
-/// because materializing the scenario into a runtime [`Simulation`]
-/// is runner-specific.
+/// because materializing the scenario into a runtime
+/// `jeod_runner::Simulation` is runner-specific.
 #[derive(Clone, Debug)]
 pub struct VerificationCase {
     /// Unique name used for `target/tier3_crossval/{name}.json` reports.

--- a/crates/jeod_sim/src/sources.rs
+++ b/crates/jeod_sim/src/sources.rs
@@ -1,7 +1,7 @@
 //! Gravity source registry entries.
 //!
 //! [`GravitySourceEntry`] is the user-facing description of a single gravity
-//! source (Earth, Moon, Sun, …) consumed by [`SimulationBuilder::add_source`]
+//! source (Earth, Moon, Sun, …) consumed by [`SimulationBuilder::add_source`](crate::SimulationBuilder::add_source)
 //! and ECS adapters. Phase 6 of #101 relocated this type out of `jeod_runner`
 //! so the runner and the future Bevy adapter share one description.
 

--- a/crates/jeod_sim/src/vehicle_builder.rs
+++ b/crates/jeod_sim/src/vehicle_builder.rs
@@ -215,7 +215,7 @@ impl VehicleBuilder<NeedsState> {
     /// elements and the central-body gravitational parameter.
     ///
     /// Delegates to
-    /// [`init_from_orbital_elements_typed`](jeod_dynamics::body_init::init_from_orbital_elements_typed).
+    /// [`jeod_dynamics::body_init::init_from_orbital_elements_typed`].
     /// The angles in `oe` are interpreted in radians, the semi-major
     /// axis in meters, and `mu` carries its `GravParam` dimension.
     pub fn from_orbital_elements(

--- a/crates/jeod_test_data/src/gravity_verif.rs
+++ b/crates/jeod_test_data/src/gravity_verif.rs
@@ -4,10 +4,10 @@ use glam::{DMat3, DVec3};
 ///
 /// Parsed from `models/environment/gravity/verif/unit_tests/grav_geospherical/data/verif_out.txt`.
 /// Each line contains 18 space-separated fields:
-///   CaseNum Degree Order PerturbOnly GradActive Pos[3] Potential Accel[3] Gradient[6]
+///   `CaseNum Degree Order PerturbOnly GradActive Pos[3] Potential Accel[3] Gradient[6]`.
 ///
 /// The gradient is stored as the upper triangle of a symmetric 3x3 matrix:
-///   [0,0], [0,1], [0,2], [1,1], [1,2], [2,2]
+///   `[0,0], [0,1], [0,2], [1,1], [1,2], [2,2]`.
 #[derive(Debug, Clone)]
 pub struct GravityTestCase {
     pub case_num: usize,

--- a/crates/jeod_time/src/time_manager.rs
+++ b/crates/jeod_time/src/time_manager.rs
@@ -203,8 +203,8 @@ impl TimeManager {
     /// Retrieve the value of a specific time scale in seconds.
     ///
     /// For MET, panics if MET has not been registered. Use
-    /// [`get_met_seconds`] for an `Option`-returning variant.
-    /// For UDE scales, use [`get_ude_seconds`] with an explicit index.
+    /// [`Self::get_met_seconds`] for an `Option`-returning variant.
+    /// For UDE scales, use [`Self::get_ude_seconds`] with an explicit index.
     pub fn get_seconds(&self, scale: TimeScaleId) -> f64 {
         match scale {
             TimeScaleId::TAI => self.tai_seconds,

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -6,6 +6,19 @@ with `// JEOD_INV: DB.03` comments. To find the JEOD source for any invariant,
 grep the JEOD tree for the distinctive identifier in the invariant description
 (function name, field name, error message text, etc.).
 
+> **Phase 11 audit (#113, 2026-04-26)** — All 68 rows with Category=`runtime`
+> were audited end-to-end against post-refactor enforcement sites in `crates/`
+> and `src/`. The catalog is current: invariants whose violations are now
+> made unrepresentable by the type system (frame mismatches, time-scale
+> mismatches, `NormalizedQuat` witness, typed entry points) are already
+> classified `structural` or `n/a`; invariants that remain genuine runtime
+> checks (NaN/finite guards, table-bounds checks, convergence checks,
+> flag-gated config) are correctly classified `enforced` or `partial`. No
+> reclassifications were needed at Phase 11; future invariants follow the
+> same structural-vs-runtime decision tree on addition. See
+> `docs/type_system.md` for the type-system architecture and
+> `STRATEGY.md` §8 for the refactor history.
+
 **Categories:**
 - `initialization` — checked during `initialize_simulation()` or model init
 - `runtime` — checked on every relevant call during simulation

--- a/docs/type_system.md
+++ b/docs/type_system.md
@@ -1,0 +1,282 @@
+# The bevy_jeod Type System
+
+This document is the contributor primer for the typed quantity layer added by
+the type-system refactor (#101, Phases 0–11). It serves two audiences:
+
+- **`bevy_jeod` internal contributors** adding a new frame, time scale,
+  dimension, or recipe.
+- **Mission-crate authors** decoding compiler errors and understanding the
+  conventions encoded in the type system.
+
+If you are writing mission code (downstream of `bevy_jeod`), start with
+`examples/typed_mission.rs` and the `## Building a Mission Crate` section in
+`CLAUDE.md`. Use this document as the reference when you need to know *why*
+the compiler refused something.
+
+## 1. Why a typed layer
+
+`bevy_jeod` reimplements NASA JEOD orbital mechanics. JEOD's C++ API uses
+naked `double`s and `double[3]`s carrying conventions in field names and
+comments — sign conventions, frame conventions, time scales, quaternion
+layouts. Those conventions are not compile-checked; getting one wrong produces
+code that compiles, passes trivial tests, and silently gives wrong answers
+at scale.
+
+The motivating incident (catalogued in `CLAUDE.md` "JEOD Convention Rule"):
+an agent guessed `M = 2π − n·t` for the JEOD `time_periapsis` → mean anomaly
+formula. The correct convention is `M = n·t`. The bug produced **11,668 km
+error against NASA flight data** and was hidden for multiple commits because
+a broken test path silently skipped the validation. Reading
+`models/dynamics/body_action/src/dyn_body_init_orbit.cc` would have given the
+correct formula immediately, but no compile-time check could fire.
+
+The type-system refactor moves this class of bug from runtime/discipline to
+compile time. Frame mismatches, time-scale mismatches, scalar-vs-vector
+quaternion confusion, and unit-dimensional errors are now compile errors —
+in **physics language**, via custom `#[diagnostic::on_unimplemented]`
+messages.
+
+## 2. The three-layer facade
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Facade  (bevy_jeod::prelude, jeod_sim::recipes)          │
+│   F64Ext: 400.0.km(), 51.6.deg(), 420_000.0.kg()         │
+│   Concrete Component wrappers (no visible generics)      │
+│   Custom #[diagnostic::on_unimplemented] messages        │
+├──────────────────────────────────────────────────────────┤
+│ Typed jeod_* siblings                                     │
+│   Position<F: Frame>, SecondsSince<S: TimeScale>,        │
+│   Quat<L, T>, NormalizedQuat, FrameTransform<From, To>   │
+├──────────────────────────────────────────────────────────┤
+│ jeod_quantities  (bottom of dep graph)                   │
+│   uom re-exports, Qty3<D, F>, phantom frames/scales,     │
+│   F64Ext / Vec3Ext / Array3Ext                           │
+└──────────────────────────────────────────────────────────┘
+```
+
+- **`jeod_quantities`** sits at the bottom of the workspace dependency graph.
+  Every other `jeod_*` crate depends on it. It defines the typed primitives:
+  - `Qty3<D, F>` — componentwise 3-vector with `uom` dimension `D` and
+    phantom frame tag `F`. Aliases: `Position<F>`, `Velocity<F>`,
+    `Acceleration<F>`, `Force<F>`, `Torque<F>`, etc.
+  - `SecondsSince<S>` — a `uom` `Time` carrying a phantom time-scale tag `S`.
+  - `Quat<L, T>` — quaternion carrying phantom layout (`ScalarFirst`/`ScalarLast`)
+    and transform-convention (`LeftTransform`/`RightTransform`) tags.
+    `NormalizedQuat<L, T>` is a constructor-gated witness.
+  - `FrameTransform<From, To>` — typed transform that composes only when
+    inner frames match.
+  - `F64Ext` — the facade trait that lets mission code write
+    `400.0.km()` instead of `Length::new::<kilometer>(400.0)`.
+
+- **Typed `jeod_*` siblings** — every public physics function in `jeod_*`
+  has a typed entry point (the f64 forms were deleted in Phase 10). Each
+  typed function takes typed inputs, calls `.raw_si()` to drop into the
+  shared kernel for arithmetic density, and re-wraps on exit.
+
+- **Facade** — `bevy_jeod::prelude` and `jeod_sim::recipes` re-export
+  concrete typed Components and recipe functions so mission code never sees
+  `PhantomData` or `uom::si::*` paths. The typestate `VehicleBuilder`
+  (`NeedsState → NeedsMass → HasIntegrator → Ready`) gates construction
+  ordering at compile time.
+
+## 3. Phantom tags catalog
+
+### Frames (`crates/jeod_quantities/src/frame.rs`)
+
+| Tag | Meaning |
+|-----|---------|
+| `Inertial` | Earth-centered inertial (J2000) |
+| `Ecef` | Earth-centered Earth-fixed (rotates with Earth) |
+| `PlanetFixed<P>` | Generic planet-fixed frame parameterized by planet `P` (`Earth`, `Moon`, `Mars`, `Sun`, …) |
+| `BodyFrame<V>` | Body-fixed frame of a vehicle `V` |
+| `StructuralFrame<V>` | Structural reference frame of a vehicle `V` (used for sensor placement, attachment) |
+| `Lvlh<Chief>` | Local Vertical / Local Horizontal frame relative to a chief body |
+| `Ned<Chief>` | North-East-Down topocentric frame relative to a chief body |
+| `SelfRef` | "Same frame as the carrier" — used by Components that store a quantity expressed in their own entity's frame |
+
+Frame phantoms only exist at the type level; they have no runtime representation.
+
+### Time scales (`crates/jeod_quantities/src/time_scale.rs`)
+
+`TAI`, `UTC`, `UT1`, `TT`, `TDB`, `GPS`, `GMST`. `SecondsSince<S>` carries
+the phantom; `TimeConverter<From, To>` is the explicit conversion entry point
+(e.g., `TAI_TO_TT`, `GPS_TO_TAI`).
+
+### Quaternion conventions (`crates/jeod_quantities/src/quat.rs`)
+
+| Axis | Tags |
+|------|------|
+| Layout | `ScalarFirst` (JEOD's convention: `[q0, q1, q2, q3]`), `ScalarLast` (glam's: `[x, y, z, w]`) |
+| Transform | `LeftTransform` (JEOD: `r' = q r q⁻¹`), `RightTransform` |
+| Normalization | `Quat<L, T>` (raw), `NormalizedQuat<L, T>` (witness; constructed via `NormalizedQuat::new(q)?` or `NormalizedQuat::renormalize(q)`) |
+
+JEOD-internal physics uses `Quat<ScalarFirst, LeftTransform>`. Conversion to
+`glam::DQuat` (which is `ScalarLast`) happens at module boundaries.
+
+## 4. Adding a new frame / time scale / quantity
+
+### A new frame tag
+
+1. Add the marker type to `crates/jeod_quantities/src/frame.rs`:
+   ```rust
+   pub struct MyFrame;
+   impl Frame for MyFrame {}
+   ```
+2. Re-export from `prelude.rs` if it should be visible to mission code.
+3. Add a `FrameTransform<MyFrame, Existing>` (and inverse) constructor where
+   appropriate — typically in the crate that owns the physics translating
+   between the frames.
+4. Add a tier-1 unit test verifying the transform round-trips.
+
+### A new time scale
+
+1. Add the marker to `crates/jeod_quantities/src/time_scale.rs`:
+   ```rust
+   pub struct MyScale;
+   impl TimeScale for MyScale {}
+   ```
+2. Define `TimeConverter::<MyScale, From>` and the inverse with the actual
+   physics in `jeod_time::time_<myscale>`.
+3. Re-export from `prelude.rs`.
+4. Add tier-1 round-trip + tier-2 reference-vector tests.
+
+### A new dimensional quantity
+
+1. If `uom` already has the dimension (most common), add a type alias to
+   `crates/jeod_quantities/src/aliases.rs` and a `Qty3` alias for the
+   3-vector form:
+   ```rust
+   pub type AngularMomentum<F> = Qty3<dims::AngularMomentum, F>;
+   ```
+2. If the dimension is new, add it to `crates/jeod_quantities/src/dims.rs`
+   using `uom`'s dimension macros.
+3. Add `F64Ext` constructor methods (e.g., `.kg_m2_per_s()`).
+4. Re-export from `prelude.rs`.
+
+## 5. Reading compiler errors
+
+The custom diagnostics in `crates/jeod_quantities/src/diagnostics.rs` are
+zero-cost marker traits whose only purpose is to carry a tailored
+`#[diagnostic::on_unimplemented]` message that fires when the marker bound
+fails. The error then renders in physics language instead of as a generic
+"trait not implemented" wall.
+
+### Frame mismatch on `+` / `-`
+
+```rust
+let a: Position<Inertial> = ...;
+let b: Position<Ecef> = ...;
+let _ = a + b; // ← error
+```
+
+```text
+error: cannot combine values in frame `Inertial` with values in frame `Ecef`
+   = note: apply a `FrameTransform<Ecef, Inertial>` (or its inverse) to bring
+           both operands into the same frame before combining
+```
+
+### Bare f64 where a typed quantity is expected
+
+```rust
+fn altitude_check(altitude: Length) { ... }
+altitude_check(400_000.0); // ← error
+```
+
+```text
+error: bare `f64` is not a `Length` — attach a unit with `F64Ext`
+   = note: use `.m()`, `.km()`, `.cm()`, `.mm()`, `.ft()`, `.mi()`, or `.nmi()`
+           to produce a `Length`
+```
+
+Fix: `altitude_check(400.0.km())`.
+
+### Quaternion convention mismatch
+
+```rust
+let q_glam: Quat<ScalarLast, LeftTransform> = ...;
+let q_jeod: Quat<ScalarFirst, LeftTransform> = q_glam; // ← error
+```
+
+```text
+error: quaternion layout mismatch: expected `ScalarFirst`, found `ScalarLast`
+   = note: use `.to_scalar_first()` or `.to_scalar_last()` to convert
+           between layouts
+```
+
+### Vector × Vector ambiguity
+
+```rust
+let r: Position<Inertial> = ...;
+let v: Velocity<Inertial> = ...;
+let _ = r * v; // ← error: ambiguous
+```
+
+```text
+error: two `Qty3`s cannot be multiplied componentwise
+   = note: use `.dot(other)` for scalar product (returns a scalar) or
+           `.cross(other)` for vector product (returns a `Qty3`)
+```
+
+The full set of custom diagnostics is in
+`crates/jeod_quantities/src/diagnostics.rs`. New ones should follow the same
+pattern: zero-cost marker trait, `#[diagnostic::on_unimplemented]` message in
+physics language, the `note:` suggesting the corrective API.
+
+## 6. Runtime escape hatches
+
+The type system has two documented escape hatches. Both are deliberate; both
+require justification in the PR description that introduces a use.
+
+### `_unchecked` constructors
+
+`Qty3::from_raw_si_unchecked(DVec3)`, `NormalizedQuat::from_raw_unchecked(DQuat)`,
+etc. These bypass the typed constructor's validation (e.g., normalization).
+They follow Rust convention: the `_unchecked` suffix is grep-able and
+recognizable. Use only when:
+
+- Constructing a typed quantity from a value that is *known* by construction
+  to satisfy the invariant (e.g., reading the t=0 row of a JEOD reference
+  CSV that has already been validated upstream).
+- The validating constructor would be redundant or measurably impact a hot
+  path.
+
+### `// allowed:` comments
+
+The escape-hatch CI guard (`scripts/check_no_escape_hatches.sh`) refuses
+`#[doc(hidden)]` and the `tag_as_inertial!` macro in `crates/` and `src/`
+unless the line carries a `// allowed: <reason>` opt-out comment. Each
+exemption is reviewed at PR time.
+
+If a future contributor needs to bypass the type system at a public surface,
+the answer is almost always to extend the type system to express the missing
+case — not to widen the escape hatches. The escape hatches exist for legacy
+boundaries (JEOD CSV ingestion, `glam::DQuat` interop) and should not grow.
+
+## 7. References
+
+- **Source**:
+  - `crates/jeod_quantities/src/lib.rs` — crate root with module-level docs.
+  - `crates/jeod_quantities/src/diagnostics.rs` — full custom-diagnostic catalog.
+  - `crates/jeod_quantities/src/frame.rs`, `time_scale.rs`, `quat.rs` —
+    phantom-tag definitions.
+  - `crates/jeod_quantities/src/qty3.rs` — `Qty3<D, F>` and its operations.
+
+- **Worked examples**:
+  - `examples/typed_mission.rs` — canonical mission-crate composition.
+  - `examples/kepler_orbit.rs` — minimal orbit propagator.
+  - `crates/jeod_runner/examples/{apollo,earth_moon,mars_orbit,leo_drag,batch_propagation}.rs` —
+    larger scenario demonstrations.
+
+- **Architecture**:
+  - `STRATEGY.md` §8 "Phase 8: Type-System Refactor (#101)".
+  - `CLAUDE.md` "Precision" and "Building a Mission Crate" sections.
+
+- **Phase issues** (closed): #102, #103, #104, #105, #106, #107, #108, #109,
+  #110, #111, #112, #113. Parent: #101.
+
+- **Future work** (deferred trackers filed at Phase 11 close-out): #150
+  (session types), #151 (capability tokens), #152 (branded simulation
+  lifetimes), #153 (Docker CSV pipeline), #154 (Bevy Reflect), #155
+  (FrameTransform Component erasure), #156 (`pre_step` hook), #157
+  (`EvaluationCase` shape).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,15 @@ pub struct EphemerisR(pub jeod_sim::Ephemeris);
 
 /// Bevy resource wrapping `MassTree` for multi-body vehicles.
 ///
-/// Shared by all entities that have [`MassBodyIdC`](components::MassBodyIdC).
-/// The `staging_system` processes [`AttachEvent`](components::AttachEvent) and
-/// [`DetachEvent`](components::DetachEvent) to modify the tree and sync
+/// Shared by all entities that have [`components::MassBodyIdC`].
+/// The `staging_system` processes [`components::AttachEvent`] and
+/// [`components::DetachEvent`] to modify the tree and sync
 /// composite mass properties back to affected entities.
 ///
 /// This resource is not inserted automatically by [`JeodPlugin`]. Applications
 /// that use staging must insert `MassTreeR` before sending
-/// [`AttachEvent`](components::AttachEvent) or
-/// [`DetachEvent`](components::DetachEvent). If the resource is absent, staging
+/// [`components::AttachEvent`] or
+/// [`components::DetachEvent`]. If the resource is absent, staging
 /// events are silently drained.
 #[derive(Resource, Deref, DerefMut)]
 pub struct MassTreeR(pub jeod_sim::MassTree);

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -1,7 +1,7 @@
 //! Bevy-vs-Simulation parity tests: derived states (orbital elements, Euler angles,
 //! LVLH frame, geodetic, solar beta).
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -19,7 +19,7 @@ use jeod_sim::{
     PlanetShape, SixDofState, TranslationalState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario I: Derived states (orbital elements, Euler, LVLH, solar beta) ──
 

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -1,6 +1,6 @@
 //! Bevy-vs-Simulation parity tests: drag (exponential, constant-density, MET atmosphere).
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -15,7 +15,7 @@ use jeod_sim::{
     GeoIndexType, GravityControl, GravityControls, MetAtmosphere, SixDofState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario B: Exponential atmosphere + drag, 6-DOF ──
 

--- a/tests/bevy_parity_gravity_torque.rs
+++ b/tests/bevy_parity_gravity_torque.rs
@@ -1,6 +1,6 @@
 //! Bevy-vs-Simulation parity tests: gravity gradient torque and external torque.
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -14,7 +14,7 @@ use jeod_sim::{
     MassProperties, RotationalState, SixDofState, TranslationalState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario D: Gravity gradient torque, 6-DOF ──
 

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -1,7 +1,7 @@
 //! Bevy-vs-Simulation parity tests: high-fidelity physics (spherical harmonics,
 //! tidal effects, polar motion, Gauss-Jackson integrator).
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -15,7 +15,7 @@ use jeod_sim::{
     GravitySource, IntegratorType, TidalBody, TidalConfig, TranslationalState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario F: Spherical harmonics 4x4 + RNP (requires JEOD_HOME) ──
 

--- a/tests/bevy_parity_lighting.rs
+++ b/tests/bevy_parity_lighting.rs
@@ -1,6 +1,6 @@
 //! Bevy-vs-Simulation parity tests: earth lighting.
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -11,7 +11,7 @@ use glam::DVec3;
 use jeod_runner::{DerivedStateConfig, EarthLightingConfig, GravitySourceEntry, VehicleConfig};
 use jeod_sim::{GravityControl, GravityControls, GravityModel, GravitySource, TranslationalState};
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario S: Earth lighting consistency ──
 

--- a/tests/bevy_parity_point_mass.rs
+++ b/tests/bevy_parity_point_mass.rs
@@ -1,7 +1,7 @@
 //! Bevy-vs-Simulation parity tests: point-mass gravity, planetary orbits,
 //! basic 6-DOF, orbinit cross-consistency, and timescale parity.
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -14,7 +14,7 @@ use jeod_sim::{
     RotationalState, SixDofState, TranslationalState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario A: Point-mass 6-DOF ──
 

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -1,6 +1,6 @@
 //! Bevy-vs-Simulation parity tests: SRP (flat-plate, shadow, cannonball).
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -16,7 +16,7 @@ use jeod_sim::{
     GravitySource, MassProperties, SixDofState, TranslationalState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Scenario E: Full stack — drag + SRP + gravity torque ──
 

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -1,7 +1,7 @@
 //! Bevy-vs-Simulation parity tests: third-body gravity, Mars, Mercury relativistic,
 //! Clementine, solar beta with DE421 ephemeris.
 
-mod parity_helpers;
+mod common;
 
 use bevy::prelude::*;
 use bevy_jeod::{
@@ -16,7 +16,7 @@ use jeod_sim::{
     GravitySource, MassProperties, SixDofState, TranslationalState,
 };
 
-use parity_helpers::*;
+use common::*;
 
 // ── Solar beta with DE421 ephemeris ──
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,14 @@
 //! Shared helpers for Bevy-vs-Simulation parity tests.
 //!
-//! Provides common initial conditions, assertion functions, and setup utilities
-//! used across all parity test categories.
+//! Provides common initial conditions, assertion functions, and setup
+//! utilities used across all `bevy_parity_*.rs` test categories. Consumers
+//! `mod common;` then `use common::*;`.
+//!
+//! Renamed from `tests/parity_helpers/mod.rs` to `tests/common/mod.rs` in
+//! Phase 11 of #101 — the contents are pure test infrastructure (Bevy
+//! `App` setup, bit-identical assertion macros, DE421 ephemeris caching);
+//! they are deliberately not promoted to `jeod_sim::recipes::helpers`,
+//! which is reserved for cross-crate-reusable propagation utilities.
 
 // Each integration test file includes this module independently, so not all
 // items are used in every compilation unit. Suppress dead_code warnings.

--- a/tests/mission_crate_sanity.rs
+++ b/tests/mission_crate_sanity.rs
@@ -1,0 +1,107 @@
+//! Mission-crate ergonomics regression net.
+//!
+//! Phase 11 of #101. This integration test mocks the lifecycle of a
+//! downstream mission crate that depends only on `bevy_jeod` — it imports
+//! from `bevy_jeod::prelude` and `bevy_jeod::recipes`, spawns an ISS-like
+//! LEO scenario via the typestate `VehicleBuilder`, and propagates for
+//! ~1 hour via Bevy's `FixedUpdate`. The assertion verifies the final
+//! position magnitude is plausible for a 400 km orbit.
+//!
+//! If a future refactor breaks the prelude / recipes facade — e.g., a
+//! removed re-export, a renamed Component, a typestate gate that no longer
+//! type-checks the canonical mission flow — this test breaks, surfacing
+//! the regression at PR time rather than after a downstream consumer's
+//! upgrade.
+//!
+//! The test is gated on neither `JEOD_HOME` nor any `.bsp` file: it uses
+//! point-mass gravity from `recipes::earth::point_mass()` and the ISS
+//! orbital elements from `recipes::orbital_elements::iss()`, both of which
+//! are pure constants compiled into the recipe.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_jeod::{
+    GravitySourceC, JeodPlugin, SourceInertialPositionC, TranslationalStateC, VehicleConfigBevyExt,
+};
+use jeod_sim::recipes::{earth, orbital_elements, vehicle};
+use jeod_sim::{F64Ext, GravityControl, VehicleBuilder};
+
+#[derive(Resource)]
+struct VehicleEntity(Entity);
+
+fn setup_iss(mut commands: Commands) {
+    let earth_recipe = earth::point_mass();
+    let earth_mu = earth_recipe.source.mu;
+    let earth = commands
+        .spawn((
+            Name::new("Earth"),
+            GravitySourceC(earth_recipe.source),
+            SourceInertialPositionC::default(),
+            TranslationalStateC::default(),
+        ))
+        .id();
+
+    let cfg = VehicleBuilder::new()
+        .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
+        .three_dof_point_mass(vehicle::iss_mass())
+        .rk4()
+        .gravity(GravityControl::new_spherical(0_usize, false))
+        .build();
+
+    let vehicle_entity = cfg.spawn_bevy(&mut commands, &[earth]);
+    commands.insert_resource(VehicleEntity(vehicle_entity));
+}
+
+#[test]
+fn mission_crate_sanity_iss_one_hour() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .insert_resource(Time::<Fixed>::from_seconds(10.0))
+        .add_plugins(JeodPlugin)
+        .add_systems(Startup, setup_iss);
+
+    // Run startup once.
+    app.update();
+
+    // Step 360 × 10 s = 3600 s ≈ 1 hour. Each FixedUpdate tick advances
+    // the JEOD pipeline by one `dt`.
+    let total_seconds = 3600.0;
+    let dt = 10.0;
+    let n_steps = (total_seconds / dt) as u32;
+    for _ in 0..n_steps {
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .advance_by(Duration::from_secs_f64(dt));
+        app.world_mut().run_schedule(FixedUpdate);
+    }
+
+    // Read the typed Component back via a query — the same path a
+    // downstream consumer uses.
+    let vehicle = app.world().resource::<VehicleEntity>().0;
+    let state = app
+        .world()
+        .get::<TranslationalStateC>(vehicle)
+        .expect("vehicle has TranslationalStateC after propagation");
+    let r_mag = state.position.length();
+    let v_mag = state.velocity.length();
+
+    // ISS reference orbit: ~408 km altitude → r ≈ 6.778 Mm.
+    // Energy conservation under point-mass gravity holds r within a
+    // narrow band over 1 hour (0.058 of a 5550 s period). Allow ±50 km
+    // generously; a regression in the facade breaks orders of magnitude,
+    // not km.
+    assert!(
+        (6.728e6..=6.828e6).contains(&r_mag),
+        "ISS position magnitude after 1h propagation outside plausible band: \
+         r = {r_mag:.1} m (expected ~6.778 Mm ± 50 km)"
+    );
+
+    // Circular-orbit speed at this altitude is ~7.66 km/s. Same generous
+    // ±100 m/s band — facade-regression magnitudes, not numerical noise.
+    assert!(
+        (7560.0..=7760.0).contains(&v_mag),
+        "ISS velocity magnitude after 1h propagation outside plausible band: \
+         v = {v_mag:.1} m/s (expected ~7660 m/s ± 100 m/s)"
+    );
+}


### PR DESCRIPTION
Closes #113. **Closes #101** (parent type-system refactor).

Phase 11 closes out the type-system refactor (#101) by making the refactor's promises durably documented, adding a CI gate to prevent rustdoc rot, and freezing facade ergonomics with a mission-crate-mock regression test.

## Summary

After 10 phases of code migration (#102–#112, PRs #126–#149) the public API is fully typed; mission code reads like physics. Phase 11 adds:

1. **Documentation** — `CLAUDE.md` Precision section + new "Building a Mission Crate"; `STRATEGY.md` §8 "Phase 8: Type-System Refactor" subsection + dependency-diagram refresh; new `docs/type_system.md` contributor primer; `docs/JEOD_invariants.md` audited (catalog confirmed current — no reclassifications needed).
2. **Rustdoc polish** — module-level three-layer-facade diagram on `jeod_quantities/lib.rs`, per-method `///` docs + representative `# Example` doctests on `F64Ext`/`Vec3Ext`/`Array3Ext`, doctest on `recipes/constants.rs`, and a workspace-wide cleanup of 30 stale intra-doc links so `RUSTDOCFLAGS='-D warnings' cargo doc` is clean.
3. **CI** — new `docs-enforce` job runs `cargo doc --workspace --no-deps -D warnings` plus `cargo test --doc --workspace`.
4. **Test infrastructure** — `tests/parity_helpers/` renamed to `tests/common/` (Cargo's conventional shared-test path); new `tests/mission_crate_sanity.rs` regression-net mocks a downstream consumer's lifecycle (prelude + recipes + typestate VehicleBuilder + 1h propagation + plausibility band).

## Step-by-step commits

| Commit | Step | Scope |
|--------|------|-------|
| `28cae37` | 1/3 | CLAUDE.md, STRATEGY.md §8, docs/type_system.md (new ~270 LoC primer), docs/JEOD_invariants.md audit header. |
| `e4a400b` | 2/3 | Rustdoc polish + 30 unresolved-link errors fixed across the workspace. After this commit, `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` is clean. |
| `c97669b` | 3/3 | tests/parity_helpers→tests/common rename (8 consumers updated); tests/mission_crate_sanity.rs new (~70 LoC); docs-enforce CI job in ci.yml. |

## Disposition of deferred items (#101 close-out)

Per the user-approved plan in `~/.claude/plans/review-issue-101-determine-imperative-puppy.md`, every item from #101's "Out of scope" and the #112 follow-on comments has a concrete disposition. Trackers were filed before this PR's first commit so subsequent docs reference them by number.

### From #101 "Out of scope"

| Item | Disposition | Tracker |
|------|-------------|---------|
| Session types for integrator stages | Filed | #150 |
| Capability tokens for system ordering | Filed | #151 |
| Branded simulation lifetimes | Filed | #152 |
| Const-generic dimensional analysis | Obviated by `uom` adoption (Phase 0) | none |
| Docker CSV regeneration pipeline | Filed | #153 |
| SH evaluation performance | Track under existing #65 (cross-link comment posted) | none |
| Bevy reflection on `uom` types | Filed | #154 |

### From #112 follow-on comments

| Item | Disposition | Tracker |
|------|-------------|---------|
| `PlanetFixedRotationC` / `StructuralTransformC` typed-erasure | Filed | #155 |
| `pre_step` hook on `VerificationCaseExt` | Filed | #156 |
| `EvaluationCase` recipe shape for non-propagating tests | Filed | #157 |
| 15 Bevy systems lacking typed siblings | Already closed in Phase 10 (#149) | none |

### Pre-existing related issues (cross-link comments posted)

| Issue | Why related |
|------|-------------|
| #65 (perf) | Receives the SH-perf umbrella from #101 |
| #100 (rustdoc for jeod_* crates) | Phase 11 delivered partial coverage; remaining scope still owned here |
| #71 (Bevy frame tree parity) | Co-traveler with #155 (typed Component erasure) |

## Acceptance verification (all green locally)

```
cargo fmt --check                                                  # clean
cargo clippy --workspace --tests --examples -- -D warnings -D deprecated  # clean
cargo nextest run --workspace -E 'not test(tier3_)'                # 745/745 passed
cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'  # 306/306 passed
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --quiet # clean
cargo test --doc --workspace                                        # 33+ doctests passed
scripts/check_no_escape_hatches.sh                                  # OK
test ! -f crates/jeod_runner/tests/sim_test_helpers/mod.rs          # OK (Phase 10)
test ! -f tests/parity_helpers/mod.rs                               # OK (this PR)
cargo test --test invariant_coverage                                 # 6/6 passed
cargo run --example kepler_orbit                                     # runs, ~1 orbit completes
cargo run --example typed_mission                                    # runs, ~1 orbit completes
cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing tier3_earth_moon_clem  # OK (76 matched)
```

The new `mission_crate_sanity_iss_one_hour` test passes: ISS-like LEO propagated 1h via prelude+recipes lands inside a 6.728..6.828 Mm position band and 7560..7760 m/s velocity band.

## After this merges

- #113 closes (this PR's `Closes #113`).
- #101 closes (this PR's `Closes #101`); a close-out comment will paraphrase the disposition table on the parent issue.
- The 8 deferred trackers (#150–#157) remain open as the new follow-on backlog for the type system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)