### PR TITLE
[#172] M2 + L3: GravityControl::retag_source + FrameTransform::from_matrix_validated

### DIFF
--- a/crates/jeod_gravity/src/gravity_controls.rs
+++ b/crates/jeod_gravity/src/gravity_controls.rs
@@ -121,6 +121,31 @@ impl<SourceId> GravityControl<SourceId> {
         }
     }
 
+    /// Re-tag the source identifier through a mapper, producing a fresh
+    /// [`GravityControl<T>`] with all other fields copied verbatim.
+    ///
+    /// Used by ECS adapters that translate `GravityControl<usize>` (recipe-side
+    /// source-table index) to `GravityControl<Entity>` (Bevy entity handle)
+    /// without enumerating the field list at every call site.
+    ///
+    /// Adding a new field to `GravityControl` requires updating only this
+    /// constructor; ECS adapters are unaffected.
+    pub fn retag_source<T>(self, mapper: impl FnOnce(SourceId) -> T) -> GravityControl<T> {
+        GravityControl {
+            source_name: mapper(self.source_name),
+            gradient: self.gradient,
+            spherical: self.spherical,
+            degree: self.degree,
+            order: self.order,
+            perturbing_only: self.perturbing_only,
+            gradient_degree: self.gradient_degree,
+            gradient_order: self.gradient_order,
+            differential: self.differential,
+            battin_method: self.battin_method,
+            relativistic: self.relativistic,
+        }
+    }
+
     /// Validate this control against its gravity source, matching JEOD's
     /// `SphericalHarmonicsGravityControls::check_validity()`.
     ///
@@ -635,6 +660,33 @@ mod tests {
             mu,
             model: GravityModel::SphericalHarmonics(Box::new(data)),
         }
+    }
+
+    /// `retag_source` returns a `GravityControl<T>` whose `source_name`
+    /// is the mapped value and every other field is bit-identical.
+    #[test]
+    fn retag_source_preserves_all_fields() {
+        let mut original = GravityControl::<usize>::new_nonspherical(7, 8, 4, true);
+        original.perturbing_only = true;
+        original.gradient_degree = 6;
+        original.gradient_order = 3;
+        original.differential = true;
+        original.battin_method = true;
+        original.relativistic = true;
+
+        let retagged: GravityControl<&'static str> = original.clone().retag_source(|_| "Earth");
+
+        assert_eq!(retagged.source_name, "Earth");
+        assert_eq!(retagged.gradient, original.gradient);
+        assert_eq!(retagged.spherical, original.spherical);
+        assert_eq!(retagged.degree, original.degree);
+        assert_eq!(retagged.order, original.order);
+        assert_eq!(retagged.perturbing_only, original.perturbing_only);
+        assert_eq!(retagged.gradient_degree, original.gradient_degree);
+        assert_eq!(retagged.gradient_order, original.gradient_order);
+        assert_eq!(retagged.differential, original.differential);
+        assert_eq!(retagged.battin_method, original.battin_method);
+        assert_eq!(retagged.relativistic, original.relativistic);
     }
 
     /// `effective_orders` for a spherical control returns all zeros

