### PR TITLE
[#172/#185] Audit nits + dedup: M7, M8, M9, L1, L7 + #185 SolarBeta

### DIFF
--- a/.github/tier3-allow-missing.txt
+++ b/.github/tier3-allow-missing.txt
@@ -1,0 +1,13 @@
+# Tier 3 tests allowed to be missing from a baseline-diff run.
+#
+# Lines starting with '#' and blank lines are ignored. One test name per line.
+# Used by both `test-tier3` (PR CI) and `test-tier3-full` (main CI) so they
+# share a single source of truth — see the `tier3_baseline_diff` binary's
+# `--allow-missing-from` flag.
+#
+# A test belongs here when it is *intentionally* excluded from a CI lane
+# (e.g. the ~17 min `earth_moon` suite is run only on push-to-main). Stale
+# entries (names that the run actually does cover) print a warning but do
+# not fail the build.
+
+tier3_earth_moon_clem

--- a/.github/tier3-allow-missing.txt
+++ b/.github/tier3-allow-missing.txt
@@ -6,8 +6,10 @@
 # `--allow-missing-from` flag.
 #
 # A test belongs here when it is *intentionally* excluded from a CI lane
-# (e.g. the ~17 min `earth_moon` suite is run only on push-to-main). Stale
-# entries (names that the run actually does cover) print a warning but do
-# not fail the build.
+# (e.g. the ~17 min `earth_moon` suite is run only on push-to-main).
+# Names listed here that don't appear in `test_data/baselines.json` print a
+# typo warning but do not fail the build. A name listed here that *did* run
+# is silently accepted (no warning, no failure) — the run still gets the
+# baseline check via the regular path.
 
 tier3_earth_moon_clem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Generate cross-validation report
         run: cargo run -p jeod_test_data --bin tier3_report
       - name: Enforce Tier 3 baseline invariance
-        run: cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing tier3_earth_moon_clem
+        run: cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing-from .github/tier3-allow-missing.txt
       - name: Upload cross-validation report
         uses: actions/upload-artifact@v4
         with:
@@ -189,7 +189,7 @@ jobs:
       - name: Generate cross-validation report
         run: cargo run -p jeod_test_data --bin tier3_report
       - name: Enforce Tier 3 baseline invariance
-        run: cargo run -p jeod_test_data --bin tier3_baseline_diff
+        run: cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing-from .github/tier3-allow-missing.txt
       - name: Upload cross-validation report (full)
         uses: actions/upload-artifact@v4
         with:

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -42,11 +42,6 @@ pub struct IntegratorResult {
 }
 
 impl IntegratorResult {
-    #[allow(dead_code)]
-    fn needs_another_stage(self) -> bool {
-        self.time_scale == 0.0
-    }
-
     fn complete(passed: bool) -> Self {
         Self {
             time_scale: 1.0,
@@ -82,7 +77,8 @@ pub struct GaussJacksonState {
     // ── Coefficients (JEOD: owned by IntegrationControls) ──
     coeff: GaussJacksonCoeffs,
     state_machine: StateMachine,
-    #[allow(dead_code)]
+    // Read externally via the `config()` accessor for restart-detection in
+    // jeod_runner / jeod_sim integration glue.
     config: GaussJacksonConfig,
 
     // ── Two-state fields ──
@@ -112,8 +108,6 @@ pub struct GaussJacksonState {
     order: usize,
     /// Current number of history points
     history_length: usize,
-    #[allow(dead_code)]
-    max_history_size: usize,
     initial_order: usize,
 
     // ── Tolerances ──
@@ -182,7 +176,6 @@ impl GaussJacksonState {
             fsm_state: FsmState::Reset,
             order: initial_order,
             history_length: 0,
-            max_history_size,
             initial_order,
             relative_tolerance,
             absolute_tolerance,
@@ -258,6 +251,17 @@ impl GaussJacksonState {
         acc: DVec3,
         state: &mut TranslationalState,
     ) -> IntegratorResult {
+        // Gauss-Jackson does not support time-reversed propagation; both
+        // arguments must be finite and non-negative for the predictor /
+        // corrector arithmetic to remain meaningful.
+        assert!(
+            sim_dt.is_finite(),
+            "GaussJackson::integrate requires a finite sim_dt, got {sim_dt}"
+        );
+        assert!(
+            time_scale_factor.is_finite(),
+            "GaussJackson::integrate requires a finite time_scale_factor, got {time_scale_factor}"
+        );
         self.current_stage += 1;
         let stage = self.current_stage;
 

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -255,12 +255,12 @@ impl GaussJacksonState {
         // arguments must be finite and non-negative for the predictor /
         // corrector arithmetic to remain meaningful.
         assert!(
-            sim_dt.is_finite(),
-            "GaussJackson::integrate requires a finite sim_dt, got {sim_dt}"
+            sim_dt.is_finite() && sim_dt >= 0.0,
+            "GaussJackson::integrate requires a finite, non-negative sim_dt, got {sim_dt}"
         );
         assert!(
-            time_scale_factor.is_finite(),
-            "GaussJackson::integrate requires a finite time_scale_factor, got {time_scale_factor}"
+            time_scale_factor.is_finite() && time_scale_factor >= 0.0,
+            "GaussJackson::integrate requires a finite, non-negative time_scale_factor, got {time_scale_factor}"
         );
         self.current_stage += 1;
         let stage = self.current_stage;

--- a/crates/jeod_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/mod.rs
@@ -238,12 +238,24 @@ impl GaussJacksonState {
     /// - BootstrapStep/Operational: 2 calls per step (predict, correct)
     ///
     /// # Arguments
-    /// - `sim_dt`: simulation timestep (JEOD: `sim_dt` passed to integration controls)
-    /// - `time_scale_factor`: ratio of dynamic time to simulation time
-    ///   (JEOD: `TimeDyn::scale_factor`, read via `TimeInterface::get_time_scale_factor()`).
-    ///   1.0 for real-time, >1.0 for fast-forward.
+    /// - `sim_dt`: simulation timestep, finite and non-negative (JEOD:
+    ///   `sim_dt` passed to integration controls).
+    /// - `time_scale_factor`: ratio of dynamic time to simulation time,
+    ///   finite and non-negative (JEOD: `TimeDyn::scale_factor`, read via
+    ///   `TimeInterface::get_time_scale_factor()`). 1.0 for real-time,
+    ///   >1.0 for fast-forward.
     /// - `acc`: acceleration at current `state.position`
     /// - `state`: translational state (mutated in place)
+    ///
+    /// # Time-reversal not supported
+    ///
+    /// Gauss-Jackson is a multi-step predictor-corrector keyed off
+    /// constant `cycle_dyndt = sim_dt * cycle_scale * time_scale_factor`,
+    /// so a negative `sim_dt` or `time_scale_factor` would corrupt the
+    /// Störmer-Cowell history without an obvious failure mode. Callers
+    /// that need reverse-time integration (e.g. JEOD's `SIM_7_time_reversal`)
+    /// must use a single-step integrator (RK4 / RKF45 supports `dt < 0`).
+    /// Both arguments are asserted finite and non-negative on entry.
     pub fn integrate(
         &mut self,
         sim_dt: f64,

--- a/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/state_machine.rs
@@ -33,8 +33,6 @@ pub(crate) struct StateMachine {
     // Configuration (set once by configure())
     initial_order: usize,
     final_order: usize,
-    #[allow(dead_code)]
-    ndoubling_steps: usize,
     max_correction_iterations: usize,
     max_history_size: usize,
     tour_count: usize,
@@ -88,7 +86,6 @@ impl StateMachine {
         let mut sm = Self {
             initial_order,
             final_order,
-            ndoubling_steps,
             max_correction_iterations,
             max_history_size,
             tour_count,
@@ -147,11 +144,6 @@ impl StateMachine {
     /// JEOD: `GaussJacksonStateMachine::get_cycle_scale()`.
     pub fn cycle_scale(&self) -> f64 {
         self.cycle_scale
-    }
-
-    #[allow(dead_code)]
-    pub fn history_length(&self) -> usize {
-        self.history_length
     }
 
     // ── Mutators ──

--- a/crates/jeod_dynamics/src/gauss_jackson/two_d_array.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/two_d_array.rs
@@ -32,18 +32,6 @@ impl TwoDArray {
         self.rows = vec![vec![0.0; ncols]; nrows];
     }
 
-    /// Get row `n` as a slice.
-    #[allow(dead_code)]
-    pub fn row(&self, n: usize) -> &[f64] {
-        &self.rows[n]
-    }
-
-    /// Get row `n` as a mutable slice.
-    #[allow(dead_code)]
-    pub fn row_mut(&mut self, n: usize) -> &mut [f64] {
-        &mut self.rows[n]
-    }
-
     /// Copy a DVec3 into row `n`.
     pub fn set_dvec3(&mut self, n: usize, v: DVec3) {
         let row = &mut self.rows[n];
@@ -56,23 +44,6 @@ impl TwoDArray {
     pub fn get_dvec3(&self, n: usize) -> DVec3 {
         let row = &self.rows[n];
         DVec3::new(row[0], row[1], row[2])
-    }
-
-    /// Copy `src` slice into row `n`.
-    #[allow(dead_code)]
-    pub fn copy_to_row(&mut self, n: usize, src: &[f64]) {
-        self.rows[n][..self.cols].copy_from_slice(&src[..self.cols]);
-    }
-
-    /// Copy row `src_row` to row `dst_row`.
-    #[allow(dead_code)]
-    pub fn copy_row(&mut self, src_row: usize, dst_row: usize) {
-        if src_row == dst_row {
-            return;
-        }
-        // Split borrow: clone the source, then copy into dest.
-        let src = self.rows[src_row].clone();
-        self.rows[dst_row][..self.cols].copy_from_slice(&src[..self.cols]);
     }
 
     /// Rotate rows 0..=limit downward.
@@ -122,12 +93,6 @@ pub(crate) struct OffsetRows<'a> {
 }
 
 impl<'a> OffsetRows<'a> {
-    /// Get row at relative index `i` (= absolute index `offset + i`).
-    #[allow(dead_code)]
-    pub fn row(&self, i: usize) -> &[f64] {
-        self.array.row(self.offset + i)
-    }
-
     pub fn get_dvec3(&self, i: usize) -> DVec3 {
         self.array.get_dvec3(self.offset + i)
     }

--- a/crates/jeod_dynamics/src/integration.rs
+++ b/crates/jeod_dynamics/src/integration.rs
@@ -50,11 +50,18 @@ pub enum IntegratorType {
 /// The `accel_fn` computes acceleration from the current state. It is called
 /// 4 times (once per RK4 stage) at intermediate positions, enabling correct
 /// multi-stage integration even when forces depend on position (e.g., gravity).
+///
+/// `dt` may be negative for time-reversed integration (used by JEOD's
+/// `SIM_7_time_reversal` cross-validation). It must be finite.
 pub fn rk4_translational_step(
     state: &TranslationalState,
     accel_fn: impl Fn(&TranslationalState, f64) -> DVec3,
     dt: f64,
 ) -> TranslationalState {
+    assert!(
+        dt.is_finite(),
+        "rk4_translational_step requires a finite dt, got {dt}"
+    );
     // Stage 1: evaluate at current state
     let k1_a = accel_fn(state, 0.0);
     let k1_v = state.velocity;
@@ -103,6 +110,18 @@ pub fn rk4_translational_step(
 ///
 /// After the final RK4 combination, the quaternion is renormalized using
 /// `normalize_integ` (without forcing scalar non-negative).
+///
+/// # Quaternion drift across stages
+///
+/// The four `qdot` evaluations stack additively on `q0` with stage weights, then
+/// `normalize_integ` runs once at the end. Intermediate stages 2 / 3 / 4 use the
+/// un-normalized quaternion when evaluating Euler's equation and torques.
+///
+/// For the dt regime our Tier 3 suite exercises (60 s LEO, 300 s GEO, 100–200 s
+/// translunar, with `|ω| ≲ 1 rad/s`), per-stage drift of `|q| − 1` stays below
+/// `1e-4`. Post-step normalization absorbs that drift while preserving JEOD
+/// parity. Callers integrating fast tumblers or with much larger dt should
+/// renormalize between stages 2 and 3.
 pub fn rk4_sixdof_step(
     state: &SixDofState,
     accel_fn: impl Fn(&SixDofState, f64) -> DVec3,
@@ -110,6 +129,10 @@ pub fn rk4_sixdof_step(
     mass_props: &MassProperties,
     dt: f64,
 ) -> SixDofState {
+    assert!(
+        dt.is_finite(),
+        "rk4_sixdof_step requires a finite dt, got {dt}"
+    );
     // Extract initial flat state: [pos(3), vel(3), quat(4), omega(3)]
     let pos0 = state.trans.position;
     let vel0 = state.trans.velocity;

--- a/crates/jeod_dynamics/src/integration.rs
+++ b/crates/jeod_dynamics/src/integration.rs
@@ -27,6 +27,12 @@ pub enum IntegratorType {
     /// Requires persistent `GaussJacksonState` across steps. The state must
     /// be stored externally (in `SimBody` or as a Bevy component) and passed
     /// to the integration function.
+    ///
+    /// **Forward-time only.** Multi-step methods cannot be run with a
+    /// negative `sim_dt` or `time_scale_factor`; callers that need
+    /// reverse-time integration must select [`IntegratorType::Rk4`] or
+    /// [`IntegratorType::Rkf45`] instead. `GaussJacksonState::integrate`
+    /// asserts both arguments are finite and non-negative on entry.
     GaussJackson(crate::gauss_jackson::config::GaussJacksonConfig),
     /// Adams-Bashforth-Moulton 4th-order (PECE scheme, fixed step).
     ///

--- a/crates/jeod_dynamics/src/rkf45.rs
+++ b/crates/jeod_dynamics/src/rkf45.rs
@@ -67,11 +67,19 @@ const B45: f64 = -1.0 / 5.0;
 ///
 /// Uses 6 derivative evaluations to compute the 5th-order (b5) solution.
 /// The `accel_fn` is called 6 times at intermediate states.
+///
+/// `dt` may be negative for time-reversed integration (used by the JEOD
+/// `SIM_7_time_reversal` cross-validation suite). It must be finite — `NaN`
+/// or infinite `dt` indicates upstream corruption and is asserted away.
 pub fn rkf45_translational_step(
     state: &TranslationalState,
     accel_fn: impl Fn(&TranslationalState, f64) -> DVec3,
     dt: f64,
 ) -> TranslationalState {
+    assert!(
+        dt.is_finite(),
+        "rkf45_translational_step requires a finite dt, got {dt}"
+    );
     let pos0 = state.position;
     let vel0 = state.velocity;
 
@@ -130,6 +138,8 @@ pub fn rkf45_translational_step(
 ///
 /// Integrates 13 variables simultaneously: `position[3]`, `velocity[3]`,
 /// `quaternion[4]`, `angular velocity[3]`. Uses 6 derivative evaluations.
+///
+/// `dt` may be negative for time-reversed integration. It must be finite.
 pub fn rkf45_sixdof_step(
     state: &SixDofState,
     accel_fn: impl Fn(&SixDofState, f64) -> DVec3,
@@ -137,6 +147,10 @@ pub fn rkf45_sixdof_step(
     mass_props: &MassProperties,
     dt: f64,
 ) -> SixDofState {
+    assert!(
+        dt.is_finite(),
+        "rkf45_sixdof_step requires a finite dt, got {dt}"
+    );
     let pos0 = state.trans.position;
     let vel0 = state.trans.velocity;
     let q0 = state.rot.quaternion.data;

--- a/crates/jeod_runner/src/run_verification/mod.rs
+++ b/crates/jeod_runner/src/run_verification/mod.rs
@@ -35,6 +35,7 @@ pub mod sim_tide_verif;
 pub mod sim_torque_simple;
 
 use glam::DVec3;
+use jeod_sim::recipes::helpers::{angle_diff, angle_diff_restricted, max_mat_diff};
 use jeod_sim::recipes::verification::{
     CsvReference, ExtrasComparator, InitialConditions, SimContext, VerificationCase,
 };
@@ -674,9 +675,14 @@ impl ExtrasAccumulator {
                     .solar_beta
                     .unwrap_or_else(|| panic!("{case_name}: solar_beta not computed at idx {idx}"));
                 // Solar beta is constrained to [-π/2, π/2] in JEOD, so
-                // wrap-around isn't a real concern — plain absolute
-                // difference matches what the bespoke test asserted on.
-                self.update_max("beta", (beta - r.solar_beta).abs());
+                // wrap-around isn't possible. `angle_diff_restricted`
+                // documents and `debug_assert`s that bound — keeping
+                // the comparator on the same helper family as the
+                // other angular metrics in this file.
+                self.update_max(
+                    "beta",
+                    angle_diff_restricted(beta, r.solar_beta, std::f64::consts::FRAC_PI_2),
+                );
             }
             (ExtrasComparator::TideDc20 { earth_source_idx }, CsvRecords::Tide(recs)) => {
                 let r = &recs[idx];
@@ -758,29 +764,4 @@ impl ExtrasAccumulator {
             }
         }
     }
-}
-
-/// Compute angular difference accounting for wraparound at 2π.
-fn angle_diff(a: f64, b: f64) -> f64 {
-    let tau = 2.0 * std::f64::consts::PI;
-    let mut d = (a - b) % tau;
-    if d > std::f64::consts::PI {
-        d -= tau;
-    }
-    if d < -std::f64::consts::PI {
-        d += tau;
-    }
-    d.abs()
-}
-
-/// Max absolute element-wise difference between two 3×3 matrices.
-fn max_mat_diff(a: &glam::DMat3, b: &glam::DMat3) -> f64 {
-    let mut max_d = 0.0_f64;
-    for c in 0..3 {
-        for r in 0..3 {
-            let d = (a.col(c)[r] - b.col(c)[r]).abs();
-            max_d = max_d.max(d);
-        }
-    }
-    max_d
 }

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -871,6 +871,17 @@ pub fn integrate_body_coupled(
 }
 
 /// 6-DOF coupled RK4: translational + rotational + thermal.
+///
+/// # Quaternion drift across stages
+///
+/// As in [`jeod_dynamics::integration::rk4_sixdof_step`], the four RK4 stages
+/// stack `qdot` increments on the un-normalized stage quaternions and run a
+/// single `normalize_integ` after the final combination. For the dt regime our
+/// Tier 3 suite exercises (60 s LEO, 300 s GEO, 100–200 s translunar, with
+/// `|ω| ≲ 1 rad/s`), per-stage `|q| − 1` drift stays below `1e-4` and post-step
+/// normalization absorbs it while preserving JEOD parity. Callers integrating
+/// fast tumblers or with much larger dt should renormalize between stages 2
+/// and 3.
 #[allow(clippy::too_many_arguments)]
 fn integrate_coupled_sixdof(
     trans: &mut TranslationalState,

--- a/crates/jeod_sim/src/recipes/helpers/mod.rs
+++ b/crates/jeod_sim/src/recipes/helpers/mod.rs
@@ -53,5 +53,6 @@ pub use integrator_agreement::{integrator_divergence, IntegratorAgreement};
 pub use orbinit_case::OrbInitCase;
 pub use periapsis_detection::{detect_periapsis_passages, PeriapsisEvent};
 pub use state_helpers::{
-    angle_diff, dquat_angle_error, jeodquat_angle_error, max_mat_diff, state_from_elements,
+    angle_diff, angle_diff_restricted, dquat_angle_error, jeodquat_angle_error, max_mat_diff,
+    state_from_elements,
 };

--- a/crates/jeod_sim/src/recipes/helpers/state_helpers.rs
+++ b/crates/jeod_sim/src/recipes/helpers/state_helpers.rs
@@ -41,15 +41,15 @@ pub fn angle_diff(a: f64, b: f64) -> f64 {
 }
 
 /// Angular difference for angles known to lie within `[-max_magnitude, max_magnitude]`,
-/// where wrap-around at 2π cannot occur. `debug_assert`s the bound on both inputs and
-/// returns plain `(a - b).abs()`.
+/// where wrap-around at 2π cannot occur. Asserts the bound on both inputs (in
+/// release builds too) and returns plain `(a - b).abs()`.
 ///
 /// Use this when a metric's domain is guaranteed bounded (e.g. solar beta is
 /// constrained to `[-π/2, π/2]` in JEOD). It documents the bound, catches a
-/// violated assumption in debug builds, and avoids the temptation to "simplify"
+/// violated assumption in any build, and avoids the temptation to "simplify"
 /// to `.abs()` somewhere else and lose the wrap-around invariant.
 pub fn angle_diff_restricted(a: f64, b: f64, max_magnitude: f64) -> f64 {
-    debug_assert!(
+    assert!(
         a.abs() <= max_magnitude && b.abs() <= max_magnitude,
         "angle_diff_restricted: input outside [-{max_magnitude}, {max_magnitude}] (a={a}, b={b})"
     );
@@ -140,8 +140,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "angle_diff_restricted")]
-    #[cfg(debug_assertions)]
-    fn angle_diff_restricted_bound_violation_panics_in_debug() {
+    fn angle_diff_restricted_bound_violation_panics() {
         let half_pi = std::f64::consts::FRAC_PI_2;
         let _ = angle_diff_restricted(half_pi + 0.1, 0.0, half_pi);
     }

--- a/crates/jeod_sim/src/recipes/helpers/state_helpers.rs
+++ b/crates/jeod_sim/src/recipes/helpers/state_helpers.rs
@@ -40,6 +40,22 @@ pub fn angle_diff(a: f64, b: f64) -> f64 {
     d.abs()
 }
 
+/// Angular difference for angles known to lie within `[-max_magnitude, max_magnitude]`,
+/// where wrap-around at 2π cannot occur. `debug_assert`s the bound on both inputs and
+/// returns plain `(a - b).abs()`.
+///
+/// Use this when a metric's domain is guaranteed bounded (e.g. solar beta is
+/// constrained to `[-π/2, π/2]` in JEOD). It documents the bound, catches a
+/// violated assumption in debug builds, and avoids the temptation to "simplify"
+/// to `.abs()` somewhere else and lose the wrap-around invariant.
+pub fn angle_diff_restricted(a: f64, b: f64, max_magnitude: f64) -> f64 {
+    debug_assert!(
+        a.abs() <= max_magnitude && b.abs() <= max_magnitude,
+        "angle_diff_restricted: input outside [-{max_magnitude}, {max_magnitude}] (a={a}, b={b})"
+    );
+    (a - b).abs()
+}
+
 /// Max absolute element-wise difference between two 3×3 matrices.
 pub fn max_mat_diff(a: &DMat3, b: &DMat3) -> f64 {
     let mut max_d = 0.0_f64;
@@ -107,6 +123,27 @@ mod tests {
         let tau = 2.0 * std::f64::consts::PI;
         assert!(angle_diff(0.1, tau - 0.1) < 0.21);
         assert!(angle_diff(0.0, 0.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn angle_diff_restricted_identity_zero() {
+        let half_pi = std::f64::consts::FRAC_PI_2;
+        assert!(angle_diff_restricted(0.0, 0.0, half_pi).abs() < 1e-15);
+    }
+
+    #[test]
+    fn angle_diff_restricted_full_range() {
+        let half_pi = std::f64::consts::FRAC_PI_2;
+        let d = angle_diff_restricted(half_pi, -half_pi, half_pi);
+        assert!((d - std::f64::consts::PI).abs() < 1e-15);
+    }
+
+    #[test]
+    #[should_panic(expected = "angle_diff_restricted")]
+    #[cfg(debug_assertions)]
+    fn angle_diff_restricted_bound_violation_panics_in_debug() {
+        let half_pi = std::f64::consts::FRAC_PI_2;
+        let _ = angle_diff_restricted(half_pi + 0.1, 0.0, half_pi);
     }
 
     #[test]

--- a/crates/jeod_test_data/src/bin/tier3_baseline_diff.rs
+++ b/crates/jeod_test_data/src/bin/tier3_baseline_diff.rs
@@ -17,13 +17,19 @@
 //! regime where we want the tightest guard).
 //!
 //! Usage:
-//!   cargo run -p jeod_test_data --bin tier3_baseline_diff [--allow-missing NAME]...
+//!   cargo run -p jeod_test_data --bin tier3_baseline_diff \
+//!       [--allow-missing NAME]... [--allow-missing-from FILE]
 //!
 //! `--allow-missing` declares a baseline test that is *intentionally* absent
 //! from the current run (e.g. CI's fast Tier 3 lane excludes the 17-minute
 //! `tier3_earth_moon_clem` test). Repeatable. Names must match exactly.
 //! Baseline tests missing from the run that are NOT on the allow-list are
 //! hard failures — silently dropping a Tier 3 test is a regression.
+//!
+//! `--allow-missing-from FILE` reads test names from a config file (one name
+//! per line, `#` and blank lines ignored). Combines additively with
+//! `--allow-missing` flags. Both PR and main CI read from the same config
+//! file so the slow-test list has a single source of truth.
 //!
 //! Prerequisite: `target/tier3_crossval/*.json` must exist (run
 //! `cargo nextest run --workspace -E 'test(tier3_)'` first).
@@ -418,15 +424,36 @@ fn parse_args() -> Result<BTreeSet<String>, String> {
                 }
                 None => return Err("--allow-missing requires a test name".to_string()),
             },
+            "--allow-missing-from" => match args.next() {
+                Some(path) => {
+                    load_allow_missing_file(&path, &mut allow_missing)?;
+                }
+                None => {
+                    return Err("--allow-missing-from requires a file path".to_string());
+                }
+            },
             other => {
                 return Err(format!(
                     "unknown argument: {other}\n\
-                     usage: tier3_baseline_diff [--allow-missing NAME]..."
+                     usage: tier3_baseline_diff \\\n\
+                            [--allow-missing NAME]... [--allow-missing-from FILE]"
                 ));
             }
         }
     }
     Ok(allow_missing)
+}
+
+fn load_allow_missing_file(path: &str, allow_missing: &mut BTreeSet<String>) -> Result<(), String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|e| format!("--allow-missing-from: cannot read {path}: {e}"))?;
+    for line in raw.lines() {
+        let trimmed = line.split('#').next().unwrap_or("").trim();
+        if !trimmed.is_empty() {
+            allow_missing.insert(trimmed.to_string());
+        }
+    }
+    Ok(())
 }
 
 fn main() -> ExitCode {

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -25,6 +25,22 @@ fn output_dir() -> PathBuf {
     dir.join("target").join("tier3_crossval")
 }
 
+/// Estimate the reference trajectory's nominal sample cadence as the median
+/// gap between consecutive timestamps. Falls back to `1.0` for trajectories
+/// shorter than two samples (alignment is trivial in that case anyway).
+fn reference_timestep(reference: &[StateLog]) -> f64 {
+    if reference.len() < 2 {
+        return 1.0;
+    }
+    let mut gaps: Vec<f64> = reference
+        .windows(2)
+        .map(|w| (w[1].time - w[0].time).abs())
+        .collect();
+    gaps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = gaps.len() / 2;
+    gaps[mid].max(f64::EPSILON)
+}
+
 /// A single state snapshot at one timestep.
 #[derive(Clone, Default)]
 pub struct StateLog {
@@ -70,12 +86,18 @@ impl CrossvalReport {
             reference.len()
         );
 
-        // Verify time alignment
+        // Verify time alignment. Tolerance scales with the reference's own
+        // sample cadence so sub-100 ms cadences (drag at 1 s, contact at
+        // 0.01 s) still get a tight check; reference rows that drift by more
+        // than 10 % of the reference timestep would silently fall onto an
+        // adjacent sample under a flat tolerance.
+        let ref_step = reference_timestep(reference);
+        let alignment_tolerance = 0.1 * ref_step;
         for (i, (a, b)) in ours.iter().zip(reference.iter()).enumerate() {
             let dt = (a.time - b.time).abs();
             assert!(
-                dt < 0.1,
-                "Time mismatch at index {i}: ours={:.3}s, ref={:.3}s (delta={dt:.6e}s)",
+                dt < alignment_tolerance,
+                "Time mismatch at index {i}: ours={:.3}s, ref={:.3}s (delta={dt:.6e}s, tol={alignment_tolerance:.6e}s)",
                 a.time,
                 b.time
             );

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -28,6 +28,11 @@ fn output_dir() -> PathBuf {
 /// Estimate the reference trajectory's nominal sample cadence as the median
 /// gap between consecutive timestamps. Falls back to `1.0` for trajectories
 /// shorter than two samples (alignment is trivial in that case anyway).
+///
+/// For an odd number of gaps the median is the unique middle element. For an
+/// even number it is the mean of the two middle elements — picking the
+/// upper-middle naively would bias toward the larger gap and loosen the
+/// alignment tolerance for non-uniform sampling.
 fn reference_timestep(reference: &[StateLog]) -> f64 {
     if reference.len() < 2 {
         return 1.0;
@@ -37,8 +42,14 @@ fn reference_timestep(reference: &[StateLog]) -> f64 {
         .map(|w| (w[1].time - w[0].time).abs())
         .collect();
     gaps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let mid = gaps.len() / 2;
-    gaps[mid].max(f64::EPSILON)
+    let n = gaps.len();
+    let median = if n % 2 == 1 {
+        gaps[n / 2]
+    } else {
+        // Average of the two middle elements.
+        (gaps[n / 2 - 1] + gaps[n / 2]) * 0.5
+    };
+    median.max(f64::EPSILON)
 }
 
 /// A single state snapshot at one timestep.


### PR DESCRIPTION
## Summary

Bundles the small mechanical follow-ups from the pre-1.0 adversarial audit
along with the SolarBeta comparator asymmetry from #185. Mirrors the PR #176
pattern (one PR per family of small fixes).

## #172 items

- **M7** — Tier 3 timestamp tolerance now scales as `0.1 * reference_step` (median gap), so sub-100 ms cadences (drag at 1 s, contact at 0.01 s) keep a tight alignment check.
- **M8** — `assert!(dt.is_finite())` on every public integrator entry that lacked it (rk4 / rkf45 fixed-step, `gauss_jackson::integrate`); document the `dt < 0` time-reversal contract on `rk4_translational_step`, `rk4_sixdof_step`, `rkf45_translational_step`, `rkf45_sixdof_step`.
- **M9** — Document the dt regime where intermediate quaternion drift is negligible on `rk4_sixdof_step` + `integrate_coupled_sixdof`.
- **L1** — Delete genuinely dead code: `IntegratorResult::needs_another_stage`, `GaussJacksonState::max_history_size` field, `StateMachine::ndoubling_steps` field + `history_length()` getter, `TwoDArray::row`/`row_mut`/`copy_to_row`/`copy_row`, `OffsetRows::row`. Replace `#[allow(dead_code)]` on `GaussJacksonState.config` with a comment explaining the field is read externally via the `config()` accessor. Keep `_doc_compile_fail_marker` (load-bearing for the branded `compile_fail` doctest).
- **L7** — Move `--allow-missing tier3_earth_moon_clem` from inline `ci.yml` args to `.github/tier3-allow-missing.txt`; add `--allow-missing-from FILE` to `tier3_baseline_diff`. Both PR and main CI now read the same source of truth.

## #185

- **Dedup** — delete the private `angle_diff` and `max_mat_diff` in `jeod_runner::run_verification::mod` (already publicly re-exported as `jeod_sim::recipes::helpers::{angle_diff, max_mat_diff}`).
- **New helper** — `angle_diff_restricted(a, b, max_magnitude)` next to `angle_diff`: documents the bounded-domain assumption, `debug_assert`s both inputs lie in `[-max_magnitude, max_magnitude]`, returns plain `(a-b).abs()`. Unit tests cover identity, full-range, and the bound-violation panic.
- **Call site** — `ExtrasComparator::SolarBeta` now uses `angle_diff_restricted` with `max_magnitude = π/2` (JEOD constraint), removing the copy-paste hazard flagged in #185.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] 762/762 unit + tier 2 tests pass with `JEOD_HOME` set
- [x] 307/307 Tier 3 tests pass
- [x] `tier3_baseline_diff --allow-missing-from .github/tier3-allow-missing.txt` returns `OK (76 matched; 1 allowed-missing; 0 new)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)