### PR TITLE
[Phase 11 follow-up] Add bevy_jeod::prelude/recipes modules + fix doc snippets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,14 +435,14 @@ use bevy_jeod::prelude::*;        // JeodPlugin, typed Components, JeodSet
 use bevy_jeod::recipes::*;        // earth, orbital_elements, vehicle, scenarios
 ```
 
-**Compose a vehicle** with the typestate `VehicleBuilder`. The compiler refuses
-`.three_dof_point_mass(...)` until a state is set, refuses `.rk4()` until mass
-is set, refuses `.build()` until an integrator is chosen.
+**Compose a vehicle** with the typestate `VehicleBuilder` (re-exported by
+`bevy_jeod::prelude`). The compiler refuses `.three_dof_point_mass(...)`
+until a state is set, refuses `.rk4()` until mass is set, refuses `.build()`
+until an integrator is chosen.
 
 ```rust
-use jeod_sim::{F64Ext, GravityControl, VehicleBuilder};
-use jeod_sim::recipes::{earth, orbital_elements, vehicle};
-
+// `VehicleBuilder`, `GravityControl`, and `F64Ext` come from `bevy_jeod::prelude`.
+// `earth`, `orbital_elements`, `vehicle` come from `bevy_jeod::recipes`.
 let mu = earth::point_mass().source.mu.m3_per_s2();
 let cfg = VehicleBuilder::new()
     .from_orbital_elements(orbital_elements::iss(), mu)

--- a/docs/type_system.md
+++ b/docs/type_system.md
@@ -116,30 +116,65 @@ JEOD-internal physics uses `Quat<ScalarFirst, LeftTransform>`. Conversion to
 
 ## 4. Adding a new frame / time scale / quantity
 
+The `Frame` and `TimeScale` traits are **sealed** (`Sealed + 'static`) and
+require a `const NAME: &'static str`. New tags must be added inside the
+`jeod_quantities` crate so the `Sealed` bound can be satisfied. External
+crates cannot add new frame/time-scale tags — this is intentional, so the
+catalog of valid frames/scales is a finite, auditable set.
+
 ### A new frame tag
 
