### PR TITLE
Replace unsafe split-borrow with iter_mut + forbid unsafe workspace-wide (#172 M4 + M5)

### DIFF
--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub use jeod_quantities::prelude::*;
 
 pub mod exponential;

--- a/crates/jeod_dynamics/src/lib.rs
+++ b/crates/jeod_dynamics/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod abm4;
 pub mod body_init;
 pub mod constraints;

--- a/crates/jeod_ephemeris/src/lib.rs
+++ b/crates/jeod_ephemeris/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub use jeod_quantities::prelude::*;
 
 pub mod bodies;

--- a/crates/jeod_frames/src/lib.rs
+++ b/crates/jeod_frames/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod data_nutation_j2000;
 pub mod frame_tree;
 pub mod nutation_j2000;

--- a/crates/jeod_gravity/src/lib.rs
+++ b/crates/jeod_gravity/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod coefficients;
 pub mod compute;
 pub mod gravity_controls;

--- a/crates/jeod_interactions/src/lib.rs
+++ b/crates/jeod_interactions/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod aero_drag;
 pub mod contact;
 pub mod earth_lighting;

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -6,6 +6,8 @@
 //! LeftTransform>` type alias), and all algebraic/conversion methods live
 //! on that unified type so there is only one quaternion in the workspace.
 
+#![forbid(unsafe_code)]
+
 pub use jeod_quantities::prelude::*;
 
 pub mod error;

--- a/crates/jeod_planet/src/lib.rs
+++ b/crates/jeod_planet/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub use jeod_quantities::prelude::*;
 
 pub mod planet;

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -26,6 +26,8 @@
 //! println!("{:?}", output.trans.position);
 //! ```
 
+#![forbid(unsafe_code)]
+
 use glam::{DMat3, DVec3};
 
 use jeod_frames::{FrameTree, RefFrameKind, RefFrameRot, RefFrameState, RefFrameTrans};
@@ -1990,7 +1992,6 @@ impl Simulation {
             // everything we need up front. Cloning `gravity_controls`
             // happens here (and only here, since contact_pairs is
             // non-empty) — the non-contact path above borrows directly.
-            let n_bodies = bodies_mut.len();
             let t_struct_body_vec: Vec<DMat3> =
                 bodies_mut.iter().map(|b| b.t_struct_body).collect();
             let mass_vec: Vec<MassProperties> = bodies_mut
@@ -2007,34 +2008,36 @@ impl Simulation {
                 .collect();
 
             // Build coupled inputs. `CoupledBodyInput` needs separate &mut
-            // for trans / rot from the same SimBody; raw pointers produce
-            // the split borrow that the checker can't infer.
-            let mut inputs: Vec<CoupledBodyInput<'_>> = Vec::with_capacity(n_bodies);
-            // Safety: we produce exactly one &mut per disjoint field (trans
-            // and rot) per distinct SimBody; no shared refs into bodies_mut
-            // exist while these &muts are live (all immutable data was
-            // extracted above). `mass_vec` is a local copy, not a borrow.
-            unsafe {
-                let ptr = bodies_mut.as_mut_ptr();
-                for i in 0..n_bodies {
-                    let body: *mut SimBody = ptr.add(i);
-                    let trans_ref: &mut TranslationalState = &mut (*body).trans;
-                    let rot_ref: &mut RotationalState = (*body)
+            // borrows for `trans` and `rot.as_mut()` on each `SimBody`. The
+            // borrow checker accepts this when both come out of a single
+            // `iter_mut()` chain — each closure invocation receives a
+            // distinct `&mut SimBody` (the iterator hands them out one at
+            // a time), and disjoint-field projection within that body
+            // produces the two split mutable borrows.
+            //
+            // Earlier revisions used raw pointers in an `unsafe` block to
+            // simulate the same effect, but the immutable-snapshot
+            // pattern above (mass_vec, non_grav_*_vec, …) means no
+            // shared borrow into `bodies_mut` is held while the &muts
+            // are live, so the safe projection compiles cleanly.
+            //
+            // The `expect`s match the validated invariants — the
+            // contact-coupled path requires 6-DOF + 3-component mass on
+            // every body (enforced by `Self::validate`).
+            let mut inputs: Vec<CoupledBodyInput<'_>> = bodies_mut
+                .iter_mut()
+                .enumerate()
+                .map(|(i, body)| CoupledBodyInput {
+                    trans: &mut body.trans,
+                    rot: body
                         .rot
                         .as_mut()
-                        .expect("validated: 6-DOF required for contact-coupled path");
-                    // `total_force.force` = non-grav forces (aero + SRP +
-                    // external); gravity is reapplied inside the per-stage
-                    // gravity_fn and must NOT be included here.
-                    inputs.push(CoupledBodyInput {
-                        trans: trans_ref,
-                        rot: rot_ref,
-                        mass: &mass_vec[i],
-                        non_grav_non_contact_force: non_grav_non_contact_vec[i],
-                        non_contact_torque_body: non_contact_torque_vec[i],
-                    });
-                }
-            }
+                        .expect("validated: 6-DOF required for contact-coupled path"),
+                    mass: &mass_vec[i],
+                    non_grav_non_contact_force: non_grav_non_contact_vec[i],
+                    non_contact_torque_body: non_contact_torque_vec[i],
+                })
+                .collect();
 
             integrate_bodies_contact_coupled(
                 &mut inputs,

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -1985,11 +1985,12 @@ impl Simulation {
             let bodies_mut = &mut self.bodies;
 
             // Gather per-body immutable data (t_struct_body, mass, constant
-            // forces/torques, gravity_controls) BEFORE the unsafe &mut
-            // block below. Creating any shared reference into `bodies_mut`
-            // while the unsafe &muts are live would violate Rust's
-            // aliasing rules even for disjoint fields, so snapshot
-            // everything we need up front. Cloning `gravity_controls`
+            // forces/torques, gravity_controls) BEFORE the per-body
+            // `iter_mut()` projection below builds the `CoupledBodyInput`
+            // vector. Once that vector is live, holding any shared borrow
+            // into `bodies_mut` (even for a disjoint field on a different
+            // body) would conflict with the &mut field projections, so
+            // snapshot everything up front. Cloning `gravity_controls`
             // happens here (and only here, since contact_pairs is
             // non-empty) — the non-contact path above borrows directly.
             let t_struct_body_vec: Vec<DMat3> =

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -34,6 +34,8 @@
 //! See [`PipelineStage`] and [`PIPELINE_ORDER`] for the canonical stage
 //! execution order that any adapter must respect.
 
+#![forbid(unsafe_code)]
+
 pub mod atmosphere;
 pub mod derived;
 pub mod forces;

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub use jeod_quantities::prelude::*;
 
 pub mod apollo_mass_tree;

--- a/crates/jeod_time/src/lib.rs
+++ b/crates/jeod_time/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub use jeod_quantities::prelude::*;
 
 pub mod epoch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 pub mod bundles;
 pub mod components;
 pub mod prelude;


### PR DESCRIPTION
## Summary

- Eliminates the only `unsafe` block in production code (`Simulation::step_internal`, contact-coupled RK4 path) by replacing the raw-pointer split-borrow with a safe `bodies_mut.iter_mut().enumerate().map(...)` chain. The audit's Phase-1 explore confirmed all immutable per-body data was already snapshotted into local `Vec`s before the loop, so no shared borrow into `bodies_mut` is held while the `&mut`s are live — the borrow checker accepts disjoint-field projection on the iterator.
- Adds `#![forbid(unsafe_code)]` to all 12 `jeod_*` crates plus the `bevy_jeod` root crate (`jeod_quantities` already had it). With this, **the entire workspace is `unsafe`-free** and the lint hard-fails any future incidental `unsafe` introduction.

Addresses [#172](https://github.com/simnaut/bevy_jeod/issues/172) findings **M4** (replace `unsafe` split-borrow with `iter_mut` chain) and **M5** (`#![forbid(unsafe_code)]` workspace-wide).

## Test plan

- [x] `cargo build --workspace` — succeeds; the new `iter_mut` form compiles
- [x] `cargo nextest run -p jeod_runner --test tier3_sim_contact` — all 5 Tier 3 contact tests pass (`tier3_contact_point_pair`, `_line_pair`, `_line_point`, `_line_side_to_side`, `_point_off_center`) — the path that used to be unsafe
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 755 unit + Tier 2 tests pass with `JEOD_HOME=../jeod`
- [x] `grep -rE 'unsafe' crates/ src/` returns only docs/comments (zero `unsafe` blocks or fns in production)
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)