### PR TITLE
[#172] Audit nits: M6 + L4 + L5

### DIFF
--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -369,8 +369,11 @@ impl GaussJacksonState {
         acc: DVec3,
         state: &mut TranslationalState,
     ) -> IntegratorResult {
+        let offset = self
+            .history_length
+            .checked_sub(self.order + 1)
+            .expect("integrate_bootstrap_step called before bootstrap primed history");
         let hist_len = self.history_length as isize;
-        let offset = (hist_len - (self.order as isize + 1)) as usize;
 
         let passed = self.integrate_gj(
             cycle_dyndt,

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -248,20 +248,6 @@ pub enum ExtrasComparator {
     SolarBeta,
 }
 
-impl Default for Tolerances {
-    /// Default tolerances broad enough to spot a regression while not
-    /// rejecting bit-stable runs. Concrete cases tighten these.
-    fn default() -> Self {
-        Self {
-            position_m: [1.0, 1.0, 1.0],
-            velocity_m_s: [1.0e-3, 1.0e-3, 1.0e-3],
-            quat_angle_rad: 1.0e-6,
-            ang_vel_rad_s: [1.0e-9, 1.0e-9, 1.0e-9],
-            extras: &[],
-        }
-    }
-}
-
 /// A single Tier 3 verification case.
 ///
 /// Phase 6 shipped the type; Phase 7+ populates `verification::*`

--- a/crates/jeod_time/src/leap_second.rs
+++ b/crates/jeod_time/src/leap_second.rs
@@ -100,6 +100,10 @@ impl LeapSecondTable {
     /// second: within the leap second, UTC rewinds by 1 s so the interval
     /// `23:59:59..24:00:00` is traversed twice (once labelled 23:59:59, once
     /// labelled 23:59:60).
+    ///
+    /// O(n) over the leap-second table (28 entries today, growing by 0–1 per
+    /// year). Fine for occasional UTC↔TAI conversions; do not call in tight
+    /// integrator inner loops — cache the result if you need it per step.
     fn find_index_for_tai(&self, tai_tjt: f64) -> usize {
         let last = self.entries.len() - 1;
         // Before the first entry: JEOD uses val_vec[0], so return index 0.


### PR DESCRIPTION
## Summary

Three contained audit fixes from the adversarial pre-release audit
(#172):

- **M6**: Replace `(isize as usize)` cast in
  `gauss_jackson::integrate_bootstrap_step` with
  `checked_sub(...).expect(...)`. An underflow now surfaces as a clear
  panic message instead of wrapping silently to a huge offset and
  crashing with an unrelated out-of-bounds.

- **L4**: Add an O(n) performance note to
  `LeapSecondTable::find_index_for_tai` documenting that it should not
  be called in tight integrator inner loops (cache the result).

- **L5**: Delete `Tolerances::default()`. The default values
  (position 1.0 m, velocity 1e-3 m/s) were too loose to flag a real
  regression — coarser than every actual Tier 3 case. Zero callers
  outside the impl itself; every case already declares tolerances
  explicitly.

## Out of scope

- **H1, H2** — type-system facade architectural decision, multi-body
  vehicle/planet identity macros. These need user input.
- **M1** (escape-hatch guard) — refusing `from_untyped_unchecked` /
  `from_dmat3_unchecked` outside an allowlisted module would fail CI on
  130+ existing usages. Depends on H1.
- **H3** (Gauss-Jackson convergence health) — separate PR.
- **H4** (gravity validation in `evaluate_inner`) — separate PR.
- **M4/M5** (replace unsafe split-borrow + add `forbid(unsafe_code)`) —
  separate PR.

## Bit-stability

No physics paths touched. Baseline freeze remains in force.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings` clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 758/758 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)