### PR TITLE
[#186] Mission/recipe cleanup: builder-fn contract + epoch dedup + scenario cross-refs

### DIFF
--- a/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
+++ b/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
@@ -215,12 +215,12 @@ const SIM_SOLAR_BETA_DIR: &str = "models/dynamics/derived_state/verif/SIM_SolarB
 // (TT JD passed to ephemeris queries as a TDB approximation, TAI TJT for
 // SimulationTime::new) are computed from one canonical UTC anchor + the
 // 1991 TAI-UTC offset so a future change in either applies to both
-// consumers automatically.
+// consumers automatically. The TT-TAI offset is shared with the
+// `jeod_time` epoch module so the time arithmetic here cannot drift from
+// the canonical definition.
 const SIM_SOLAR_BETA_EPOCH_UTC_JD: f64 = 2_448_257.5;
 /// TAI-UTC offset at 1991-01-01 (seconds).
 const SIM_SOLAR_BETA_TAI_UTC_S: f64 = 26.0;
-/// TT − TAI offset (constant; defined by the IAU TT redefinition).
-const SIM_SOLAR_BETA_TT_TAI_S: f64 = 32.184;
 
 /// SIM_SolarBeta epoch in **TT JD**, passed to
 /// [`Ephemeris::get_earth_centered_state_typed`] as a TDB approximation.
@@ -239,9 +239,10 @@ const SIM_SOLAR_BETA_TT_TAI_S: f64 = 32.184;
 ///   physical-correctness improvement and refreeze if desired; this
 ///   constant is kept stable for now.
 ///
-/// Computed as JD(TT) = JD(UTC) + (TAI-UTC + TT-TAI) / 86 400.
+/// Computed as JD(TT) = JD(UTC) + (TAI-UTC + TT-TAI) / 86 400, where
+/// TT-TAI is the canonical [`jeod_time::TAI_TT_OFFSET`] (= 32.184 s).
 const SIM_SOLAR_BETA_EPOCH_TT_JD: f64 =
-    SIM_SOLAR_BETA_EPOCH_UTC_JD + (SIM_SOLAR_BETA_TAI_UTC_S + SIM_SOLAR_BETA_TT_TAI_S) / 86_400.0;
+    SIM_SOLAR_BETA_EPOCH_UTC_JD + (SIM_SOLAR_BETA_TAI_UTC_S + jeod_time::TAI_TT_OFFSET) / 86_400.0;
 
 /// SIM_SolarBeta epoch as TAI TJT (the form `SimulationTime::new` consumes).
 /// = MJD(TAI) − 40 000 = (JD(UTC) + TAI-UTC/86 400 − 2 400 000.5) − 40 000.

--- a/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
+++ b/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
@@ -211,13 +211,26 @@ pub fn solar_beta_run2() -> VerificationCase {
 
 const SIM_SOLAR_BETA_DIR: &str = "models/dynamics/derived_state/verif/SIM_SolarBeta";
 
-/// SIM_SolarBeta epoch JD: 1991-01-01 00:00:00 UTC = JD 2_448_257.5
-/// (with TAI-UTC = 26 s, TT = TAI + 32.184 s → TDB JD baseline below).
-const SIM_SOLAR_BETA_EPOCH_TDB_JD: f64 = 2_448_257.5 + 58.184 / 86_400.0;
+// SIM_SolarBeta epoch is 1991-01-01 00:00:00 UTC. The two derived forms
+// (TDB JD for ephemeris queries, TAI TJT for SimulationTime::new) are
+// computed from one canonical UTC anchor + the 1991 TAI-UTC offset so a
+// future change in either applies to both consumers automatically.
+const SIM_SOLAR_BETA_EPOCH_UTC_JD: f64 = 2_448_257.5;
+/// TAI-UTC offset at 1991-01-01 (seconds).
+const SIM_SOLAR_BETA_TAI_UTC_S: f64 = 26.0;
+/// TT − TAI offset (constant; defined by the IAU TT redefinition).
+const SIM_SOLAR_BETA_TT_TAI_S: f64 = 32.184;
+
+/// SIM_SolarBeta epoch in TDB JD (used for `Ephemeris::get_earth_centered_state_typed`).
+/// TDB ≈ TT for sub-second-precision purposes here, so JD(TT) = JD(UTC) +
+/// (TAI-UTC + TT-TAI) / 86 400.
+const SIM_SOLAR_BETA_EPOCH_TDB_JD: f64 =
+    SIM_SOLAR_BETA_EPOCH_UTC_JD + (SIM_SOLAR_BETA_TAI_UTC_S + SIM_SOLAR_BETA_TT_TAI_S) / 86_400.0;
 
 /// SIM_SolarBeta epoch as TAI TJT (the form `SimulationTime::new` consumes).
-/// = MJD(TAI) − 40000 = (JD + TAI-UTC/86400 − 2_400_000.5) − 40000.
-const SIM_SOLAR_BETA_EPOCH_TAI_TJT: f64 = 2_448_257.5 + 26.0 / 86_400.0 - 2_400_000.5 - 40_000.0;
+/// = MJD(TAI) − 40 000 = (JD(UTC) + TAI-UTC/86 400 − 2 400 000.5) − 40 000.
+const SIM_SOLAR_BETA_EPOCH_TAI_TJT: f64 =
+    SIM_SOLAR_BETA_EPOCH_UTC_JD + SIM_SOLAR_BETA_TAI_UTC_S / 86_400.0 - 2_400_000.5 - 40_000.0;
 
 fn sim_solar_beta_time() -> SimulationTime {
     let jeod = jeod_root();

--- a/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
+++ b/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
@@ -212,19 +212,35 @@ pub fn solar_beta_run2() -> VerificationCase {
 const SIM_SOLAR_BETA_DIR: &str = "models/dynamics/derived_state/verif/SIM_SolarBeta";
 
 // SIM_SolarBeta epoch is 1991-01-01 00:00:00 UTC. The two derived forms
-// (TDB JD for ephemeris queries, TAI TJT for SimulationTime::new) are
-// computed from one canonical UTC anchor + the 1991 TAI-UTC offset so a
-// future change in either applies to both consumers automatically.
+// (TT JD passed to ephemeris queries as a TDB approximation, TAI TJT for
+// SimulationTime::new) are computed from one canonical UTC anchor + the
+// 1991 TAI-UTC offset so a future change in either applies to both
+// consumers automatically.
 const SIM_SOLAR_BETA_EPOCH_UTC_JD: f64 = 2_448_257.5;
 /// TAI-UTC offset at 1991-01-01 (seconds).
 const SIM_SOLAR_BETA_TAI_UTC_S: f64 = 26.0;
 /// TT − TAI offset (constant; defined by the IAU TT redefinition).
 const SIM_SOLAR_BETA_TT_TAI_S: f64 = 32.184;
 
-/// SIM_SolarBeta epoch in TDB JD (used for `Ephemeris::get_earth_centered_state_typed`).
-/// TDB ≈ TT for sub-second-precision purposes here, so JD(TT) = JD(UTC) +
-/// (TAI-UTC + TT-TAI) / 86 400.
-const SIM_SOLAR_BETA_EPOCH_TDB_JD: f64 =
+/// SIM_SolarBeta epoch in **TT JD**, passed to
+/// [`Ephemeris::get_earth_centered_state_typed`] as a TDB approximation.
+///
+/// `Ephemeris::get_earth_centered_state_typed` documents its argument as
+/// TDB JD. We pass TT JD here because:
+/// * The TT−TDB periodic offset at 1991-01-01 00:00:00 UTC is ≈ 1.6 ms
+///   (peak ~1.6 ms, varies by season). Sun's apparent motion against the
+///   celestial sphere is ~30 km/s, so a 1.6 ms offset shifts the
+///   Earth-centered Sun position by ≲ 50 m — well under this test's beta
+///   tolerance (≈ 50 m / 1.5e11 m → 3.3e-10 rad, vs the asserted
+///   1.892e-5 rad).
+/// * Tier 3 baselines are frozen with this TT-as-TDB value; switching to
+///   true TDB via [`SimulationTime::tdb_julian_date`] would shift the
+///   baselines by the magnitudes above. A future PR can make that
+///   physical-correctness improvement and refreeze if desired; this
+///   constant is kept stable for now.
+///
+/// Computed as JD(TT) = JD(UTC) + (TAI-UTC + TT-TAI) / 86 400.
+const SIM_SOLAR_BETA_EPOCH_TT_JD: f64 =
     SIM_SOLAR_BETA_EPOCH_UTC_JD + (SIM_SOLAR_BETA_TAI_UTC_S + SIM_SOLAR_BETA_TT_TAI_S) / 86_400.0;
 
 /// SIM_SolarBeta epoch as TAI TJT (the form `SimulationTime::new` consumes).
@@ -260,7 +276,7 @@ fn build_solar_beta_equ(init: &InitialConditions) -> SimulationBuilder {
 
     let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (sun_t0, _) = ephemeris
-        .get_earth_centered_state_typed(EphemerisBody::Sun, SIM_SOLAR_BETA_EPOCH_TDB_JD)
+        .get_earth_centered_state_typed(EphemerisBody::Sun, SIM_SOLAR_BETA_EPOCH_TT_JD)
         .expect("Sun position at SIM_SolarBeta epoch");
 
     let mut sb = SimulationBuilder::new(sim_solar_beta_time(), sim_solar_beta_dt());
@@ -322,7 +338,7 @@ fn build_solar_beta_obliquity(init: &InitialConditions) -> SimulationBuilder {
 
     let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (sun_t0, _) = ephemeris
-        .get_earth_centered_state_typed(EphemerisBody::Sun, SIM_SOLAR_BETA_EPOCH_TDB_JD)
+        .get_earth_centered_state_typed(EphemerisBody::Sun, SIM_SOLAR_BETA_EPOCH_TT_JD)
         .expect("Sun position at SIM_SolarBeta epoch");
 
     let time = sim_solar_beta_time();

--- a/crates/jeod_sim/src/recipes/mission.rs
+++ b/crates/jeod_sim/src/recipes/mission.rs
@@ -28,8 +28,25 @@ use crate::SimulationTime;
 /// Construct one via [`Mission::iss_leo`] / [`Mission::apollo_translunar`] /
 /// etc., optionally compose with [`with_time`](Self::with_time), then
 /// finalize with [`into_builder`](Self::into_builder).
+///
+/// # Builder-fn contract
+///
+/// `builder_fn` is a bare function pointer that *must be infallible*. Every
+/// scenario currently in this catalog is hand-coded against compile-time
+/// constants (`recipes::scenarios::*`), so panics there indicate a bug in
+/// the scenario code rather than a runtime / I/O failure mode the caller
+/// can recover from.
+///
+/// If a future scenario needs fallible setup (dynamic asset loading, network
+/// fetch, user-supplied configuration), promote `builder_fn` to
+/// `fn() -> Result<SimulationBuilder, MissionBuildError>` then — and embed
+/// the mission name in the error so panics from `into_builder` still
+/// identify which mission failed. Today's contract is "stay infallible";
+/// the bare-fn surface is deliberate.
 pub struct Mission {
     description: &'static str,
+    /// Infallible scenario constructor. Panicking from this fn is a bug
+    /// in the scenario, not an expected runtime path.
     builder_fn: fn() -> SimulationBuilder,
     time_override: Option<SimulationTime>,
 }
@@ -37,6 +54,9 @@ pub struct Mission {
 impl Mission {
     /// 3-DOF point-mass ISS-like LEO with Earth point-mass gravity.
     /// Epoch J2000, 60 s timestep.
+    ///
+    /// See [`scenarios::iss_leo::iss_leo`] for the underlying setup
+    /// (orbital elements, mass, integrator).
     pub fn iss_leo() -> Self {
         Self {
             description: "ISS-class LEO; 3-DOF point-mass Earth gravity at J2000.",
@@ -47,6 +67,9 @@ impl Mission {
 
     /// ISS-like LEO with atmospheric drag (MET solar-mean atmosphere) and
     /// 6-DOF identity attitude. 60 s timestep.
+    ///
+    /// See [`scenarios::iss_leo::iss_leo_drag`] for the underlying setup
+    /// (atmosphere model, drag coefficient, ballistic frontal area).
     pub fn iss_leo_drag() -> Self {
         Self {
             description: "ISS-class LEO with MET solar-mean drag; 6-DOF identity attitude.",
@@ -56,6 +79,9 @@ impl Mission {
     }
 
     /// Apollo translunar trajectory with multi-body Earth + Moon + Sun.
+    ///
+    /// See [`scenarios::apollo::apollo_translunar`] for the underlying setup
+    /// (initial state, source geometry, integration frame).
     pub fn apollo_translunar() -> Self {
         Self {
             description: "Apollo translunar trajectory; Earth + Moon + Sun gravity.",
@@ -65,6 +91,10 @@ impl Mission {
     }
 
     /// Earth-Moon translunar reference orbit using DE421 ephemerides.
+    ///
+    /// See [`scenarios::earth_moon::earth_moon_translunar`] for the
+    /// underlying setup. Aliased to
+    /// [`scenarios::clementine_lunar::clementine_lunar`] today.
     pub fn earth_moon_translunar() -> Self {
         Self {
             description: "Earth-Moon translunar trajectory; DE421 ephemeris.",
@@ -74,6 +104,9 @@ impl Mission {
     }
 
     /// Geostationary equatorial orbit at sidereal rate.
+    ///
+    /// See [`scenarios::geostationary::geo`] for the underlying setup
+    /// (orbital elements, integrator, 300 s timestep).
     pub fn geo() -> Self {
         Self {
             description: "Geostationary equatorial orbit at sidereal rate.",
@@ -83,6 +116,9 @@ impl Mission {
     }
 
     /// Clementine lunar mission setup at the 1994 launch epoch.
+    ///
+    /// See [`scenarios::clementine_lunar::clementine_lunar`] for the
+    /// underlying setup (DE421 ephemerides, multi-body gravity).
     pub fn clementine_lunar() -> Self {
         Self {
             description: "Clementine lunar mission; 1994 launch epoch.",
@@ -92,6 +128,9 @@ impl Mission {
     }
 
     /// Mars-centered orbit with Sun perturbation; Dawn 2009 epoch.
+    ///
+    /// See [`scenarios::mars_orbit::mars_orbit`] for the underlying setup
+    /// (Mars + Sun gravity sources, ephemeris attachment).
     pub fn mars_orbit() -> Self {
         Self {
             description: "Mars-centered orbit; Sun perturbation, Dawn 2009 epoch.",
@@ -101,6 +140,9 @@ impl Mission {
     }
 
     /// Heliocentric Mercury orbit with PPN relativistic corrections.
+    ///
+    /// See [`scenarios::mercury::mercury_relativistic`] for the underlying
+    /// setup (initial state, PPN parameters, GR perihelion-advance test).
     pub fn mercury_relativistic() -> Self {
         Self {
             description: "Mercury heliocentric orbit; PPN relativistic corrections.",

--- a/crates/jeod_sim/src/recipes/mission.rs
+++ b/crates/jeod_sim/src/recipes/mission.rs
@@ -40,8 +40,8 @@ use crate::SimulationTime;
 /// If a future scenario needs fallible setup (dynamic asset loading, network
 /// fetch, user-supplied configuration), promote `builder_fn` to
 /// `fn() -> Result<SimulationBuilder, MissionBuildError>` then — and embed
-/// the mission name in the error so panics from `into_builder` still
-/// identify which mission failed. Today's contract is "stay infallible";
+/// the mission name in the error so the error returned from `into_builder`
+/// identifies which mission failed. Today's contract is "stay infallible";
 /// the bare-fn surface is deliberate.
 pub struct Mission {
     description: &'static str,


### PR DESCRIPTION
## Summary

Closes #186. Three small follow-ups from the post-#170 audit, packaged as one PR per the issue author's request.

### Finding 1 — Mission builder_fn infallibility contract

Adds a documentation paragraph to \`Mission\`'s struct docstring stating the bare \`fn() -> SimulationBuilder\` is required to be infallible: every scenario in the catalog is hand-coded against compile-time constants and panics from a builder fn signal a scenario bug, not a runtime path. If a future scenario needs fallible setup, the contract is to promote \`builder_fn\` to \`fn() -> Result<SimulationBuilder, MissionBuildError>\` with the mission name embedded in the error. Field-level comment also restated.

### Finding 2 — Dedup \`SIM_SOLAR_BETA\` epoch constants

Replaces the two parallel constants (\`SIM_SOLAR_BETA_EPOCH_TDB_JD\` / \`SIM_SOLAR_BETA_EPOCH_TAI_TJT\`) with one canonical UTC anchor (\`SIM_SOLAR_BETA_EPOCH_UTC_JD\`) plus the 1991 TAI-UTC offset and the constant TT-TAI offset. The two derived forms are computed via \`const fn\` arithmetic, so a future change in either applies to both consumers automatically. Tier 3 baselines remain bit-identical (verified via \`tier3_baseline_diff\`).

> Note: the file path in the original issue (\`mod.rs:216,220\`) is stale — the constants moved to \`sim_solar_beta.rs\` post-issue.

### Finding 3 — Cross-reference scenarios in Mission docstrings

Each \`Mission::*\` constructor now has a "See [\`scenarios::...\`]" cross-ref pointing at the underlying setup, restoring the parity with the bare scenario fn doctests they replaced.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] 775/775 unit + tier 2 tests pass
- [x] 307/307 Tier 3 tests pass
- [x] \`tier3_baseline_diff\` returns 76 matched / 0 new (Finding 2 doesn't move any baseline)
- [x] \`cargo test --doc -p jeod_sim\` resolves the new intra-doc links
- [x] \`cargo doc --workspace --no-deps\` clean under \`RUSTDOCFLAGS=-D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)