### PR TITLE
[#69] Populate acceleration columns in Tier 3 cross-validation report

### DIFF
--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -153,6 +153,14 @@ pub struct VehicleOutput {
     pub integ_frame_id: FrameId,
     /// Current rotational state (quaternion, angular velocity). `None` for 3-DOF.
     pub rot: Option<RotationalState>,
+    /// Total translational acceleration in the integration frame (m/s²) at the
+    /// end of the last `step()`. Sum of gravity and non-gravity contributions —
+    /// mirrors JEOD's `derivs.trans_accel`. Zero before the first `step()`.
+    pub trans_accel: DVec3,
+    /// Total rotational acceleration in the body frame (rad/s²) at the end of
+    /// the last `step()` — mirrors JEOD's `derivs.rot_accel`. `None` for 3-DOF
+    /// bodies; zero before the first `step()`.
+    pub rot_accel: Option<DVec3>,
     /// Orbital elements from the latest step.
     pub orbital_elements: Option<OrbitalElements>,
     /// Euler angles `[phi, theta, psi]` from the latest step.
@@ -317,6 +325,8 @@ impl SimBody {
             trans: self.trans,
             integ_frame_id: self.integ_frame_id,
             rot: self.rot,
+            trans_accel: self.frame_derivs.trans_accel,
+            rot_accel: self.rot.map(|_| self.frame_derivs.rot_accel),
             orbital_elements: self.orbital_elements.clone(),
             euler_angles: self.euler_angles,
             lvlh_frame: self.lvlh_frame,

--- a/crates/jeod_runner/src/run_verification/mod.rs
+++ b/crates/jeod_runner/src/run_verification/mod.rs
@@ -253,10 +253,10 @@ fn snapshot_from(body: &VehicleOutput, ref_record: &StateLog) -> StateLog {
         time: ref_record.time,
         position: Some(body.trans.position),
         velocity: Some(body.trans.velocity),
-        acceleration: None,
+        acceleration: Some(body.trans_accel),
         quaternion: body.rot.as_ref().map(|r| r.quaternion.to_glam()),
         ang_vel: body.rot.as_ref().map(|r| r.ang_vel_body),
-        ang_accel: None,
+        ang_accel: body.rot_accel,
     }
 }
 

--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -222,6 +222,37 @@ struct RefState {
     ang_vel_body: DVec3,
 }
 
+/// Load `derivs.trans_accel` from the V_1 CSV in row order. Aligned 1:1
+/// with [`load_reference_sixdof`] when both CSVs come from the same Trick
+/// run, so callers can index by the same loop counter.
+///
+/// Columns 11–13 (1-indexed) of `*_V_1_State.csv` are
+/// `derivs.trans_accel[0..2]`.
+fn load_reference_v1_trans_accel(filename: &str) -> Vec<DVec3> {
+    let path = test_data_dir().join(filename);
+    assert!(
+        path.exists(),
+        "Apollo 8 V_1 reference data not found at {}. \
+         Generate it with: docker run ... trick/generate_references.sh",
+        path.display()
+    );
+
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
+
+    let mut accel = Vec::new();
+    for line in content.lines().skip(1) {
+        let vals: Vec<f64> = line
+            .split(',')
+            .filter_map(|s| s.trim().parse().ok())
+            .collect();
+        if vals.len() >= 13 {
+            accel.push(DVec3::new(vals[10], vals[11], vals[12]));
+        }
+    }
+    accel
+}
+
 /// Load reference CSV in 6-DOF interleaved format.
 ///
 /// Columns: time, pos[0], vel[0], pos[1], vel[1], pos[2], vel[2],
@@ -271,6 +302,14 @@ fn tier3_apollo8_eci_integ() {
     let (mut sim, body_idx, _moon) = build_apollo8_sim(false);
 
     let ref_states = load_reference_sixdof("apollo8_eci_sixdof_state.csv");
+    let ref_trans_accel = load_reference_v1_trans_accel("apollo8_eci_V_1_State.csv");
+    assert_eq!(
+        ref_states.len(),
+        ref_trans_accel.len(),
+        "sixdof and V_1 CSVs disagree on row count: {} vs {}",
+        ref_states.len(),
+        ref_trans_accel.len()
+    );
 
     let steps = (TOTAL_TIME / DT).round() as usize;
     let mut our_log = Vec::with_capacity(steps);
@@ -288,17 +327,19 @@ fn tier3_apollo8_eci_integ() {
                 time: r.time,
                 position: Some(body.trans.position),
                 velocity: Some(body.trans.velocity),
+                acceleration: Some(body.trans_accel),
                 quaternion: body.rot.as_ref().map(|rot| rot.quaternion.to_glam()),
                 ang_vel: body.rot.as_ref().map(|rot| rot.ang_vel_body),
-                ..Default::default()
+                ang_accel: body.rot_accel,
             });
             ref_log.push(StateLog {
                 time: r.time,
                 position: Some(r.position),
                 velocity: Some(r.velocity),
+                acceleration: Some(ref_trans_accel[ref_idx]),
                 quaternion: Some(r.quaternion),
                 ang_vel: Some(r.ang_vel_body),
-                ..Default::default()
+                ang_accel: None,
             });
         }
     }

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
@@ -11,7 +11,7 @@ use jeod_sim::{
 };
 use jeod_test_data::crossval::{CrossvalReport, StateLog};
 use jeod_test_data::mass_data::MassInitData;
