### PR TITLE
Add Bevy Reflect derives on typed Components (#154)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ name = "bevy_jeod"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bevy_reflect",
  "glam 0.30.10",
  "jeod_dynamics",
  "jeod_quantities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 jeod_sim = { path = "crates/jeod_sim" }
 glam = { workspace = true }
 bevy = { workspace = true }
+bevy_reflect = { workspace = true }
 
 [dev-dependencies]
 glam = { workspace = true }
@@ -47,6 +48,7 @@ bevy = { version = "0.18", default-features = false, features = [
     "std",
     "multi_threaded",
 ] }
+bevy_reflect = { version = "0.18", default-features = false }
 log = "0.4"
 thiserror = "2"
 uom = { version = "0.38", default-features = false, features = ["f64", "si", "std"] }

--- a/src/components.rs
+++ b/src/components.rs
@@ -10,25 +10,32 @@ use jeod_sim::{
 // ── Dynamics ──
 
 // JEOD_INV: DB.24 — default integrated_frame is composite_body (we integrate composite_body state)
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default)]
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
+#[reflect(opaque)]
 pub struct TranslationalStateC(pub TranslationalState);
 
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct RotationalStateC(pub RotationalState);
 
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct MassPropertiesC(pub MassProperties);
 
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default)]
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
+#[reflect(opaque)]
 pub struct GravityAccelerationC(pub GravityAcceleration);
 
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default)]
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
+#[reflect(opaque)]
 pub struct TotalForceC(pub TotalForce);
 
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default)]
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
+#[reflect(opaque)]
 pub struct FrameDerivativesC(pub FrameDerivatives);
 
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 #[require(FrameDerivativesC)]
 pub struct DynamicsConfigC(pub DynamicsConfig);
 
@@ -36,7 +43,8 @@ pub struct DynamicsConfigC(pub DynamicsConfig);
 ///
 /// When present on a dynamic body entity, the integration system dispatches
 /// to the specified method. When absent, `IntegratorType::Rk4` is used.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct IntegratorTypeC(pub jeod_sim::IntegratorType);
 
 /// Persistent Gauss-Jackson (Störmer-Cowell) integrator state.
@@ -44,7 +52,8 @@ pub struct IntegratorTypeC(pub jeod_sim::IntegratorType);
 /// Required on entities using `IntegratorType::GaussJackson`. Created once
 /// with `GaussJacksonState::new(config)` and maintained across steps.
 /// When absent, `integration_system` will panic if `IntegratorTypeC` is GJ.
-#[derive(Component, Debug, Clone, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct GaussJacksonStateC(pub jeod_sim::GaussJacksonState);
 
 /// Persistent Adams-Bashforth-Moulton 4 integrator state.
@@ -52,14 +61,17 @@ pub struct GaussJacksonStateC(pub jeod_sim::GaussJacksonState);
 /// Required on entities using `IntegratorType::Abm4`. Created once with
 /// `Abm4State::new()` and maintained across steps. When absent,
 /// `integration_system` will panic if `IntegratorTypeC` is `Abm4`.
-#[derive(Component, Debug, Clone, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct Abm4StateC(pub jeod_sim::Abm4State);
 
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(opaque)]
 #[require(GravityAccelerationC, TotalForceC)]
 pub struct GravityControlsC(pub GravityControls<Entity>);
 
-#[derive(Component, Debug, Clone, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct GravitySourceC(pub GravitySource);
 
 /// Inertial-frame position of a gravity source.
@@ -73,7 +85,8 @@ pub struct GravitySourceC(pub GravitySource);
 /// Required on all gravity source entities. The gravity systems will panic
 /// if a source entity referenced by a `GravityControlsC` is missing this
 /// component.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct SourceInertialPositionC(pub Position<Inertial>);
 
 /// Inertial-frame velocity of a gravity source.
@@ -88,7 +101,8 @@ pub struct SourceInertialPositionC(pub Position<Inertial>);
 /// the relativistic correction computation. Stored separately from
 /// `TranslationalStateC` to avoid Bevy query conflicts (the body's
 /// `TranslationalStateC` is already mutably queried by the integration system).
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct SourceInertialVelocityC(pub Velocity<Inertial>);
 
 /// Aerodynamic force and torque in the **structural** frame (N, N*m).
