### PR TITLE
[#172] M3 + L6 + L8: Added<>-triggered validation + private FlatPlateScratch

### DIFF
--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -202,9 +202,9 @@ impl FlatPlateState {
     ///
     /// Combines k1–k4 temperature derivatives via the standard RK4 formula
     /// and applies JEOD overshoot clamping (thermal_integrable_object.cc:106-121).
-    /// Reads the step-start snapshots from `temps_snapshot` /
-    /// `t_pow4_snapshot`, which [`IntegrableObject::snapshot`] populated at
-    /// the start of the step.
+    /// Reads the step-start snapshots from `scratch.temps_snapshot` /
+    /// `scratch.t_pow4_snapshot`, which [`IntegrableObject::snapshot`]
+    /// populated at the start of the step.
     ///
     /// This is the coupled-integration counterpart of
     /// [`Self::integrate_temperatures`]: instead of deriving k2–k4 internally

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -139,18 +139,27 @@ pub struct FlatPlateState {
     /// `Scheduled` mode. Consumed by the Stage-8 integration closure;
     /// cleared at the start of the next step's Stage 5.
     pub stage_inputs: Option<FlatPlateStageInputs>,
-    /// Step-start temperature snapshot, populated by
-    /// [`IntegrableObject::snapshot`] and read by
+    /// RK4 kernel scratch: step-start temperature and T^4 snapshots.
+    ///
+    /// Populated by [`IntegrableObject::snapshot`] and consumed by
     /// [`IntegrableObject::advance_intermediate`] /
-    /// [`IntegrableObject::finalize_rk4`]. Managed by the RK4 kernel; do
-    /// not set manually. Hidden from rustdoc to discourage direct access
-    /// while still allowing struct-update syntax (`..Default::default()`)
-    /// at call sites that build `FlatPlateState` literals.
-    #[doc(hidden)] // allowed: RK4 kernel scratch; pub for ..Default::default() access only
-    pub temps_snapshot: Vec<f64>,
-    /// Step-start T^4 snapshot; companion to `temps_snapshot`.
-    #[doc(hidden)] // allowed: RK4 kernel scratch; pub for ..Default::default() access only
-    pub t_pow4_snapshot: Vec<f64>,
+    /// [`IntegrableObject::finalize_rk4`]. Inner fields are crate-private
+    /// so external callers cannot accidentally corrupt mid-step RK4
+    /// state. The field itself is `pub` so struct-update syntax
+    /// (`FlatPlateState { plates, ..Default::default() }`) keeps working
+    /// at literal sites — those callers receive a default-constructed
+    /// `FlatPlateScratch` they can hold but not mutate.
+    pub scratch: FlatPlateScratch,
+}
+
+/// Step-start RK4 snapshot vectors for [`FlatPlateState`].
+///
+/// Inner storage is private. Construct via `Default::default()`; mutate
+/// only through `IntegrableObject::snapshot` (called by the RK4 kernel).
+#[derive(Debug, Clone, Default)]
+pub struct FlatPlateScratch {
+    temps_snapshot: Vec<f64>,
+    t_pow4_snapshot: Vec<f64>,
 }
 
 impl FlatPlateState {
@@ -215,8 +224,8 @@ impl FlatPlateState {
             let emissivity = self.plates[i].2.emissivity;
             let heat_capacity_per_area = self.plates[i].2.heat_capacity_per_area;
             let (new_temp, new_t_pow4) = jeod_interactions::integrate_plate_temperature_rk4(
-                self.temps_snapshot[i],
-                self.t_pow4_snapshot[i],
+                self.scratch.temps_snapshot[i],
+                self.scratch.t_pow4_snapshot[i],
                 k1_tdots[i],
                 k2_tdots[i],
                 k3_tdots[i],
@@ -244,10 +253,14 @@ impl IntegrableObject for FlatPlateState {
     }
 
     fn snapshot(&mut self) {
-        self.temps_snapshot.clear();
-        self.temps_snapshot.extend_from_slice(&self.temperatures);
-        self.t_pow4_snapshot.clear();
-        self.t_pow4_snapshot.extend_from_slice(&self.t_pow4_cached);
+        self.scratch.temps_snapshot.clear();
+        self.scratch
+            .temps_snapshot
+            .extend_from_slice(&self.temperatures);
+        self.scratch.t_pow4_snapshot.clear();
+        self.scratch
+            .t_pow4_snapshot
+            .extend_from_slice(&self.t_pow4_cached);
     }
 
     fn advance_intermediate(&mut self, deriv: &[f64], h: f64) {
@@ -262,7 +275,7 @@ impl IntegrableObject for FlatPlateState {
             "t_pow4_cached length must equal temperatures length",
         );
         assert_eq!(
-            self.temps_snapshot.len(),
+            self.scratch.temps_snapshot.len(),
             n,
             "temps_snapshot length must equal temperatures length; \
              call IntegrableObject::snapshot before advance_intermediate",
@@ -278,7 +291,7 @@ impl IntegrableObject for FlatPlateState {
         // precisely the pattern we're trying to avoid.
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
-            let new_t = (self.temps_snapshot[i] + deriv[i] * h).max(0.0);
+            let new_t = (self.scratch.temps_snapshot[i] + deriv[i] * h).max(0.0);
             self.temperatures[i] = new_t;
             self.t_pow4_cached[i] = new_t * new_t * new_t * new_t;
         }

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -109,7 +109,7 @@ grep the JEOD tree for the distinctive identifier in the invariant description
 |-----|-----------|-------------|----------|------------|
 | DM.01 | At most one GravityManager registered | error | structural | n/a (no GravityManager singleton in ECS) |
 | DM.02 | GravityManager registered before `initialized=true` | error | ordering | n/a |
-| DM.03 | `initialized` flag set last in init sequence | structural | initialization | partial (validation system uses `Local<bool>` for one-shot) |
+| DM.03 | `initialized` flag set last in init sequence | structural | initialization | partial (validation system fires on `Added<GravityControlsC>` so bodies spawned mid-simulation are validated on the next tick) |
 | DM.04 | Init order: ephemerides → gravity controls → frame ownership → activate → update → gravity state → integ groups → dyn bodies | structural | ordering | partial (system set ordering: TimeUpdate → Ephemeris → Environment → ...) |
 | DM.05 | All required states initialized before first integration | fatal | initialization | partial (`validation.rs` warns on zero state) |
 | DM.06 | DynBody name unique across all bodies | error | structural | n/a (ECS entity IDs are unique) |

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -3,7 +3,12 @@
 //! Delegates to [`jeod_sim::validate_body`] for the per-body invariant checks,
 //! wrapping results with Bevy entity context and panicking on errors.
 //!
-//! This system runs once at the start of the first `FixedUpdate` tick.
+//! This system fires whenever a body with [`GravityControlsC`] is added —
+//! once per startup tick (covering the bodies spawned at app build) and
+//! again when bodies are spawned mid-mission (staging, dynamic constellation
+//! growth). Bodies added without `GravityControlsC` are not validated; this
+//! matches JEOD's `DynManager` which only invariants bodies that participate
+//! in integration.
 
 use bevy::prelude::*;
 
@@ -13,30 +18,41 @@ use crate::components::{
     SunMarker, TidalConfigC, TidalDeltaC20C, TranslationalStateC,
 };
 
-/// Validates JEOD invariants on all dynamic body entities.
+/// Validates JEOD invariants on dynamic body entities.
 ///
-/// Runs once at startup (first `FixedUpdate` tick), matching JEOD's
-/// `DynManager::initialize_simulation()` which validates all bodies
-/// before the first integration step.
+/// Triggered by [`Added<GravityControlsC>`]: the system body short-circuits
+/// to a no-op on ticks where no new bodies have been spawned, and runs
+/// the full validation pass otherwise. This means bodies attached to the
+/// app at build time are validated on the first `FixedUpdate` tick, and
+/// bodies added later (e.g. by a staging system or a runtime spawn event)
+/// are validated on the next tick after they appear.
+///
+/// Global checks (marker counts, tidal pairing, SRP mutual exclusion) are
+/// idempotent and re-run on every trigger; the per-body invariant checks
+/// run for *all* bodies with `GravityControlsC` so that a late-added body
+/// can still catch invariants involving inter-body relationships.
 ///
 /// Delegates per-body checks to [`jeod_sim::validate_body`] and applies
 /// gravity control auto-corrections via `check_validity()`.
 ///
 /// # Panics
 /// Panics with a descriptive message for any violated invariant.
-// JEOD_INV: DM.03 — one-shot validation gate (Local<bool>); does not block integration like JEOD's initialized flag
+// JEOD_INV: DM.03 — `Added<GravityControlsC>` filter on the body query fires on every body addition; bodies added mid-simulation are validated on the following tick
 #[allow(clippy::type_complexity)]
 pub fn validate_jeod_invariants(
-    mut bodies: Query<(
-        Entity,
-        &DynamicsConfigC,
-        &mut GravityControlsC,
-        Option<&GravityAccelerationC>,
-        Option<&MassPropertiesC>,
-        Option<&RotationalStateC>,
-        Option<&TranslationalStateC>,
-        Option<&FlatPlateConfigC>,
-    )>,
+    mut bodies: Query<
+        (
+            Entity,
+            &DynamicsConfigC,
+            &mut GravityControlsC,
+            Option<&GravityAccelerationC>,
+            Option<&MassPropertiesC>,
+            Option<&RotationalStateC>,
+            Option<&TranslationalStateC>,
+            Option<&FlatPlateConfigC>,
+        ),
+        Added<GravityControlsC>,
+    >,
     sources: Query<(Entity, &GravitySourceC)>,
     tidal_sources: Query<(
         Entity,
@@ -53,12 +69,13 @@ pub fn validate_jeod_invariants(
         Option<&MoonMarker>,
         Option<&TranslationalStateC>,
     )>,
-    mut has_run: Local<bool>,
 ) {
-    if *has_run {
+    if bodies.is_empty() {
+        // No body with `GravityControlsC` has appeared this tick — nothing
+        // new to validate. Existing bodies were validated on the tick they
+        // were spawned and the work is otherwise idempotent.
         return;
     }
-    *has_run = true;
 
     // Validate derived-state marker prerequisites.
     // Matches Simulation::validate() which errors on missing sun_source/moon_source.

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -20,17 +20,29 @@ use crate::components::{
 
 /// Validates JEOD invariants on dynamic body entities.
 ///
-/// Triggered by [`Added<GravityControlsC>`]: the system body short-circuits
-/// to a no-op on ticks where no new bodies have been spawned, and runs
-/// the full validation pass otherwise. This means bodies attached to the
-/// app at build time are validated on the first `FixedUpdate` tick, and
-/// bodies added later (e.g. by a staging system or a runtime spawn event)
-/// are validated on the next tick after they appear.
+/// Triggered by [`Added<GravityControlsC>`] on the body query: the system
+/// short-circuits to a no-op on ticks where no body with
+/// `GravityControlsC` has been newly attached. When the trigger fires,
+/// the system runs the validation pass below; bodies attached to the app
+/// at build time are validated on the first `FixedUpdate` tick, and
+/// bodies spawned later (staging, hot-attach, runtime spawn events) are
+/// validated on the tick following their insertion.
 ///
-/// Global checks (marker counts, tidal pairing, SRP mutual exclusion) are
-/// idempotent and re-run on every trigger; the per-body invariant checks
-/// run for *all* bodies with `GravityControlsC` so that a late-added body
-/// can still catch invariants involving inter-body relationships.
+/// Two scopes participate:
+///
+/// * **Global state checks** (Sun/Moon marker counts, tidal-config pairing
+///   on gravity sources) iterate the *unfiltered* `derived_state_markers`
+///   and `tidal_sources` queries, so they re-evaluate the entire world's
+///   marker/source set on every trigger. Adding a stray second
+///   `SunMarker` mid-mission is therefore caught the next tick a body
+///   with `GravityControlsC` is added.
+/// * **Per-body invariant checks** (SRP mutual exclusion, the full
+///   `jeod_sim::validate_body` pass, gravity-control `check_validity`
+///   auto-corrections) iterate the `Added`-filtered `bodies` query, so
+///   they validate only newly-attached bodies. Existing bodies were
+///   validated on the tick they first appeared, and the per-body
+///   invariants do not depend on inter-body state, so re-running them
+///   for unchanged bodies would be wasteful.
 ///
 /// Delegates per-body checks to [`jeod_sim::validate_body`] and applies
 /// gravity control auto-corrections via `check_validity()`.

--- a/tests/validation_added_trigger.rs
+++ b/tests/validation_added_trigger.rs
@@ -10,18 +10,17 @@
 //!      vehicle attached at startup.
 //!   2. Running several `FixedUpdate` ticks so the startup body has been
 //!      validated and `Added` is no longer set on it.
-//!   3. Spawning a *second* vehicle whose `GravityControlsC` references a
-//!      bogus source index. The validation system must catch this on the
-//!      next tick and panic — proving the late-add validation path runs.
+//!   3. Spawning a *second* vehicle after those ticks whose
+//!      `GravityControlsC` still references source index `0` (which
+//!      resolves to Earth), but is intentionally invalid for that source.
 //!
-//! The bogus reference is a deliberate trip wire: the inner `validate_body`
-//! call doesn't itself reach the gravity-control auto-correction step (which
-//! would silently skip an unresolved entity), but `check_validity` *does*
-//! get called for every control, and a bad source index makes
-//! `sources.get(...)` return Err — so the auto-correction is skipped but
-//! the per-step gravity computation in `gravity_computation_system` will
-//! eventually panic on a missing source. We capture the panic via
-//! `std::panic::catch_unwind` to keep the test deterministic.
+//! The deliberate trip wire is `GravityControl::new_nonspherical(0, 4, 4,
+//! false)` against a `PointMass` Earth source. When the late-added body is
+//! picked up by the `Added<GravityControlsC>` validation path on the next
+//! tick, `check_validity()` rejects that configuration and panics. That
+//! panic is what proves validation is being rerun for newly-added bodies,
+//! rather than the body slipping past validation after startup. We capture
+//! the panic via `std::panic::catch_unwind` to keep the test deterministic.
 
 use std::panic::AssertUnwindSafe;
 use std::time::Duration;
@@ -78,33 +77,25 @@ fn build_app() -> (App, Entity) {
 fn validation_fires_for_body_added_after_startup() {
     let (mut app, earth) = build_app();
 
-    // Add a *second* vehicle mid-simulation. This time give it a
-    // non-spherical GravityControl with a non-existent source name. The
-    // `validate_body` kernel does not panic on this (the `sources.get()`
-    // closure simply returns `None` for an unresolved source, which
-    // validate_body interprets as "skip"), but `check_validity` clamps
-    // degree/order — and the integration step that follows will fail to
-    // find the source. We assert that the validation system *runs* (which
-    // we measure by observing the gravity-control's `degree`/`order` got
-    // clamped at the second tick); a stale `has_run` gate would skip this
-    // mutation and the assertion below would fail.
+    // Add a *second* vehicle mid-simulation. Give it a non-spherical
+    // GravityControl targeting the existing Earth source, even though
+    // Earth is configured as a point-mass model. When this body is
+    // inserted, `Added<GravityControlsC>` should cause validation to run
+    // on the next `FixedUpdate`. That validation panics immediately
+    // because non-spherical gravity is only supported for
+    // `SphericalHarmonics` sources; if the old `Local<bool>` gate were
+    // still suppressing validation after startup, the schedule would
+    // complete without error and the assertion below would fail.
 
     let earth_mu = earth::point_mass().source.mu;
     let bogus_cfg = VehicleBuilder::new()
         .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()
-        // Request a degree that exceeds the source's degree (point-mass
-        // = degree 0). validation's `check_validity` should catch this
-        // and either panic or auto-correct depending on the request.
-        .gravity({
-            let mut g = GravityControl::new_nonspherical(0_usize, 4, 4, false);
-            // Request degree=4 against a point-mass source. `check_validity`
-            // panics with "Non-spherical gravity (spherical=false) is only
-            // supported for SphericalHarmonics gravity models."
-            g.degree = 4;
-            g
-        })
+        // Request degree=4 against a point-mass source. `check_validity`
+        // panics with "Non-spherical gravity (spherical=false) is only
+        // supported for SphericalHarmonics gravity models."
+        .gravity(GravityControl::new_nonspherical(0_usize, 4, 4, false))
         .build();
 
     let mut commands_state = bevy::ecs::system::SystemState::<Commands>::new(app.world_mut());

--- a/tests/validation_added_trigger.rs
+++ b/tests/validation_added_trigger.rs
@@ -1,0 +1,141 @@
+//! Regression test for #172 M3: validation runs on bodies added mid-simulation.
+//!
+//! Before #172 M3 the validation system was gated by `Local<bool> has_run`,
+//! so any body added after the first `FixedUpdate` tick skipped validation
+//! entirely. The fix replaces the local with an `Added<GravityControlsC>`
+//! filter on the body query.
+//!
+//! This test exercises the late-addition path by:
+//!   1. Building an `App` with `JeodPlugin` and one Earth source plus one
+//!      vehicle attached at startup.
+//!   2. Running several `FixedUpdate` ticks so the startup body has been
+//!      validated and `Added` is no longer set on it.
+//!   3. Spawning a *second* vehicle whose `GravityControlsC` references a
+//!      bogus source index. The validation system must catch this on the
+//!      next tick and panic — proving the late-add validation path runs.
+//!
+//! The bogus reference is a deliberate trip wire: the inner `validate_body`
+//! call doesn't itself reach the gravity-control auto-correction step (which
+//! would silently skip an unresolved entity), but `check_validity` *does*
+//! get called for every control, and a bad source index makes
+//! `sources.get(...)` return Err — so the auto-correction is skipped but
+//! the per-step gravity computation in `gravity_computation_system` will
+//! eventually panic on a missing source. We capture the panic via
+//! `std::panic::catch_unwind` to keep the test deterministic.
+
+use std::panic::AssertUnwindSafe;
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_jeod::prelude::*;
+use bevy_jeod::recipes::{earth, orbital_elements, vehicle};
+
+fn build_app() -> (App, Entity) {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .insert_resource(Time::<Fixed>::from_seconds(10.0))
+        .add_plugins(JeodPlugin);
+
+    // Spawn Earth + ISS body via Startup so the regular pipeline runs them.
+    let earth_recipe = earth::point_mass();
+    let earth_mu = earth_recipe.source.mu;
+    let earth = app
+        .world_mut()
+        .spawn((
+            Name::new("Earth"),
+            GravitySourceC(earth_recipe.source),
+            SourceInertialPositionC::default(),
+            TranslationalStateC::default(),
+        ))
+        .id();
+
+    let cfg = VehicleBuilder::new()
+        .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
+        .three_dof_point_mass(vehicle::iss_mass())
+        .rk4()
+        .gravity(GravityControl::new_spherical(0_usize, false))
+        .build();
+
+    let mut commands_state = bevy::ecs::system::SystemState::<Commands>::new(app.world_mut());
+    let mut commands = commands_state.get_mut(app.world_mut());
+    let _ = cfg.spawn_bevy(&mut commands, &[earth]);
+    commands_state.apply(app.world_mut());
+
+    // Drive startup + two FixedUpdate ticks so the body has been validated
+    // and the `Added<GravityControlsC>` filter no longer matches it.
+    app.update();
+    for _ in 0..2 {
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .advance_by(Duration::from_secs_f64(10.0));
+        app.world_mut().run_schedule(FixedUpdate);
+    }
+
+    (app, earth)
+}
+
+#[test]
+fn validation_fires_for_body_added_after_startup() {
+    let (mut app, earth) = build_app();
+
+    // Add a *second* vehicle mid-simulation. This time give it a
+    // non-spherical GravityControl with a non-existent source name. The
+    // `validate_body` kernel does not panic on this (the `sources.get()`
+    // closure simply returns `None` for an unresolved source, which
+    // validate_body interprets as "skip"), but `check_validity` clamps
+    // degree/order — and the integration step that follows will fail to
+    // find the source. We assert that the validation system *runs* (which
+    // we measure by observing the gravity-control's `degree`/`order` got
+    // clamped at the second tick); a stale `has_run` gate would skip this
+    // mutation and the assertion below would fail.
+
+    let earth_mu = earth::point_mass().source.mu;
+    let bogus_cfg = VehicleBuilder::new()
+        .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
+        .three_dof_point_mass(vehicle::iss_mass())
+        .rk4()
+        // Request a degree that exceeds the source's degree (point-mass
+        // = degree 0). validation's `check_validity` should catch this
+        // and either panic or auto-correct depending on the request.
+        .gravity({
+            let mut g = GravityControl::new_nonspherical(0_usize, 4, 4, false);
+            // Request degree=4 against a point-mass source. `check_validity`
+            // panics with "Non-spherical gravity (spherical=false) is only
+            // supported for SphericalHarmonics gravity models."
+            g.degree = 4;
+            g
+        })
+        .build();
+
+    let mut commands_state = bevy::ecs::system::SystemState::<Commands>::new(app.world_mut());
+    let mut commands = commands_state.get_mut(app.world_mut());
+    let _ = bogus_cfg.spawn_bevy(&mut commands, &[earth]);
+    commands_state.apply(app.world_mut());
+
+    // Step once more — validation must run for the new body and panic.
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        app.world_mut()
+            .resource_mut::<Time<Fixed>>()
+            .advance_by(Duration::from_secs_f64(10.0));
+        app.world_mut().run_schedule(FixedUpdate);
+    }));
+
+    // If the validation system had been gated by `Local<bool>`, no panic
+    // would fire because the gate would have closed after the first tick.
+    let panic = result.expect_err(
+        "expected validation to panic on the late-added body's bad GravityControl, \
+         but the FixedUpdate schedule completed without error — \
+         the Added<GravityControlsC> trigger is not firing for late additions",
+    );
+    let msg = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&'static str>().copied())
+        .unwrap_or("<non-string panic payload>");
+    assert!(
+        msg.contains("Non-spherical gravity")
+            || msg.contains("PointMass")
+            || msg.contains("SphericalHarmonics"),
+        "panic message did not mention gravity validation: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Three #172 audit items, packaged together because L6 and L8 share a fix surface and M3 has been the longest-pending mid-tier item.

### M3 — \`validate_jeod_invariants\` on \`Added<GravityControlsC>\`

The validation system was previously gated by \`Local<bool> has_run\`, running once at app start and ignoring all subsequent body additions. Replace the gate with an \`Added<GravityControlsC>\` filter on the body query: the system runs the full pass whenever a body with \`GravityControlsC\` is newly attached, returns early when no new body has appeared this tick, and bodies spawned mid-mission are validated on the next FixedUpdate tick.

The \`Added\` filter lives on the existing \`bodies: Query<..., Added<...>>\` to avoid an aliasing conflict with a separate \`Query<(), Added<...>>\` parameter (Bevy rejects two queries that reach the same component, one of which is mut). Updates \`JEOD_INV: DM.03\` in the catalog to reflect the new mechanism.

A new integration test \`tests/validation_added_trigger.rs\` spawns a body after several FixedUpdate ticks with a deliberately invalid \`GravityControl\` (degree=4, spherical=false against a PointMass source) and asserts the validation system panics — proving the late-addition path runs.

### L6 — Wrap \`FlatPlateState\` scratch in a private struct

The two \`pub temps_snapshot\` / \`pub t_pow4_snapshot\` fields on \`FlatPlateState\` were \`#[doc(hidden)]\` but still mutable from outside the crate. Replace them with a single \`pub scratch: FlatPlateScratch\` field whose inner \`temps_snapshot\` / \`t_pow4_snapshot\` Vecs are crate-private.

External callers can still write \`FlatPlateState { plates, ..Default::default() }\` (the new \`FlatPlateScratch\` derives \`Default\`), but they cannot read or mutate the inner Vecs — keeping mid-step RK4 scratch out of reach of mission code. Updates the four internal accessors (\`snapshot\`, \`advance_intermediate\`, \`finalize_rk4_temperatures\`, length-parity assert) to dereference through \`self.scratch.<field>\`.

### L8 — Confirmed no-op

\`FlatPlateState\` does not derive \`Reflect\` / \`Serialize\` / \`Deserialize\` on this branch, so there are no \`#[reflect(skip)]\` / \`#[serde(skip)]\` attributes to add today. L6 already removes the public surface, so when those derives are added in the future the scratch fields will not leak through reflection or serialization.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] 776/776 unit + tier 2 tests pass (includes new \`validation_added_trigger\`)
- [x] 307/307 Tier 3 tests pass
- [x] \`invariant_coverage\` tests pass after \`DM.03\` update

🤖 Generated with [Claude Code](https://claude.com/claude-code)