### PR TITLE
Type-erase PlanetFixedRotationC + StructuralTransformC (Strategy 5, #155)

### DIFF
--- a/crates/jeod_quantities/src/frame.rs
+++ b/crates/jeod_quantities/src/frame.rs
@@ -56,6 +56,23 @@ planet_marker!(Moon, "Moon");
 planet_marker!(Sun, "Sun");
 planet_marker!(Mars, "Mars");
 
+/// Phantom marker for "this entity's own planet" — used by ECS adapters
+/// whose per-entity components carry `PlanetFixed<P>` phantoms but whose
+/// planet identity is determined at runtime by the entity itself.
+///
+/// Planet-side analog of [`SelfRef`] (which serves the same role for
+/// `Vehicle`-parameterized frames). Use when wrapping a per-entity
+/// rotation Component such as `PlanetFixedRotationC` whose Bevy entity
+/// already carries a `PlanetC` discriminator — the typed `FrameTransform`
+/// inside the Component encodes the *direction* (Inertial → PlanetFixed)
+/// while the planet identity stays at the entity level.
+#[derive(Debug, Clone, Copy)]
+pub struct SelfPlanet;
+impl Sealed for SelfPlanet {}
+impl Planet for SelfPlanet {
+    const NAME: &'static str = "SelfPlanet";
+}
+
 // --- Frame markers ------------------------------------------------------------
 
 /// Quasi-inertial (ICRF / J2000 Earth-centered inertial) frame.

--- a/crates/jeod_quantities/src/frame_transform.rs
+++ b/crates/jeod_quantities/src/frame_transform.rs
@@ -96,6 +96,72 @@ impl<From: Frame, To: Frame> FrameTransform<From, To> {
     pub const fn matrix(&self) -> DMat3 {
         self.matrix
     }
+
+    /// Borrowing accessor for the cached matrix. Parallels [`Self::matrix`]
+    /// (which copies by value); prefer this in tight loops or when passing
+    /// the matrix to a function that takes `&DMat3`.
+    #[inline]
+    pub const fn matrix_ref(&self) -> &DMat3 {
+        &self.matrix
+    }
+
+    /// Construct from a raw rotation matrix. The matrix is stored as-is
+    /// (bit-identical to the input); the cached quaternion is derived via
+    /// `DQuat::from_mat3`.
+    ///
+    /// The caller must pass a proper orthonormal rotation matrix —
+    /// `debug_assert!`s check `det ≈ 1.0` and `M·Mᵀ ≈ I`. Production
+    /// behaviour on a non-rotation matrix is unspecified (`from_mat3`
+    /// produces an arbitrary quaternion; subsequent `.apply()` calls
+    /// continue to use the original matrix and remain bit-identical to a
+    /// raw `M * v` multiply).
+    ///
+    /// **Use when** the matrix is the source of truth — e.g., RNP / Mars /
+    /// Moon / DE421 rotation kernels — and round-tripping through
+    /// [`Self::from_quat`] would introduce floating-point drift in the
+    /// stored matrix.
+    ///
+    /// **Bit-stability invariant**: `from_matrix(M).matrix_ref() == &M`
+    /// exactly. The quaternion derivation does not influence the stored
+    /// matrix.
+    #[inline]
+    pub fn from_matrix(matrix: DMat3) -> Self {
+        // Orthonormality checks are debug-only — the cached quaternion is
+        // already an approximation when the input isn't a perfect rotation,
+        // and we'd rather catch the bug in tests than impose a release-mode
+        // cost on every per-step rotation update.
+        debug_assert!(
+            (matrix.determinant() - 1.0).abs() < 1.0e-9,
+            "FrameTransform::from_matrix: input must have determinant ≈ 1.0 \
+             (got {})",
+            matrix.determinant()
+        );
+        debug_assert!(
+            {
+                let drift = (matrix * matrix.transpose() - DMat3::IDENTITY)
+                    .to_cols_array()
+                    .iter()
+                    .map(|x| x.abs())
+                    .fold(0.0_f64, f64::max);
+                drift < 1.0e-9
+            },
+            "FrameTransform::from_matrix: input must be orthonormal (M·Mᵀ ≈ I)"
+        );
+
+        // Derive the JEOD-canonical (scalar-first, left-transform) quaternion
+        // from the matrix. `glam::DQuat::from_mat3` returns a scalar-last
+        // quaternion; we re-pack into JEOD layout.
+        let g = glam::DQuat::from_mat3(&matrix);
+        let jeod = JeodQuat::from_array([g.w, g.x, g.y, g.z]);
+        let quat = NormalizedQuat::renormalize(jeod)
+            .expect("DQuat::from_mat3 of a non-zero matrix yields a non-zero quaternion");
+        Self {
+            quat,
+            matrix,
+            _from: PhantomData,
+            _to: PhantomData,
+        }
+    }
 }
 
 /// Compose two transforms: `(A→B) ∘ (B→C) = A→C`.
@@ -129,5 +195,76 @@ impl<A: Frame, B: Frame, C: Frame> Mul<FrameTransform<B, C>> for FrameTransform<
             _from: PhantomData,
             _to: PhantomData,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::{Ecef, Inertial};
+
+    /// `from_matrix(M).matrix_ref() == &M` exactly (bit-identical).
+    /// The quaternion derivation does not influence the stored matrix —
+    /// this is the load-bearing invariant of the Strategy 5 Component
+    /// erasure (#155): rotation matrices entering via Components must
+    /// emerge bit-identical when read back.
+    #[test]
+    fn from_matrix_preserves_input_bit_exact() {
+        // Use a non-trivial rotation (45° about Y) so any quaternion
+        // round-trip would surface as a few-ULP drift.
+        let theta = core::f64::consts::FRAC_PI_4;
+        let m = DMat3::from_cols(
+            DVec3::new(theta.cos(), 0.0, -theta.sin()),
+            DVec3::new(0.0, 1.0, 0.0),
+            DVec3::new(theta.sin(), 0.0, theta.cos()),
+        );
+        let t: FrameTransform<Inertial, Ecef> = FrameTransform::from_matrix(m);
+        assert_eq!(
+            *t.matrix_ref(),
+            m,
+            "matrix not bit-preserved by from_matrix"
+        );
+        assert_eq!(t.matrix(), m, "matrix() must agree with matrix_ref()");
+    }
+
+    /// Identity input round-trips through `from_matrix` cleanly and the
+    /// derived quaternion is the identity unit quaternion.
+    #[test]
+    fn from_matrix_identity_round_trip() {
+        let t: FrameTransform<Inertial, Inertial> = FrameTransform::from_matrix(DMat3::IDENTITY);
+        assert_eq!(*t.matrix_ref(), DMat3::IDENTITY);
+        // The cached quaternion should be near-identity (q0 ≈ 1, qi ≈ 0).
+        let q = t.quat().inner();
+        assert!((q.data[0].abs() - 1.0).abs() < 1.0e-12);
+        assert!(q.data[1].abs() < 1.0e-12);
+        assert!(q.data[2].abs() < 1.0e-12);
+        assert!(q.data[3].abs() < 1.0e-12);
+    }
+
+    /// `apply()` after `from_matrix` produces the same vector as a raw
+    /// `M * v` multiply — confirms `apply()` reads from the stored matrix,
+    /// not from the derived quaternion.
+    #[test]
+    fn apply_after_from_matrix_matches_raw_multiply() {
+        let theta: f64 = 0.37; // arbitrary non-special angle
+        let m = DMat3::from_cols(
+            DVec3::new(theta.cos(), theta.sin(), 0.0),
+            DVec3::new(-theta.sin(), theta.cos(), 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+        );
+        let t: FrameTransform<Inertial, Ecef> = FrameTransform::from_matrix(m);
+        let v_raw = DVec3::new(1.0, 2.0, 3.0);
+        let v_in: Qty3<uom::si::length::Dimension, Inertial> = Qty3::from_raw_si(v_raw);
+        let v_out = t.apply(v_in);
+        assert_eq!(v_out.raw_si(), m * v_raw);
+    }
+
+    /// `debug_assert!` panic on a non-orthonormal input (in debug builds).
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "determinant")]
+    fn from_matrix_rejects_non_unit_determinant() {
+        let m = DMat3::from_diagonal(DVec3::new(2.0, 1.0, 1.0)); // det = 2
+        let _: FrameTransform<Inertial, Ecef> = FrameTransform::from_matrix(m);
     }
 }

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -166,8 +166,8 @@ pub use jeod_quantities::aliases::{
 pub use jeod_quantities::dims::{GravParam, MassFlowRate, SpecificAngMom, SpecificEnergy};
 pub use jeod_quantities::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use jeod_quantities::frame::{
-    BodyFrame, Earth, Ecef, Frame, Inertial, Lvlh, Mars, Moon, Ned, Planet, PlanetFixed, SelfRef,
-    StructuralFrame, Sun, Vehicle,
+    BodyFrame, Earth, Ecef, Frame, Inertial, Lvlh, Mars, Moon, Ned, Planet, PlanetFixed,
+    SelfPlanet, SelfRef, StructuralFrame, Sun, Vehicle,
 };
 pub use jeod_quantities::frame_transform::FrameTransform;
 pub use jeod_quantities::inertia::InertiaTensor;

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -5,7 +5,7 @@
 //! components directly.
 
 use bevy::prelude::*;
-use jeod_sim::{GravityModel, GravitySource, PlanetConfig};
+use jeod_sim::{FrameTransform, GravityModel, GravitySource, PlanetConfig};
 
 use crate::components::*;
 
@@ -42,7 +42,7 @@ impl PlanetBundle {
             source: GravitySourceC(source),
             position: SourceInertialPositionC::default(),
             trans: TranslationalStateC::default(),
-            rotation: PlanetFixedRotationC(glam::DMat3::IDENTITY),
+            rotation: PlanetFixedRotationC(FrameTransform::from_matrix(glam::DMat3::IDENTITY)),
             rotation_model: RotationModelC(config.rotation_model),
             shape: PlanetC(config.shape),
         }

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,8 +2,9 @@ use bevy::prelude::*;
 use glam::DVec3;
 use jeod_sim::{
     Angle, BodyFrame, DragConfig, DragConfigTyped, DynamicsConfig, FrameDerivatives,
-    GravityAcceleration, GravityControls, GravitySource, Inertial, MassProperties, PlanetShape,
-    Position, Ratio, RotationalState, SelfRef, Torque, TotalForce, TranslationalState, Velocity,
+    FrameTransform, GravityAcceleration, GravityControls, GravitySource, Inertial, MassProperties,
+    PlanetFixed, PlanetShape, Position, Ratio, RotationalState, SelfPlanet, SelfRef,
+    StructuralFrame, Torque, TotalForce, TranslationalState, Velocity,
 };
 
 // ── Dynamics ──
@@ -128,9 +129,15 @@ pub struct GravityTorqueC(pub Torque<BodyFrame<SelfRef>>);
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
 pub struct AtmosphericStateC(pub jeod_sim::AtmosphereState);
 
-/// Rotation matrix from structural frame to body (composite_body) frame.
+/// Typed structural→body rotation for a vehicle entity.
 ///
-/// Matches JEOD `mass.composite_properties.T_parent_this` where parent=structure.
+/// Stores the rotation that maps structural-frame vectors into body-frame
+/// vectors (matches JEOD `mass.composite_properties.T_parent_this` where
+/// parent=structure). The `FrameTransform`'s phantom `<StructuralFrame<SelfRef>,
+/// BodyFrame<SelfRef>>` parameters encode the *direction* — `SelfRef` is the
+/// wildcard `Vehicle` marker indicating "this entity's vehicle"; the actual
+/// vehicle identity stays at the entity level via Bevy queries.
+///
 /// Default is identity (structural frame = body frame), which is correct for
 /// single-body vehicles with `eigen_angle=0`.
 ///
@@ -140,22 +147,29 @@ pub struct AtmosphericStateC(pub jeod_sim::AtmosphereState);
 // JEOD_INV: DB.28 — forces collected in structural frame, rotated to inertial at root
 // JEOD_INV: DB.29 — torques collected in structural frame, rotated to body at root
 #[derive(Component, Debug, Clone, Copy)]
-pub struct StructuralTransformC(pub glam::DMat3);
+pub struct StructuralTransformC(pub FrameTransform<StructuralFrame<SelfRef>, BodyFrame<SelfRef>>);
 
 impl Default for StructuralTransformC {
     fn default() -> Self {
-        Self(glam::DMat3::IDENTITY)
+        Self(FrameTransform::from_matrix(glam::DMat3::IDENTITY))
     }
 }
 
-/// Inertial-to-planet-fixed rotation matrix for a gravity source entity.
+/// Typed inertial→planet-fixed rotation for a gravity source entity.
+///
+/// Stores the rotation that maps inertial-frame vectors into the planet-fixed
+/// frame of the source. The `FrameTransform`'s phantom `<Inertial,
+/// PlanetFixed<SelfPlanet>>` parameters encode the *direction* — `SelfPlanet`
+/// is the wildcard `Planet` marker indicating "this entity's planet"; the
+/// actual planet identity stays at the entity level via the existing
+/// `PlanetC` discriminator.
 ///
 /// When present on a gravity source entity, `gravity_computation_system` and
-/// `integration_system` use this matrix instead of `DMat3::IDENTITY` to rotate
-/// the spacecraft position into the body-fixed frame before evaluating
+/// `integration_system` use this rotation instead of `DMat3::IDENTITY` to
+/// rotate the spacecraft position into the body-fixed frame before evaluating
 /// spherical-harmonic gravity.
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut)]
-pub struct PlanetFixedRotationC(pub glam::DMat3);
+#[derive(Component, Debug, Clone, Copy)]
+pub struct PlanetFixedRotationC(pub FrameTransform<Inertial, PlanetFixed<SelfPlanet>>);
 
 /// Tidal configuration for a gravity source entity.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,9 @@ impl VehicleConfigBevyExt for jeod_sim::VehicleConfig {
             components::DynamicsConfigC(dynamics_config),
             components::GravityControlsC(entity_controls),
             components::IntegratorTypeC(self.integrator),