@@ -96,7 +110,8 @@ pub struct SourceInertialVelocityC(pub Velocity<Inertial>);
 /// Written by `aero_drag_system`.
 /// `force_collection_system` rotates force to inertial and torque to body
 /// via `StructuralTransformC`.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque)]
 pub struct AerodynamicForceC {
     pub force: DVec3,
     pub torque: DVec3,
@@ -109,7 +124,8 @@ pub struct AerodynamicForceC {
 /// Torque is always in the **structural** frame.
 /// Written by `flat_plate_srp_system`.
 /// `force_collection_system` rotates torque to body via `StructuralTransformC`.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque)]
 pub struct RadiationForceC {
     pub force: DVec3,
     pub torque: DVec3,
@@ -119,14 +135,16 @@ pub struct RadiationForceC {
 ///
 /// Written by the gravity torque system.
 /// Read by `force_collection_system` as `Option<&GravityTorqueC>`.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct GravityTorqueC(pub Torque<BodyFrame<SelfRef>>);
 
 // JEOD_INV: AT.01 — active flag gates computation (presence of AtmosphericStateC = active)
 /// Atmospheric state at the vehicle's position.
 ///
 /// Written by the atmosphere system. Read by the aerodynamic drag system.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct AtmosphericStateC(pub jeod_sim::AtmosphereState);
 
 /// Typed structural→body rotation for a vehicle entity.
@@ -146,7 +164,8 @@ pub struct AtmosphericStateC(pub jeod_sim::AtmosphereState);
 /// - Rotate structural-frame torques to body frame
 // JEOD_INV: DB.28 — forces collected in structural frame, rotated to inertial at root
 // JEOD_INV: DB.29 — torques collected in structural frame, rotated to body at root
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 pub struct StructuralTransformC(pub FrameTransform<StructuralFrame<SelfRef>, BodyFrame<SelfRef>>);
 
 impl Default for StructuralTransformC {
@@ -168,7 +187,8 @@ impl Default for StructuralTransformC {
 /// `integration_system` use this rotation instead of `DMat3::IDENTITY` to
 /// rotate the spacecraft position into the body-fixed frame before evaluating
 /// spherical-harmonic gravity.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 pub struct PlanetFixedRotationC(pub FrameTransform<Inertial, PlanetFixed<SelfPlanet>>);
 
 /// Tidal configuration for a gravity source entity.
@@ -185,7 +205,8 @@ pub struct PlanetFixedRotationC(pub FrameTransform<Inertial, PlanetFixed<SelfPla
 /// (Vec collect + per-body f64 → typed boxing). Convenience constructors
 /// `from_untyped` / `From` impls are provided for callers building from
 /// the untyped struct.
-#[derive(Component, Debug, Clone, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 #[require(TidalDeltaC20C)]
 pub struct TidalConfigC(pub jeod_sim::TidalConfigTyped);
 
@@ -222,7 +243,8 @@ impl From<jeod_sim::TidalConfigTyped> for TidalConfigC {
 /// Wrapped as a [`Ratio`] (dimensionless) so the value carries unit
 /// metadata at the type level — matching `compute_delta_c20_typed`'s
 /// return type.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct TidalDeltaC20C(pub Ratio);
 
 // ── Interactions ──
@@ -235,7 +257,8 @@ pub struct TidalDeltaC20C(pub Ratio);
 /// `new` are provided for callers building from raw `f64` fields.
 ///
 /// Auto-inserts [`AtmosphericStateC`] and [`AerodynamicForceC`] when added.
-#[derive(Component, Debug, Clone, Copy, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 #[require(AtmosphericStateC, AerodynamicForceC)]
 pub struct DragConfigC(pub DragConfigTyped);
 
@@ -270,7 +293,8 @@ impl From<DragConfigTyped> for DragConfigC {
 /// `integrate_temperatures` method) is shared with the `Simulation` runner.
 ///
 /// Auto-inserts [`RadiationForceC`] when added.
-#[derive(Component, Debug, Clone, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 #[require(RadiationForceC)]
 pub struct FlatPlateConfigC(pub jeod_sim::FlatPlateState);
 
@@ -279,7 +303,8 @@ pub struct FlatPlateConfigC(pub jeod_sim::FlatPlateState);
 /// The shadow detection system queries all entities with this component
 /// and computes the illumination factor for SRP. Place on any planet
 /// entity along with `TranslationalStateC`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 pub struct ShadowBodyC {
     /// Body radius (m) for conical shadow computation.
     pub radius: f64,
@@ -291,7 +316,8 @@ pub struct ShadowBodyC {
 /// the `planet_fixed_rotation_system` dispatches to the correct rotation
 /// computation based on this value. When absent, `EarthRNP` is assumed
 /// for backward compatibility.
-#[derive(Component, Debug, Clone, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct RotationModelC(pub jeod_sim::RotationModel);
 
 /// Ephemeris body mapping for automatic position updates from DE4xx.
@@ -299,7 +325,8 @@ pub struct RotationModelC(pub jeod_sim::RotationModel);
 /// When present on a gravity source entity, the `ephemeris_update_system`
 /// queries the `EphemerisR` resource each step to update the entity's
 /// `SourceInertialPositionC` (and optionally `TranslationalStateC`).
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 pub struct EphemerisBodyC {
     /// The body this source represents (e.g., `EphemerisBody::Sun`).
     pub target: jeod_sim::EphemerisBody,
@@ -316,7 +343,8 @@ pub struct EphemerisBodyC {
 /// Writes to `RadiationForceC`.
 ///
 /// Auto-inserts [`RadiationForceC`] when added.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 #[require(RadiationForceC)]
 pub struct CannonballSrpC {
     /// Cross-section area * Cr (m²).
@@ -328,17 +356,20 @@ pub struct CannonballSrpC {
 }
 
 /// Marker component for the Sun entity (used by SRP system to find Sun position).
-#[derive(Component)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(opaque)]
 pub struct SunMarker;
 
 /// Marker component for the Moon entity (used by earth lighting system).
-#[derive(Component)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(opaque)]
 pub struct MoonMarker;
 
 // ── Planet ──
 
 /// Bevy component wrapping `PlanetShape`.
-#[derive(Component, Debug, Clone, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct PlanetC(pub PlanetShape);
 
 // ── Derived State Configuration ──
@@ -348,7 +379,8 @@ pub struct PlanetC(pub PlanetShape);
 /// The `gravity_source` entity is queried for `GravitySourceC` to obtain `mu`.
 /// Presence of this component + `OrbitalElementsC` on an entity enables
 /// per-step orbital elements computation in `JeodSet::DerivedState`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 #[require(OrbitalElementsC)]
 pub struct OrbitalElementsConfigC {
     pub gravity_source: Entity,
@@ -358,7 +390,8 @@ pub struct OrbitalElementsConfigC {
 ///
 /// Presence of this component + `EulerAnglesC` on an entity enables
 /// per-step Euler angle computation in `JeodSet::DerivedState`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 #[require(EulerAnglesC)]
 pub struct EulerAnglesConfigC {
     pub sequence: jeod_sim::EulerSequence,
@@ -370,7 +403,8 @@ pub struct EulerAnglesConfigC {
 /// to obtain the rotation matrix and ellipsoid radii.
 /// Presence of this component + `GeodeticStateC` on an entity enables
 /// per-step geodetic computation in `JeodSet::DerivedState`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 #[require(GeodeticStateC)]
 pub struct GeodeticConfigC {
     pub planet: Entity,
@@ -382,7 +416,8 @@ pub struct GeodeticConfigC {
 ///
 /// Written by `orbital_elements_system` for entities that also have
 /// `OrbitalElementsConfigC`.
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(opaque)]
 pub struct OrbitalElementsC(pub jeod_sim::OrbitalElements);
 
 /// Euler angles `[phi, theta, psi]` computed each step.
@@ -390,27 +425,31 @@ pub struct OrbitalElementsC(pub jeod_sim::OrbitalElements);
 /// Written by `euler_angles_system` for entities that also have
 /// `EulerAnglesConfigC`. Each component is a [`Angle`] (uom radian-backed
 /// scalar) so consumers don't have to remember the radian convention.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque)]
 pub struct EulerAnglesC(pub [Angle; 3]);
 
 /// LVLH (Local Vertical Local Horizontal) frame computed each step.
 ///
 /// Presence of this component alone enables computation — no separate
 /// config component needed (only requires translational state).
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque)]
 pub struct LvlhFrameC(pub jeod_sim::LvlhFrame);
 
 /// Geodetic state (latitude, longitude, altitude) computed each step.
 ///
 /// Written by `geodetic_system` for entities that also have `GeodeticConfigC`.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque)]
 pub struct GeodeticStateC(pub jeod_sim::GeodeticState);
 
 /// Solar beta angle (radians) computed each step.
 ///
 /// Presence of this component alone enables computation — requires a
 /// `SunMarker` entity to exist in the world.
-#[derive(Component, Debug, Clone, Copy, Default)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque)]
 pub struct SolarBetaC(pub f64);
 
 /// Configuration for Earth lighting (eclipse/albedo) computation.
@@ -418,7 +457,8 @@ pub struct SolarBetaC(pub f64);
 /// Requires `SunMarker` and `MoonMarker` entities to exist in the world.
 /// Presence of this component + `EarthLightingStateC` on an entity enables
 /// per-step earth lighting computation in `JeodSet::DerivedState`.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 #[require(EarthLightingStateC)]
 pub struct EarthLightingConfigC {
     /// Earth equatorial radius (m).
@@ -433,7 +473,8 @@ pub struct EarthLightingConfigC {
 ///
 /// Written by `earth_lighting_system` for entities that also have
 /// `EarthLightingConfigC`.
-#[derive(Component, Debug, Clone, Default)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
+#[reflect(opaque)]
 pub struct EarthLightingStateC(pub jeod_sim::EarthLightingState);
 
 // ── External Loads ──
@@ -444,7 +485,8 @@ pub struct EarthLightingStateC(pub jeod_sim::EarthLightingState);
 /// Matches `SimBody.external_force` in `jeod_sim::Simulation`.
 ///
 /// Mutate between steps to implement time-scheduled force injection.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct ExternalForceC(pub jeod_sim::Force<Inertial>);
 
 /// External torque in the **body** frame.
@@ -453,7 +495,8 @@ pub struct ExternalForceC(pub jeod_sim::Force<Inertial>);
 /// Matches `SimBody.external_torque` in `jeod_sim::Simulation`.
 ///
 /// Mutate between steps to implement time-scheduled torque injection.
-#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque)]
 pub struct ExternalTorqueC(pub Torque<BodyFrame<SelfRef>>);
 
 // ── Mass Tree (Staging) ──
@@ -463,7 +506,8 @@ pub struct ExternalTorqueC(pub Torque<BodyFrame<SelfRef>>);
 /// Entities with this component participate in the mass tree. After
 /// attach/detach events are processed, the entity's [`MassPropertiesC`]
 /// is synced from the tree's composite properties.
-#[derive(Component, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque)]
 pub struct MassBodyIdC(pub jeod_sim::MassBodyId);
 
 /// Message: attach a child body to a parent in the mass tree.

--- a/src/components.rs
+++ b/src/components.rs
@@ -11,31 +11,31 @@ use jeod_sim::{
 
 // JEOD_INV: DB.24 — default integrated_frame is composite_body (we integrate composite_body state)
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct TranslationalStateC(pub TranslationalState);
 
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct RotationalStateC(pub RotationalState);
 
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct MassPropertiesC(pub MassProperties);
 
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct GravityAccelerationC(pub GravityAcceleration);
 
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct TotalForceC(pub TotalForce);
 
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct FrameDerivativesC(pub FrameDerivatives);
 
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(FrameDerivativesC)]
 pub struct DynamicsConfigC(pub DynamicsConfig);
 
@@ -44,7 +44,7 @@ pub struct DynamicsConfigC(pub DynamicsConfig);
 /// When present on a dynamic body entity, the integration system dispatches
 /// to the specified method. When absent, `IntegratorType::Rk4` is used.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct IntegratorTypeC(pub jeod_sim::IntegratorType);
 
 /// Persistent Gauss-Jackson (Störmer-Cowell) integrator state.
@@ -53,7 +53,7 @@ pub struct IntegratorTypeC(pub jeod_sim::IntegratorType);
 /// with `GaussJacksonState::new(config)` and maintained across steps.
 /// When absent, `integration_system` will panic if `IntegratorTypeC` is GJ.
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct GaussJacksonStateC(pub jeod_sim::GaussJacksonState);
 
 /// Persistent Adams-Bashforth-Moulton 4 integrator state.
@@ -62,16 +62,16 @@ pub struct GaussJacksonStateC(pub jeod_sim::GaussJacksonState);
 /// `Abm4State::new()` and maintained across steps. When absent,
 /// `integration_system` will panic if `IntegratorTypeC` is `Abm4`.
 #[derive(Component, Debug, Clone, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct Abm4StateC(pub jeod_sim::Abm4State);
 
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(GravityAccelerationC, TotalForceC)]
 pub struct GravityControlsC(pub GravityControls<Entity>);
 
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct GravitySourceC(pub GravitySource);
 
 /// Inertial-frame position of a gravity source.
@@ -86,7 +86,7 @@ pub struct GravitySourceC(pub GravitySource);
 /// if a source entity referenced by a `GravityControlsC` is missing this
 /// component.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct SourceInertialPositionC(pub Position<Inertial>);
 
 /// Inertial-frame velocity of a gravity source.
@@ -102,7 +102,7 @@ pub struct SourceInertialPositionC(pub Position<Inertial>);
 /// `TranslationalStateC` to avoid Bevy query conflicts (the body's
 /// `TranslationalStateC` is already mutably queried by the integration system).
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct SourceInertialVelocityC(pub Velocity<Inertial>);
 
 /// Aerodynamic force and torque in the **structural** frame (N, N*m).
@@ -111,7 +111,7 @@ pub struct SourceInertialVelocityC(pub Velocity<Inertial>);
 /// `force_collection_system` rotates force to inertial and torque to body
 /// via `StructuralTransformC`.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct AerodynamicForceC {
     pub force: DVec3,
     pub torque: DVec3,
@@ -125,7 +125,7 @@ pub struct AerodynamicForceC {
 /// Written by `flat_plate_srp_system`.
 /// `force_collection_system` rotates torque to body via `StructuralTransformC`.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct RadiationForceC {
     pub force: DVec3,
     pub torque: DVec3,
@@ -136,7 +136,7 @@ pub struct RadiationForceC {
 /// Written by the gravity torque system.
 /// Read by `force_collection_system` as `Option<&GravityTorqueC>`.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct GravityTorqueC(pub Torque<BodyFrame<SelfRef>>);
 
 // JEOD_INV: AT.01 — active flag gates computation (presence of AtmosphericStateC = active)
@@ -144,7 +144,7 @@ pub struct GravityTorqueC(pub Torque<BodyFrame<SelfRef>>);
 ///
 /// Written by the atmosphere system. Read by the aerodynamic drag system.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct AtmosphericStateC(pub jeod_sim::AtmosphereState);
 
 /// Typed structural→body rotation for a vehicle entity.
@@ -165,7 +165,7 @@ pub struct AtmosphericStateC(pub jeod_sim::AtmosphereState);
 // JEOD_INV: DB.28 — forces collected in structural frame, rotated to inertial at root
 // JEOD_INV: DB.29 — torques collected in structural frame, rotated to body at root
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct StructuralTransformC(pub FrameTransform<StructuralFrame<SelfRef>, BodyFrame<SelfRef>>);
 
 impl Default for StructuralTransformC {
@@ -188,7 +188,7 @@ impl Default for StructuralTransformC {
 /// rotate the spacecraft position into the body-fixed frame before evaluating
 /// spherical-harmonic gravity.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct PlanetFixedRotationC(pub FrameTransform<Inertial, PlanetFixed<SelfPlanet>>);
 
 /// Tidal configuration for a gravity source entity.
@@ -206,7 +206,7 @@ pub struct PlanetFixedRotationC(pub FrameTransform<Inertial, PlanetFixed<SelfPla
 /// `from_untyped` / `From` impls are provided for callers building from
 /// the untyped struct.
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(TidalDeltaC20C)]
 pub struct TidalConfigC(pub jeod_sim::TidalConfigTyped);
 
@@ -244,7 +244,7 @@ impl From<jeod_sim::TidalConfigTyped> for TidalConfigC {
 /// metadata at the type level — matching `compute_delta_c20_typed`'s
 /// return type.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct TidalDeltaC20C(pub Ratio);
 
 // ── Interactions ──
@@ -258,7 +258,7 @@ pub struct TidalDeltaC20C(pub Ratio);
 ///
 /// Auto-inserts [`AtmosphericStateC`] and [`AerodynamicForceC`] when added.
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(AtmosphericStateC, AerodynamicForceC)]
 pub struct DragConfigC(pub DragConfigTyped);
 
@@ -294,7 +294,7 @@ impl From<DragConfigTyped> for DragConfigC {
 ///
 /// Auto-inserts [`RadiationForceC`] when added.
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(RadiationForceC)]
 pub struct FlatPlateConfigC(pub jeod_sim::FlatPlateState);
 
@@ -304,7 +304,7 @@ pub struct FlatPlateConfigC(pub jeod_sim::FlatPlateState);
 /// and computes the illumination factor for SRP. Place on any planet
 /// entity along with `TranslationalStateC`.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct ShadowBodyC {
     /// Body radius (m) for conical shadow computation.
     pub radius: f64,
@@ -317,7 +317,7 @@ pub struct ShadowBodyC {
 /// computation based on this value. When absent, `EarthRNP` is assumed
 /// for backward compatibility.
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct RotationModelC(pub jeod_sim::RotationModel);
 
 /// Ephemeris body mapping for automatic position updates from DE4xx.
@@ -326,7 +326,7 @@ pub struct RotationModelC(pub jeod_sim::RotationModel);
 /// queries the `EphemerisR` resource each step to update the entity's
 /// `SourceInertialPositionC` (and optionally `TranslationalStateC`).
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct EphemerisBodyC {
     /// The body this source represents (e.g., `EphemerisBody::Sun`).
     pub target: jeod_sim::EphemerisBody,
@@ -344,7 +344,7 @@ pub struct EphemerisBodyC {
 ///
 /// Auto-inserts [`RadiationForceC`] when added.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(RadiationForceC)]
 pub struct CannonballSrpC {
     /// Cross-section area * Cr (m²).
@@ -357,19 +357,19 @@ pub struct CannonballSrpC {
 
 /// Marker component for the Sun entity (used by SRP system to find Sun position).
 #[derive(Component, Reflect, Default, Clone, Copy, Debug)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct SunMarker;
 
 /// Marker component for the Moon entity (used by earth lighting system).
 #[derive(Component, Reflect, Default, Clone, Copy, Debug)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct MoonMarker;
 
 // ── Planet ──
 
 /// Bevy component wrapping `PlanetShape`.
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct PlanetC(pub PlanetShape);
 
 // ── Derived State Configuration ──
@@ -380,7 +380,7 @@ pub struct PlanetC(pub PlanetShape);
 /// Presence of this component + `OrbitalElementsC` on an entity enables
 /// per-step orbital elements computation in `JeodSet::DerivedState`.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(OrbitalElementsC)]
 pub struct OrbitalElementsConfigC {
     pub gravity_source: Entity,
@@ -391,7 +391,7 @@ pub struct OrbitalElementsConfigC {
 /// Presence of this component + `EulerAnglesC` on an entity enables
 /// per-step Euler angle computation in `JeodSet::DerivedState`.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(EulerAnglesC)]
 pub struct EulerAnglesConfigC {
     pub sequence: jeod_sim::EulerSequence,
@@ -404,7 +404,7 @@ pub struct EulerAnglesConfigC {
 /// Presence of this component + `GeodeticStateC` on an entity enables
 /// per-step geodetic computation in `JeodSet::DerivedState`.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(GeodeticStateC)]
 pub struct GeodeticConfigC {
     pub planet: Entity,
@@ -417,7 +417,7 @@ pub struct GeodeticConfigC {
 /// Written by `orbital_elements_system` for entities that also have
 /// `OrbitalElementsConfigC`.
 #[derive(Component, Debug, Clone, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct OrbitalElementsC(pub jeod_sim::OrbitalElements);
 
 /// Euler angles `[phi, theta, psi]` computed each step.
@@ -426,7 +426,7 @@ pub struct OrbitalElementsC(pub jeod_sim::OrbitalElements);
 /// `EulerAnglesConfigC`. Each component is a [`Angle`] (uom radian-backed
 /// scalar) so consumers don't have to remember the radian convention.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct EulerAnglesC(pub [Angle; 3]);
 
 /// LVLH (Local Vertical Local Horizontal) frame computed each step.
@@ -434,14 +434,14 @@ pub struct EulerAnglesC(pub [Angle; 3]);
 /// Presence of this component alone enables computation — no separate
 /// config component needed (only requires translational state).
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct LvlhFrameC(pub jeod_sim::LvlhFrame);
 
 /// Geodetic state (latitude, longitude, altitude) computed each step.
 ///
 /// Written by `geodetic_system` for entities that also have `GeodeticConfigC`.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct GeodeticStateC(pub jeod_sim::GeodeticState);
 
 /// Solar beta angle (radians) computed each step.
@@ -449,7 +449,7 @@ pub struct GeodeticStateC(pub jeod_sim::GeodeticState);
 /// Presence of this component alone enables computation — requires a
 /// `SunMarker` entity to exist in the world.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct SolarBetaC(pub f64);
 
 /// Configuration for Earth lighting (eclipse/albedo) computation.
@@ -458,7 +458,7 @@ pub struct SolarBetaC(pub f64);
 /// Presence of this component + `EarthLightingStateC` on an entity enables
 /// per-step earth lighting computation in `JeodSet::DerivedState`.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 #[require(EarthLightingStateC)]
 pub struct EarthLightingConfigC {
     /// Earth equatorial radius (m).
@@ -474,7 +474,7 @@ pub struct EarthLightingConfigC {
 /// Written by `earth_lighting_system` for entities that also have
 /// `EarthLightingConfigC`.
 #[derive(Component, Debug, Clone, Default, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct EarthLightingStateC(pub jeod_sim::EarthLightingState);
 
 // ── External Loads ──
@@ -486,7 +486,7 @@ pub struct EarthLightingStateC(pub jeod_sim::EarthLightingState);
 ///
 /// Mutate between steps to implement time-scheduled force injection.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct ExternalForceC(pub jeod_sim::Force<Inertial>);
 
 /// External torque in the **body** frame.
@@ -496,7 +496,7 @@ pub struct ExternalForceC(pub jeod_sim::Force<Inertial>);
 ///
 /// Mutate between steps to implement time-scheduled torque injection.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct ExternalTorqueC(pub Torque<BodyFrame<SelfRef>>);
 
 // ── Mass Tree (Staging) ──
@@ -507,7 +507,7 @@ pub struct ExternalTorqueC(pub Torque<BodyFrame<SelfRef>>);
 /// attach/detach events are processed, the entity's [`MassPropertiesC`]
 /// is synced from the tree's composite properties.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(opaque)]
+#[reflect(opaque, Component)]
 pub struct MassBodyIdC(pub jeod_sim::MassBodyId);
 
 /// Message: attach a child body to a parent in the mass tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,38 +103,9 @@ impl Plugin for JeodPlugin {
         app.init_resource::<SimulationTimeR>();
 
         // ── Typed-Component reflection (#154) ──
-        // Register every typed Component so Bevy editor / scene
-        // serialization can identify them. Inner `jeod_*` types are
-        // marked `#[reflect(opaque)]` (see `src/components.rs`) so the
-        // Component appears as a leaf with its type name; field-level
-        // introspection requires propagating `Reflect` into the source
-        // crates and is out of scope here.
-        app.register_type::<components::TranslationalStateC>();
-        app.register_type::<components::RotationalStateC>();
-        app.register_type::<components::MassPropertiesC>();
-        app.register_type::<components::GravityAccelerationC>();
-        app.register_type::<components::TotalForceC>();
-        app.register_type::<components::FrameDerivativesC>();
-        app.register_type::<components::DynamicsConfigC>();
-        app.register_type::<components::IntegratorTypeC>();
-        app.register_type::<components::GaussJacksonStateC>();
-        app.register_type::<components::Abm4StateC>();
-        app.register_type::<components::GravityControlsC>();
-        app.register_type::<components::GravitySourceC>();
-        app.register_type::<components::SourceInertialPositionC>();
-        app.register_type::<components::SourceInertialVelocityC>();
-        app.register_type::<components::AerodynamicForceC>();
-        app.register_type::<components::RadiationForceC>();
-        app.register_type::<components::GravityTorqueC>();
-        app.register_type::<components::AtmosphericStateC>();
-        app.register_type::<components::StructuralTransformC>();
-        app.register_type::<components::PlanetFixedRotationC>();
-        app.register_type::<components::TidalConfigC>();
-        app.register_type::<components::TidalDeltaC20C>();
-        app.register_type::<components::DragConfigC>();
-        app.register_type::<components::FlatPlateConfigC>();
-        app.register_type::<components::SunMarker>();
-        app.register_type::<components::MoonMarker>();
+        // Centralized in `register_jeod_component_types` so the smoke
+        // test and any other consumer registers exactly the same set.
+        register_jeod_component_types(app);
 
         // ── Events ──
         app.add_message::<AttachEvent>();
@@ -193,6 +164,78 @@ impl Plugin for JeodPlugin {
             ),
         );
     }
+}
+
+/// Register every `Reflect`-derived Component from
+/// [`crate::components`] in the `App`'s `TypeRegistry`.
+///
+/// `JeodPlugin::build` calls this; downstream consumers that don't use
+/// `JeodPlugin` (e.g. test harnesses, custom adapters that compose only
+/// a subset of systems) can call it directly to populate the same
+/// registry. Tests use this through the same entry point so the list
+/// can't drift between production and verification.
+///
+/// Inner `jeod_*` types are `#[reflect(opaque)]` so the Component
+/// appears as a leaf with its type name. Field-level introspection of
+/// `Position<Inertial>`, `RotationalState`, etc. would require
+/// propagating `Reflect` into the source crates and is out of scope
+/// here.
+pub fn register_jeod_component_types(app: &mut App) {
+    // Dynamics state
+    app.register_type::<components::TranslationalStateC>();
+    app.register_type::<components::RotationalStateC>();
+    app.register_type::<components::MassPropertiesC>();
+    app.register_type::<components::GravityAccelerationC>();
+    app.register_type::<components::TotalForceC>();
+    app.register_type::<components::FrameDerivativesC>();
+    // Dynamics config + integrator state
+    app.register_type::<components::DynamicsConfigC>();
+    app.register_type::<components::IntegratorTypeC>();
+    app.register_type::<components::GaussJacksonStateC>();
+    app.register_type::<components::Abm4StateC>();
+    // Gravity
+    app.register_type::<components::GravityControlsC>();
+    app.register_type::<components::GravitySourceC>();
+    app.register_type::<components::SourceInertialPositionC>();
+    app.register_type::<components::SourceInertialVelocityC>();
+    // Interactions
+    app.register_type::<components::AerodynamicForceC>();
+    app.register_type::<components::RadiationForceC>();
+    app.register_type::<components::GravityTorqueC>();
+    app.register_type::<components::AtmosphericStateC>();
+    // Frame transforms
+    app.register_type::<components::StructuralTransformC>();
+    app.register_type::<components::PlanetFixedRotationC>();
+    // Tidal
+    app.register_type::<components::TidalConfigC>();
+    app.register_type::<components::TidalDeltaC20C>();
+    // Drag / SRP
+    app.register_type::<components::DragConfigC>();
+    app.register_type::<components::FlatPlateConfigC>();
+    app.register_type::<components::CannonballSrpC>();
+    app.register_type::<components::ShadowBodyC>();
+    // External loads
+    app.register_type::<components::ExternalForceC>();
+    app.register_type::<components::ExternalTorqueC>();
+    // Body / planet identity + ephemeris
+    app.register_type::<components::MassBodyIdC>();
+    app.register_type::<components::PlanetC>();
+    app.register_type::<components::RotationModelC>();
+    app.register_type::<components::EphemerisBodyC>();
+    app.register_type::<components::SunMarker>();
+    app.register_type::<components::MoonMarker>();
+    // Derived-state config
+    app.register_type::<components::OrbitalElementsConfigC>();
+    app.register_type::<components::EulerAnglesConfigC>();
+    app.register_type::<components::GeodeticConfigC>();
+    app.register_type::<components::EarthLightingConfigC>();
+    // Derived-state output
+    app.register_type::<components::OrbitalElementsC>();
+    app.register_type::<components::EulerAnglesC>();
+    app.register_type::<components::LvlhFrameC>();
+    app.register_type::<components::GeodeticStateC>();
+    app.register_type::<components::SolarBetaC>();
+    app.register_type::<components::EarthLightingStateC>();
 }
 
 // ── Bevy spawn helpers for the typestate VehicleBuilder ──

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,40 @@ impl Plugin for JeodPlugin {
         // ── Resources ──
         app.init_resource::<SimulationTimeR>();
 
+        // ── Typed-Component reflection (#154) ──
+        // Register every typed Component so Bevy editor / scene
+        // serialization can identify them. Inner `jeod_*` types are
+        // marked `#[reflect(opaque)]` (see `src/components.rs`) so the
+        // Component appears as a leaf with its type name; field-level
+        // introspection requires propagating `Reflect` into the source
+        // crates and is out of scope here.
+        app.register_type::<components::TranslationalStateC>();
+        app.register_type::<components::RotationalStateC>();
+        app.register_type::<components::MassPropertiesC>();
+        app.register_type::<components::GravityAccelerationC>();
+        app.register_type::<components::TotalForceC>();
+        app.register_type::<components::FrameDerivativesC>();
+        app.register_type::<components::DynamicsConfigC>();
+        app.register_type::<components::IntegratorTypeC>();
+        app.register_type::<components::GaussJacksonStateC>();
+        app.register_type::<components::Abm4StateC>();
+        app.register_type::<components::GravityControlsC>();
+        app.register_type::<components::GravitySourceC>();
+        app.register_type::<components::SourceInertialPositionC>();
+        app.register_type::<components::SourceInertialVelocityC>();
+        app.register_type::<components::AerodynamicForceC>();
+        app.register_type::<components::RadiationForceC>();
+        app.register_type::<components::GravityTorqueC>();
+        app.register_type::<components::AtmosphericStateC>();
+        app.register_type::<components::StructuralTransformC>();
+        app.register_type::<components::PlanetFixedRotationC>();
+        app.register_type::<components::TidalConfigC>();
+        app.register_type::<components::TidalDeltaC20C>();
+        app.register_type::<components::DragConfigC>();
+        app.register_type::<components::FlatPlateConfigC>();
+        app.register_type::<components::SunMarker>();
+        app.register_type::<components::MoonMarker>();
+
         // ── Events ──
         app.add_message::<AttachEvent>();
         app.add_message::<DetachEvent>();

--- a/tests/bevy_reflect_smoke.rs
+++ b/tests/bevy_reflect_smoke.rs
@@ -1,116 +1,192 @@
 //! Smoke test for the Bevy `Reflect` derives on the typed Components (#154).
 //!
-//! Verifies that the typed Components registered in `src/components.rs`
-//! are reflectable: they implement `Reflect` (so a Bevy editor / scene
-//! tooling can identify them by type), they carry the `Component`
-//! reflect-data so the editor can spawn / inspect entities that hold
-//! them, and the `TypeRegistry` round-trips a representative selection.
+//! Verifies three things:
 //!
-//! The Components use `#[reflect(opaque)]` so the inner `jeod_*` types
-//! (which do not depend on Bevy) are not field-introspected. The editor
-//! sees the Component as a leaf with its type name. Field-level
-//! introspection of the inner `Position<Inertial>` / `RotationalState` /
-//! etc. is a follow-up that requires either propagating `Reflect`
-//! through the source crates or hand-rolling impls — out of scope for
-//! this PR per the layering decision (`jeod_quantities` stays Bevy-free).
+//! 1. **The registration list is centralized.** Both `JeodPlugin::build`
+//!    and downstream callers populate the `AppTypeRegistry` via
+//!    [`register_jeod_component_types`], so the production registration
+//!    set and what the tests cover cannot drift apart.
+//! 2. **Every `Reflect`-derived Component in `src/components.rs` shows
+//!    up in the registry** — addresses the previous miss where
+//!    `JeodPlugin` registered only a 26-entry subset of the 44 derived
+//!    types.
+//! 3. **Reflective component insertion actually works.** A live `World`
+//!    looks up `TranslationalStateC` by type path, retrieves its
+//!    `ReflectComponent` registration, and uses it to insert / remove
+//!    the Component on an entity through the `Reflect` trait object —
+//!    proving the editor / scene-tooling path is wired, not just the
+//!    static type-registry side.
+//!
+//! Inner `jeod_*` types are `#[reflect(opaque)]`, so field-level
+//! introspection (e.g. `position[0]: f64` inside a
+//! `TranslationalStateC`) is *not* in scope here. That requires
+//! propagating `Reflect` into the source crates and is the natural
+//! follow-up.
 
 use bevy::prelude::*;
-use bevy::reflect::TypeRegistry;
 use bevy_jeod::*;
 
-/// Build a fresh `TypeRegistry` and register every Bevy-side typed
-/// Component. Returns the populated registry so individual asserts can
-/// look up by type.
-fn registry_with_components() -> TypeRegistry {
-    let mut reg = TypeRegistry::new();
-    reg.register::<TranslationalStateC>();
-    reg.register::<RotationalStateC>();
-    reg.register::<MassPropertiesC>();
-    reg.register::<GravityAccelerationC>();
-    reg.register::<TotalForceC>();
-    reg.register::<FrameDerivativesC>();
-    reg.register::<DynamicsConfigC>();
-    reg.register::<IntegratorTypeC>();
-    reg.register::<GaussJacksonStateC>();
-    reg.register::<Abm4StateC>();
-    reg.register::<GravityControlsC>();
-    reg.register::<GravitySourceC>();
-    reg.register::<SourceInertialPositionC>();
-    reg.register::<SourceInertialVelocityC>();
-    reg.register::<AerodynamicForceC>();
-    reg.register::<RadiationForceC>();
-    reg.register::<GravityTorqueC>();
-    reg.register::<AtmosphericStateC>();
-    reg.register::<StructuralTransformC>();
-    reg.register::<PlanetFixedRotationC>();
-    reg.register::<TidalConfigC>();
-    reg.register::<TidalDeltaC20C>();
-    reg.register::<DragConfigC>();
-    reg.register::<FlatPlateConfigC>();
-    reg.register::<SunMarker>();
-    reg.register::<MoonMarker>();
-    reg
-}
+/// The full inventory of `Reflect`-derived Components in
+/// `src/components.rs`. Kept in sync with
+/// `register_jeod_component_types`. If a Component is added there but
+/// not added here, `every_reflect_derived_component_is_registered`
+/// will fail and the test forces the inventory to update.
+const EXPECTED_REGISTERED_TYPE_PATHS: &[&str] = &[
+    // Dynamics state
+    "bevy_jeod::components::TranslationalStateC",
+    "bevy_jeod::components::RotationalStateC",
+    "bevy_jeod::components::MassPropertiesC",
+    "bevy_jeod::components::GravityAccelerationC",
+    "bevy_jeod::components::TotalForceC",
+    "bevy_jeod::components::FrameDerivativesC",
+    // Dynamics config + integrator state
+    "bevy_jeod::components::DynamicsConfigC",
+    "bevy_jeod::components::IntegratorTypeC",
+    "bevy_jeod::components::GaussJacksonStateC",
+    "bevy_jeod::components::Abm4StateC",
+    // Gravity
+    "bevy_jeod::components::GravityControlsC",
+    "bevy_jeod::components::GravitySourceC",
+    "bevy_jeod::components::SourceInertialPositionC",
+    "bevy_jeod::components::SourceInertialVelocityC",
+    // Interactions
+    "bevy_jeod::components::AerodynamicForceC",
+    "bevy_jeod::components::RadiationForceC",
+    "bevy_jeod::components::GravityTorqueC",
+    "bevy_jeod::components::AtmosphericStateC",
+    // Frame transforms
+    "bevy_jeod::components::StructuralTransformC",
+    "bevy_jeod::components::PlanetFixedRotationC",
+    // Tidal
+    "bevy_jeod::components::TidalConfigC",
+    "bevy_jeod::components::TidalDeltaC20C",
+    // Drag / SRP
+    "bevy_jeod::components::DragConfigC",
+    "bevy_jeod::components::FlatPlateConfigC",
+    "bevy_jeod::components::CannonballSrpC",
+    "bevy_jeod::components::ShadowBodyC",
+    // External loads
+    "bevy_jeod::components::ExternalForceC",
+    "bevy_jeod::components::ExternalTorqueC",
+    // Body / planet identity + ephemeris
+    "bevy_jeod::components::MassBodyIdC",
+    "bevy_jeod::components::PlanetC",
+    "bevy_jeod::components::RotationModelC",
+    "bevy_jeod::components::EphemerisBodyC",
+    "bevy_jeod::components::SunMarker",
+    "bevy_jeod::components::MoonMarker",
+    // Derived-state config
+    "bevy_jeod::components::OrbitalElementsConfigC",
+    "bevy_jeod::components::EulerAnglesConfigC",
+    "bevy_jeod::components::GeodeticConfigC",
+    "bevy_jeod::components::EarthLightingConfigC",
+    // Derived-state output
+    "bevy_jeod::components::OrbitalElementsC",
+    "bevy_jeod::components::EulerAnglesC",
+    "bevy_jeod::components::LvlhFrameC",
+    "bevy_jeod::components::GeodeticStateC",
+    "bevy_jeod::components::SolarBetaC",
+    "bevy_jeod::components::EarthLightingStateC",
+];
 
-/// Headline assertion: the typed Components register cleanly and are
-/// looked up by their fully-qualified type names.
+/// Every `Reflect`-derived Component in `src/components.rs` is
+/// reachable from the `AppTypeRegistry` after
+/// `register_jeod_component_types` runs against a bare `App`.
 #[test]
-fn typed_components_register_in_type_registry() {
-    let reg = registry_with_components();
-
-    let names = [
-        "bevy_jeod::components::TranslationalStateC",
-        "bevy_jeod::components::RotationalStateC",
-        "bevy_jeod::components::MassPropertiesC",
-        "bevy_jeod::components::PlanetFixedRotationC",
-        "bevy_jeod::components::StructuralTransformC",
-        "bevy_jeod::components::SunMarker",
-        "bevy_jeod::components::MoonMarker",
-    ];
-
-    for name in &names {
-        assert!(
-            reg.get_with_type_path(name).is_some(),
-            "Component `{name}` did not register; check #[derive(Reflect)] on src/components.rs"
-        );
-    }
-}
-
-/// Spot-check that a reflected `TranslationalStateC` knows its own type
-/// path — proves the derived `TypePath` impl is reachable through the
-/// `Reflect` trait object.
-#[test]
-fn reflect_trait_object_round_trips_translational_state() {
-    let c = TranslationalStateC::default();
-    let r: &dyn Reflect = &c;
-    let info = r.reflect_type_path();
+fn every_reflect_derived_component_is_registered() {
+    let mut app = App::new();
+    register_jeod_component_types(&mut app);
+    let registry = app.world().resource::<AppTypeRegistry>().read();
+    let missing: Vec<&str> = EXPECTED_REGISTERED_TYPE_PATHS
+        .iter()
+        .copied()
+        .filter(|p| registry.get_with_type_path(p).is_none())
+        .collect();
     assert!(
-        info.contains("TranslationalStateC"),
-        "Reflect type path missing TranslationalStateC: got {info}"
+        missing.is_empty(),
+        "register_jeod_component_types missed Components:\n  {}",
+        missing.join("\n  "),
     );
 }
 
-/// `JeodPlugin`'s `App::register_type::<TypedComponent>()` calls (added
-/// in this PR) should populate the App-wide registry. Builds a minimal
-/// `App` with `MinimalPlugins + JeodPlugin` and verifies a representative
-/// Component is present.
+/// `JeodPlugin::build` populates the same registry as the standalone
+/// helper. Confirms the production path matches the test path.
 #[test]
-fn jeod_plugin_registers_typed_components() {
+fn jeod_plugin_registers_full_component_inventory() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
     app.add_plugins(JeodPlugin);
 
     let registry = app.world().resource::<AppTypeRegistry>().read();
+    let missing: Vec<&str> = EXPECTED_REGISTERED_TYPE_PATHS
+        .iter()
+        .copied()
+        .filter(|p| registry.get_with_type_path(p).is_none())
+        .collect();
     assert!(
-        registry
-            .get_with_type_path("bevy_jeod::components::TranslationalStateC")
-            .is_some(),
-        "JeodPlugin did not register TranslationalStateC in AppTypeRegistry"
+        missing.is_empty(),
+        "JeodPlugin missed Components:\n  {}",
+        missing.join("\n  "),
     );
+}
+
+/// Reflective component insertion: looks up `TranslationalStateC` in
+/// the registry, retrieves the `ReflectComponent` registration, and
+/// inserts the Component onto an entity through a `&dyn Reflect`. This
+/// is the path Bevy editor / scene-deserialization tooling uses.
+#[test]
+fn reflective_component_insertion_round_trips() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(JeodPlugin);
+
+    let entity = app.world_mut().spawn_empty().id();
+
+    // Build a default `TranslationalStateC`, lift it to `&dyn Reflect`,
+    // and insert via the registry's `ReflectComponent`. This exercises
+    // the same code path Bevy editor tooling uses to materialize a
+    // Component from a scene file.
+    let initial = components::TranslationalStateC::default();
+    let registry = app.world().resource::<AppTypeRegistry>().clone();
+    {
+        let registry_read = registry.read();
+        let registration = registry_read
+            .get_with_type_path("bevy_jeod::components::TranslationalStateC")
+            .expect("TranslationalStateC must be registered");
+        let reflect_component = registration
+            .data::<bevy::ecs::reflect::ReflectComponent>()
+            .expect("TranslationalStateC must carry ReflectComponent data");
+        reflect_component.insert(
+            &mut app.world_mut().entity_mut(entity),
+            &initial,
+            &registry_read,
+        );
+    }
+
+    // Verify the insert took effect — the Component is on the entity
+    // and matches what we inserted.
+    let stored = app
+        .world()
+        .get::<components::TranslationalStateC>(entity)
+        .expect("TranslationalStateC should be on the entity after reflective insert");
+    assert_eq!(stored.0.position, initial.0.position);
+    assert_eq!(stored.0.velocity, initial.0.velocity);
+
+    // And reflective remove works too.
+    {
+        let registry_read = registry.read();
+        let registration = registry_read
+            .get_with_type_path("bevy_jeod::components::TranslationalStateC")
+            .expect("TranslationalStateC must be registered");
+        let reflect_component = registration
+            .data::<bevy::ecs::reflect::ReflectComponent>()
+            .expect("TranslationalStateC must carry ReflectComponent data");
+        reflect_component.remove(&mut app.world_mut().entity_mut(entity));
+    }
     assert!(
-        registry
-            .get_with_type_path("bevy_jeod::components::PlanetFixedRotationC")
-            .is_some(),
-        "JeodPlugin did not register PlanetFixedRotationC in AppTypeRegistry"
+        app.world()
+            .get::<components::TranslationalStateC>(entity)
+            .is_none(),
+        "TranslationalStateC should have been removed by reflective remove",
     );
 }

--- a/tests/bevy_reflect_smoke.rs
+++ b/tests/bevy_reflect_smoke.rs
@@ -1,0 +1,116 @@
+//! Smoke test for the Bevy `Reflect` derives on the typed Components (#154).
+//!
+//! Verifies that the typed Components registered in `src/components.rs`
+//! are reflectable: they implement `Reflect` (so a Bevy editor / scene
+//! tooling can identify them by type), they carry the `Component`
+//! reflect-data so the editor can spawn / inspect entities that hold
+//! them, and the `TypeRegistry` round-trips a representative selection.
+//!
+//! The Components use `#[reflect(opaque)]` so the inner `jeod_*` types
+//! (which do not depend on Bevy) are not field-introspected. The editor
+//! sees the Component as a leaf with its type name. Field-level
+//! introspection of the inner `Position<Inertial>` / `RotationalState` /
+//! etc. is a follow-up that requires either propagating `Reflect`
+//! through the source crates or hand-rolling impls — out of scope for
+//! this PR per the layering decision (`jeod_quantities` stays Bevy-free).
+
+use bevy::prelude::*;
+use bevy::reflect::TypeRegistry;
+use bevy_jeod::*;
+
+/// Build a fresh `TypeRegistry` and register every Bevy-side typed
+/// Component. Returns the populated registry so individual asserts can
+/// look up by type.
+fn registry_with_components() -> TypeRegistry {
+    let mut reg = TypeRegistry::new();
+    reg.register::<TranslationalStateC>();
+    reg.register::<RotationalStateC>();
+    reg.register::<MassPropertiesC>();
+    reg.register::<GravityAccelerationC>();
+    reg.register::<TotalForceC>();
+    reg.register::<FrameDerivativesC>();
+    reg.register::<DynamicsConfigC>();
+    reg.register::<IntegratorTypeC>();
+    reg.register::<GaussJacksonStateC>();
+    reg.register::<Abm4StateC>();
+    reg.register::<GravityControlsC>();
+    reg.register::<GravitySourceC>();
+    reg.register::<SourceInertialPositionC>();
+    reg.register::<SourceInertialVelocityC>();
+    reg.register::<AerodynamicForceC>();
+    reg.register::<RadiationForceC>();
+    reg.register::<GravityTorqueC>();
+    reg.register::<AtmosphericStateC>();
+    reg.register::<StructuralTransformC>();
+    reg.register::<PlanetFixedRotationC>();
+    reg.register::<TidalConfigC>();
+    reg.register::<TidalDeltaC20C>();
+    reg.register::<DragConfigC>();
+    reg.register::<FlatPlateConfigC>();
+    reg.register::<SunMarker>();
+    reg.register::<MoonMarker>();
+    reg
+}
+
+/// Headline assertion: the typed Components register cleanly and are
+/// looked up by their fully-qualified type names.
+#[test]
+fn typed_components_register_in_type_registry() {
+    let reg = registry_with_components();
+
+    let names = [
+        "bevy_jeod::components::TranslationalStateC",
+        "bevy_jeod::components::RotationalStateC",
+        "bevy_jeod::components::MassPropertiesC",
+        "bevy_jeod::components::PlanetFixedRotationC",
+        "bevy_jeod::components::StructuralTransformC",
+        "bevy_jeod::components::SunMarker",
+        "bevy_jeod::components::MoonMarker",
+    ];
+
+    for name in &names {
+        assert!(
+            reg.get_with_type_path(name).is_some(),
+            "Component `{name}` did not register; check #[derive(Reflect)] on src/components.rs"
+        );
+    }
+}
+
+/// Spot-check that a reflected `TranslationalStateC` knows its own type
+/// path — proves the derived `TypePath` impl is reachable through the
+/// `Reflect` trait object.
+#[test]
+fn reflect_trait_object_round_trips_translational_state() {
+    let c = TranslationalStateC::default();
+    let r: &dyn Reflect = &c;
+    let info = r.reflect_type_path();
+    assert!(
+        info.contains("TranslationalStateC"),
+        "Reflect type path missing TranslationalStateC: got {info}"
+    );
+}
+
+/// `JeodPlugin`'s `App::register_type::<TypedComponent>()` calls (added
+/// in this PR) should populate the App-wide registry. Builds a minimal
+/// `App` with `MinimalPlugins + JeodPlugin` and verifies a representative
+/// Component is present.
+#[test]
+fn jeod_plugin_registers_typed_components() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(JeodPlugin);
+
+    let registry = app.world().resource::<AppTypeRegistry>().read();
+    assert!(
+        registry
+            .get_with_type_path("bevy_jeod::components::TranslationalStateC")
+            .is_some(),
+        "JeodPlugin did not register TranslationalStateC in AppTypeRegistry"
+    );
+    assert!(
+        registry
+            .get_with_type_path("bevy_jeod::components::PlanetFixedRotationC")
+            .is_some(),
+        "JeodPlugin did not register PlanetFixedRotationC in AppTypeRegistry"
+    );
+}


### PR DESCRIPTION
Closes #154.

## Summary

Every typed Bevy Component in `src/components.rs` now `#[derive(Reflect)]` with `#[reflect(opaque)]`, and `JeodPlugin` registers them in the `AppTypeRegistry`. Editor tooling, scene serialization, and runtime-introspecting consumers can identify the project's Components by type name and spawn them through reflection.

## Layering

Per the issue's revised approach: `Reflect` impls live in `bevy_jeod` (which already depends on Bevy), NOT in `jeod_quantities`. `#[reflect(opaque)]` treats each Component as a leaf — Bevy sees the type name and can spawn / route it, but field-level introspection of inner `jeod_*` types isn't surfaced.

This preserves the architectural premise that `jeod_quantities` and the other `jeod_*` crates stay Bevy-free. Field-level introspection (so an editor can see `position[0]: f64` inside a `TranslationalStateC`) is a future deeper-integration step; the opaque shape lands now to unblock editor consumers.

## Changes

- `Cargo.toml`: add `bevy_reflect` as a workspace dependency. Declared separately from the `bevy` umbrella crate because Bevy 0.18 doesn't expose `bevy_reflect` as a feature on the umbrella crate (only on `bevy_internal` upstream).
- `src/components.rs`: 25 typed Components gain `#[derive(Reflect)] #[reflect(opaque)]`. `SunMarker` / `MoonMarker` gain `Default + Clone + Copy + Debug` (required by the Reflect derive).
- `src/lib.rs`: `JeodPlugin::build` registers all 26 typed Components in the `AppTypeRegistry`. Adding `JeodPlugin` is enough — no per-Component `app.register_type` calls needed downstream.
- `tests/bevy_reflect_smoke.rs` (new): 3 smoke tests covering manual `TypeRegistry` registration, `Reflect` trait-object `reflect_type_path()` round-trip, and `JeodPlugin`-driven `AppTypeRegistry` population.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`: clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`: clean
- Unit + Tier 2: 755/755 passing (+3 from `bevy_reflect_smoke`)
- Tier 3 fast: 307/307 passing

## Future work

Field-level Reflect (drilling into `position[0]: f64` etc.) requires propagating `Reflect` derives through `jeod_dynamics`, `jeod_math`, and `jeod_quantities` as an optional feature. Larger architectural decision — the opaque shape ships now; the deeper integration follows when an editor consumer materializes and informs the per-field exposure decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)