-1. Add the marker type to `crates/jeod_quantities/src/frame.rs`:
-   ```rust
-   pub struct MyFrame;
-   impl Frame for MyFrame {}
-   ```
-2. Re-export from `prelude.rs` if it should be visible to mission code.
-3. Add a `FrameTransform<MyFrame, Existing>` (and inverse) constructor where
+Add the marker to `crates/jeod_quantities/src/frame.rs`:
+
+```rust
+// Inside crate jeod_quantities:
+use crate::sealed::Sealed;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MyFrame;
+impl Sealed for MyFrame {}
+impl Frame for MyFrame {
+    const NAME: &'static str = "MyFrame";
+}
+```
+
+Then:
+
+1. Re-export from `prelude.rs` (and from `jeod_sim::lib.rs` so the root
+   `bevy_jeod::prelude` picks it up via `jeod_sim`'s re-export chain).
+2. Add a `FrameTransform<MyFrame, Existing>` (and inverse) constructor where
    appropriate — typically in the crate that owns the physics translating
    between the frames.
-4. Add a tier-1 unit test verifying the transform round-trips.
+3. Add a tier-1 unit test verifying the transform round-trips.
+
+For a parametric frame (planet- or vehicle-tagged), use the
+`PlanetFixed<P>` / `BodyFrame<V>` patterns already in `frame.rs` as
+templates — they wrap a `PhantomData<P>` and impl `Sealed`/`Frame` with a
+generic bound. Note that `const NAME` cannot splice `V::NAME` (it must be
+a `&'static str` literal); callers that need the fully-qualified name use
+`std::any::type_name::<F>()`, which is what `Qty3`'s `Debug` impl does.
 
 ### A new time scale
 
-1. Add the marker to `crates/jeod_quantities/src/time_scale.rs`:
-   ```rust
-   pub struct MyScale;
-   impl TimeScale for MyScale {}
-   ```
-2. Define `TimeConverter::<MyScale, From>` and the inverse with the actual
+Add to `crates/jeod_quantities/src/time_scale.rs`:
+
+```rust
+use crate::sealed::Sealed;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MyScale;
+impl Sealed for MyScale {}
+impl TimeScale for MyScale {
+    const NAME: &'static str = "MyScale";
+}
+```
+
+Then:
+
+1. Define `TimeConverter::<MyScale, From>` and the inverse with the actual
    physics in `jeod_time::time_<myscale>`.
-3. Re-export from `prelude.rs`.
-4. Add tier-1 round-trip + tier-2 reference-vector tests.
+2. Re-export from `prelude.rs`.
+3. Add tier-1 round-trip + tier-2 reference-vector tests.
 
 ### A new dimensional quantity
 
@@ -228,25 +263,40 @@ physics language, the `note:` suggesting the corrective API.
 The type system has two documented escape hatches. Both are deliberate; both
 require justification in the PR description that introduces a use.
 
-### `_unchecked` constructors
+### Raw / `_unchecked` constructors
 
-`Qty3::from_raw_si_unchecked(DVec3)`, `NormalizedQuat::from_raw_unchecked(DQuat)`,
-etc. These bypass the typed constructor's validation (e.g., normalization).
-They follow Rust convention: the `_unchecked` suffix is grep-able and
-recognizable. Use only when:
+The crate provides constructors that bypass invariant validation when the
+caller has external proof that the invariant holds. They follow two
+conventions depending on the invariant:
 
-- Constructing a typed quantity from a value that is *known* by construction
-  to satisfy the invariant (e.g., reading the t=0 row of a JEOD reference
-  CSV that has already been validated upstream).
-- The validating constructor would be redundant or measurably impact a hot
-  path.
+- **Trusted SI-unit boundary**: `Qty3::from_raw_si(DVec3)` accepts a raw
+  `glam::DVec3` interpreted in SI base units. There is no separate
+  `_unchecked` variant — the choice of *which frame phantom* to attach is
+  the caller's responsibility, and the only "unchecked" aspect is that
+  the SI interpretation is taken on faith. Use at JEOD-CSV / `glam`
+  boundary code (e.g., reading the t=0 row of a reference CSV).
+- **Genuine `_unchecked` skip**: `InertiaTensor::from_dmat3_unchecked(DMat3)`
+  bypasses the symmetry check that `InertiaTensor::from_dmat3` enforces.
+  Use only when the symmetry of the source matrix is guaranteed by
+  construction (e.g., rotating a verified-symmetric tensor through an
+  orthogonal change-of-basis: `R^T · I · R` preserves symmetry up to
+  floating-point noise).
+
+For quaternion validity, use `NormalizedQuat::new(q)?` (which validates the
+norm against `NormalizedQuat::DEFAULT_TOLERANCE = 1e-12` and returns
+`Err(NotNormalized)` if it fails) or `NormalizedQuat::renormalize(q)`
+(which forces `|q| = 1` and returns `Option`). There is no
+`from_raw_unchecked` variant; callers that need the witness without a
+runtime check should renormalize.
 
 ### `// allowed:` comments
 
 The escape-hatch CI guard (`scripts/check_no_escape_hatches.sh`) refuses
 `#[doc(hidden)]` and the `tag_as_inertial!` macro in `crates/` and `src/`
-unless the line carries a `// allowed: <reason>` opt-out comment. Each
-exemption is reviewed at PR time.
+unless the line carries a `// allowed: <reason>` opt-out comment. (The
+`tag_as_inertial!` macro itself does not currently exist — the script
+greps defensively to keep the door closed against future re-introduction.)
+Each `// allowed:` exemption is reviewed at PR time.
 
 If a future contributor needs to bypass the type system at a public surface,
 the answer is almost always to extend the type system to express the missing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod bundles;
 pub mod components;
+pub mod prelude;
+pub mod recipes;
 pub mod sets;
 pub mod systems;
 pub mod validation;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,42 @@
+//! Mission-crate prelude: `use bevy_jeod::prelude::*;`.
+//!
+//! Brings into scope the typed Bevy Components, the [`JeodPlugin`] and
+//! [`JeodSet`] schedule sets, the [`VehicleConfigBevyExt`] terminal that
+//! materializes a [`jeod_sim::VehicleConfig`] onto a Bevy entity, and the
+//! [`F64Ext`] / [`Vec3Ext`] / [`Array3Ext`] facade traits so mission code
+//! can write `400.0.km()` and `DVec3::new(...).m_at::<Inertial>()`.
+//!
+//! Pair with [`crate::recipes`] (`use bevy_jeod::recipes::*;`) for the
+//! scenario-composition catalogue (`earth::point_mass()`,
+//! `orbital_elements::iss()`, `vehicle::iss_mass()`, …).
+//!
+//! ```ignore
+//! use bevy::prelude::*;
+//! use bevy_jeod::prelude::*;
+//! use bevy_jeod::recipes::*;
+//!
+//! let cfg = VehicleBuilder::new()
+//!     .from_orbital_elements(orbital_elements::iss(), earth::point_mass().source.mu.m3_per_s2())
+//!     .three_dof_point_mass(vehicle::iss_mass())
+//!     .rk4()
+//!     .gravity(GravityControl::new_spherical(0_usize, false))
+//!     .build();
+//! ```
+
+pub use crate::{
+    Abm4StateC, AerodynamicForceC, AtmosphericStateC, DynamicsConfigC, FrameDerivativesC,
+    GaussJacksonStateC, GravityAccelerationC, GravityControlsC, GravitySourceC, GravityTorqueC,
+    IntegratorTypeC, JeodPlugin, JeodSet, MassPropertiesC, PlanetFixedRotationC, RadiationForceC,
+    RotationalStateC, SimulationTimeR, SourceInertialPositionC, SourceInertialVelocityC,
+    StructuralTransformC, TotalForceC, TranslationalStateC, VehicleConfigBevyExt,
+};
+
+// All `jeod_quantities` re-exports come through `jeod_sim` so the
+// `bevy_jeod` root package keeps its single dependency on `jeod_sim`
+// (per CLAUDE.md "Three-Layer Architecture": the root package depends
+// only on `jeod_sim` + `bevy`).
+pub use jeod_sim::{
+    Array3Ext, BodyFrame, Ecef, F64Ext, Frame, FrameTransform, GravityControl, Inertial, JeodQuat,
+    Lvlh, Ned, Planet, PlanetFixed, Qty3, SelfRef, StructuralFrame, Vec3Ext, Vehicle,
+    VehicleBuilder, VehicleConfig,
+};

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -1,0 +1,23 @@
+//! Recipe catalogue re-export: `use bevy_jeod::recipes::*;`.
+//!
+//! Re-exports [`jeod_sim::recipes`] under the `bevy_jeod` crate root so
+//! mission crates that depend only on `bevy_jeod` can compose scenarios
+//! without an explicit `jeod_sim` dependency line in `Cargo.toml`.
+//!
+//! Submodules:
+//!
+//! - `constants` — typed physical constants (`mu_ggm05c()`, `r_eq_earth()`, …)
+//! - `earth` / `moon` / `sun` / `mars` / `mercury` — gravity-source presets
+//!   (`earth::point_mass()`, `earth::ggm05c_8x8()`, …)
+//! - `orbital_elements` — reference orbits (`orbital_elements::iss()`,
+//!   `orbital_elements::geo_inclined()`, …)
+//! - `vehicle` — vehicle mass-property presets (`vehicle::iss_mass()`, …)
+//! - `epoch` — time epochs (`epoch::j2000()`, …)
+//! - `atmosphere` — atmospheric-model presets
+//! - `scenarios` — fully-composed `SimulationBuilder` shortcuts
+//! - `verification` — Tier 3 `VerificationCase` shape (cross-validation tests)
+//! - `helpers` — propagation utilities for archetype-B Tier 3 tests
+//!
+//! See the corresponding modules in `jeod_sim::recipes` for full inventories.
+
+pub use jeod_sim::recipes::*;

--- a/tests/mission_crate_sanity.rs
+++ b/tests/mission_crate_sanity.rs
@@ -21,11 +21,8 @@
 use std::time::Duration;
 
 use bevy::prelude::*;
-use bevy_jeod::{
-    GravitySourceC, JeodPlugin, SourceInertialPositionC, TranslationalStateC, VehicleConfigBevyExt,
-};
-use jeod_sim::recipes::{earth, orbital_elements, vehicle};
-use jeod_sim::{F64Ext, GravityControl, VehicleBuilder};
+use bevy_jeod::prelude::*;
+use bevy_jeod::recipes::{earth, orbital_elements, vehicle};
 
 #[derive(Resource)]
 struct VehicleEntity(Entity);


### PR DESCRIPTION
Follow-up to merged PR #158 — addresses 5 unresolved review threads flagging factual errors in the Phase 11 docs.

## Summary

The original PR's docs claimed APIs that didn't exist (`bevy_jeod::prelude`, `bevy_jeod::recipes`, `Qty3::from_raw_si_unchecked`, `NormalizedQuat::from_raw_unchecked`) and a frame-recipe code snippet that wouldn't compile (`Frame`/`TimeScale` are sealed and require `const NAME`). Two reviewer comments asked for the prelude/recipes modules to be added (or for the docs to drop the claim); the others asked for the doc snippets to match the actual code.

Higher-quality fix taken: **add the missing facade modules** (so the docs become accurate) and correct the two doc passages whose claims couldn't be satisfied by adding code.

## Added

- `src/prelude.rs` — `bevy_jeod::prelude` re-exports the full mission-facing surface (typed Components, `JeodPlugin`, `JeodSet`, `VehicleConfigBevyExt`, facade traits, frame/time-scale tags, `VehicleBuilder`, `GravityControl`). `jeod_quantities` types come through `jeod_sim`'s re-export chain so the root package keeps its single dependency on `jeod_sim` per CLAUDE.md.
- `src/recipes.rs` — `bevy_jeod::recipes` re-exports `jeod_sim::recipes::*` so mission crates depending only on `bevy_jeod` get the recipe catalog.

## Updated

- `tests/mission_crate_sanity.rs` — now imports via `bevy_jeod::prelude::*` + `bevy_jeod::recipes::{...}` (matching the module docstring's claim that the test depends only on `bevy_jeod`).
- `docs/type_system.md` §4 — frame / time-scale snippets now show the real `Sealed + const NAME` pattern.
- `docs/type_system.md` §6 — escape-hatch section replaces the fictional `_unchecked` constructors with `Qty3::from_raw_si()`, `InertiaTensor::from_dmat3_unchecked()`, and the `NormalizedQuat::new(q)?` / `renormalize(q)` pair. Notes that `tag_as_inertial!` is greppable defensively but does not currently exist.
- `CLAUDE.md` "Building a Mission Crate" — worked-example imports updated to match the prose.

## Verification

```
cargo fmt --check                                                    ✓
cargo clippy --workspace --tests --examples -- -D warnings -D deprecated  ✓
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps           ✓
cargo test --doc --workspace                                          ✓
cargo nextest run --workspace -E 'not test(tier3_)'                  ✓ (745/745)
cargo nextest run --test mission_crate_sanity                         ✓ (1/1, now via prelude+recipes)
scripts/check_no_escape_hatches.sh                                    ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)