-            components::StructuralTransformC(self.t_struct_body),
+            components::StructuralTransformC(jeod_sim::FrameTransform::from_matrix(
+                self.t_struct_body,
+            )),
         ));
         if let Some(rot) = self.rot {
             entity.insert(components::RotationalStateC(rot));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -37,6 +37,6 @@ pub use crate::{
 // only on `jeod_sim` + `bevy`).
 pub use jeod_sim::{
     Array3Ext, BodyFrame, Ecef, F64Ext, Frame, FrameTransform, GravityControl, Inertial, JeodQuat,
-    Lvlh, Ned, Planet, PlanetFixed, Qty3, SelfRef, StructuralFrame, Vec3Ext, Vehicle,
+    Lvlh, Ned, Planet, PlanetFixed, Qty3, SelfPlanet, SelfRef, StructuralFrame, Vec3Ext, Vehicle,
     VehicleBuilder, VehicleConfig,
 };

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use glam::DVec3;
-use jeod_sim::{BodyFrame, Inertial, Position, SelfRef, Velocity};
+use jeod_sim::{BodyFrame, Inertial, Position, SelfPlanet, SelfRef, Velocity};
 
 use crate::components::*;
 use crate::AtmosphereModelR;
@@ -38,8 +38,13 @@ pub fn planet_fixed_rotation_system(
     mut query: Query<(&mut PlanetFixedRotationC, Option<&RotationModelC>)>,
 ) {
     let polar_params = polar.map(|p| (p.xp, p.yp));
-    // Lazy-compute Earth RNP only if needed (most common case).
-    let mut earth_rotation: Option<glam::DMat3> = Option::None;
+    // Lazy-compute Earth RNP only if needed (most common case). Cache the
+    // already-typed `FrameTransform` rather than the bare matrix so the
+    // expensive `from_matrix` work (matrix→quat extraction + renormalization)
+    // happens once per tick total, not once per EarthRNP entity per tick —
+    // all EarthRNP entities share the same rotation each step.
+    type EarthRot = jeod_sim::FrameTransform<jeod_sim::Inertial, jeod_sim::PlanetFixed<SelfPlanet>>;
+    let mut earth_rotation: Option<EarthRot> = Option::None;
     for (mut rot, model) in &mut query {
         let default_model = jeod_sim::RotationModel::EarthRNP;
         let rotation_model = model.map_or(&default_model, |m| &m.0);
@@ -47,13 +52,15 @@ pub fn planet_fixed_rotation_system(
             jeod_sim::RotationModel::None => {}
             jeod_sim::RotationModel::EarthRNP => {
                 let rotation = *earth_rotation.get_or_insert_with(|| {
-                    jeod_sim::compute_t_parent_this_from_tjt_with_polar(
-                        sim_time.gmst_seconds,
-                        sim_time.tt_tjt(),
-                        polar_params,
+                    jeod_sim::FrameTransform::from_matrix(
+                        jeod_sim::compute_t_parent_this_from_tjt_with_polar(
+                            sim_time.gmst_seconds,
+                            sim_time.tt_tjt(),
+                            polar_params,
+                        ),
                     )
                 });
-                rot.0 = jeod_sim::FrameTransform::from_matrix(rotation);
+                rot.0 = rotation;
             }
             jeod_sim::RotationModel::MarsIAU => {
                 let tt_s_since_j2000 =

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -53,27 +53,32 @@ pub fn planet_fixed_rotation_system(
                         polar_params,
                     )
                 });
-                rot.0 = rotation;
+                rot.0 = jeod_sim::FrameTransform::from_matrix(rotation);
             }
             jeod_sim::RotationModel::MarsIAU => {
                 let tt_s_since_j2000 =
                     (sim_time.tt_tjt() - jeod_sim::J2000_TT_TJT) * jeod_sim::SECONDS_PER_DAY;
-                rot.0 = jeod_sim::rotation_mars::compute_mars_rotation(tt_s_since_j2000);
+                rot.0 = jeod_sim::FrameTransform::from_matrix(
+                    jeod_sim::rotation_mars::compute_mars_rotation(tt_s_since_j2000),
+                );
             }
             jeod_sim::RotationModel::MoonIAU => {
                 let tdb_jd = sim_time.tdb_julian_date();
                 let tdb_s_since_j2000 =
                     (tdb_jd - jeod_sim::J2000_TT_JD) * jeod_sim::SECONDS_PER_DAY;
-                rot.0 = jeod_sim::rotation_moon::compute_moon_rotation(tdb_s_since_j2000);
+                rot.0 = jeod_sim::FrameTransform::from_matrix(
+                    jeod_sim::rotation_moon::compute_moon_rotation(tdb_s_since_j2000),
+                );
             }
             jeod_sim::RotationModel::MoonDE421 => {
                 let eph = ephemeris
                     .as_ref()
                     .expect("MoonDE421 rotation requires EphemerisR resource with BPC loaded.");
                 let tdb_jd = sim_time.tdb_julian_date();
-                rot.0 = eph
-                    .get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd)
-                    .expect("Moon DE421 BPC rotation query failed");
+                rot.0 = jeod_sim::FrameTransform::from_matrix(
+                    eph.get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd)
+                        .expect("Moon DE421 BPC rotation query failed"),
+                );
             }
         }
     }
