### PR TITLE
[#164] Promote recipes::scenarios fns to first-class Mission types

### DIFF
--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -1,7 +1,7 @@
 //! Apollo trans-lunar injection: multi-body gravity, staging, impulsive maneuver.
 //!
 //! Demonstrates a recipe-aware pattern: starts from
-//! [`scenarios::apollo_translunar`](jeod_sim::recipes::scenarios::apollo_translunar)
+//! [`Mission::apollo_translunar`](jeod_sim::recipes::Mission::apollo_translunar)
 //! for the simulation shape (Earth + Moon + Sun point-mass gravity),
 //! then layers mission-specific maneuvers — TLI impulsive Δv, stage
 //! separation via mass tree, parking-orbit override — directly on the
@@ -20,7 +20,8 @@ use std::path::Path;
 use glam::{DMat3, DVec3};
 use jeod_dynamics::MassProperties;
 use jeod_runner::SimulationBuilderExt;
-use jeod_sim::recipes::scenarios::{self, apollo};
+use jeod_sim::recipes::scenarios::apollo;
+use jeod_sim::recipes::Mission;
 use jeod_sim::{EphemerisBody, TranslationalState};
 
 const MU_EARTH: f64 = 3.986_004_418e14;
@@ -55,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let init_pos = DVec3::new(r_park, 0.0, 0.0);
     let init_vel = DVec3::new(0.0, v_circ * inc.cos(), v_circ * inc.sin());
 
-    let mut sb = scenarios::apollo_translunar();
+    let mut sb = Mission::apollo_translunar().into_builder();
     sb.dt = DT;
     // Override the scenario's default vehicle state with the parking-orbit IC.
     sb.bodies[0].trans = TranslationalState {

--- a/crates/jeod_runner/examples/batch_propagation.rs
+++ b/crates/jeod_runner/examples/batch_propagation.rs
@@ -2,12 +2,12 @@
 //!
 //! Propagates a circular LEO orbit for 10 periods, printing eccentricity
 //! and energy drift at regular intervals. Uses
-//! [`scenarios::iss_leo`](jeod_sim::recipes::scenarios::iss_leo) as the
+//! [`Mission::iss_leo`](jeod_sim::recipes::Mission::iss_leo) as the
 //! starting scenario.
 
 use glam::DVec3;
 use jeod_runner::SimulationBuilderExt;
-use jeod_sim::recipes::{constants, scenarios};
+use jeod_sim::recipes::{constants, Mission};
 
 fn specific_energy(mu: f64, position: DVec3, velocity: DVec3) -> f64 {
     0.5 * velocity.length_squared() - mu / position.length()
@@ -25,9 +25,9 @@ fn main() {
     // 10 orbits of an ISS-altitude circular LEO. The recipe defaults to
     // a 60 s step (good enough for verification accuracy); override to
     // 10 s here so the energy-drift demo passes its <1e-8 threshold.
-    let mut sb = scenarios::iss_leo();
+    let mut sb = Mission::iss_leo().into_builder();
     sb.dt = 10.0;
-    let mut sim = sb.build().expect("iss_leo() must validate");
+    let mut sim = sb.build().expect("iss_leo must validate");
 
     let r0 = sim.body(0).trans.position.length();
     let period = 2.0 * std::f64::consts::PI * (r0.powi(3) / mu_earth).sqrt();

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -2,11 +2,11 @@
 //!
 //! Propagates an ISS-like orbit (400 km, i=51.6 deg) with the MET
 //! atmosphere model and shows altitude decay over 24 hours. Uses
-//! [`scenarios::iss_leo_drag`](jeod_sim::recipes::scenarios::iss_leo_drag).
+//! [`Mission::iss_leo_drag`](jeod_sim::recipes::Mission::iss_leo_drag).
 
 use glam::DVec3;
 use jeod_runner::SimulationBuilderExt;
-use jeod_sim::recipes::{constants, scenarios};
+use jeod_sim::recipes::{constants, Mission};
 
 fn specific_energy(mu: f64, position: DVec3, velocity: DVec3) -> f64 {
     0.5 * velocity.length_squared() - mu / position.length()
@@ -26,9 +26,10 @@ fn main() {
     let mu_earth = constants::mu_ggm05c().value;
     let r_eq = 6_378_137.0;
 
-    let mut sim = scenarios::iss_leo_drag()
+    let mut sim = Mission::iss_leo_drag()
+        .into_builder()
         .build()
-        .expect("iss_leo_drag() must validate");
+        .expect("iss_leo_drag must validate");
     let body_idx = 0;
 
     let initial = sim.body(body_idx).trans;

--- a/crates/jeod_runner/src/builder.rs
+++ b/crates/jeod_runner/src/builder.rs
@@ -9,7 +9,7 @@
 //!
 //! - [`Simulation::from_builder`] — inherent constructor on `Simulation`.
 //! - [`SimulationBuilderExt::build`] — extension trait that lets
-//!   `scenarios::iss_leo().build()?` keep its fluent ergonomics.
+//!   `Mission::iss_leo().into_builder().build()?` read naturally.
 
 use jeod_sim::simulation_builder::SimulationBuilder;
 
@@ -84,7 +84,7 @@ impl Simulation {
 ///
 /// Mission code typically imports this via `jeod_runner::prelude::*` (or
 /// directly via `use jeod_runner::SimulationBuilderExt;`) so
-/// `scenarios::iss_leo().build()?` reads naturally. Callers that prefer the
+/// `Mission::iss_leo().into_builder().build()?` reads naturally. Callers that prefer the
 /// explicit form can use [`Simulation::from_builder`] directly.
 pub trait SimulationBuilderExt: Sized {
     /// Build and validate the simulation. Returns `Err` on validation

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -264,7 +264,7 @@ fn load_reference_sixdof(filename: &str) -> Vec<RefState> {
 // non-recipe: SIM_verif_frame_switch uses the Apollo 8 trans-lunar-coast
 // state vector (Dec 23 1968 19:38 UTC) with vehicle.py-specific inertia in
 // slug-ft² and CoM offset in inches. This is materially different from
-// `scenarios::apollo_translunar()` (J2000 epoch, 200 km parking orbit,
+// `Mission::apollo_translunar()` (J2000 epoch, 200 km parking orbit,
 // generic CSM mass) — substituting would change what's being verified.
 #[test]
 fn tier3_apollo8_eci_integ() {

--- a/crates/jeod_sim/src/recipes/mission.rs
+++ b/crates/jeod_sim/src/recipes/mission.rs
@@ -1,0 +1,167 @@
+//! First-class catalog of pre-composed reference missions.
+//!
+//! [`Mission`] replaces the bare `recipes::scenarios::*()` fn pointers with
+//! a discoverable type-driven catalog. Each constructor returns a `Mission`
+//! carrying scenario metadata; [`into_builder()`](Mission::into_builder)
+//! materializes the underlying `SimulationBuilder` and
+//! [`with_time()`](Mission::with_time) overrides the epoch without
+//! reconstructing the scenario.
+//!
+//! # Example
+//! ```
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::iss_leo().into_builder();
+//! ```
+//!
+//! Override the epoch:
+//! ```
+//! use jeod_sim::recipes::{epoch, Mission};
+//! let sb = Mission::iss_leo().with_time(epoch::j2000()).into_builder();
+//! ```
+
+use crate::recipes::scenarios;
+use crate::SimulationBuilder;
+use crate::SimulationTime;
+
+/// A reference mission scenario.
+///
+/// Construct one via [`Mission::iss_leo`] / [`Mission::apollo_translunar`] /
+/// etc., optionally compose with [`with_time`](Self::with_time), then
+/// finalize with [`into_builder`](Self::into_builder).
+pub struct Mission {
+    description: &'static str,
+    builder_fn: fn() -> SimulationBuilder,
+    time_override: Option<SimulationTime>,
+}
+
+impl Mission {
+    /// 3-DOF point-mass ISS-like LEO with Earth point-mass gravity.
+    /// Epoch J2000, 60 s timestep.
+    pub fn iss_leo() -> Self {
+        Self {
+            description: "ISS-class LEO; 3-DOF point-mass Earth gravity at J2000.",
+            builder_fn: scenarios::iss_leo::iss_leo,
+            time_override: None,
+        }
+    }
+
+    /// ISS-like LEO with atmospheric drag (MET solar-mean atmosphere) and
+    /// 6-DOF identity attitude. 60 s timestep.
+    pub fn iss_leo_drag() -> Self {
+        Self {
+            description: "ISS-class LEO with MET solar-mean drag; 6-DOF identity attitude.",
+            builder_fn: scenarios::iss_leo::iss_leo_drag,
+            time_override: None,
+        }
+    }
+
+    /// Apollo translunar trajectory with multi-body Earth + Moon + Sun.
+    pub fn apollo_translunar() -> Self {
+        Self {
+            description: "Apollo translunar trajectory; Earth + Moon + Sun gravity.",
+            builder_fn: scenarios::apollo::apollo_translunar,
+            time_override: None,
+        }
+    }
+
+    /// Earth-Moon translunar reference orbit using DE421 ephemerides.
+    pub fn earth_moon_translunar() -> Self {
+        Self {
+            description: "Earth-Moon translunar trajectory; DE421 ephemeris.",
+            builder_fn: scenarios::earth_moon::earth_moon_translunar,
+            time_override: None,
+        }
+    }
+
+    /// Geostationary equatorial orbit at sidereal rate.
+    pub fn geo() -> Self {
+        Self {
+            description: "Geostationary equatorial orbit at sidereal rate.",
+            builder_fn: scenarios::geostationary::geo,
+            time_override: None,
+        }
+    }
+
+    /// Clementine lunar mission setup at the 1994 launch epoch.
+    pub fn clementine_lunar() -> Self {
+        Self {
+            description: "Clementine lunar mission; 1994 launch epoch.",
+            builder_fn: scenarios::clementine_lunar::clementine_lunar,
+            time_override: None,
+        }
+    }
+
+    /// Mars-centered orbit with Sun perturbation; Dawn 2009 epoch.
+    pub fn mars_orbit() -> Self {
+        Self {
+            description: "Mars-centered orbit; Sun perturbation, Dawn 2009 epoch.",
+            builder_fn: scenarios::mars_orbit::mars_orbit,
+            time_override: None,
+        }
+    }
+
+    /// Heliocentric Mercury orbit with PPN relativistic corrections.
+    pub fn mercury_relativistic() -> Self {
+        Self {
+            description: "Mercury heliocentric orbit; PPN relativistic corrections.",
+            builder_fn: scenarios::mercury::mercury_relativistic,
+            time_override: None,
+        }
+    }
+
+    /// Human-readable scenario description.
+    pub fn description(&self) -> &'static str {
+        self.description
+    }
+
+    /// Override the simulation epoch (e.g. to start the mission at a
+    /// non-default time). The override is applied to the
+    /// [`SimulationBuilder`] inside [`into_builder`](Self::into_builder).
+    pub fn with_time(mut self, time: SimulationTime) -> Self {
+        self.time_override = Some(time);
+        self
+    }
+
+    /// Materialize the underlying [`SimulationBuilder`].
+    pub fn into_builder(self) -> SimulationBuilder {
+        let mut sb = (self.builder_fn)();
+        if let Some(time) = self.time_override {
+            sb.time = time;
+        }
+        sb
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recipes::epoch;
+
+    #[test]
+    fn each_constructor_returns_a_buildable_scenario() {
+        // Smoke: every scenario must materialize without panicking.
+        let _ = Mission::iss_leo().into_builder();
+        let _ = Mission::iss_leo_drag().into_builder();
+        let _ = Mission::apollo_translunar().into_builder();
+        let _ = Mission::earth_moon_translunar().into_builder();
+        let _ = Mission::geo().into_builder();
+        let _ = Mission::clementine_lunar().into_builder();
+        let _ = Mission::mars_orbit().into_builder();
+        let _ = Mission::mercury_relativistic().into_builder();
+    }
+
+    #[test]
+    fn description_is_non_empty() {
+        assert!(!Mission::iss_leo().description().is_empty());
+        assert!(!Mission::apollo_translunar().description().is_empty());
+    }
+
+    #[test]
+    fn with_time_overrides_simulation_epoch() {
+        let custom = epoch::clementine_1994();
+        let sb = Mission::iss_leo().with_time(custom).into_builder();
+        let default = Mission::iss_leo().into_builder();
+        // Custom override must differ from the default J2000 epoch.
+        assert_ne!(sb.time.tai_tjt_at_epoch, default.time.tai_tjt_at_epoch);
+    }
+}

--- a/crates/jeod_sim/src/recipes/mission.rs
+++ b/crates/jeod_sim/src/recipes/mission.rs
@@ -16,7 +16,7 @@
 //! Override the epoch:
 //! ```
 //! use jeod_sim::recipes::{epoch, Mission};
-//! let sb = Mission::iss_leo().with_time(epoch::j2000()).into_builder();
+//! let sb = Mission::iss_leo().with_time(epoch::clementine_1994()).into_builder();
 //! ```
 
 use crate::recipes::scenarios;

--- a/crates/jeod_sim/src/recipes/mod.rs
+++ b/crates/jeod_sim/src/recipes/mod.rs
@@ -8,10 +8,12 @@
 //!   [`atmosphere`], [`epoch`], [`vehicle`], [`orbital_elements`],
 //!   [`constants`]): named typed primitives that mission code combines
 //!   freely.
-//! - **Scenarios** ([`scenarios`]): pre-composed
-//!   [`SimulationBuilder`](crate::SimulationBuilder)s for common
-//!   reference setups (`scenarios::iss_leo()`,
-//!   `scenarios::clementine_lunar()`, …). Each scenario is the
+//! - **Missions** ([`Mission`]): first-class catalog of pre-composed
+//!   reference scenarios. `Mission::iss_leo()`,
+//!   `Mission::clementine_lunar()`, … each return a typed `Mission`
+//!   that materializes into a
+//!   [`SimulationBuilder`](crate::SimulationBuilder) via
+//!   [`into_builder`](Mission::into_builder). Each scenario is the
 //!   smallest composition of building blocks plus vehicle config that
 //!   matches a JEOD verification simulation.
 //! - **Verification** ([`verification`]):
@@ -24,12 +26,12 @@
 //! ```ignore
 //! // Standalone runner
 //! use jeod_runner::SimulationBuilderExt;          // .build() terminal
-//! use jeod_sim::recipes::scenarios;
-//! let sim = scenarios::iss_leo().build()?;
+//! use jeod_sim::recipes::Mission;
+//! let sim = Mission::iss_leo().into_builder().build()?;
 //!
 //! // Bevy adapter (Phase 9)
 //! use bevy_jeod::prelude::*;                      // .spawn() terminal
-//! commands.spawn_scenario(scenarios::iss_leo());
+//! commands.spawn_scenario(Mission::iss_leo().into_builder());
 //! ```
 //!
 //! Recipes that depend on JEOD source data (`$JEOD_HOME/...`) panic
@@ -42,9 +44,12 @@ pub mod earth;
 pub mod epoch;
 pub mod helpers;
 pub mod mars;
+pub mod mission;
 pub mod moon;
 pub mod orbital_elements;
 pub mod scenarios;
 pub mod sun;
 pub mod vehicle;
 pub mod verification;
+
+pub use mission::Mission;

--- a/crates/jeod_sim/src/recipes/scenarios/apollo.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/apollo.rs
@@ -2,7 +2,8 @@
 //!
 //! ```
 //! use jeod_sim::recipes::scenarios::apollo;
-//! let sb = apollo::apollo_translunar();
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::apollo_translunar().into_builder();
 //! assert_eq!(sb.sources.len(), 3);
 //! assert_eq!(apollo::EARTH_IDX, 0);
 //! assert_eq!(apollo::MOON_IDX, 1);

--- a/crates/jeod_sim/src/recipes/scenarios/clementine_lunar.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/clementine_lunar.rs
@@ -1,8 +1,8 @@
 //! Clementine 1994 lunar-orbit scenario.
 //!
 //! ```
-//! use jeod_sim::recipes::scenarios;
-//! let sb = scenarios::clementine_lunar();
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::clementine_lunar().into_builder();
 //! // Three sources: Moon (central), Earth (third-body), Sun (third-body / SRP).
 //! assert_eq!(sb.sources.len(), 3);
 //! ```

--- a/crates/jeod_sim/src/recipes/scenarios/geostationary.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/geostationary.rs
@@ -1,8 +1,8 @@
 //! Geostationary orbit scenario.
 //!
 //! ```
-//! use jeod_sim::recipes::scenarios;
-//! let sb = scenarios::geo();
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::geo().into_builder();
 //! assert_eq!(sb.bodies.len(), 1);
 //! ```
 

--- a/crates/jeod_sim/src/recipes/scenarios/iss_leo.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/iss_leo.rs
@@ -1,8 +1,8 @@
 //! ISS-class LEO scenarios.
 //!
 //! ```
-//! use jeod_sim::recipes::scenarios;
-//! let sb = scenarios::iss_leo();
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::iss_leo().into_builder();
 //! assert_eq!(sb.bodies.len(), 1);
 //! assert_eq!(sb.sources.len(), 1);
 //! ```

--- a/crates/jeod_sim/src/recipes/scenarios/mars_orbit.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mars_orbit.rs
@@ -1,8 +1,8 @@
 //! Mars-orbit scenario.
 //!
 //! ```
-//! use jeod_sim::recipes::scenarios;
-//! let sb = scenarios::mars_orbit();
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::mars_orbit().into_builder();
 //! assert_eq!(sb.sources.len(), 2);
 //! ```
 

--- a/crates/jeod_sim/src/recipes/scenarios/mercury.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mercury.rs
@@ -1,8 +1,8 @@
 //! Mercury / GR-perihelion-advance scenario.
 //!
 //! ```
-//! use jeod_sim::recipes::scenarios;
-//! let sb = scenarios::mercury_relativistic();
+//! use jeod_sim::recipes::Mission;
+//! let sb = Mission::mercury_relativistic().into_builder();
 //! assert_eq!(sb.bodies.len(), 1);
 //! ```
 

--- a/crates/jeod_sim/src/recipes/scenarios/mod.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mod.rs
@@ -1,13 +1,14 @@
-//! Pre-composed [`SimulationBuilder`](crate::SimulationBuilder)s for
-//! common reference scenarios.
+//! Per-scenario `SimulationBuilder` constructors.
 //!
-//! Each scenario function returns a fully-configured builder. Mission
-//! code adds an adapter-specific terminal step:
+//! These submodules host the per-scenario physics setup. The user-facing
+//! catalog is [`crate::recipes::Mission`] — mission code should construct
+//! scenarios as `Mission::iss_leo().into_builder()` rather than calling
+//! into these submodules directly.
 //!
 //! ```ignore
 //! use jeod_runner::SimulationBuilderExt;
-//! use jeod_sim::recipes::scenarios;
-//! let sim = scenarios::iss_leo().build()?;
+//! use jeod_sim::recipes::Mission;
+//! let sim = Mission::iss_leo().into_builder().build()?;
 //! ```
 //!
 //! Scenarios that mirror JEOD verification simulations (Tier 3
@@ -26,11 +27,3 @@ pub mod geostationary;
 pub mod iss_leo;
 pub mod mars_orbit;
 pub mod mercury;
-
-pub use apollo::apollo_translunar;
-pub use clementine_lunar::clementine_lunar;
-pub use earth_moon::earth_moon_translunar;
-pub use geostationary::geo;
-pub use iss_leo::{iss_leo, iss_leo_drag};
-pub use mars_orbit::mars_orbit;
-pub use mercury::mercury_relativistic;


### PR DESCRIPTION
## Summary

Replaces the bare module-level fn pointers in `recipes::scenarios::*` with
a typed `Mission` catalog. `Mission::iss_leo()` etc. become discoverable
via IDE auto-complete on the `Mission` type, carry scenario metadata, and
support composition (e.g. `with_time(...)` for epoch override).

```rust
use jeod_sim::recipes::Mission;

let sb = Mission::iss_leo().into_builder();

// Compose with epoch override:
let sb = Mission::iss_leo()
    .with_time(epoch::clementine_1994())
    .into_builder();
```

## Shape

`Mission` exposes:
- **8 constructors** — `iss_leo`, `iss_leo_drag`, `apollo_translunar`,
  `earth_moon_translunar`, `geo`, `clementine_lunar`, `mars_orbit`,
  `mercury_relativistic`.
- `description() -> &'static str` for IDE-discoverable scenario summaries.
- `with_time(SimulationTime) -> Self` for epoch override without
  reconstructing the scenario.
- `into_builder() -> SimulationBuilder` for the terminal step.

Implementation: `Mission` stores a fn pointer to the existing scenario fn
plus an optional time override; `into_builder()` invokes the fn and applies
the override before returning. **Zero numeric impact** on the underlying
scenarios — this is a shape change.

## Migration

- **4 actual callers** updated: `examples/apollo`, `examples/batch_propagation`,
  `examples/leo_drag` (one each), `tests/tier3_apollo8_frame_switch` (comment).
- Doctest updates in 5 scenario submodules + 1 in `apollo.rs`.
- Drops the top-level `scenarios::iss_leo()` re-exports; the per-scenario
  submodules remain `pub` for Mission's internal use and for the
  apollo.rs example which reaches into `scenarios::apollo` for the named
  `SUN_IDX`/`MOON_IDX`/`EARTH_IDX` constants.

## Bit-stability

`Mission::xxx().into_builder()` produces a `SimulationBuilder` that is
identical to the previous `scenarios::xxx()` form (literally calls the
same fn underneath). No physics paths touched. Baseline freeze remains in
force.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings` clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] `cargo test --doc -p jeod_sim` — 19 doctests pass
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 758/758 pass
- [x] `cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'` — 307/307 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)