### PR TITLE
[#172] H3: Surface Gauss-Jackson bootstrap convergence health

### DIFF
--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -221,6 +221,17 @@ impl GaussJacksonState {
         matches!(self.fsm_state, FsmState::Reset | FsmState::Priming)
     }
 
+    /// Cumulative count of `BootstrapEdit` iterations that hit
+    /// `max_correction_iterations` without converging. A non-zero value
+    /// means the integrator silently accepted a non-converged correction
+    /// and proceeded. JEOD's behavior under this condition is matched
+    /// (non-fatal); callers who want a louder signal — e.g. long
+    /// missions where small bootstrap error compounds — should poll
+    /// this and `log::warn!` the first time it transitions from 0.
+    pub fn bootstrap_unconverged_iterations(&self) -> u32 {
+        self.state_machine.bootstrap_unconverged_iterations()
+    }
+
     /// Drive one stage of integration.
     ///
     /// Combines JEOD's `GaussJacksonIntegrationControls::integrate()` (stage

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -221,7 +221,7 @@ impl GaussJacksonState {
         matches!(self.fsm_state, FsmState::Reset | FsmState::Priming)
     }
 
-    /// Cumulative count of `BootstrapEdit` iterations that hit
+    /// Cumulative count of `BootstrapEdit` iterations that reached
     /// `max_correction_iterations` without converging. A non-zero value
     /// means the integrator silently accepted a non-converged correction
     /// and proceeded. JEOD's behavior under this condition is matched

--- a/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
@@ -53,7 +53,7 @@ pub(crate) struct StateMachine {
     bootstrap_edit_redo_needed: bool,
 
     // ── Convergence diagnostics ──
-    /// Cumulative count of `BootstrapEdit` iterations that exceeded
+    /// Cumulative count of `BootstrapEdit` iterations that reached
     /// `max_correction_iterations` without converging. Each occurrence
     /// means the FSM accepted a non-converged correction and proceeded
     /// to the next phase. Matches JEOD's behavior; surfaced here so
@@ -157,7 +157,8 @@ impl StateMachine {
     // ── Mutators ──
 
     /// Tell the state machine that the edit did not pass convergence.
-    /// Only requests a redo if another iteration is still allowed; otherwise
+    /// Only requests a redo if another iteration is still allowed
+    /// (`correction_iterations < max_correction_iterations`); otherwise
     /// no redo is requested and the edit proceeds with the non-converged
     /// result, incrementing
     /// [`bootstrap_unconverged_iterations`](Self::bootstrap_unconverged_iterations)
@@ -177,7 +178,7 @@ impl StateMachine {
         }
     }
 
-    /// Cumulative count of `BootstrapEdit` iterations that hit
+    /// Cumulative count of `BootstrapEdit` iterations that reached
     /// `max_correction_iterations` without converging. A non-zero value
     /// indicates the integrator accepted a non-converged edit and
     /// continued — long missions where small bootstrap error compounds
@@ -380,6 +381,44 @@ mod tests {
         assert_eq!(sm.fsm_state(), FsmState::BootstrapEdit);
         sm.perform_step(); // history_length=5 == history_size → Operational
         assert_eq!(sm.fsm_state(), FsmState::Operational);
+    }
+
+    #[test]
+    fn bootstrap_unconverged_counter_increments_at_max_and_survives_reset() {
+        // max_correction_iterations = 1: after exit_priming sets
+        // correction_iterations = 1, the very next failed edit hits
+        // `1 < 1 == false` and accepts the non-converged edit.
+        let config = GaussJacksonConfig {
+            initial_order: 4,
+            final_order: 4,
+            ndoubling_steps: 0,
+            max_correction_iterations: 1,
+            ..Default::default()
+        };
+        let mut sm = StateMachine::configure(&config);
+
+        // Drive into BootstrapEdit (Reset → Priming → BootstrapEdit). With
+        // initial=final=4 and ndoubling=0, history_size = order+1 = 5.
+        for _ in 0..5 {
+            sm.perform_step();
+        }
+        assert_eq!(sm.fsm_state(), FsmState::BootstrapEdit);
+        assert_eq!(sm.bootstrap_unconverged_iterations(), 0);
+
+        // Force a non-converged edit. correction_iterations is at 1 (set
+        // by exit_priming), max is 1, so 1 < 1 is false → counter ticks.
+        sm.set_bootstrap_edit_redo_needed();
+        assert_eq!(sm.bootstrap_unconverged_iterations(), 1);
+        assert!(
+            !sm.bootstrap_edit_redo_needed,
+            "redo must NOT be requested when at the iteration cap"
+        );
+
+        // Counter must persist across reset() — long missions span
+        // multiple bootstrap-reset cycles, and the cumulative history is
+        // exactly the diagnostic the audit asked for.
+        sm.reset();
+        assert_eq!(sm.bootstrap_unconverged_iterations(), 1);
     }
 
     #[test]

--- a/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
@@ -52,6 +52,14 @@ pub(crate) struct StateMachine {
     cycle_start_time: f64,
     bootstrap_edit_redo_needed: bool,
 
+    // ── Convergence diagnostics ──
+    /// Cumulative count of `BootstrapEdit` iterations that exceeded
+    /// `max_correction_iterations` without converging. Each occurrence
+    /// means the FSM accepted a non-converged correction and proceeded
+    /// to the next phase. Matches JEOD's behavior; surfaced here so
+    /// callers can log a warning instead of silently continuing.
+    bootstrap_unconverged_iterations: u32,
+
     // Flags (set by perform_step, read by integrator)
     at_downsample: bool,
     at_reinitialize: bool,
@@ -96,6 +104,7 @@ impl StateMachine {
             cycle_scale: 1.0 / tour_count as f64,
             cycle_start_time: 0.0,
             bootstrap_edit_redo_needed: false,
+            bootstrap_unconverged_iterations: 0,
             at_downsample: false,
             at_reinitialize: false,
             at_order_change: false,
@@ -150,14 +159,31 @@ impl StateMachine {
     /// Tell the state machine that the edit did not pass convergence.
     /// Only requests a redo if another iteration is still allowed; otherwise
     /// no redo is requested and the edit proceeds with the non-converged
-    /// result.
+    /// result, incrementing
+    /// [`bootstrap_unconverged_iterations`](Self::bootstrap_unconverged_iterations)
+    /// so callers can surface a warning.
     ///
     /// JEOD: `GaussJacksonStateMachine::set_bootstrap_edit_redo_needed()`.
     pub fn set_bootstrap_edit_redo_needed(&mut self) {
         assert_eq!(self.fsm_state, FsmState::BootstrapEdit);
         if self.correction_iterations < self.max_correction_iterations {
             self.bootstrap_edit_redo_needed = true;
+        } else {
+            // JEOD_INV: IG.36 — non-converged bootstrap edit accepted; counter
+            // surfaces this to callers (matches JEOD's MessageHandler::error
+            // semantics, which we don't have a direct equivalent for).
+            self.bootstrap_unconverged_iterations =
+                self.bootstrap_unconverged_iterations.saturating_add(1);
         }
+    }
+
+    /// Cumulative count of `BootstrapEdit` iterations that hit
+    /// `max_correction_iterations` without converging. A non-zero value
+    /// indicates the integrator accepted a non-converged edit and
+    /// continued — long missions where small bootstrap error compounds
+    /// should log a warning the first time this is observed.
+    pub fn bootstrap_unconverged_iterations(&self) -> u32 {
+        self.bootstrap_unconverged_iterations
     }
 
     /// Reset the state machine.

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -649,6 +649,7 @@ pub fn integrate_body(
                     .saturating_mul(tour_count)
                     .clamp(100, 10_000_000) // hard cap: prevent runaway loops
             };
+            let unconverged_before = gj.bootstrap_unconverged_iterations();
             let mut completed = false;
             for _ in 0..max_stages {
                 let acc = gravity_fn(trans.position, trans.velocity, 0.0) + non_grav_accel;
@@ -663,6 +664,15 @@ pub fn integrate_body(
                     completed = true;
                     break;
                 }
+            }
+            let unconverged_after = gj.bootstrap_unconverged_iterations();
+            if unconverged_after > unconverged_before && unconverged_before == 0 {
+                log::warn!(
+                    "GaussJackson bootstrap edit accepted a non-converged correction \
+                     ({unconverged_after} iteration(s) total — JEOD-faithful behavior, \
+                     but long missions where bootstrap error compounds may want to \
+                     review the integration setup)."
+                );
             }
             assert!(
                 completed,

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -341,6 +341,7 @@ Source: `../jeod/models/utils/integration/` (core + `gauss_jackson/` + `lsode/`)
 | IG.33 | IntegrationGroup::remove_integrable_object: entry must exist (`jeod_integration_group.cc`) | error | runtime | n/a (no runtime integration-group membership; bodies are Bevy entities) |
 | IG.34 | Integrator step `dt` must be finite and strictly positive; zero-step silently rotates multi-step history (ABM4) (no JEOD equivalent — JEOD relies on Trick scheduler) | runtime | runtime | enforced (`abm4.rs:172`; `integration.rs` asserts dt non-zero in stepping paths) |
 | IG.35 | Integrator state: position and velocity must remain finite across stages (structural JEOD assumption — never asserted in production; verified by test harness) | structural | consistency | n/a (JEOD does not assert; neither do we — unit tests exercise the shape) |
+| IG.36 | Gauss-Jackson `BootstrapEdit` accepts a non-converged correction once `correction_iterations >= max_correction_iterations` and proceeds (`gauss_jackson_integration_controls.cc` — JEOD logs via `MessageHandler::error`, non-fatal) | warn | runtime | enforced (`gauss_jackson/state_machine.rs` increments `bootstrap_unconverged_iterations`; `integration.rs` `log::warn!`s on first occurrence) |
 
 ## Section QT: Quaternion
 


### PR DESCRIPTION
## Summary

Audit finding **H3** from #172: the Gauss-Jackson FSM silently accepts a
non-converged `BootstrapEdit` correction once
`correction_iterations >= max_correction_iterations`, with no signal to
the caller. JEOD's behavior under this condition is matched (non-fatal),
but JEOD logs via `MessageHandler::error` — we previously had no
equivalent.

This PR adds:

- `bootstrap_unconverged_iterations: u32` counter on the
  `GaussJackson` `StateMachine`, incremented each time a non-converged
  edit is accepted.
- `GaussJacksonState::bootstrap_unconverged_iterations()` accessor for
  direct polling.
- A `log::warn!` at the integrator call site
  (`integration.rs::integrate_translational` for the
  `IntegratorType::GaussJackson` arm) the **first time** the counter
  transitions from zero — so long missions where bootstrap error
  compounds get a louder signal than silent continuation.
- New invariant entry **IG.36** in `docs/JEOD_invariants.md`.

The counter is intentionally cumulative across `reset()` so a
multi-bootstrap-cycle mission's history is visible at any point.

## Bit-stability

No physics paths touched. The counter is a pure observation; the
warning is a side-effect log. Baseline freeze remains in force.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings` clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 758/758 pass
- [x] `cargo nextest run --test invariant_coverage` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)