@@ -94,7 +99,7 @@ pub fn tidal_update_system(
         // `Vec` allocation or per-body f64 → typed conversion.
         // `compute_delta_c20_typed` returns `Ratio`, matching
         // `TidalDeltaC20C`'s storage type.
-        delta.0 = jeod_sim::compute_delta_c20_typed(&config.0, &rotation.0);
+        delta.0 = jeod_sim::compute_delta_c20_typed(&config.0, rotation.0.matrix_ref());
     }
 }
 
@@ -205,7 +210,7 @@ pub fn force_collection_system(
         ext_torque,
     ) in &mut query
     {
-        let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
+        let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| *s.0.matrix_ref());
         let grav_accel = grav.map_or(DVec3::ZERO, |g| g.grav_accel);
 
         // Map Bevy component references to jeod_interactions types for jeod_sim.
@@ -325,7 +330,7 @@ pub fn integration_system(
                 |source_entity| match sources.get(source_entity) {
                     Ok((s, r, p, _, tidal, tidal_config)) => Some(jeod_sim::ResolvedSource {
                         source: &s.0,
-                        rotation: r.map(|r| &r.0),
+                        rotation: r.map(|r| r.0.matrix_ref()),
                         position: p.0.raw_si(),
                         delta_c20: tidal.map_or(0.0, |t| t.0.value),
                         has_delta_coeffs: tidal_config.is_some(),
@@ -410,7 +415,7 @@ pub fn integration_system(
                 "Entity {entity:?}: derivative-class ThermalIntegrationOrder \
                  requires RK4 integrator; use Scheduled or switch integrator.",
             );
-            let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
+            let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| *s.0.matrix_ref());
             let non_grav_non_srp_force = total_force.force;
             let constant_torque = total_force.torque;
             let mut final_srp_inertial_force = DVec3::ZERO;
@@ -574,7 +579,7 @@ pub fn gravity_computation_system(
                 Ok((source, rot, pos, _, tidal, tidal_config)) => {
                     Some(jeod_sim::ResolvedSource {
                         source: &source.0,
-                        rotation: rot.map(|r| &r.0),
+                        rotation: rot.map(|r| r.0.matrix_ref()),
                         position: pos.0.raw_si(),
                         delta_c20: tidal.map_or(0.0, |t| t.0.value),
                         // JEOD gates on n_deltacoeffs > 0 (tidal config
@@ -642,7 +647,7 @@ pub fn atmosphere_update_system(
                  the planet entity or set planet_entity to None for spherical fallback."
             );
         };
-        Some(r.0)
+        Some(*r.0.matrix_ref())
     } else {
         None
     };
@@ -687,7 +692,7 @@ pub fn aero_drag_system(
     )>,
 ) {
     for (drag_config, atmos, state, rot, struct_xform, mut aero_force) in &mut query {
-        let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
+        let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| *s.0.matrix_ref());
 
         // `DragConfigC` already wraps `DragConfigTyped` — the dimensional
         // lift happened once at insertion (`DragConfigC::from_untyped`),
@@ -842,8 +847,12 @@ pub fn geodetic_system(
         // numerics to the f64 path.
         use jeod_sim::F64Ext;
         let pos = Position::<Inertial>::from_raw_si(state.position);
-        geodetic.0 =
-            jeod_sim::compute_body_geodetic_typed(pos, &rot.0, planet.r_eq.m(), planet.r_pol.m());
+        geodetic.0 = jeod_sim::compute_body_geodetic_typed(
+            pos,
+            rot.0.matrix_ref(),
+            planet.r_eq.m(),
+            planet.r_pol.m(),
+        );
     }
 }
 
@@ -1028,7 +1037,8 @@ pub fn flat_plate_srp_system(
                 let t_inertial_body = rot.map_or(glam::DMat3::IDENTITY, |r| {
                     r.quaternion.left_quat_to_transformation()
                 });
-                let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| s.0);
+                let t_struct_body =
+                    struct_xform.map_or(glam::DMat3::IDENTITY, |s| *s.0.matrix_ref());
                 let t_inertial_struct =
                     jeod_sim::compute_t_inertial_struct(&t_struct_body, &t_inertial_body);
                 let flux_struct_hat = t_inertial_struct * flux_inertial_hat;

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -177,7 +177,7 @@ fn tier3_bevy_geodetic_derived_state() {
             GravitySourceC(earth_source()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
             PlanetC(earth_shape),
         ))
         .id();
@@ -446,7 +446,7 @@ fn tier3_bevy_polar_geodetic() {
             GravitySourceC(earth_source()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
             PlanetC(earth_shape),
         ))
         .id();
@@ -834,7 +834,7 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
             GravitySourceC(earth_source()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
             PlanetC(earth_shape),
         ))
         .id();

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -224,7 +224,7 @@ fn tier3_bevy_met_atmosphere_drag_sixdof() {
             GravitySourceC(earth_source()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
         ))
         .id();
 
@@ -320,7 +320,7 @@ fn tier3_bevy_met_run5a() {
             GravitySourceC(earth_source()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
         ))
         .id();
 
@@ -428,7 +428,7 @@ fn tier3_bevy_drag_run6b() {
             GravitySourceC(earth_source()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
         ))
         .id();
 

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -56,7 +56,7 @@ fn tier3_bevy_sh4x4_rnp() {
             GravitySourceC(sh_source.clone()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
         ))
         .id();
 
@@ -166,7 +166,7 @@ fn tier3_bevy_tidal_sh4x4() {
             GravitySourceC(sh_source.clone()),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
             TidalConfigC::from_untyped(&tidal_config),
         ))
         .id();

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -769,7 +769,7 @@ fn tier3_bevy_srp_derivative_rk4_with_rotated_struct_frame() {
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
             }),
-            StructuralTransformC(t_struct_body),
+            StructuralTransformC(jeod_sim::FrameTransform::from_matrix(t_struct_body)),
             FlatPlateConfigC(jeod_sim::FlatPlateState {
                 plates: offset_plate.clone(),
                 temperatures: vec![270.0],

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -469,7 +469,7 @@ fn tier3_bevy_mars_dawn() {
             }),
             SourceInertialPositionC::default(),
             TranslationalStateC::default(),
-            PlanetFixedRotationC(DMat3::IDENTITY),
+            PlanetFixedRotationC(jeod_sim::FrameTransform::from_matrix(DMat3::IDENTITY)),
             RotationModelC(RotationModel::MarsIAU),
         ))
         .id();


