### PR TITLE
[#172 L2] Closes #172: Simulation::step → Result<(), StepError>

### DIFF
--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -142,7 +142,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "---"
             );
         }
-        sim.step();
+        sim.step().expect("step failed");
         if step % steps_per_print == 0 {
             let body = sim.body(0);
             let pos = body.trans.position;

--- a/crates/jeod_runner/examples/batch_propagation.rs
+++ b/crates/jeod_runner/examples/batch_propagation.rs
@@ -50,7 +50,7 @@ fn main() {
 
     for step in 0..=steps {
         if step > 0 {
-            sim.step();
+            sim.step().expect("step failed");
         }
         if step % report_interval == 0 || step == steps {
             let s = sim.body(0).trans;

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -122,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let steps_per_print = (print_interval / DT).round() as usize;
 
     for step in 1..=total_steps {
-        sim.step();
+        sim.step().expect("step failed");
         if step % steps_per_print == 0 {
             let body = sim.body(0);
             let pos = body.trans.position;

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -57,7 +57,7 @@ fn main() {
     let print_interval = steps / 24;
 
     for step in 0..steps {
-        sim.step();
+        sim.step().expect("step failed");
         let sim_time = (step + 1) as f64 * dt;
         if (step + 1) % print_interval == 0 {
             let time_h = sim_time / 3600.0;

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -88,7 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let steps_per_print = (print_interval / DT).round() as usize;
 
     for step in 1..=total_steps {
-        sim.step();
+        sim.step().expect("step failed");
         if step % steps_per_print == 0 {
             let body = sim.body(0);
             let pos = body.trans.position;

--- a/crates/jeod_runner/src/branded.rs
+++ b/crates/jeod_runner/src/branded.rs
@@ -194,14 +194,14 @@ impl<'sim> BrandedSimulation<'sim> {
     // ── Pass-through forwarders for the common non-index methods ──
 
     /// Advance the simulation by one timestep.
-    pub fn step(&mut self) {
-        self.inner.step();
+    pub fn step(&mut self) -> Result<(), crate::StepError> {
+        self.inner.step()
     }
 
     /// Advance until the simulation time reaches `target_time` (whole
     /// `dt` increments only — fractional residuals panic).
-    pub fn step_until(&mut self, target_time: f64) {
-        self.inner.step_until(target_time);
+    pub fn step_until(&mut self, target_time: f64) -> Result<(), crate::StepError> {
+        self.inner.step_until(target_time)
     }
 
     /// Run JEOD invariant validation on the current sim state.

--- a/crates/jeod_runner/src/branded.rs
+++ b/crates/jeod_runner/src/branded.rs
@@ -198,8 +198,13 @@ impl<'sim> BrandedSimulation<'sim> {
         self.inner.step()
     }
 
-    /// Advance until the simulation time reaches `target_time` (whole
-    /// `dt` increments only — fractional residuals panic).
+    /// Advance until the simulation time reaches `target_time`.
+    ///
+    /// If the underlying integrator supports it, this may take a final
+    /// fractional step to hit `target_time` exactly. A fractional residual
+    /// only panics when such a step is required for an integrator that
+    /// does not support it (e.g. multi-step `GaussJackson` / `Abm4`,
+    /// whose history arrays assume constant dt).
     pub fn step_until(&mut self, target_time: f64) -> Result<(), crate::StepError> {
         self.inner.step_until(target_time)
     }

--- a/crates/jeod_runner/src/error.rs
+++ b/crates/jeod_runner/src/error.rs
@@ -42,6 +42,38 @@ use jeod_sim::EphemerisBody;
 /// `step_internal` on the relevant failure paths). Inspect via pattern
 /// match. Implements [`core::error::Error`] so it composes with `?` and
 /// the rest of the standard error-handling ecosystem.
+///
+/// # Reading the carried context
+///
+/// All variant fields are part of the public surface (an enum variant's
+/// fields inherit the enum's visibility, so no per-field `pub` qualifier
+/// is needed or accepted by the language). Downstream recovery logic can
+/// destructure freely:
+///
+/// ```ignore
+/// use jeod_runner::StepError;
+///
+/// fn handle(err: StepError) {
+///     match err {
+///         StepError::EphemerisLookup {
+///             source_idx,
+///             tdb_jd,
+///             ..
+///         } => {
+///             eprintln!("source {source_idx} missing at TDB JD {tdb_jd}");
+///         }
+///         StepError::FrameSwitchTargetMissing {
+///             body_idx,
+///             target_source,
+///             num_sources,
+///         } => {
+///             eprintln!(
+///                 "body {body_idx}: target {target_source} >= {num_sources}"
+///             );
+///         }
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub enum StepError {
     /// DE4xx ephemeris lookup failed for a source whose position is

--- a/crates/jeod_runner/src/error.rs
+++ b/crates/jeod_runner/src/error.rs
@@ -1,0 +1,82 @@
+//! Error type returned by [`Simulation::step`] and [`Simulation::step_until`].
+//!
+//! Per #172 L2, mission-runtime conditions inside `step_internal` (ephemeris
+//! lookup failure, frame-switch target out of range) propagate as a typed
+//! `StepError` rather than aborting the process via `panic!`. This lets
+//! mission programmes catch the failure (Monte Carlo, batch propagation,
+//! resilient long-running services) without resorting to `catch_unwind`.
+//!
+//! Programmer / configuration errors (bad source index passed to an
+//! accessor method, typestate violations) remain `panic!`s — they signal a
+//! bug in the calling code and recovering from them is not meaningful.
+
+use core::fmt;
+
+use jeod_sim::EphemerisBody;
+
+/// Reasons a [`Simulation`](crate::Simulation) step can fail at runtime.
+///
+/// Construct via the variant constructors (the kernel returns these from
+/// `step_internal` on the relevant failure paths). Inspect via pattern
+/// match. Implements [`core::error::Error`] so it composes with `?` and
+/// the rest of the standard error-handling ecosystem.
+#[derive(Debug, Clone)]
+pub enum StepError {
+    /// DE4xx ephemeris lookup failed for a source whose position is
+    /// driven by an attached ephemeris. Carries enough context to
+    /// identify the source and the time scale at which the lookup failed.
+    EphemerisLookup {
+        /// Index of the source whose position update failed.
+        source_idx: usize,
+        /// Target body passed to `Ephemeris::get_state_typed`.
+        target: EphemerisBody,
+        /// Observer body passed to `Ephemeris::get_state_typed`.
+        observer: EphemerisBody,
+        /// TDB Julian Date at which the lookup was attempted.
+        tdb_jd: f64,
+        /// Underlying error message from the ephemeris kernel.
+        message: String,
+    },
+    /// A body's [`crate::FrameSwitch`] referenced a `target_source`
+    /// index that doesn't correspond to any registered gravity source.
+    /// Typically a mid-mission edit hazard caught at step time when
+    /// `Simulation::validate` wasn't re-run after the change.
+    FrameSwitchTargetMissing {
+        /// Index of the body whose frame switch contains the bad target.
+        body_idx: usize,
+        /// Out-of-range target source index.
+        target_source: usize,
+        /// Number of sources currently registered.
+        num_sources: usize,
+    },
+}
+
+impl fmt::Display for StepError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EphemerisLookup {
+                source_idx,
+                target,
+                observer,
+                tdb_jd,
+                message,
+            } => write!(
+                f,
+                "Ephemeris lookup failed for source {source_idx} \
+                 ({target:?} wrt {observer:?}) at TDB JD {tdb_jd}: {message}"
+            ),
+            Self::FrameSwitchTargetMissing {
+                body_idx,
+                target_source,
+                num_sources,
+            } => write!(
+                f,
+                "frame switch evaluation: body {body_idx} references target_source \
+                 {target_source} but only {num_sources} source(s) are configured. \
+                 Run validate() before step()."
+            ),
+        }
+    }
+}
+
+impl core::error::Error for StepError {}

--- a/crates/jeod_runner/src/error.rs
+++ b/crates/jeod_runner/src/error.rs
@@ -1,14 +1,36 @@
-//! Error type returned by [`Simulation::step`] and [`Simulation::step_until`].
+//! Error type returned by stepping methods on [`Simulation`](crate::Simulation).
 //!
-//! Per #172 L2, mission-runtime conditions inside `step_internal` (ephemeris
-//! lookup failure, frame-switch target out of range) propagate as a typed
-//! `StepError` rather than aborting the process via `panic!`. This lets
-//! mission programmes catch the failure (Monte Carlo, batch propagation,
-//! resilient long-running services) without resorting to `catch_unwind`.
+//! [`Simulation::step`](crate::Simulation::step),
+//! [`Simulation::step_n`](crate::Simulation::step_n), and
+//! [`Simulation::step_until`](crate::Simulation::step_until) all return
+//! `Result<(), StepError>`. Per #172 L2, mission-runtime conditions inside
+//! `step_internal` (ephemeris lookup failure, frame-switch target out of
+//! range) propagate as a typed `StepError` rather than aborting the process
+//! via `panic!`. This lets mission programmes catch the failure (Monte
+//! Carlo, batch propagation, resilient long-running services) without
+//! resorting to `catch_unwind`.
 //!
 //! Programmer / configuration errors (bad source index passed to an
 //! accessor method, typestate violations) remain `panic!`s — they signal a
 //! bug in the calling code and recovering from them is not meaningful.
+//!
+//! # State semantics on `Err`
+//!
+//! When a stepping method returns `Err`, the simulation has been
+//! **partially advanced** for the failing step. Specifically:
+//!
+//! - [`StepError::EphemerisLookup`] fires after time has advanced but
+//!   before integration runs, so simulation time is ahead by `dt` while
+//!   body states are still at the previous step.
+//! - [`StepError::FrameSwitchTargetMissing`] fires after both time advance
+//!   and integration, but before derived-state computation. Body states
+//!   correspond to the new time but derived states (orbital elements,
+//!   Euler angles, …) lag by one step.
+//!
+//! Either way the state is **not safe to step from again**. Mission code
+//! that wants to recover should reconstruct the simulation from a saved
+//! checkpoint (or from a fresh `SimulationBuilder`) rather than retry the
+//! failing step.
 
 use core::fmt;
 
@@ -37,10 +59,11 @@ pub enum StepError {
         /// Underlying error message from the ephemeris kernel.
         message: String,
     },
-    /// A body's [`crate::FrameSwitch`] referenced a `target_source`
-    /// index that doesn't correspond to any registered gravity source.
-    /// Typically a mid-mission edit hazard caught at step time when
-    /// `Simulation::validate` wasn't re-run after the change.
+    /// A body's [`FrameSwitchConfig`](jeod_sim::FrameSwitchConfig)
+    /// referenced a `target_source` index that doesn't correspond to any
+    /// registered gravity source. Typically a mid-mission edit hazard
+    /// caught at step time when [`Simulation::validate`](crate::Simulation::validate)
+    /// wasn't re-run after the change.
     FrameSwitchTargetMissing {
         /// Index of the body whose frame switch contains the bad target.
         body_idx: usize,
@@ -73,7 +96,9 @@ impl fmt::Display for StepError {
                 f,
                 "frame switch evaluation: body {body_idx} references target_source \
                  {target_source} but only {num_sources} source(s) are configured. \
-                 Run validate() before step()."
+                 Re-run Simulation::validate() before stepping; if a frame switch \
+                 was added or edited mid-mission, also check the body's \
+                 frame_switches list."
             ),
         }
     }

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -46,10 +46,12 @@ use jeod_sim::{
 
 pub mod branded;
 pub mod builder;
+pub mod error;
 pub mod prelude;
 pub mod run_verification;
 
 pub use branded::{BodyIdx, BrandedSimulation, SourceIdx};
+pub use error::StepError;
 
 // Re-export jeod_sim so downstream tests can access types through either path.
 pub use jeod_sim;
@@ -1145,8 +1147,8 @@ impl Simulation {
     /// 7. Force collection and frame derivative computation
     /// 8. State integration (RK4, with sub-stage tree updates)
     /// 9. Derived state computation
-    pub fn step(&mut self) {
-        self.step_internal(self.dt);
+    pub fn step(&mut self) -> Result<(), StepError> {
+        self.step_internal(self.dt)
     }
 
     /// Get the position and velocity of a frame relative to the root inertial frame.
@@ -1182,7 +1184,7 @@ impl Simulation {
 
     /// Internal step with explicit dt (avoids temporary mutation of `self.dt`
     /// in `step_until`).
-    fn step_internal(&mut self, dt: f64) {
+    fn step_internal(&mut self, dt: f64) -> Result<(), StepError> {
         // ── 1. Time update ──
         self.time.advance(dt);
 
@@ -1281,12 +1283,13 @@ impl Simulation {
                 if let Some(Some((target, observer))) = self.source_ephem_bodies.get(i) {
                     let (pos_typed, vel_typed) = eph
                         .get_state_typed(*target, *observer, tdb_jd)
-                        .unwrap_or_else(|e| {
-                            panic!(
-                                "Ephemeris lookup failed for source {i} \
-                                 ({target:?} wrt {observer:?}) at TDB JD {tdb_jd}: {e}"
-                            )
-                        });
+                        .map_err(|e| StepError::EphemerisLookup {
+                            source_idx: i,
+                            target: *target,
+                            observer: *observer,
+                            tdb_jd,
+                            message: e.to_string(),
+                        })?;
                     let (pos, vel) = (pos_typed.raw_si(), vel_typed.raw_si());
                     // Root-mapped sources cannot consume ephemeris position updates:
                     // the root frame must remain identity, so accepting such a
@@ -2107,17 +2110,15 @@ impl Simulation {
                 if !sw.active {
                     continue;
                 }
+                let num_sources = self.source_frame_ids.len();
                 let target_fid = self
                     .source_frame_ids
                     .get(sw.target_source)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "frame switch evaluation: target_source {} out of range; \
-                             {} source(s) configured. Run validate() before step().",
-                            sw.target_source,
-                            self.source_frame_ids.len()
-                        )
-                    })
+                    .ok_or(StepError::FrameSwitchTargetMissing {
+                        body_idx,
+                        target_source: sw.target_source,
+                        num_sources,
+                    })?
                     .inertial;
                 let (target_origin, _) = self.frame_origin(target_fid);
                 let (current_origin, _) = self.frame_origin(self.bodies[body_idx].integ_frame_id);
@@ -2246,22 +2247,24 @@ impl Simulation {
                 }
             }
         }
+        Ok(())
     }
 
     /// Advance the simulation by `n` timesteps.
-    pub fn step_n(&mut self, n: usize) {
+    pub fn step_n(&mut self, n: usize) -> Result<(), StepError> {
         for _ in 0..n {
-            self.step();
+            self.step()?;
         }
+        Ok(())
     }
 
     /// Advance the simulation until `target_time` (in simulation seconds).
     ///
     /// Steps at `self.dt` until the remaining time is less than `dt`,
     /// then takes a final fractional step if the remainder exceeds 1 ms.
-    pub fn step_until(&mut self, target_time: f64) {
+    pub fn step_until(&mut self, target_time: f64) -> Result<(), StepError> {
         while self.time.simtime + self.dt <= target_time + 0.001 {
-            self.step();
+            self.step()?;
         }
         let remainder = target_time - self.time.simtime;
         if remainder > 0.001 {
@@ -2282,8 +2285,9 @@ impl Simulation {
                  Ensure target_time is an integer multiple of dt.",
                 self.dt
             );
-            self.step_internal(remainder);
+            self.step_internal(remainder)?;
         }
+        Ok(())
     }
 
     // JEOD_INV: DS.01 — derived state config immutable after init; read-only access only

--- a/crates/jeod_runner/src/run_verification/mod.rs
+++ b/crates/jeod_runner/src/run_verification/mod.rs
@@ -181,7 +181,8 @@ impl VerificationCaseExt for VerificationCase {
             if let Some(hook) = pre_step.as_mut() {
                 hook(&mut sim, record.time);
             }
-            sim.step_until(record.time);
+            sim.step_until(record.time)
+                .unwrap_or_else(|e| panic!("{}: step_until failed: {e}", self.name));
             let body = sim.body(0);
             if let Some(acc) = extras_acc.as_mut() {
                 acc.observe(&body, &sim, &typed_records, idx, self.name);

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -144,7 +144,7 @@ fn pipeline_earth_lighting_smoke() {
     let mut shadow_count = 0;
 
     for _ in 0..num_steps {
-        sim.step();
+        sim.step().expect("step failed");
 
         let body = sim.body(0);
         let lighting = body

--- a/crates/jeod_runner/tests/step_error_destructure.rs
+++ b/crates/jeod_runner/tests/step_error_destructure.rs
@@ -1,0 +1,84 @@
+//! Compile-time witness that `StepError` variant fields are part of the
+//! public surface and can be destructured from a downstream crate.
+//!
+//! Background: a review of #172 L2 raised the concern that struct-variant
+//! fields (`source_idx`, `tdb_jd`, `body_idx`, …) might be inaccessible
+//! to downstream recovery logic. In Rust, an enum variant's fields inherit
+//! the enum's visibility, so when the enum is `pub` the fields are part
+//! of the public surface and `pub field: T` syntax is neither needed nor
+//! accepted. This integration test proves the pattern by destructuring
+//! both variants from outside `jeod_runner::error` (specifically, from a
+//! `tests/` integration target, which sits in the same crate-as-consumer
+//! position downstream code does).
+//!
+//! The `error_path_executes_known_unwrap` smoke test additionally
+//! confirms `StepError` round-trips through the `Display` /
+//! `core::error::Error` traits without panicking.
+
+use jeod_runner::StepError;
+use jeod_sim::EphemerisBody;
+
+#[test]
+fn ephemeris_lookup_destructures_all_fields() {
+    let err = StepError::EphemerisLookup {
+        source_idx: 7,
+        target: EphemerisBody::Sun,
+        observer: EphemerisBody::Earth,
+        tdb_jd: 2_460_000.5,
+        message: "test failure".to_string(),
+    };
+    match err {
+        StepError::EphemerisLookup {
+            source_idx,
+            target,
+            observer,
+            tdb_jd,
+            message,
+        } => {
+            assert_eq!(source_idx, 7);
+            assert_eq!(target, EphemerisBody::Sun);
+            assert_eq!(observer, EphemerisBody::Earth);
+            assert!((tdb_jd - 2_460_000.5).abs() < 1e-9);
+            assert_eq!(message, "test failure");
+        }
+        StepError::FrameSwitchTargetMissing { .. } => {
+            panic!("matched the wrong variant")
+        }
+    }
+}
+
+#[test]
+fn frame_switch_target_missing_destructures_all_fields() {
+    let err = StepError::FrameSwitchTargetMissing {
+        body_idx: 3,
+        target_source: 99,
+        num_sources: 4,
+    };
+    match err {
+        StepError::FrameSwitchTargetMissing {
+            body_idx,
+            target_source,
+            num_sources,
+        } => {
+            assert_eq!(body_idx, 3);
+            assert_eq!(target_source, 99);
+            assert_eq!(num_sources, 4);
+        }
+        StepError::EphemerisLookup { .. } => panic!("matched the wrong variant"),
+    }
+}
+
+#[test]
+fn step_error_implements_core_error() {
+    let err = StepError::FrameSwitchTargetMissing {
+        body_idx: 0,
+        target_source: 0,
+        num_sources: 0,
+    };
+    // Smoke check: the trait composition (Display + core::error::Error)
+    // works through trait objects, which is what `?` and downstream
+    // error wrappers rely on.
+    let dyn_err: &dyn core::error::Error = &err;
+    let msg = format!("{dyn_err}");
+    assert!(msg.contains("frame switch evaluation"));
+}

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -277,7 +277,7 @@ fn tier3_apollo8_eci_integ() {
     let mut ref_log = Vec::with_capacity(steps);
 
     for step in 0..steps {
-        sim.step();
+        sim.step().expect("step failed");
 
         let ref_idx = step + 1;
         if ref_idx < ref_states.len() {
@@ -329,7 +329,7 @@ fn tier3_apollo8_frame_switch() {
     let mut max_err_moon = 0.0_f64;
 
     for step in 0..steps {
-        sim.step();
+        sim.step().expect("step failed");
         let ref_idx = step + 1;
         if ref_idx >= ref_positions.len() {
             break;

--- a/crates/jeod_runner/tests/tier3_sim_battin.rs
+++ b/crates/jeod_runner/tests/tier3_sim_battin.rs
@@ -228,7 +228,7 @@ fn propagate(
             earth_centered_state(EphemerisBody::Moon, target_tdb_jd, ephemeris);
         sim.set_source_state(moon_source, moon_pos, moon_vel);
 
-        sim.step_until(target_time);
+        sim.step_until(target_time).expect("step_until failed");
 
         let body = sim.body(0);
         times.push(target_time);

--- a/crates/jeod_runner/tests/tier3_sim_contact.rs
+++ b/crates/jeod_runner/tests/tier3_sim_contact.rs
@@ -298,7 +298,7 @@ fn propagate_with_contact(
             break;
         }
 
-        sim.step_n(1);
+        sim.step_n(1).expect("step_n failed");
     }
     out
 }

--- a/crates/jeod_runner/tests/tier3_sim_drag_6dof.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_6dof.rs
@@ -140,7 +140,7 @@ fn tier3_drag_with_rotation_energy_loss() {
     // Propagate for 1 orbit
     let period = 2.0 * std::f64::consts::PI * (r.powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     let e_final = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
@@ -224,8 +224,8 @@ fn tier3_drag_attitude_invariance_ballistic() {
     // Propagate for 1 orbit
     let period = 2.0 * std::f64::consts::PI * (r.powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
-    sim1.step_n(n_steps);
-    sim2.step_n(n_steps);
+    sim1.step_n(n_steps).expect("step_n failed");
+    sim2.step_n(n_steps).expect("step_n failed");
 
     let body1 = sim1.body(0);
     let body2 = sim2.body(0);

--- a/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_analytical.rs
@@ -139,7 +139,7 @@ fn tier3_drag_constant_density_energy_loss() {
     // Propagate for 1 orbit (~92 min at 400 km)
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     let e_final = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
@@ -187,7 +187,7 @@ fn tier3_drag_altitude_decay() {
     // Propagate for 2 orbits
     let period = 2.0 * std::f64::consts::PI * (a_initial.powi(3) / MU_EARTH).sqrt();
     let n_steps = (2.0 * period / dt) as usize;
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     let a_final = semi_major_axis_from_energy(
@@ -241,7 +241,7 @@ fn tier3_drag_higher_density_faster_decay() {
     // Case 1: low density
     let density_low = 1e-12;
     let mut sim_low = make_drag_sim(pos, vel, mass, cd, area, density_low, dt);
-    sim_low.step_n(n_steps);
+    sim_low.step_n(n_steps).expect("step_n failed");
     let body_low = sim_low.body(0);
     let e_loss_low = e_initial
         - specific_orbital_energy(body_low.trans.position, body_low.trans.velocity, MU_EARTH);
@@ -249,7 +249,7 @@ fn tier3_drag_higher_density_faster_decay() {
     // Case 2: high density (10x)
     let density_high = 1e-11;
     let mut sim_high = make_drag_sim(pos, vel, mass, cd, area, density_high, dt);
-    sim_high.step_n(n_steps);
+    sim_high.step_n(n_steps).expect("step_n failed");
     let body_high = sim_high.body(0);
     let e_loss_high = e_initial
         - specific_orbital_energy(body_high.trans.position, body_high.trans.velocity, MU_EARTH);
@@ -289,7 +289,7 @@ fn tier3_drag_larger_area_faster_decay() {
     // Case 1: small area
     let area_small = 5.0;
     let mut sim_small = make_drag_sim(pos, vel, mass, cd, area_small, density, dt);
-    sim_small.step_n(n_steps);
+    sim_small.step_n(n_steps).expect("step_n failed");
     let body_small = sim_small.body(0);
     let e_loss_small = e_initial
         - specific_orbital_energy(
@@ -301,7 +301,7 @@ fn tier3_drag_larger_area_faster_decay() {
     // Case 2: large area (4x)
     let area_large = 20.0;
     let mut sim_large = make_drag_sim(pos, vel, mass, cd, area_large, density, dt);
-    sim_large.step_n(n_steps);
+    sim_large.step_n(n_steps).expect("step_n failed");
     let body_large = sim_large.body(0);
     let e_loss_large = e_initial
         - specific_orbital_energy(
@@ -344,7 +344,7 @@ fn tier3_drag_no_drag_at_zero_density() {
     // Propagate for 1 orbit
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     let e_final = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
@@ -410,14 +410,14 @@ fn tier3_drag_corotation_wind_effect() {
 
     // Prograde orbit with co-rotation wind
     let mut sim_pro = make_drag_sim_with_wind(pos, vel_prograde, mass, cd, area, density, dt);
-    sim_pro.step_n(n_steps);
+    sim_pro.step_n(n_steps).expect("step_n failed");
     let body_pro = sim_pro.body(0);
     let e_loss_pro = e_initial
         - specific_orbital_energy(body_pro.trans.position, body_pro.trans.velocity, MU_EARTH);
 
     // Retrograde orbit with co-rotation wind
     let mut sim_retro = make_drag_sim_with_wind(pos, vel_retrograde, mass, cd, area, density, dt);
-    sim_retro.step_n(n_steps);
+    sim_retro.step_n(n_steps).expect("step_n failed");
     let body_retro = sim_retro.body(0);
     // For retrograde, initial energy is the same magnitude
     let e_loss_retro = e_initial

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_combinations.rs
@@ -121,7 +121,7 @@ fn tier3_dyncomp_point_mass_3dof_conservation() {
     // Propagate for 3 orbits.
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
     let n_steps = (3.0 * period / dt) as usize;
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     let e1 = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
@@ -227,7 +227,7 @@ fn tier3_dyncomp_point_mass_plus_thirdbody_conservation() {
     // Integrate for one orbit.
     let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
     let n_steps = (period / dt) as usize;
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     let e1 = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
@@ -324,7 +324,7 @@ fn tier3_dyncomp_drag_point_mass_monotonic_decay() {
 
     let mut sma_samples = Vec::new();
     for _ in 0..5 {
-        sim.step_n(steps_per_orbit);
+        sim.step_n(steps_per_orbit).expect("step_n failed");
         let body = sim.body(0);
         let e = specific_orbital_energy(body.trans.position, body.trans.velocity, MU_EARTH);
         let a = -MU_EARTH / (2.0 * e);
@@ -409,7 +409,7 @@ fn tier3_dyncomp_6dof_rigid_body_invariance() {
     let h_inertial_0 = t0.transpose() * h_body0;
 
     // Propagate for 60 seconds.
-    sim.step_n((60.0 / dt) as usize);
+    sim.step_n((60.0 / dt) as usize).expect("step_n failed");
 
     let body = sim.body(0);
     let q1 = body.rot.as_ref().unwrap().quaternion;
@@ -462,7 +462,8 @@ fn tier3_dyncomp_external_force_impulse_response() {
 
     // Apply force for force_duration seconds.
     sim.set_body_external_force(0, force_inertial);
-    sim.step_n((force_duration / dt) as usize);
+    sim.step_n((force_duration / dt) as usize)
+        .expect("step_n failed");
     sim.set_body_external_force(0, DVec3::ZERO);
 
     let v_after = sim.body(0).trans.velocity;
@@ -474,7 +475,9 @@ fn tier3_dyncomp_external_force_impulse_response() {
     let mut ref_sim = make_kepler_sim(pos, vel0, mass, dt);
     // Advance the reference simulation by the same elapsed time as the force
     // window started at t=0 and lasted `force_duration`.
-    ref_sim.step_n((force_duration / dt) as usize);
+    ref_sim
+        .step_n((force_duration / dt) as usize)
+        .expect("step_n failed");
     let v_reference = ref_sim.body(0).trans.velocity;
 
     let force_delta_v = v_after - v_reference;
@@ -557,7 +560,8 @@ fn tier3_dyncomp_external_torque_impulse_response() {
 
     // Apply torque window.
     sim.set_body_external_torque(0, torque_body);
-    sim.step_n((torque_duration / dt) as usize);
+    sim.step_n((torque_duration / dt) as usize)
+        .expect("step_n failed");
     sim.set_body_external_torque(0, DVec3::ZERO);
 
     let omega_after = sim.body(0).rot.as_ref().unwrap().ang_vel_body;
@@ -643,7 +647,7 @@ fn tier3_dyncomp_attitude_stability_major_axis() {
     // Propagate 60 s and sample omega regularly.
     let mut max_perp = 0.0_f64;
     for _ in 0..600 {
-        sim.step_n(1);
+        sim.step_n(1).expect("step_n failed");
         let omega = sim.body(0).rot.as_ref().unwrap().ang_vel_body;
         let perp = (omega.x.powi(2) + omega.y.powi(2)).sqrt();
         if perp > max_perp {

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
@@ -137,7 +137,7 @@ where
         let (force, torque) = force_torque_fn(sim.elapsed(), &quat);
         sim.set_body_external_force(0, force);
         sim.set_body_external_torque(0, torque);
-        sim.step();
+        sim.step().expect("step failed");
     }
     // Fractional remainder
     let remainder = target_time - sim.elapsed();
@@ -147,7 +147,7 @@ where
         sim.set_body_external_force(0, force);
         sim.set_body_external_torque(0, torque);
         sim.set_dt(remainder);
-        sim.step();
+        sim.step().expect("step failed");
         sim.set_dt(dt);
     }
 }

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -223,7 +223,7 @@ fn tier3_simulation_earth_moon_clem() {
     }];
 
     for (i, record) in ref_states[1..].iter().enumerate() {
-        sim.step_until(record.time);
+        sim.step_until(record.time).expect("step_until failed");
         let body = sim.body(0);
         if i == 0 {
             let jeod_pos = record.position.unwrap();

--- a/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
+++ b/crates/jeod_runner/tests/tier3_sim_force_torque_response.rs
@@ -120,7 +120,7 @@ fn tier3_force_constant_acceleration() {
 
     let mut sim = make_free_body_3dof(mass, dt);
     sim.set_body_external_force(0, force);
-    sim.step_n((t_total / dt) as usize);
+    sim.step_n((t_total / dt) as usize).expect("step_n failed");
 
     let body = sim.body(0);
 
@@ -172,7 +172,7 @@ fn tier3_torque_constant_angular_acceleration() {
 
     let mut sim = make_free_body_6dof(mass, inertia, dt);
     sim.set_body_external_torque(0, tau);
-    sim.step_n((t_total / dt) as usize);
+    sim.step_n((t_total / dt) as usize).expect("step_n failed");
 
     let body = sim.body(0);
     let omega = body.rot.as_ref().unwrap().ang_vel_body;
@@ -227,14 +227,18 @@ fn tier3_force_and_torque_decoupled() {
     // Case A: only force.
     let mut sim_a = make_free_body_6dof(mass, inertia, dt);
     sim_a.set_body_external_force(0, force);
-    sim_a.step_n((t_total / dt) as usize);
+    sim_a
+        .step_n((t_total / dt) as usize)
+        .expect("step_n failed");
     let v_a = sim_a.body(0).trans.velocity;
     let omega_a = sim_a.body(0).rot.as_ref().unwrap().ang_vel_body;
 
     // Case B: only torque.
     let mut sim_b = make_free_body_6dof(mass, inertia, dt);
     sim_b.set_body_external_torque(0, tau);
-    sim_b.step_n((t_total / dt) as usize);
+    sim_b
+        .step_n((t_total / dt) as usize)
+        .expect("step_n failed");
     let v_b = sim_b.body(0).trans.velocity;
     let omega_b = sim_b.body(0).rot.as_ref().unwrap().ang_vel_body;
 
@@ -242,7 +246,9 @@ fn tier3_force_and_torque_decoupled() {
     let mut sim_c = make_free_body_6dof(mass, inertia, dt);
     sim_c.set_body_external_force(0, force);
     sim_c.set_body_external_torque(0, tau);
-    sim_c.step_n((t_total / dt) as usize);
+    sim_c
+        .step_n((t_total / dt) as usize)
+        .expect("step_n failed");
     let v_c = sim_c.body(0).trans.velocity;
     let omega_c = sim_c.body(0).rot.as_ref().unwrap().ang_vel_body;
 
@@ -306,11 +312,13 @@ fn tier3_force_symmetric_impulse_returns_to_rest() {
 
     let mut sim = make_free_body_3dof(mass, dt);
     sim.set_body_external_force(0, force);
-    sim.step_n((half_duration / dt) as usize);
+    sim.step_n((half_duration / dt) as usize)
+        .expect("step_n failed");
     let v_mid = sim.body(0).trans.velocity;
 
     sim.set_body_external_force(0, -force);
-    sim.step_n((half_duration / dt) as usize);
+    sim.step_n((half_duration / dt) as usize)
+        .expect("step_n failed");
     let v_end = sim.body(0).trans.velocity;
     let x_end = sim.body(0).trans.position;
 

--- a/crates/jeod_runner/tests/tier3_sim_gj.rs
+++ b/crates/jeod_runner/tests/tier3_sim_gj.rs
@@ -112,7 +112,7 @@ fn run_gj_test(
 
     let mut our_states = Vec::with_capacity(trajectory.len() - 1);
     for record in &trajectory[1..] {
-        sim.step_until(record.time);
+        sim.step_until(record.time).expect("step_until failed");
         let body = sim.body(0);
         our_states.push(StateLog {
             time: record.time,

--- a/crates/jeod_runner/tests/tier3_sim_integ_analytical.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_analytical.rs
@@ -121,7 +121,7 @@ fn compare_analytical(integrator: IntegratorType, dt: f64) -> AnalyticalResult {
 
     for i in 1..=n_steps {
         let t = (i as f64) * dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
         let body = sim.body(0);
 
         let pos_err = (body.trans.position - analytical_position(t)).length();

--- a/crates/jeod_runner/tests/tier3_sim_integ_comparison.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_comparison.rs
@@ -109,7 +109,7 @@ fn propagate_one_orbit(integrator: IntegratorType, dt: f64) -> (DVec3, DVec3, f6
 
     for i in 1..=n_steps {
         let t = (i as f64) * adjusted_dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
         let body = sim.body(0);
         monitor.observe(body.trans.position, body.trans.velocity);
     }
@@ -222,7 +222,7 @@ fn tier3_integ_rk4_vs_gj_agreement() {
 /// Propagate for a fixed duration and return the final position.
 fn propagate_fixed_time(integrator: IntegratorType, dt: f64, duration: f64) -> DVec3 {
     let mut sim = make_sim(integrator, dt);
-    sim.step_until(duration);
+    sim.step_until(duration).expect("step_until failed");
     sim.body(0).trans.position
 }
 

--- a/crates/jeod_runner/tests/tier3_sim_integ_gj_orders.rs
+++ b/crates/jeod_runner/tests/tier3_sim_integ_gj_orders.rs
@@ -92,7 +92,7 @@ fn gj_energy_error(order: usize) -> f64 {
 
     let mut max_rel_err = 0.0_f64;
     for _ in 1..=n_steps {
-        sim.step();
+        sim.step().expect("step failed");
         let body = sim.body(0);
         let e = specific_energy(body.trans.position, body.trans.velocity);
         let rel_err = ((e - e0) / e0).abs();

--- a/crates/jeod_runner/tests/tier3_sim_lsode.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lsode.rs
@@ -215,7 +215,7 @@ fn run_integ_test(
 
     let mut our_states = Vec::with_capacity(trajectory.len() - 1);
     for record in &trajectory[1..] {
-        sim.step_until(record.time);
+        sim.step_until(record.time).expect("step_until failed");
         let body = sim.body(0);
         our_states.push(StateLog {
             time: record.time,

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
@@ -108,7 +108,7 @@ fn tier3_lvlh_retrograde_orbit() {
         },
     );
     sim_prograde.validate().unwrap();
-    sim_prograde.step_until(dt);
+    sim_prograde.step_until(dt).expect("step_until failed");
     let lvlh_p = sim_prograde
         .body(0)
         .lvlh_frame
@@ -125,7 +125,7 @@ fn tier3_lvlh_retrograde_orbit() {
         },
     );
     sim_retro.validate().unwrap();
-    sim_retro.step_until(dt);
+    sim_retro.step_until(dt).expect("step_until failed");
     let lvlh_r = sim_retro
         .body(0)
         .lvlh_frame
@@ -199,7 +199,7 @@ fn tier3_lvlh_eccentric_orbit() {
     let mut omega_at_min_r = 0.0_f64;
     let mut omega_at_max_r = 0.0_f64;
     for step in 1..=n_steps {
-        sim.step_until(step as f64 * dt);
+        sim.step_until(step as f64 * dt).expect("step_until failed");
         let body = sim.body(0);
         let r = body.trans.position.length();
         let lvlh = body.lvlh_frame.expect("LVLH not computed");
@@ -282,7 +282,8 @@ fn tier3_lvlh_periodicity() {
             .t_parent_this;
 
     // Propagate exactly one orbital period.
-    sim.step_until(n_steps as f64 * dt);
+    sim.step_until(n_steps as f64 * dt)
+        .expect("step_until failed");
     let lvlh_final = sim
         .body(0)
         .lvlh_frame

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_relative.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_relative.rs
@@ -111,7 +111,7 @@ fn run_lvlhrel_scenario(label: &str, csv_name: &str) {
 
     // Step through remaining records
     for rec in &records[1..] {
-        sim.step_until(rec.time);
+        sim.step_until(rec.time).expect("step_until failed");
 
         let ref_body = sim.body(0);
         let subj_body = sim.body(1);

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -175,7 +175,7 @@ fn tier3_simulation_mars_dawn() {
     }];
 
     for (i, record) in ref_states[1..].iter().enumerate() {
-        sim.step_until(record.time);
+        sim.step_until(record.time).expect("step_until failed");
         let body = sim.body(0);
         if i < 3 || i == ref_states.len() - 2 {
             let err = (body.trans.position - record.position.unwrap()).length();

--- a/crates/jeod_runner/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mercury.rs
@@ -99,7 +99,7 @@ fn propagate_mercury_periapses(
     let mut sim_time = 0.0_f64;
 
     for step in 0..steps {
-        sim.step();
+        sim.step().expect("step failed");
         sim_time += dt;
         let body = sim.body(0);
         let r = body.trans.position;
@@ -284,7 +284,7 @@ fn tier3_simulation_mercury_relativistic_effect() {
     });
     sim_n.validate().unwrap();
     let steps = (total_time / dt) as usize;
-    sim_n.step_n(steps);
+    sim_n.step_n(steps).expect("step_n failed");
     let newton_final = sim_n.body(0).trans.position;
 
     // Relativistic run
@@ -314,7 +314,7 @@ fn tier3_simulation_mercury_relativistic_effect() {
         ..Default::default()
     });
     sim_r.validate().unwrap();
-    sim_r.step_n(steps);
+    sim_r.step_n(steps).expect("step_n failed");
     let gr_final = sim_r.body(0).trans.position;
 
     // The two trajectories should diverge due to GR

--- a/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
@@ -166,7 +166,7 @@ fn verify_orbit_family(csv_name: &str, label: &str, skip_degenerate_scalars: boo
     sim.validate().unwrap();
 
     // Step once to trigger derived-state computation (stage 9)
-    sim.step();
+    sim.step().expect("step failed");
 
     let output = sim.body(0);
     let oe = output

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
@@ -98,7 +98,7 @@ fn tier3_simulation_orbinit_cross_consistency() {
         sim.validate().unwrap();
 
         // Step once to exercise the full pipeline
-        sim.step();
+        sim.step().expect("step failed");
 
         // Read back the body state after one step (confirms pipeline ran)
         let body = sim.body(0);

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_families.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_families.rs
@@ -114,7 +114,7 @@ fn verify_conservation(
     let mut max_r = r0;
 
     for step in 1..=n_steps {
-        sim.step();
+        sim.step().expect("step failed");
         let body = sim.body(0);
         let energy_now = specific_energy(body.trans.position, body.trans.velocity, MU_EARTH);
         let h_now = specific_ang_momentum(body.trans.position, body.trans.velocity);
@@ -344,7 +344,7 @@ fn tier3_orbinit_equatorial() {
     let mut eq_sim = build_sim(trans, dt);
     let mut max_z_frac = 0.0_f64;
     for _ in 0..n_steps {
-        eq_sim.step();
+        eq_sim.step().expect("step failed");
         let body = eq_sim.body(0);
         let z_frac = body.trans.position.z.abs() / body.trans.position.length();
         max_z_frac = max_z_frac.max(z_frac);
@@ -385,7 +385,7 @@ fn tier3_orbinit_polar() {
     // track the maximum |z|/r ratio across steps.
     let mut max_z_frac = 0.0_f64;
     for _ in 0..n_steps {
-        sim.step();
+        sim.step().expect("step failed");
         let body = sim.body(0);
         let z_frac = body.trans.position.z.abs() / body.trans.position.length();
         max_z_frac = max_z_frac.max(z_frac);

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_roundtrip.rs
@@ -81,7 +81,7 @@ fn roundtrip_via_simulation(
     });
 
     sim.validate().unwrap();
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     use jeod_sim::{F64Ext, Inertial, Vec3Ext};
@@ -216,7 +216,7 @@ fn tier3_orbinit_roundtrip_circular() {
     let energy_0 =
         body0.trans.velocity.length_squared() / 2.0 - MU_EARTH / body0.trans.position.length();
 
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     use jeod_sim::{F64Ext, Inertial, Vec3Ext};

--- a/crates/jeod_runner/tests/tier3_sim_relative.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative.rs
@@ -131,7 +131,7 @@ fn run_relative_scenario(label: &str, csv_name: &str) {
 
     // Step through remaining records
     for rec in &records[1..] {
-        sim.step_until(rec.time);
+        sim.step_until(rec.time).expect("step_until failed");
 
         let a = sim.body(0);
         let b = sim.body(1);

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -132,7 +132,7 @@ fn tier3_relative_two_coorbiting_vehicles() {
 
     for step in 1..=n_steps {
         let t = step as f64 * dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
 
         let chief = sim.body(0);
         let deputy = sim.body(1);
@@ -238,7 +238,7 @@ fn tier3_relative_hohmann_transfer_geometry() {
 
     for step in 1..=n_steps {
         let t = step as f64 * dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
 
         let chief = sim.body(0);
         let deputy = sim.body(1);
@@ -315,7 +315,7 @@ fn tier3_relative_same_orbit_phase_difference() {
     let n_steps = (2.0 * period / dt) as usize;
     for step in 1..=n_steps {
         let t = step as f64 * dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
         let a = sim.body(0);
         let b = sim.body(1);
         let rel = compute_relative_state(&a.trans, None, &b.trans, None);
@@ -376,7 +376,7 @@ fn tier3_relative_different_inclinations() {
     let mut max_abs_z = 0.0_f64; // inertial Z separation (cross-track)
     for step in 1..=n_steps {
         let t = step as f64 * dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
 
         let chief = sim.body(0);
         let deputy = sim.body(1);
@@ -437,7 +437,7 @@ fn tier3_relative_round_trip_frames() {
 
     for step in 1..=n_steps {
         let t = step as f64 * dt;
-        sim.step_until(t);
+        sim.step_until(t).expect("step_until failed");
 
         let a = sim.body(0);
         let b = sim.body(1);

--- a/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
+++ b/crates/jeod_runner/tests/tier3_sim_shadow_2a.rs
@@ -161,7 +161,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
     for (i, record) in records.iter().enumerate() {
         // Advance time + ephemeris before comparing (skip for t=0)
         if i > 0 {
-            sim.step();
+            sim.step().expect("step failed");
         }
 
         // Set prescribed position (matching JEOD's non-integrated motion)

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
@@ -138,7 +138,8 @@ fn tier3_solar_beta_equatorial_at_equinox() {
 
     let mut max_beta = 0.0_f64;
     for step in 1..=n_steps {
-        sim.step_until(step as f64 * 10.0);
+        sim.step_until(step as f64 * 10.0)
+            .expect("step_until failed");
         let beta = sim.body(0).solar_beta.expect("solar beta not computed");
         max_beta = max_beta.max(beta.abs());
     }
@@ -181,7 +182,7 @@ fn tier3_solar_beta_polar_orbit() {
     for (sun_pos, expected_deg) in cases {
         let mut sim = build_solar_beta_sim(mu_earth, 10.0, sun_pos, body);
         sim.validate().unwrap();
-        sim.step_until(10.0); // derived state is populated after first step
+        sim.step_until(10.0).expect("step_until failed"); // derived state is populated after first step
         let beta = sim.body(0).solar_beta.expect("solar beta not computed");
         let expected = expected_deg.to_radians();
         assert!(
@@ -220,7 +221,7 @@ fn tier3_solar_beta_iss_orbit() {
         let mut sim =
             build_solar_beta_sim(mu_earth, 10.0, DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), body);
         sim.validate().unwrap();
-        sim.step_until(10.0);
+        sim.step_until(10.0).expect("step_until failed");
         let beta = sim.body(0).solar_beta.expect("solar beta not computed");
         assert!(
             beta.abs() < 1e-4,
@@ -233,7 +234,7 @@ fn tier3_solar_beta_iss_orbit() {
         let mut sim =
             build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, 0.0, SUN_DISTANCE_M), body);
         sim.validate().unwrap();
-        sim.step_until(10.0);
+        sim.step_until(10.0).expect("step_until failed");
         let beta = sim.body(0).solar_beta.expect("solar beta not computed");
         let expected = std::f64::consts::FRAC_PI_2 - inc;
         assert!(
@@ -248,7 +249,7 @@ fn tier3_solar_beta_iss_orbit() {
         let mut sim =
             build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, -SUN_DISTANCE_M, 0.0), body);
         sim.validate().unwrap();
-        sim.step_until(10.0);
+        sim.step_until(10.0).expect("step_until failed");
         let beta = sim.body(0).solar_beta.expect("solar beta not computed");
         assert!(
             (beta - inc).abs() < 1e-4,
@@ -278,7 +279,7 @@ fn tier3_solar_beta_sun_in_orbital_plane() {
     // Sun along +X lies in the plane since +X · (orbit normal) = 0.
     let mut sim = build_solar_beta_sim(mu_earth, 10.0, DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), body);
     sim.validate().unwrap();
-    sim.step_until(10.0);
+    sim.step_until(10.0).expect("step_until failed");
     let beta = sim.body(0).solar_beta.expect("solar beta not computed");
     assert!(
         beta.abs() < 1e-4,
@@ -301,7 +302,7 @@ fn tier3_solar_beta_sun_perpendicular_to_plane() {
 
     let mut sim = build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, 0.0, SUN_DISTANCE_M), body);
     sim.validate().unwrap();
-    sim.step_until(10.0);
+    sim.step_until(10.0).expect("step_until failed");
     let beta = sim.body(0).solar_beta.expect("solar beta not computed");
 
     let pi_2 = std::f64::consts::FRAC_PI_2;
@@ -352,7 +353,8 @@ fn tier3_solar_beta_bounded() {
     let pi_2 = std::f64::consts::FRAC_PI_2;
     let mut max_abs_beta = 0.0_f64;
     for step in 1..=n_steps {
-        sim.step_until(step as f64 * 10.0);
+        sim.step_until(step as f64 * 10.0)
+            .expect("step_until failed");
         let beta = sim.body(0).solar_beta.expect("solar beta not computed");
         // Absolute bound from the asin definition.
         assert!(

--- a/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_basic.rs
@@ -162,7 +162,7 @@ fn run_srp_basic_test(csv_filename: &str, label: &str) {
     // Note: radiation_force is not exposed on VehicleOutput; force/torque
     // comparison is validated at the integration level through trajectory tests.
     for rec in records.iter().skip(1) {
-        sim.step_until(rec.time);
+        sim.step_until(rec.time).expect("step_until failed");
     }
 
     // Verify the simulation completed without error.

--- a/crates/jeod_runner/tests/tier3_sim_srp_rk4_thermal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_rk4_thermal.rs
@@ -95,7 +95,7 @@ fn run_with_order(order: ThermalIntegrationOrder) -> (f64, DVec3) {
     sim.validate().unwrap();
     // 20 steps at dt=10s.
     for _ in 0..20 {
-        sim.step();
+        sim.step().expect("step failed");
     }
 
     let t = sim

--- a/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
@@ -162,7 +162,7 @@ fn tier3_sim_time_reversal_run1() {
             sim.time.time_scale_factor = -1.0;
         }
 
-        sim.step_until(rec.time);
+        sim.step_until(rec.time).expect("step_until failed");
 
         let body = sim.body(0);
         let pos_err = (body.trans.position - rec.position).length();

--- a/crates/jeod_runner/tests/tier3_sim_timescale.rs
+++ b/crates/jeod_runner/tests/tier3_sim_timescale.rs
@@ -92,7 +92,7 @@ fn tier3_simulation_timescale_tdb() {
 
     for (i, rec) in records.iter().enumerate() {
         if i > 0 {
-            sim.step();
+            sim.step().expect("step failed");
         }
 
         let tai_err = (sim.time.tai_tjt - rec.tai_tjt).abs() * SECONDS_PER_DAY;

--- a/tests/bevy_parity.rs
+++ b/tests/bevy_parity.rs
@@ -149,7 +149,7 @@ fn run_simulation_steps() -> SixDofState {
     });
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     SixDofState {
@@ -288,7 +288,7 @@ fn tier3_bevy_rkf45_matches_simulation_bit_identical() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {

--- a/tests/bevy_parity_derived_state.rs
+++ b/tests/bevy_parity_derived_state.rs
@@ -122,7 +122,7 @@ fn tier3_bevy_derived_states() {
     sim.add_body(body);
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -239,7 +239,7 @@ fn tier3_bevy_geodetic_derived_state() {
     sim.add_body(body);
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     assert_trans_eq("Bevy vs Sim (geodetic)", &bevy_trans, &sim_body.trans);
@@ -380,7 +380,7 @@ fn tier3_bevy_eccentric_derived_states() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -507,7 +507,7 @@ fn tier3_bevy_polar_geodetic() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     assert_trans_eq("Bevy vs Sim (polar geodetic)", &bevy_trans, &sim_body.trans);
@@ -625,7 +625,7 @@ fn tier3_bevy_equatorial_solar_beta() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -696,7 +696,7 @@ fn run_euler_parity(label: &str, trans: TranslationalState, sequence: EulerSeque
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -775,7 +775,7 @@ fn run_lvlh_parity(label: &str, trans: TranslationalState) {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     assert_trans_eq(
@@ -892,7 +892,7 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     assert_trans_eq(
@@ -967,7 +967,7 @@ fn run_orbelem_parity(label: &str, trans: TranslationalState) {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step();
+    sim.step().expect("step failed");
 
     let sim_output = sim.body(0);
     let sim_oe = sim_output.orbital_elements.as_ref().expect("OE computed");
@@ -1085,7 +1085,7 @@ fn tier3_bevy_orbelem() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_output = sim.body(0);
     let sim_oe = sim_output.orbital_elements.as_ref().expect("OE computed");
@@ -1157,7 +1157,7 @@ fn tier3_bevy_solar_beta() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_beta = sim.body(0).solar_beta.expect("solar beta computed");
     assert_bits_eq("Bevy vs Sim", "solar_beta", bevy_beta, sim_beta);

--- a/tests/bevy_parity_drag.rs
+++ b/tests/bevy_parity_drag.rs
@@ -94,7 +94,7 @@ fn tier3_bevy_drag_atmosphere_sixdof() {
     body.drag = Some(drag_config);
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {
@@ -182,7 +182,7 @@ fn tier3_bevy_constant_density_drag_sixdof() {
     body.drag = Some(drag_config);
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {
@@ -288,7 +288,7 @@ fn tier3_bevy_met_atmosphere_drag_sixdof() {
     body.drag = Some(drag_config);
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {
@@ -392,7 +392,7 @@ fn tier3_bevy_met_run5a() {
     });
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -492,7 +492,7 @@ fn tier3_bevy_drag_run6b() {
     body.drag = Some(drag_config);
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {

--- a/tests/bevy_parity_gj.rs
+++ b/tests/bevy_parity_gj.rs
@@ -160,7 +160,7 @@ fn run_gj_parity(
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let sim_trans = sim.body(0).trans;
     assert_trans_eq(label, &bevy_trans, &sim_trans);

--- a/tests/bevy_parity_gravity_torque.rs
+++ b/tests/bevy_parity_gravity_torque.rs
@@ -70,7 +70,7 @@ fn tier3_bevy_gravity_torque_sixdof() {
     body.compute_gravity_gradient = true;
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {
@@ -193,7 +193,7 @@ fn tier3_bevy_external_torque_per_body() {
             DVec3::ZERO
         };
         sim.set_body_external_torque(0, torque);
-        sim.step();
+        sim.step().expect("step failed");
     }
 
     let state_a = SixDofState {
@@ -253,7 +253,7 @@ fn run_gravity_torque_parity(label: &str, trans: TranslationalState, rot: Rotati
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -372,7 +372,7 @@ fn run_external_parity(
             .resource_mut::<Time<Fixed>>()
             .advance_by(std::time::Duration::from_secs_f64(dt));
         app.world_mut().run_schedule(FixedUpdate);
-        sim.step();
+        sim.step().expect("step failed");
     }
 
     let bevy_state = read_sixdof(app.world(), vehicle);

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -105,7 +105,7 @@ fn tier3_bevy_sh4x4_rnp() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_state = sim.body(0).trans;
 
@@ -216,7 +216,7 @@ fn tier3_bevy_tidal_sh4x4() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_state = sim.body(0).trans;
 
@@ -266,7 +266,7 @@ fn tier3_bevy_run2p_polar_motion() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     assert_trans_eq(
         "Bevy vs Sim (polar motion)",
@@ -341,7 +341,7 @@ fn run_gj_parity(label: &str, config: GaussJacksonConfig, dt: f64, n_steps: usiz
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let sim_trans = sim.body(0).trans;
 

--- a/tests/bevy_parity_lighting.rs
+++ b/tests/bevy_parity_lighting.rs
@@ -151,7 +151,7 @@ fn run_earth_lighting_parity(label: &str, veh_pos: DVec3, sun_pos: DVec3, moon_p
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step();
+    sim.step().expect("step failed");
 
     let sim_body = sim.body(0);
     let sim_lighting = sim_body
@@ -360,7 +360,7 @@ fn tier3_bevy_earth_lighting_pipeline() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     assert_trans_eq(

--- a/tests/bevy_parity_point_mass.rs
+++ b/tests/bevy_parity_point_mass.rs
@@ -66,7 +66,7 @@ fn tier3_bevy_point_mass_sixdof() {
     let earth_idx = sim.add_source("Earth", earth_entry);
     sim.add_body(new_sim_body_sixdof(earth_idx, false));
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {
@@ -108,7 +108,7 @@ fn run_planetary_parity(label: &str, trans: TranslationalState) {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     assert_trans_eq(
         &format!("Bevy vs Sim ({label})"),
@@ -190,7 +190,7 @@ fn tier3_bevy_run2_6dof() {
     let (mut sim, earth_idx) = new_sim_earth(DT);
     sim.add_body(new_sim_body_sixdof(earth_idx, false));
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -261,7 +261,7 @@ fn tier3_bevy_orbinit_cross_consistency() {
             ..Default::default()
         });
         sim.validate().unwrap();
-        sim.step();
+        sim.step().expect("step failed");
         assert_trans_eq(
             &format!("Bevy vs Sim (orbinit {label})"),
             &bevy_trans,
@@ -287,7 +287,7 @@ fn tier3_bevy_timescale_tdb() {
     let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
     sim.validate().unwrap();
-    sim.step_n(n_steps);
+    sim.step_n(n_steps).expect("step_n failed");
 
     assert_bits_eq(
         "Bevy vs Sim",
@@ -341,7 +341,7 @@ fn tier3_sim_time_reversal_round_trip() {
     let initial_pos = sim.body(0).trans.position;
     let initial_vel = sim.body(0).trans.velocity;
 
-    sim.step_n(50);
+    sim.step_n(50).expect("step_n failed");
     let mid_pos = sim.body(0).trans.position;
     assert!(
         (mid_pos - initial_pos).length() > 1.0,
@@ -349,7 +349,7 @@ fn tier3_sim_time_reversal_round_trip() {
     );
 
     sim.time.time_scale_factor = -1.0;
-    sim.step_n(50);
+    sim.step_n(50).expect("step_n failed");
     let final_pos = sim.body(0).trans.position;
     let final_vel = sim.body(0).trans.velocity;
 
@@ -412,7 +412,7 @@ fn tier3_sim_relative_state_consistency() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(10);
+    sim.step_n(10).expect("step_n failed");
 
     let a = sim.body(0);
     let b = sim.body(1);
@@ -537,7 +537,7 @@ fn tier3_sim_mars_rotation_dispatch() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(10);
+    sim.step_n(10).expect("step_n failed");
 
     let rot = sim.source_pfix_rotation(mars).unwrap();
     assert!(
@@ -607,7 +607,7 @@ fn tier3_sim_multi_source_rotation() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(10);
+    sim.step_n(10).expect("step_n failed");
 
     let earth_rot = sim.source_pfix_rotation(earth).unwrap();
     let mars_rot = sim.source_pfix_rotation(mars).unwrap();
@@ -703,7 +703,7 @@ fn run_atmosphere_parity(label: &str, trans: TranslationalState) {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {

--- a/tests/bevy_parity_relative.rs
+++ b/tests/bevy_parity_relative.rs
@@ -190,7 +190,7 @@ fn run_relative_parity(
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_a_state = SixDofState {
         trans: sim.body(0).trans,
@@ -341,7 +341,7 @@ fn run_lvlhrel_parity(label: &str, ref_trans: TranslationalState, subj_trans: Tr
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_ref = sim.body(0).trans;
     let sim_subj = sim.body(1).trans;

--- a/tests/bevy_parity_srp.rs
+++ b/tests/bevy_parity_srp.rs
@@ -150,7 +150,7 @@ fn tier3_bevy_full_stack_sixdof() {
     body.compute_gravity_gradient = true;
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let body = sim.body(0);
     let sim_state = SixDofState {
@@ -345,7 +345,7 @@ fn tier3_bevy_flat_plate_srp_with_shadow() {
     });
 
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_state = sim.body(0).trans;
 
@@ -462,7 +462,7 @@ fn run_shadow_parity(label: &str, srp_plates: Vec<(FlatPlate, FlatPlateParams, F
     });
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -557,7 +557,7 @@ fn run_srp_basic_parity(
     }));
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -661,7 +661,7 @@ fn run_srp_deriv_parity(
     }));
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {
@@ -809,7 +809,7 @@ fn tier3_bevy_srp_derivative_rk4_with_rotated_struct_frame() {
     }));
     sim.add_body(body);
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_body = sim.body(0);
     let sim_state = SixDofState {

--- a/tests/bevy_parity_third_body.rs
+++ b/tests/bevy_parity_third_body.rs
@@ -99,7 +99,7 @@ fn tier3_bevy_solar_beta_equ() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_beta = sim.body(0).solar_beta.expect("solar beta computed");
     assert_bits_eq("Bevy vs Sim", "solar_beta_equ", bevy_beta, sim_beta);
@@ -192,7 +192,7 @@ fn tier3_bevy_solar_beta_obliquity() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     let sim_beta = sim.body(0).solar_beta.expect("solar beta computed");
     assert_bits_eq("Bevy vs Sim", "solar_beta_obliquity", bevy_beta, sim_beta);
@@ -372,7 +372,7 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     if sixdof {
         let bevy_state = read_sixdof(app.world(), vehicle);
@@ -560,7 +560,7 @@ fn tier3_bevy_mars_dawn() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     assert_trans_eq("Bevy vs Sim (mars_dawn)", &bevy_trans, &sim.body(0).trans);
     println!("  Mars dawn: bit-identical");
@@ -637,7 +637,7 @@ fn tier3_bevy_mercury_relativistic() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     assert_trans_eq(
         "Bevy vs Sim (mercury_relativistic)",
@@ -738,7 +738,7 @@ fn tier3_bevy_relativistic_moving_source() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     assert_trans_eq(
         "Bevy vs Sim (relativistic_moving_source)",
@@ -910,7 +910,7 @@ fn tier3_bevy_earth_moon_clem() {
         ..Default::default()
     });
     sim.validate().unwrap();
-    sim.step_n(NUM_STEPS);
+    sim.step_n(NUM_STEPS).expect("step_n failed");
 
     assert_trans_eq(
         "Bevy vs Sim (earth_moon_clem)",


### PR DESCRIPTION
## Summary

Closes #172. Final L2 follow-up from the pre-1.0 adversarial audit.

The two mission-runtime panic sites inside \`Simulation::step_internal\` — ephemeris-lookup failure and frame-switch with an out-of-range \`target_source\` — now propagate as a typed \`StepError\` instead of aborting the process. Mission programmes that want fault-tolerance (Monte Carlo, batch propagation, long-running services) can match on the variant without resorting to \`catch_unwind\`.

The four panic sites in accessor methods (\`add_body\` \`integ_source\`, \`source_frame\`, \`source_pfix_rotation\`, \`source_tidal_config_mut\`) remain panics — they signal a programmer / configuration error in the calling code, where recovery is not meaningful. This matches the audit's own guidance: *"Keep panic! for genuine programmer errors (typestate violations, config mistakes)."*

## API changes

- New \`pub enum StepError\` (\`crates/jeod_runner/src/error.rs\`) with \`EphemerisLookup\` and \`FrameSwitchTargetMissing\` variants. Implements \`core::error::Error\`.
- \`Simulation::{step, step_n, step_until}\` and the inner \`step_internal\` now return \`Result<(), StepError>\`. Bevy adapter / branded wrapper forward the result.
- All 50 test/example call sites updated to \`.expect("step* failed")\` via mechanical sed pass — keeps test ergonomics and surfaces the failure site in a panic message that includes the \`StepError\` \`Display\`.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --tests --examples -- -D warnings\`
- [x] 775/775 unit + tier 2 tests pass
- [x] 307/307 Tier 3 tests pass with bit-identical baselines (\`tier3_baseline_diff\`: 76 matched / 0 new / 1 allowed-missing)
- [x] \`cargo test --doc -p jeod_runner\` clean

## #172 closeout

This PR finalises the #172 audit follow-up. With this PR, every remaining medium / low item from the audit (M2, M3, M7, M8, M9, L1, L2, L3, L6, L7, L8) is shipped, alongside #185 (PR #189) and #186 (PR #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)