-use jeod_test_data::tier3_csv::{load_dyncomp_csv, test_data_path};
+use jeod_test_data::tier3_csv::{dyncomp_to_state_log_6dof, load_dyncomp_csv, test_data_path};
 
 /// Build [`MassProperties`] from parsed JEOD mass-init data (test-only helper).
 ///
@@ -180,23 +180,16 @@ fn tier3_simulation_run9a_torque() {
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
             quaternion: Some(body.rot.as_ref().unwrap().quaternion.to_glam()),
             ang_vel: Some(body.rot.as_ref().unwrap().ang_vel_body),
-            ..Default::default()
+            ang_accel: body.rot_accel,
         });
     }
 
     let ref_states: Vec<StateLog> = trajectory[1..]
         .iter()
-        .map(|r| StateLog {
-            time: r.time,
-            position: Some(r.composite_body.position),
-            velocity: Some(r.composite_body.velocity),
-            acceleration: r.derivs.as_ref().map(|d| d.trans_accel),
-            quaternion: Some(r.composite_body.quaternion),
-            ang_vel: Some(r.composite_body.ang_vel),
-            ang_accel: r.derivs.as_ref().map(|d| d.rot_accel),
-        })
+        .map(dyncomp_to_state_log_6dof)
         .collect();
 
     let report = CrossvalReport::compute("tier3_simulation_run9a_torque", &our_states, &ref_states);
@@ -251,23 +244,16 @@ fn tier3_simulation_run9c_force_torque() {
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
             quaternion: Some(body.rot.as_ref().unwrap().quaternion.to_glam()),
             ang_vel: Some(body.rot.as_ref().unwrap().ang_vel_body),
-            ..Default::default()
+            ang_accel: body.rot_accel,
         });
     }
 
     let ref_states: Vec<StateLog> = trajectory[1..]
         .iter()
-        .map(|r| StateLog {
-            time: r.time,
-            position: Some(r.composite_body.position),
-            velocity: Some(r.composite_body.velocity),
-            acceleration: r.derivs.as_ref().map(|d| d.trans_accel),
-            quaternion: Some(r.composite_body.quaternion),
-            ang_vel: Some(r.composite_body.ang_vel),
-            ang_accel: r.derivs.as_ref().map(|d| d.rot_accel),
-        })
+        .map(dyncomp_to_state_log_6dof)
         .collect();
 
     let report = CrossvalReport::compute(
@@ -328,23 +314,16 @@ fn tier3_simulation_run9d_force_torque_rate() {
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
             quaternion: Some(body.rot.as_ref().unwrap().quaternion.to_glam()),
             ang_vel: Some(body.rot.as_ref().unwrap().ang_vel_body),
-            ..Default::default()
+            ang_accel: body.rot_accel,
         });
     }
 
     let ref_states: Vec<StateLog> = trajectory[1..]
         .iter()