--- a/crates/jeod_quantities/src/frame_transform.rs
+++ b/crates/jeod_quantities/src/frame_transform.rs
@@ -175,8 +175,19 @@ impl<From: Frame, To: Frame> FrameTransform<From, To> {
     /// (file I/O, RPC, user-supplied configuration). For per-step rotation
     /// updates from JEOD CSV / DE421 / RNP kernels, `from_matrix` keeps
     /// the runtime check off the hot path.
+    ///
+    /// Non-finite inputs (any `NaN` or `±∞` element) are rejected up front
+    /// with [`FrameTransformError::NonFinite`] — the determinant /
+    /// orthonormality checks downstream both silently accept `NaN` (via
+    /// `(NaN - 1.0).abs() >= eps == false` and `f64::max(0.0, NaN) == 0.0`),
+    /// so the explicit guard is what keeps a `NaN` matrix from reaching
+    /// `DQuat::from_mat3`.
     #[inline]
     pub fn from_matrix_validated(matrix: DMat3) -> Result<Self, FrameTransformError> {
+        let cols = matrix.to_cols_array();
+        if !cols.iter().all(|x| x.is_finite()) {
+            return Err(FrameTransformError::NonFinite);
+        }
         let det = matrix.determinant();
         if (det - 1.0).abs() >= 1.0e-9 {
             return Err(FrameTransformError::DeterminantNotOne { determinant: det });
@@ -204,6 +215,10 @@ impl<From: Frame, To: Frame> FrameTransform<From, To> {
 /// Reasons [`FrameTransform::from_matrix_validated`] can reject an input.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FrameTransformError {
+    /// Input contains a `NaN` or infinite element. The determinant /
+    /// orthonormality checks downstream do not reject `NaN` reliably, so
+    /// this is checked first.
+    NonFinite,
     /// Determinant is not within `1e-9` of `1.0`. A reflection
     /// (`det ≈ -1`) or a scaling (`|det| ≠ 1`) lands here.
     DeterminantNotOne { determinant: f64 },
@@ -216,6 +231,9 @@ pub enum FrameTransformError {
 impl core::fmt::Display for FrameTransformError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::NonFinite => {
+                f.write_str("FrameTransform: input matrix has a NaN or infinite element")
+            }
             Self::DeterminantNotOne { determinant } => write!(
                 f,
                 "FrameTransform: input matrix determinant {determinant} not within 1e-9 of 1.0"
@@ -380,5 +398,30 @@ mod tests {
         let err = FrameTransform::<Inertial, Ecef>::from_matrix_validated(m)
             .expect_err("shear should reject");
         assert!(matches!(err, FrameTransformError::NotOrthonormal { .. }));
+    }
+
+    /// `from_matrix_validated` rejects a matrix with NaN elements via the
+    /// explicit `NonFinite` guard. The downstream determinant /
+    /// orthonormality checks both silently accept NaN — `(NaN-1).abs() >=
+    /// eps` is `false` and `f64::max(0.0, NaN) == 0.0` — so the explicit
+    /// pre-check is what keeps a NaN matrix from reaching `from_mat3`.
+    #[test]
+    fn from_matrix_validated_rejects_nan() {
+        let mut m = DMat3::IDENTITY;
+        m.x_axis.x = f64::NAN;
+        let err = FrameTransform::<Inertial, Ecef>::from_matrix_validated(m)
+            .expect_err("NaN matrix must reject");
+        assert!(matches!(err, FrameTransformError::NonFinite));
+    }
+
+    /// `from_matrix_validated` rejects a matrix with infinite elements via
+    /// the same `NonFinite` guard.
+    #[test]
+    fn from_matrix_validated_rejects_infinite() {
+        let mut m = DMat3::IDENTITY;
+        m.y_axis.z = f64::INFINITY;
+        let err = FrameTransform::<Inertial, Ecef>::from_matrix_validated(m)
+            .expect_err("infinite matrix must reject");
+        assert!(matches!(err, FrameTransformError::NonFinite));
     }
 }

--- a/crates/jeod_quantities/src/frame_transform.rs
+++ b/crates/jeod_quantities/src/frame_transform.rs
@@ -124,6 +124,10 @@ impl<From: Frame, To: Frame> FrameTransform<From, To> {
     /// **Bit-stability invariant**: `from_matrix(M).matrix_ref() == &M`
     /// exactly. The quaternion derivation does not influence the stored
     /// matrix.
+    ///
+    /// Prefer [`from_matrix_validated`](Self::from_matrix_validated) when
+    /// the input is unverified (e.g. user-supplied YAML, network protocol)
+    /// and you need a typed error rather than a `debug_assert!` panic.
     #[inline]
     pub fn from_matrix(matrix: DMat3) -> Self {
         // Orthonormality checks are debug-only — the cached quaternion is
@@ -162,7 +166,72 @@ impl<From: Frame, To: Frame> FrameTransform<From, To> {
             _to: PhantomData,
         }
     }
+
+    /// Construct from a raw rotation matrix, returning an error if the
+    /// matrix is not a proper orthonormal rotation. Same bit-stability
+    /// invariant as [`from_matrix`](Self::from_matrix).
+    ///
+    /// Prefer this over `from_matrix` when the input is unvalidated
+    /// (file I/O, RPC, user-supplied configuration). For per-step rotation
+    /// updates from JEOD CSV / DE421 / RNP kernels, `from_matrix` keeps
+    /// the runtime check off the hot path.
+    #[inline]
+    pub fn from_matrix_validated(matrix: DMat3) -> Result<Self, FrameTransformError> {
+        let det = matrix.determinant();
+        if (det - 1.0).abs() >= 1.0e-9 {
+            return Err(FrameTransformError::DeterminantNotOne { determinant: det });
+        }
+        let drift = (matrix * matrix.transpose() - DMat3::IDENTITY)
+            .to_cols_array()
+            .iter()
+            .map(|x| x.abs())
+            .fold(0.0_f64, f64::max);
+        if drift >= 1.0e-9 {
+            return Err(FrameTransformError::NotOrthonormal { drift });
+        }
+        let g = glam::DQuat::from_mat3(&matrix);
+        let jeod = JeodQuat::from_array([g.w, g.x, g.y, g.z]);
+        let quat = NormalizedQuat::renormalize(jeod).ok_or(FrameTransformError::ZeroQuaternion)?;
+        Ok(Self {
+            quat,
+            matrix,
+            _from: PhantomData,
+            _to: PhantomData,
+        })
+    }
 }
+
+/// Reasons [`FrameTransform::from_matrix_validated`] can reject an input.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FrameTransformError {
+    /// Determinant is not within `1e-9` of `1.0`. A reflection
+    /// (`det ≈ -1`) or a scaling (`|det| ≠ 1`) lands here.
+    DeterminantNotOne { determinant: f64 },
+    /// `M · Mᵀ` differs from identity by more than `1e-9` in any element.
+    NotOrthonormal { drift: f64 },
+    /// `glam::DQuat::from_mat3` produced a zero quaternion (degenerate input).
+    ZeroQuaternion,
+}
+
+impl core::fmt::Display for FrameTransformError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DeterminantNotOne { determinant } => write!(
+                f,
+                "FrameTransform: input matrix determinant {determinant} not within 1e-9 of 1.0"
+            ),
+            Self::NotOrthonormal { drift } => write!(
+                f,
+                "FrameTransform: input matrix not orthonormal — max |M·Mᵀ - I| = {drift}"
+            ),
+            Self::ZeroQuaternion => {
+                f.write_str("FrameTransform: input matrix degenerate — derived quaternion is zero")
+            }
+        }
+    }
+}
+
+impl core::error::Error for FrameTransformError {}
 
 /// Compose two transforms: `(A→B) ∘ (B→C) = A→C`.
 ///
@@ -266,5 +335,50 @@ mod tests {
     fn from_matrix_rejects_non_unit_determinant() {
         let m = DMat3::from_diagonal(DVec3::new(2.0, 1.0, 1.0)); // det = 2
         let _: FrameTransform<Inertial, Ecef> = FrameTransform::from_matrix(m);
+    }
+
+    /// `from_matrix_validated` accepts a proper rotation and round-trips
+    /// the matrix bit-exactly (same invariant as `from_matrix`).
+    #[test]
+    fn from_matrix_validated_accepts_rotation() {
+        let theta: f64 = 0.7;
+        let m = DMat3::from_cols(
+            DVec3::new(theta.cos(), theta.sin(), 0.0),
+            DVec3::new(-theta.sin(), theta.cos(), 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+        );
+        let t: FrameTransform<Inertial, Ecef> =
+            FrameTransform::from_matrix_validated(m).expect("rotation should validate");
+        assert_eq!(t.matrix_ref(), &m);
+    }
+
+    /// `from_matrix_validated` rejects a scaling matrix with a typed
+    /// `DeterminantNotOne` error rather than panicking.
+    #[test]
+    fn from_matrix_validated_rejects_scaling() {
+        let m = DMat3::from_diagonal(DVec3::new(2.0, 1.0, 1.0));
+        let err = FrameTransform::<Inertial, Ecef>::from_matrix_validated(m)
+            .expect_err("scaling should reject");
+        match err {
+            FrameTransformError::DeterminantNotOne { determinant } => {
+                assert!((determinant - 2.0).abs() < 1e-12);
+            }
+            other => panic!("expected DeterminantNotOne, got {other:?}"),
+        }
+    }
+
+    /// `from_matrix_validated` rejects a near-orthonormal but skewed matrix
+    /// with `NotOrthonormal` (det ≈ 1 but `M·Mᵀ ≠ I`).
+    #[test]
+    fn from_matrix_validated_rejects_non_orthonormal() {
+        // Shear: det = 1 but M*M^T != I. cols (1,a,0), (0,1,0), (0,0,1)
+        let m = DMat3::from_cols(
+            DVec3::new(1.0, 0.1, 0.0),
+            DVec3::new(0.0, 1.0, 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+        );
+        let err = FrameTransform::<Inertial, Ecef>::from_matrix_validated(m)
+            .expect_err("shear should reject");
+        assert!(matches!(err, FrameTransformError::NotOrthonormal { .. }));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,38 +315,20 @@ fn resolve_source_entity(source_entities: &[Entity], idx: usize, what: &str) -> 
 
 impl VehicleConfigBevyExt for jeod_sim::VehicleConfig {
     fn spawn_bevy(self, commands: &mut Commands, source_entities: &[Entity]) -> Entity {
-        // Translate `GravityControls<usize>` to `GravityControls<Entity>`
-        // by retagging the source identifier on each control. Struct-update
-        // syntax (`..c`) cannot be used here because the source-id type
-        // parameter changes (`GravityControl<usize>` → `GravityControl<Entity>`
-        // are distinct types), so every field must be enumerated explicitly.
-        //
-        // Maintenance contract: when a new field is added to `GravityControl`
-        // upstream, add a matching `field: c.field` line below — otherwise
-        // the new field is silently dropped (defaulted to whatever the
-        // struct literal yields without it, which fails to compile if all
-        // fields are non-default — keeping us honest).
+        // Translate `GravityControls<usize>` to `GravityControls<Entity>` by
+        // retagging the source identifier on each control via the
+        // `GravityControl::retag_source` helper. The field list lives in
+        // exactly one place (`jeod_gravity::gravity_controls`), so adding a
+        // new field there does not require touching this site.
         let entity_controls = jeod_sim::GravityControls::<Entity> {
             controls: self
                 .gravity_controls
                 .controls
                 .into_iter()
                 .map(|c| {
-                    let source_entity =
-                        resolve_source_entity(source_entities, c.source_name, "GravityControl");
-                    jeod_sim::GravityControl::<Entity> {
-                        source_name: source_entity,
-                        gradient: c.gradient,
-                        spherical: c.spherical,
-                        degree: c.degree,
-                        order: c.order,
-                        perturbing_only: c.perturbing_only,
-                        gradient_degree: c.gradient_degree,
-                        gradient_order: c.gradient_order,
-                        differential: c.differential,
-                        battin_method: c.battin_method,
-                        relativistic: c.relativistic,
-                    }
+                    c.retag_source(|idx| {
+                        resolve_source_entity(source_entities, idx, "GravityControl")
+                    })
                 })
                 .collect(),
         };


### PR DESCRIPTION
## Summary

Two centralization helpers from the #172 audit's pre-1.0 cleanup list, packaged as one small PR.

### M2 — `GravityControl::retag_source`

A new inherent method on `GravityControl<S>` that maps the source identifier through a closure and produces a fresh `GravityControl<T>`, copying every other field through a single struct literal.

\`VehicleConfigBevyExt::spawn_bevy\` now retags via \`.retag_source(...)\` instead of enumerating all 11 fields on a parallel literal. Adding a new field to \`GravityControl\` now only requires updating one constructor; ECS adapters are unaffected. Removes the obsolete maintenance contract comment that warned about the silent-drop hazard.

### L3 — \`FrameTransform::from_matrix_validated\`

A typed \`Result\`-returning sibling of \`from_matrix\` that rejects non-rotation inputs (det ≠ 1.0, M·Mᵀ ≠ I, degenerate quaternion derivation) instead of triggering a \`debug_assert!\` panic. Useful for unverified inputs (file I/O, RPC, user-supplied configuration); the existing \`from_matrix\` keeps its debug-only check on the hot path used by JEOD CSV / DE421 / RNP rotation kernels. New \`FrameTransformError\` enum lives in the same module and impls \`core::error::Error\`.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] 779/779 unit + tier 2 tests pass
- [x] 307/307 Tier 3 tests pass
- [x] New \`retag_source_preserves_all_fields\` test confirms the round-trip
- [x] New \`from_matrix_validated_*\` tests cover accept / reject-scaling / reject-shear

🤖 Generated with [Claude Code](https://claude.com/claude-code)