### PR DESCRIPTION
Closes #155.

## Summary

`PlanetFixedRotationC` and `StructuralTransformC` were the last bare-`DMat3` Bevy Components in a workspace that's otherwise typed end-to-end after the Phase 8 refactor. This PR wraps them in `FrameTransform<F, T>` so the rotation **direction** is encoded in the type. The "which planet/vehicle" stays at the entity level via Bevy queries — typed `<SelfPlanet>` / `<SelfRef>` wildcards mark "this entity's planet / vehicle" without leaking generics into the Component layout.

Direction-flip bugs (a system accidentally treating `T_inertial_pfix` as `T_pfix_inertial`) are now compile errors.

## Strategy chosen: 5 (direction-typed wildcard frame)

Per the design recap on the issue, of the candidate strategies:

- **Trait-object erasure** rejected — adds dyn dispatch on hot paths, doesn't actually solve the typing problem.
- **Enum-tagged Components** rejected — runtime planet enum duplicates information already at the entity level via `&PlanetC` joins.
- **FrameId-indexed Components with registry resource** rejected — overkill for a fixed set of 4 planets.
- **Generic `<P>` Components** deferred — too rigid; "iterate all PFix" Bevy queries become awkward. Kept as **future Strategy 4** upgrade if direction-typing alone proves insufficient.
- **Strategy 5: direction-typed wildcard frame** ← chosen. Captures the bug class at zero runtime cost; reuses existing `SelfRef` convention.

