### PR TITLE
[#163] Prune dead constructor API surface

### DIFF
--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -7,32 +7,20 @@
 //! remains here is the runner-specific terminal step: materializing a
 //! [`SimulationBuilder`] into a [`Simulation`].
 //!
-//! Two paths are provided so call sites read identically to the
-//! pre-relocation API:
-//!
-//! - [`Simulation::from_builder`] / [`Simulation::from_builder_unchecked`] —
-//!   inherent constructors on `Simulation`.
-//! - [`SimulationBuilderExt::build`] / `.build_unchecked()` — extension trait
-//!   that lets `scenarios::iss_leo().build()?` keep its fluent ergonomics.
+//! - [`Simulation::from_builder`] — inherent constructor on `Simulation`.
+//! - [`SimulationBuilderExt::build`] — extension trait that lets
+//!   `scenarios::iss_leo().build()?` keep its fluent ergonomics.
 
 use jeod_sim::simulation_builder::SimulationBuilder;
-use jeod_sim::SimulationTime;
 
 use crate::Simulation;
 
 impl Simulation {
-    /// Start building a simulation with the given time and timestep.
-    ///
-    /// Convenience wrapper around [`SimulationBuilder::new`] that mirrors the
-    /// pre-relocation `Simulation::builder(time, dt)` API.
-    pub fn builder(time: SimulationTime, dt: f64) -> SimulationBuilder {
-        SimulationBuilder::new(time, dt)
-    }
-
-    /// Materialize a [`SimulationBuilder`] into a runtime [`Simulation`]
-    /// without running validation. Use for tests that intentionally exercise
-    /// invalid configurations.
-    pub fn from_builder_unchecked(builder: SimulationBuilder) -> Self {
+    /// Materialize a [`SimulationBuilder`] into a runtime [`Simulation`] and
+    /// run validation. Returns `Err` on validation failure.
+    pub fn from_builder(
+        builder: SimulationBuilder,
+    ) -> Result<Self, Vec<jeod_sim::ValidationError>> {
         let SimulationBuilder {
             time,
             dt,
@@ -86,22 +74,13 @@ impl Simulation {
             }
         }
 
-        sim
-    }
-
-    /// Materialize a [`SimulationBuilder`] into a runtime [`Simulation`] and
-    /// run validation. Returns `Err` on validation failure.
-    pub fn from_builder(
-        builder: SimulationBuilder,
-    ) -> Result<Self, Vec<jeod_sim::ValidationError>> {
-        let mut sim = Self::from_builder_unchecked(builder);
         sim.validate()?;
         Ok(sim)
     }
 }
 
-/// Extension trait providing terminal `.build()` / `.build_unchecked()`
-/// methods on the relocated [`jeod_sim::SimulationBuilder`].
+/// Extension trait providing the terminal `.build()` method on the relocated
+/// [`jeod_sim::SimulationBuilder`].
 ///
 /// Mission code typically imports this via `jeod_runner::prelude::*` (or
 /// directly via `use jeod_runner::SimulationBuilderExt;`) so
@@ -111,18 +90,10 @@ pub trait SimulationBuilderExt: Sized {
     /// Build and validate the simulation. Returns `Err` on validation
     /// failure.
     fn build(self) -> Result<Simulation, Vec<jeod_sim::ValidationError>>;
-
-    /// Build without validation. Use only for tests that intentionally
-    /// exercise invalid configurations.
-    fn build_unchecked(self) -> Simulation;
 }
 
 impl SimulationBuilderExt for SimulationBuilder {
     fn build(self) -> Result<Simulation, Vec<jeod_sim::ValidationError>> {
         Simulation::from_builder(self)
-    }
-
-    fn build_unchecked(self) -> Simulation {
-        Simulation::from_builder_unchecked(self)
     }
 }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -348,14 +348,15 @@ impl SimBody {
 ///
 /// # Error handling
 ///
-/// Among the runtime instance methods on `Simulation`, `validate()` is the
-/// only `Result`-returning method, and it batches configuration errors at
-/// startup. Constructors that run validation (`Simulation::from_builder` and
-/// the `.build()` extension trait) also return `Result`. Every other runtime
-/// method panics on misuse with a method-name-prefixed message (e.g.
-/// `"set_source_position: source index 7 out of range"`). Out-of-range
-/// indices, configuration conflicts, and numerical preconditions are
-/// programmer errors, not runtime conditions.
+/// Validation can happen either at construction time or after mutation.
+/// Builder-based constructors that validate configuration
+/// (`Simulation::from_builder` and `SimulationBuilderExt::build`) return
+/// `Result`. After construction, `validate()` is the only `Result`-returning
+/// instance method on `Simulation`; it batches configuration errors before
+/// stepping. Other runtime methods panic on misuse with a method-name-prefixed
+/// message (e.g. `"set_source_position: source index 7 out of range"`).
+/// Out-of-range indices, configuration conflicts, and numerical
+/// preconditions are programmer errors, not runtime conditions.
 ///
 /// # Example
 /// ```ignore
@@ -731,7 +732,7 @@ impl Simulation {
         let fid = self.source_frame_ids[source_idx].inertial;
         assert_ne!(
             fid, self.root_frame_id,
-            "Cannot set position of the root (central body) source"
+            "set_source_position: cannot set position of the root (central body) source"
         );
         self.frame_tree.get_mut(fid).state.trans.position = position;
     }
@@ -750,7 +751,7 @@ impl Simulation {
         let fid = self.source_frame_ids[source_idx].inertial;
         assert_ne!(
             fid, self.root_frame_id,
-            "Cannot set state of the root (central body) source"
+            "set_source_state: cannot set state of the root (central body) source"
         );
         let node = self.frame_tree.get_mut(fid);
         node.state.trans.position = position;
@@ -2412,11 +2413,11 @@ impl Simulation {
     ) {
         let child_id = self.bodies[child_idx]
             .mass_body_id
-            .expect("child not in mass tree");
+            .expect("attach: child body not in mass tree");
         let parent_id = self.bodies[parent_idx]
             .mass_body_id
-            .expect("parent not in mass tree");
-        let tree = self.mass_tree.as_mut().expect("no mass tree");
+            .expect("attach: parent body not in mass tree");
+        let tree = self.mass_tree.as_mut().expect("attach: no mass tree");
         tree.attach(child_id, parent_id, offset, t_parent_child);
         // Sync parent's composite mass from tree
         self.bodies[parent_idx].mass = Some(tree.get(parent_id).composite_properties);
@@ -2432,11 +2433,11 @@ impl Simulation {
     pub fn detach(&mut self, child_idx: usize) {
         let child_id = self.bodies[child_idx]
             .mass_body_id
-            .expect("child not in mass tree");
-        let tree = self.mass_tree.as_mut().expect("no mass tree");
+            .expect("detach: child body not in mass tree");
+        let tree = self.mass_tree.as_mut().expect("detach: no mass tree");
         let parent_id = tree
             .parent(child_id)
-            .expect("detach called on body with no parent in tree");
+            .expect("detach: child body has no parent in tree");
         tree.detach(child_id);
         // Sync both bodies' mass from tree
         self.bodies[child_idx].mass = Some(tree.get(child_id).composite_properties);

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -348,9 +348,11 @@ impl SimBody {
 ///
 /// # Error handling
 ///
-/// `validate()` is the only `Result`-returning method, and it batches all
-/// configuration errors at startup. Every other method panics on misuse with
-/// a method-name-prefixed message (e.g.
+/// Among the runtime instance methods on `Simulation`, `validate()` is the
+/// only `Result`-returning method, and it batches configuration errors at
+/// startup. Constructors that run validation (`Simulation::from_builder` and
+/// the `.build()` extension trait) also return `Result`. Every other runtime
+/// method panics on misuse with a method-name-prefixed message (e.g.
 /// `"set_source_position: source index 7 out of range"`). Out-of-range
 /// indices, configuration conflicts, and numerical preconditions are
 /// programmer errors, not runtime conditions.

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -334,6 +334,27 @@ impl SimBody {
 /// functions (`accumulate_gravity`, `evaluate_atmosphere`, etc.) directly
 /// from their system functions.
 ///
+/// # Public API conventions
+///
+/// The methods on `Simulation` group into four families:
+///
+/// - **Source registry** (`add_source`, `set_source_*`, `source_*`) — gravity
+///   sources, ephemeris, planet rotation, tides.
+/// - **Body registry** (`add_body`, `body`, `set_body_*`) — dynamic vehicles.
+/// - **Mass tree** (`add_body_to_tree`, `attach`, `detach`,
+///   `sync_body_mass_from_tree`) — multi-body composites.
+/// - **Lifecycle** (`validate`, `step`, `step_n`, `step_until`, `set_dt`,
+///   `elapsed`).
+///
+/// # Error handling
+///
+/// `validate()` is the only `Result`-returning method, and it batches all
+/// configuration errors at startup. Every other method panics on misuse with
+/// a method-name-prefixed message (e.g.
+/// `"set_source_position: source index 7 out of range"`). Out-of-range
+/// indices, configuration conflicts, and numerical preconditions are
+/// programmer errors, not runtime conditions.
+///
 /// # Example
 /// ```ignore
 /// let mut sim = Simulation::new(time, 10.0);

--- a/crates/jeod_runner/src/prelude.rs
+++ b/crates/jeod_runner/src/prelude.rs
@@ -5,8 +5,7 @@
 //! ```
 //!
 //! Brings into scope the runner-side extension traits:
-//! - [`crate::SimulationBuilderExt`] — terminal
-//!   `.build()` / `.build_unchecked()` on
+//! - [`crate::SimulationBuilderExt`] — terminal `.build()` on
 //!   [`jeod_sim::SimulationBuilder`].
 //! - [`crate::VerificationCaseExt`] — terminal
 //!   `.run_and_assert()` on


### PR DESCRIPTION
## Summary

Pre-1.0 API audit of `jeod_runner::Simulation` (#163) — full
walkthrough posted as a PR comment below.

The audit's only concrete finding: three public constructors had **zero
external callers** across the workspace. Pre-1.0 is the right time to
drop speculative API surface.

- `Simulation::builder(time, dt)` — convenience wrapper that just
  forwarded to `SimulationBuilder::new`.
- `Simulation::from_builder_unchecked(builder)` — no-validate variant.
  Docstring claimed "Use only for tests that intentionally exercise
  invalid configurations" — no such test exists.
- `SimulationBuilderExt::build_unchecked()` — trait-side equivalent.

After pruning, the constructor matrix collapses from 4 entry points to 2:

```
new()              — direct, panics-on-misuse, no validation
builder.build()    — fluent, validated, returns Result
```

`from_builder` absorbs the previous `from_builder_unchecked` body inline
and appends `validate()` at the end.

Also adds a struct-level rustdoc summary on `Simulation` surfacing the
four method families (source / body / mass-tree / lifecycle) and the
panic-vs-Result error policy at the entry point.

## Bit-stability

No physics paths touched. Baseline freeze remains in force.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo build --workspace --tests --examples` — clean (zero callers
  confirmed)
- [x] `cargo clippy --workspace --tests --examples -- -D warnings` clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 755/755 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)