-        .map(|r| StateLog {
-            time: r.time,
-            position: Some(r.composite_body.position),
-            velocity: Some(r.composite_body.velocity),
-            acceleration: r.derivs.as_ref().map(|d| d.trans_accel),
-            quaternion: Some(r.composite_body.quaternion),
-            ang_vel: Some(r.composite_body.ang_vel),
-            ang_accel: r.derivs.as_ref().map(|d| d.rot_accel),
-        })
+        .map(dyncomp_to_state_log_6dof)
         .collect();
 
     let report = CrossvalReport::compute(

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -242,6 +242,8 @@ fn tier3_simulation_earth_moon_clem() {
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
+            ang_accel: body.rot_accel,
             ..Default::default()
         });
     }

--- a/crates/jeod_runner/tests/tier3_sim_gj.rs
+++ b/crates/jeod_runner/tests/tier3_sim_gj.rs
@@ -118,6 +118,8 @@ fn run_gj_test(
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
+            ang_accel: body.rot_accel,
             ..Default::default()
         });
     }

--- a/crates/jeod_runner/tests/tier3_sim_lsode.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lsode.rs
@@ -221,6 +221,8 @@ fn run_integ_test(
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
+            ang_accel: body.rot_accel,
             ..Default::default()
         });
     }

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -185,6 +185,8 @@ fn tier3_simulation_mars_dawn() {
             time: record.time,
             position: Some(body.trans.position),
             velocity: Some(body.trans.velocity),
+            acceleration: Some(body.trans_accel),
+            ang_accel: body.rot_accel,
             ..Default::default()
         });
     }


### PR DESCRIPTION
## Summary

Closes #69. The `StateLog::acceleration` / `StateLog::ang_accel` fields and the matching aggregation in `CrossvalReport::compute` were already in place, but no test populated them, so the report rendered `—` for every test. This wires the data through end-to-end.

- `VehicleOutput` gains `trans_accel: DVec3` and `rot_accel: Option<DVec3>` (`None` for 3-DOF), populated in `SimBody::output()` from `frame_derivs`. Mirrors JEOD's `derivs.trans_accel` / `derivs.rot_accel`.
- `run_verification::snapshot_from` writes both new fields — fans out to the ~26 Tier 3 tests routed through `VerificationCase`.
- Six bespoke `StateLog` builders updated (run9 a/c/d, mars_orbit, earth_moon, gj, lsode, apollo8). The run9 family also collapses its reference-side `StateLog` literal onto the shared `dyncomp_to_state_log_6dof` helper.
- Apollo 8 reference acceleration now loads from `apollo8_eci_V_1_State.csv` via a new `load_reference_v1_trans_accel` helper, so `tier3_apollo8_eci_integ` reports a real acceleration error vector.

## Sample report output

After this PR, `target/tier3_report.md` shows real numbers in the acceleration columns. Examples:

| Test | acc_x error (m/s²) | acc_y | acc_z | ang_accel error (rad/s²) |
|------|---:|---:|---:|---|
| `tier3_apollo8_eci_integ` | 4.366e-9 | 6.532e-9 | 2.072e-10 | — (3-DOF accel via run9 family below) |
| `tier3_simulation_run9a_torque` | 1.97e-4 | 3.08e-4 | 2.44e-4 | [1.93e-16, 2.10e-14, 2.81e-14] |
| `tier3_simulation_run9d_force_torque_rate` | 1.97e-4 | 3.08e-4 | 2.44e-4 | [1.49e-12, 1.24e-12, 6.96e-13] |

Tests whose reference CSVs lack accel columns (e.g. `tier3_simulation_run3a_sh4x4`, `mars_dawn`, drag verif) continue to render `—` — populating those requires extending DRAscii logging in `trick/generate_references.sh` and regenerating reference CSVs via Docker. That is a deliberate follow-up; this PR delivers the plumbing and a working acceleration-error path on every test where JEOD already logs accel.

## Test plan

- [x] `cargo build --workspace --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 788/788 pass
- [x] `cargo nextest run -p jeod_runner -E 'test(tier3_)'` (full Tier 3 incl. earth_moon) — 181/181 pass
- [x] `cargo run -p jeod_test_data --bin tier3_report` — populates acceleration columns; `target/tier3_crossval/tier3_apollo8_eci_integ.json` shows non-null `acceleration` vector

🤖 Generated with [Claude Code](https://claude.com/claude-code)