The Strategy 4 upgrade is preserved as a small additive change later: `PlanetFixedRotationC<P: Planet = SelfPlanet>(...)` keeps every existing call site compiling.

## Implementation

Two commits:

1. **Additive `jeod_quantities` changes** (commit `6584242`)
   - `SelfPlanet` planet marker (planet-side analog of existing `SelfRef`).
   - `FrameTransform::from_matrix(DMat3) -> Self` constructor for use when the matrix is the source of truth (RNP / Mars IAU / Moon IAU / DE421 kernels). Stores the matrix bit-identical; derives the quaternion *from* the matrix at construction.
   - `FrameTransform::matrix_ref(&self) -> &DMat3` borrowing accessor.
   - Four new tests in `frame_transform.rs` including the load-bearing `from_matrix_preserves_input_bit_exact`.

2. **Workspace sweep** (commit `1858832`)
   - Component shape change in `src/components.rs`.
   - `src/bundles.rs` + `src/lib.rs` wiring updated.
   - 12 call sites in `src/systems.rs` updated (4 writer sites in `planet_fixed_rotation_system`, 4 `t_struct_body` extraction sites, 4 `Option<&DMat3>` reader sites, plus `tidal_update_system`, `atmosphere_update_system`, `geodetic_system`).
   - 10 test fixture sites in `tests/bevy_parity_*.rs` updated.
   - Re-exports of `SelfPlanet` through `jeod_sim::lib.rs` and `bevy_jeod::prelude`.
   - Drops `Deref/DerefMut` from `PlanetFixedRotationC` (zero call sites used them).

## Bit-stability invariant

`FrameTransform::from_matrix(M).matrix_ref() == &M` exactly. The quaternion is derived from the matrix at construction; the stored matrix is never recomputed from the quaternion. This guarantees:

- All 11 `bevy_parity_*` tests stay bit-exact against the runner.
- `tier3_baseline_diff` reports `OK (76 matched; 0 allowed-missing)` — no numeric drift.
- The matrix path through `apply()` is identical to a raw `M * v` multiply.

## Verification (all green locally)

```bash
cargo fmt --check                                                  # clean
cargo clippy --workspace --tests --examples -- -D warnings -D deprecated  # clean
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps         # clean
cargo test --doc --workspace                                        # all doctests pass
cargo nextest run --workspace -E 'not test(tier3_)'                # 749/749 (was 745; +4 from_matrix tests)
cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'   # 306/306
cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing tier3_earth_moon_clem  # OK (76 matched; 0 allowed-missing)
scripts/check_no_escape_hatches.sh                                 # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)