### PR TITLE
[#188] Migrate tier3_sim_battin to recipe pattern

### DIFF
--- a/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
@@ -531,6 +531,146 @@ pub fn run4_3rd_body() -> VerificationCase {
     }
 }
 
+// ── Battin's method vs direct subtraction (third-body cross-compare) ──────
+
+/// Index of the Sun gravity source inside the Battin cross-compare
+/// scenario.
+const BATTIN_SUN_IDX: usize = 1;
+/// Index of the Moon gravity source inside the Battin cross-compare
+/// scenario.
+const BATTIN_MOON_IDX: usize = 2;
+
+/// Step size for the Battin cross-compare scenario.
+///
+/// SIM_dyncomp's S_define specifies `DYNAMICS = 0.03125` s (32 Hz). The
+/// cross-compare doesn't validate against a JEOD CSV, so it uses a
+/// coarser 10 s step that still resolves the fp-rounding divergence
+/// between the two methods (~5 digits lost in direct subtraction of
+/// LEO + Sun accelerations) without paying for ~921 600 inner RK4
+/// stages over 8 hours.
+const BATTIN_DT: f64 = 10.0;
+
+fn third_body_source_with_state(mu: f64, position: DVec3, velocity: DVec3) -> GravitySourceEntry {
+    GravitySourceEntry {
+        source: GravitySource {
+            mu,
+            model: GravityModel::PointMass,
+        },
+        position,
+        velocity,
+        t_inertial_pfix: None,
+        delta_c20: 0.0,
+        rotation_model: RotationModel::default(),
+        tidal_config: None,
+        planet_omega: 0.0,
+        central: false,
+    }
+}
+
+/// Build a Battin/direct cross-compare scenario with Earth (central) +
+/// Sun + Moon third-body gravity. The two sibling sims share initial
+/// conditions; only the `battin_method` flag on the Sun/Moon
+/// `GravityControl`s differs.
+///
+/// Used by the `tier3_sim_battin` test to verify that Battin's
+/// reformulation produces the same trajectory as direct subtraction up
+/// to fp rounding. There is no JEOD CSV reference for the comparison —
+/// it is internal between the two sibling sims — so this returns a
+/// [`SimulationBuilder`] directly rather than a [`VerificationCase`].
+pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> SimulationBuilder {
+    let jeod = jeod_root();
+    let grav_data_dir = jeod.join("models/environment/gravity/data/src");
+
+    let earth_grav =
+        load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth gravity");
+    let mu_sun =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+            .expect("load Sun mu");
+    let mu_moon =
+        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+            .expect("load Moon mu");
+
+    // Initial Sun/Moon state at the dyncomp epoch — refreshed each step
+    // by the `pre_step` hook returned from [`battin_pre_step`].
+    let time = dyncomp_time();
+    let epoch_tdb_jd = time.tdb_julian_date();
+    let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
+    let (sun_pos_t0, sun_vel_t0) = ephemeris
+        .get_earth_centered_state_typed(EphemerisBody::Sun, epoch_tdb_jd)
+        .expect("Sun state at epoch");
+    let (moon_pos_t0, moon_vel_t0) = ephemeris
+        .get_earth_centered_state_typed(EphemerisBody::Moon, epoch_tdb_jd)
+        .expect("Moon state at epoch");
+
+    let mut sb = SimulationBuilder::new(time, BATTIN_DT);
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
+    let sun = sb.add_source(
+        "Sun",
+        third_body_source_with_state(mu_sun, sun_pos_t0.raw_si(), sun_vel_t0.raw_si()),
+    );
+    let moon = sb.add_source(
+        "Moon",
+        third_body_source_with_state(mu_moon, moon_pos_t0.raw_si(), moon_vel_t0.raw_si()),
+    );
+    debug_assert_eq!(
+        sun, BATTIN_SUN_IDX,
+        "Sun source index drift: battin_pre_step assumes Sun is at \
+         BATTIN_SUN_IDX={BATTIN_SUN_IDX}, but add_source returned {sun}."
+    );
+    debug_assert_eq!(
+        moon, BATTIN_MOON_IDX,
+        "Moon source index drift: battin_pre_step assumes Moon is at \
+         BATTIN_MOON_IDX={BATTIN_MOON_IDX}, but add_source returned {moon}."
+    );
+
+    let mut sun_control = GravityControl::new_third_body(sun);
+    sun_control.battin_method = battin;
+    let mut moon_control = GravityControl::new_third_body(moon);
+    moon_control.battin_method = battin;
+
+    sb.add_body(VehicleConfig {
+        trans: trans_from(init),
+        rot: Some(rot_from(init, "battin_3rd_body")),
+        mass: Some(iss_mass_properties()),
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_spherical(earth, false),
+                sun_control,
+                moon_control,
+            ],
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// Pre-step factory for the Battin cross-compare scenario: capture a
+/// DE421 ephemeris and the dyncomp epoch's TDB JD once, then update the
+/// Sun and Moon source position+velocity to the upcoming step's TDB
+/// before `step_until`.
+///
+/// Sets state (position **and** velocity), not just position, to match
+/// the bespoke pre-recipe test exactly so the cross-compare baselines
+/// stay bit-stable. Velocity does not affect third-body point-mass
+/// gravity, but propagating it explicitly preserves the original
+/// behavior with no reasoning required about which fields the gravity
+/// pipeline reads.
+pub fn battin_pre_step(_init: &InitialConditions) -> PreStepClosure {
+    let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
+    let epoch_tdb_jd = dyncomp_time().tdb_julian_date();
+    Box::new(move |sim, time_s: f64| {
+        let target_tdb_jd = epoch_tdb_jd + time_s / 86_400.0;
+        let (sun_pos, sun_vel) = ephemeris
+            .get_earth_centered_state_typed(EphemerisBody::Sun, target_tdb_jd)
+            .expect("Sun state query");
+        let (moon_pos, moon_vel) = ephemeris
+            .get_earth_centered_state_typed(EphemerisBody::Moon, target_tdb_jd)
+            .expect("Moon state query");
+        sim.set_source_state(BATTIN_SUN_IDX, sun_pos.raw_si(), sun_vel.raw_si());
+        sim.set_source_state(BATTIN_MOON_IDX, moon_pos.raw_si(), moon_vel.raw_si());
+    })
+}
+
 // ── RUN_7A–7D: SH gravity + Sun/Moon third-body (± MET drag) ──────────────
 
 const RUN7_SUN_IDX: usize = 1;

--- a/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
@@ -533,22 +533,29 @@ pub fn run4_3rd_body() -> VerificationCase {
 
 // ── Battin's method vs direct subtraction (third-body cross-compare) ──────
 
-/// Index of the Sun gravity source inside the Battin cross-compare
-/// scenario.
-const BATTIN_SUN_IDX: usize = 1;
-/// Index of the Moon gravity source inside the Battin cross-compare
-/// scenario.
-const BATTIN_MOON_IDX: usize = 2;
-
 /// Step size for the Battin cross-compare scenario.
 ///
 /// SIM_dyncomp's S_define specifies `DYNAMICS = 0.03125` s (32 Hz). The
 /// cross-compare doesn't validate against a JEOD CSV, so it uses a
 /// coarser 10 s step that still resolves the fp-rounding divergence
 /// between the two methods (~5 digits lost in direct subtraction of
-/// LEO + Sun accelerations) without paying for ~921 600 inner RK4
-/// stages over 8 hours.
+/// LEO + Sun accelerations) without paying for ~921 600 integration
+/// steps over 8 hours.
 const BATTIN_DT: f64 = 10.0;
+
+/// Output of [`build_battin_3rd_body`]: the configured simulation
+/// builder plus the runtime source indices for Sun and Moon, captured
+/// from `add_source` so [`battin_pre_step`] can update the right
+/// entries without depending on registration order being stable
+/// across future edits.
+pub struct BattinScenario {
+    /// Configured simulation builder, ready for `.build()`.
+    pub builder: SimulationBuilder,
+    /// Source index for Sun (third-body).
+    pub sun_idx: usize,
+    /// Source index for Moon (third-body).
+    pub moon_idx: usize,
+}
 
 fn third_body_source_with_state(mu: f64, position: DVec3, velocity: DVec3) -> GravitySourceEntry {
     GravitySourceEntry {
@@ -576,8 +583,9 @@ fn third_body_source_with_state(mu: f64, position: DVec3, velocity: DVec3) -> Gr
 /// reformulation produces the same trajectory as direct subtraction up
 /// to fp rounding. There is no JEOD CSV reference for the comparison —
 /// it is internal between the two sibling sims — so this returns a
-/// [`SimulationBuilder`] directly rather than a [`VerificationCase`].
-pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> SimulationBuilder {
+/// [`BattinScenario`] (builder + source indices) rather than a
+/// [`VerificationCase`].
+pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> BattinScenario {
     let jeod = jeod_root();
     let grav_data_dir = jeod.join("models/environment/gravity/data/src");
 
@@ -604,28 +612,18 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> Simulati
 
     let mut sb = SimulationBuilder::new(time, BATTIN_DT);
     let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
-    let sun = sb.add_source(
+    let sun_idx = sb.add_source(
         "Sun",
         third_body_source_with_state(mu_sun, sun_pos_t0.raw_si(), sun_vel_t0.raw_si()),
     );
-    let moon = sb.add_source(
+    let moon_idx = sb.add_source(
         "Moon",
         third_body_source_with_state(mu_moon, moon_pos_t0.raw_si(), moon_vel_t0.raw_si()),
     );
-    debug_assert_eq!(
-        sun, BATTIN_SUN_IDX,
-        "Sun source index drift: battin_pre_step assumes Sun is at \
-         BATTIN_SUN_IDX={BATTIN_SUN_IDX}, but add_source returned {sun}."
-    );
-    debug_assert_eq!(
-        moon, BATTIN_MOON_IDX,
-        "Moon source index drift: battin_pre_step assumes Moon is at \
-         BATTIN_MOON_IDX={BATTIN_MOON_IDX}, but add_source returned {moon}."
-    );
 
-    let mut sun_control = GravityControl::new_third_body(sun);
+    let mut sun_control = GravityControl::new_third_body(sun_idx);
     sun_control.battin_method = battin;
-    let mut moon_control = GravityControl::new_third_body(moon);
+    let mut moon_control = GravityControl::new_third_body(moon_idx);
     moon_control.battin_method = battin;
 
     sb.add_body(VehicleConfig {
@@ -641,7 +639,11 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> Simulati
         },
         ..Default::default()
     });
-    sb
+    BattinScenario {
+        builder: sb,
+        sun_idx,
+        moon_idx,
+    }
 }
 
 /// Pre-step factory for the Battin cross-compare scenario: capture a
@@ -649,13 +651,19 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> Simulati
 /// Sun and Moon source position+velocity to the upcoming step's TDB
 /// before `step_until`.
 ///
+/// `sun_idx` and `moon_idx` come from the [`BattinScenario`] returned
+/// by [`build_battin_3rd_body`] — capturing them at construction time
+/// (rather than relying on hard-coded constants validated by
+/// `debug_assert!`) prevents a future source-registration reorder from
+/// silently updating the wrong entries in release builds.
+///
 /// Sets state (position **and** velocity), not just position, to match
 /// the bespoke pre-recipe test exactly so the cross-compare baselines
 /// stay bit-stable. Velocity does not affect third-body point-mass
 /// gravity, but propagating it explicitly preserves the original
 /// behavior with no reasoning required about which fields the gravity
 /// pipeline reads.
-pub fn battin_pre_step(_init: &InitialConditions) -> PreStepClosure {
+pub fn battin_pre_step(sun_idx: usize, moon_idx: usize) -> PreStepClosure {
     let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let epoch_tdb_jd = dyncomp_time().tdb_julian_date();
     Box::new(move |sim, time_s: f64| {
@@ -666,8 +674,8 @@ pub fn battin_pre_step(_init: &InitialConditions) -> PreStepClosure {
         let (moon_pos, moon_vel) = ephemeris
             .get_earth_centered_state_typed(EphemerisBody::Moon, target_tdb_jd)
             .expect("Moon state query");
-        sim.set_source_state(BATTIN_SUN_IDX, sun_pos.raw_si(), sun_vel.raw_si());
-        sim.set_source_state(BATTIN_MOON_IDX, moon_pos.raw_si(), moon_vel.raw_si());
+        sim.set_source_state(sun_idx, sun_pos.raw_si(), sun_vel.raw_si());
+        sim.set_source_state(moon_idx, moon_pos.raw_si(), moon_vel.raw_si());
     })
 }
 

--- a/crates/jeod_runner/tests/tier3_sim_battin.rs
+++ b/crates/jeod_runner/tests/tier3_sim_battin.rs
@@ -32,10 +32,12 @@ const LOG_INTERVAL: f64 = 60.0;
 /// Propagate one Battin/direct cross-compare run for `DURATION`,
 /// sampling position+velocity every `LOG_INTERVAL`.
 fn propagate(battin: bool, init: &InitialConditions) -> (Vec<DVec3>, Vec<DVec3>) {
-    let mut sim = sim_dyncomp::build_battin_3rd_body(init, battin)
+    let scenario = sim_dyncomp::build_battin_3rd_body(init, battin);
+    let mut pre_step = sim_dyncomp::battin_pre_step(scenario.sun_idx, scenario.moon_idx);
+    let mut sim = scenario
+        .builder
         .build()
         .expect("scenario validation failed");
-    let mut pre_step = sim_dyncomp::battin_pre_step(init);
 
     let n_points = (DURATION / LOG_INTERVAL) as usize;
     let mut positions = Vec::with_capacity(n_points);

--- a/crates/jeod_runner/tests/tier3_sim_battin.rs
+++ b/crates/jeod_runner/tests/tier3_sim_battin.rs
@@ -10,233 +10,45 @@
 //! third body, the numerical difference is negligible because the Sun is
 //! ~1 AU away while the vehicle is ~6800 km from Earth center.
 //!
-//! The test runs two independent simulations from the same ISS-like initial
-//! conditions with Earth (central) + Sun + Moon (third-body), one using
-//! direct subtraction and one using Battin's method, then asserts the
-//! trajectories agree to within floating-point rounding tolerance.
+//! Migrated from a 344-line bespoke test (#188, follow-on to #162). The
+//! scenario assembly and per-step DE421 ephemeris injection live in
+//! `sim_dyncomp::{build_battin_3rd_body, battin_pre_step}`. The
+//! cross-compare between the two simulations stays here because there is
+//! no JEOD CSV reference for it — the comparison is internal between the
+//! two sibling sims.
 
-use glam::{DMat3, DVec3};
-use jeod_runner::{GravitySourceEntry, RotationModel, Simulation, VehicleConfig};
-use jeod_sim::{
-    Ephemeris, EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource,
-    MassProperties, RotationalState, SimulationTime, TranslationalState,
-};
-use jeod_test_data::mass_data::MassInitData;
+use glam::DVec3;
+use jeod_runner::run_verification::sim_dyncomp;
+use jeod_runner::SimulationBuilderExt;
+use jeod_sim::recipes::verification::InitialConditions;
 use jeod_test_data::tier3_csv::{load_dyncomp_csv, test_data_path};
-use std::path::Path;
-
-/// Build [`MassProperties`] from parsed JEOD mass-init data (test-only helper).
-fn mass_props_from_init(init: &MassInitData) -> MassProperties {
-    let inertia = DMat3::from_cols(
-        DVec3::new(init.inertia[0][0], init.inertia[1][0], init.inertia[2][0]),
-        DVec3::new(init.inertia[0][1], init.inertia[1][1], init.inertia[2][1]),
-        DVec3::new(init.inertia[0][2], init.inertia[1][2], init.inertia[2][2]),
-    );
-    MassProperties::with_inertia(init.mass, inertia, DVec3::from_slice(&init.position))
-}
-
-/// SIM_dyncomp root directory (relative to JEOD_HOME).
-const SIM_DYNCOMP: &str = "verif/SIM_dyncomp";
 
 /// Simulation duration (seconds): 8 hours.
 const DURATION: f64 = 28800.0;
 
-/// Integration step size (seconds).
-const DT: f64 = 10.0;
-
 /// Logging interval (seconds): record state every 60s for comparison.
 const LOG_INTERVAL: f64 = 60.0;
 
-/// Compute Earth-centered position and velocity of a body from DE421 ephemeris.
-fn earth_centered_state(body: EphemerisBody, tdb_jd: f64, ephemeris: &Ephemeris) -> (DVec3, DVec3) {
-    let (pos, vel) = ephemeris
-        .get_earth_centered_state_typed(body, tdb_jd)
-        .expect("ephemeris query failed");
-    (pos.raw_si(), vel.raw_si())
-}
+/// Propagate one Battin/direct cross-compare run for `DURATION`,
+/// sampling position+velocity every `LOG_INTERVAL`.
+fn propagate(battin: bool, init: &InitialConditions) -> (Vec<DVec3>, Vec<DVec3>) {
+    let mut sim = sim_dyncomp::build_battin_3rd_body(init, battin)
+        .build()
+        .expect("scenario validation failed");
+    let mut pre_step = sim_dyncomp::battin_pre_step(init);
 
-/// Build a `Simulation` with ISS-like orbit, Earth central, Sun + Moon third-body.
-///
-/// When `battin` is true, the Sun and Moon gravity controls use Battin's method.
-fn build_sim(
-    battin: bool,
-    jeod_root: &Path,
-    ephemeris: &Ephemeris,
-) -> (Simulation, f64, usize, usize) {
-    let sim_dir = jeod_root.join(SIM_DYNCOMP);
-    let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
-
-    // Load epoch and time offsets from JEOD time config
-    let time_cfg =
-        jeod_test_data::time_config::load_time_config(&sim_dir.join("Modified_data/time.py"));
-    let epoch_tai_tjt = time_cfg.tai_tjt();
-    let ut1_tai_offset = time_cfg
-        .ut1_tai_offset()
-        .expect("SIM_dyncomp time.py must specify tai_to_ut1_override_val");
-
-    // Load mu values from JEOD gravity coefficient files.
-    let earth_grav =
-        jeod_sim::coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
-            .expect("load Earth gravity");
-    let mu_sun =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
-            .expect("load Sun mu");
-    let mu_moon =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
-            .expect("load Moon mu");
-
-    // Load ISS mass properties from SIM_dyncomp mass.py
-    let mass_init = jeod_test_data::mass_data::load_mass_from_file(
-        &sim_dir.join("Modified_data/mass.py"),
-        Some("set_mass_iss"),
-    );
-    let mass_props = mass_props_from_init(&mass_init);
-
-    // Load ISS initial conditions from the JEOD reference CSV (t=0 row).
-    let csv_path = test_data_path("dyncomp_run4_state.csv");
-    assert!(
-        csv_path.exists(),
-        "JEOD reference not found at {}.\n\
-         Generate with: docker run --rm -v $(pwd)/test_data:/output \
-         -v $(pwd)/trick/generate_references.sh:/generate_references.sh:ro jeod-trick",
-        csv_path.display()
-    );
-    let trajectory = load_dyncomp_csv(&csv_path);
-    assert!(trajectory.len() > 100);
-    let init = &trajectory[0];
-
-    // Initialize simulation at the SIM_dyncomp epoch.
-    let mut time = SimulationTime::new(epoch_tai_tjt, jeod_sim::default_leap_second_table());
-    time.set_ut1_tai_offset(ut1_tai_offset);
-    let mut sim = Simulation::new(time, DT);
-
-    // Earth: central body at origin
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: earth_grav.mu,
-                model: GravityModel::PointMass,
-            },
-            position: DVec3::ZERO,
-            velocity: DVec3::ZERO,
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-        },
-    );
-
-    // Sun: third-body (differential acceleration)
-    let tdb_jd = sim.time.tdb_julian_date();
-    let (initial_sun_pos, initial_sun_vel) =
-        earth_centered_state(EphemerisBody::Sun, tdb_jd, ephemeris);
-    let sun = sim.add_source(
-        "Sun",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_sun,
-                model: GravityModel::PointMass,
-            },
-            position: initial_sun_pos,
-            velocity: initial_sun_vel,
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-        },
-    );
-
-    // Moon: third-body (differential acceleration)
-    let (initial_moon_pos, initial_moon_vel) =
-        earth_centered_state(EphemerisBody::Moon, tdb_jd, ephemeris);
-    let moon = sim.add_source(
-        "Moon",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_moon,
-                model: GravityModel::PointMass,
-            },
-            position: initial_moon_pos,
-            velocity: initial_moon_vel,
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-        },
-    );
-
-    // Build gravity controls with battin_method flag on third-body sources.
-    let mut sun_control = GravityControl::new_third_body(sun);
-    sun_control.battin_method = battin;
-    let mut moon_control = GravityControl::new_third_body(moon);
-    moon_control.battin_method = battin;
-
-    sim.add_body(VehicleConfig {
-        trans: TranslationalState {
-            position: init.composite_body.position,
-            velocity: init.composite_body.velocity,
-        },
-        rot: Some(RotationalState {
-            quaternion: jeod_sim::JeodQuat::from_glam(init.composite_body.quaternion),
-            ang_vel_body: init.composite_body.ang_vel,
-        }),
-        mass: Some(mass_props),
-        gravity_controls: GravityControls {
-            controls: vec![
-                GravityControl::new_spherical(earth, false),
-                sun_control,
-                moon_control,
-            ],
-        },
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-
-    (sim, tdb_jd, sun, moon)
-}
-
-/// Propagate a simulation for 8 hours, logging states every 60s.
-/// Returns (times, positions, velocities).
-fn propagate(
-    sim: &mut Simulation,
-    tdb_jd: f64,
-    sun_source: usize,
-    moon_source: usize,
-    ephemeris: &Ephemeris,
-) -> (Vec<f64>, Vec<DVec3>, Vec<DVec3>) {
     let n_points = (DURATION / LOG_INTERVAL) as usize;
-    let mut times = Vec::with_capacity(n_points);
     let mut positions = Vec::with_capacity(n_points);
     let mut velocities = Vec::with_capacity(n_points);
-
     for i in 1..=n_points {
         let target_time = i as f64 * LOG_INTERVAL;
-
-        // Update ephemeris-driven source state before stepping.
-        let target_tdb_jd = tdb_jd + target_time / 86400.0;
-        let (sun_pos, sun_vel) = earth_centered_state(EphemerisBody::Sun, target_tdb_jd, ephemeris);
-        sim.set_source_state(sun_source, sun_pos, sun_vel);
-        let (moon_pos, moon_vel) =
-            earth_centered_state(EphemerisBody::Moon, target_tdb_jd, ephemeris);
-        sim.set_source_state(moon_source, moon_pos, moon_vel);
-
+        pre_step(&mut sim, target_time);
         sim.step_until(target_time).expect("step_until failed");
-
         let body = sim.body(0);
-        times.push(target_time);
         positions.push(body.trans.position);
         velocities.push(body.trans.velocity);
     }
-
-    (times, positions, velocities)
+    (positions, velocities)
 }
 
 /// Verify Battin's method produces identical trajectory to direct method
@@ -250,68 +62,55 @@ fn propagate(
 /// should agree to within machine epsilon accumulated over 8 hours.
 #[test]
 fn tier3_battin_vs_direct_trajectory() {
-    let jeod_root = jeod_test_data::jeod_path();
+    // Initial conditions come from the t=0 row of the JEOD reference CSV
+    // (same JEOD source data as RUN_4). The recipe asserts JEOD source
+    // and DE421 BSP existence internally.
+    let csv_path = test_data_path("dyncomp_run4_state.csv");
     assert!(
-        jeod_root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
-        jeod_root.display()
+        csv_path.exists(),
+        "JEOD reference not found at {}.\n\
+         Generate with: docker run --rm -v $(pwd)/test_data:/output \
+         -v $(pwd)/trick/generate_references.sh:/generate_references.sh:ro jeod-trick",
+        csv_path.display()
     );
+    let trajectory = load_dyncomp_csv(&csv_path);
+    assert!(trajectory.len() > 100);
+    let t0 = &trajectory[0];
+    let init = InitialConditions {
+        time: t0.time,
+        position: t0.composite_body.position,
+        velocity: t0.composite_body.velocity,
+        quaternion: Some(t0.composite_body.quaternion),
+        ang_vel: Some(t0.composite_body.ang_vel),
+    };
 
-    let bsp_path = test_data_path("de421.bsp");
-    assert!(
-        bsp_path.exists(),
-        "DE421 ephemeris not found at {}",
-        bsp_path.display()
-    );
-    let ephemeris = Ephemeris::from_bsp(&bsp_path).expect("load DE421");
+    let (pos_d, vel_d) = propagate(false, &init);
+    let (pos_b, vel_b) = propagate(true, &init);
 
-    // Run 1: direct subtraction (default, battin_method = false)
-    let (mut sim_direct, tdb_jd, sun_direct, moon_direct) =
-        build_sim(false, &jeod_root, &ephemeris);
-    let (times_d, pos_d, vel_d) =
-        propagate(&mut sim_direct, tdb_jd, sun_direct, moon_direct, &ephemeris);
+    assert_eq!(pos_d.len(), pos_b.len());
 
-    // Run 2: Battin's method (battin_method = true)
-    let (mut sim_battin, tdb_jd_b, sun_battin, moon_battin) =
-        build_sim(true, &jeod_root, &ephemeris);
-    let (times_b, pos_b, vel_b) = propagate(
-        &mut sim_battin,
-        tdb_jd_b,
-        sun_battin,
-        moon_battin,
-        &ephemeris,
-    );
-
-    assert_eq!(times_d.len(), times_b.len());
-
-    // Compare trajectories
     let mut max_pos_diff = 0.0_f64;
     let mut max_vel_diff = 0.0_f64;
-    let mut max_pos_time = 0.0_f64;
-    let mut max_vel_time = 0.0_f64;
-
-    for i in 0..times_d.len() {
-        assert!(
-            (times_d[i] - times_b[i]).abs() < 1e-12,
-            "Time mismatch at index {i}"
-        );
-
+    let mut max_pos_idx = 0usize;
+    let mut max_vel_idx = 0usize;
+    for i in 0..pos_d.len() {
         let pos_diff = (pos_d[i] - pos_b[i]).length();
         let vel_diff = (vel_d[i] - vel_b[i]).length();
-
         if pos_diff > max_pos_diff {
             max_pos_diff = pos_diff;
-            max_pos_time = times_d[i];
+            max_pos_idx = i;
         }
         if vel_diff > max_vel_diff {
             max_vel_diff = vel_diff;
-            max_vel_time = times_d[i];
+            max_vel_idx = i;
         }
     }
+    let max_pos_time = (max_pos_idx + 1) as f64 * LOG_INTERVAL;
+    let max_vel_time = (max_vel_idx + 1) as f64 * LOG_INTERVAL;
 
     println!(
         "Tier 3 (Battin vs Direct): {} points over {} hours",
-        times_d.len(),
+        pos_d.len(),
         DURATION / 3600.0
     );
     println!("  Max position difference: {max_pos_diff:.6e} m at t={max_pos_time:.0}s");


### PR DESCRIPTION
## Summary

- Final `pre_step` migration target from #162. Moves Battin scenario assembly and per-step DE421 ephemeris injection into `sim_dyncomp`:
  - `build_battin_3rd_body(init, battin)` — Earth + Sun + Moon scaffold, `battin_method` flag on the Sun/Moon `GravityControl`s.
  - `battin_pre_step(init)` — DE421 → `set_source_state` on the Sun + Moon source indices each step.
- Cross-compare (Battin reformulation vs direct subtraction) stays in the test file — no JEOD CSV reference, the comparison is internal — implementing the issue's option (2).
- Test file: 344 → 142 LoC; tolerances unchanged (`5.808e-1 m`, `4.798e-4 m/s`). Closes #188 and umbrella #162.

## Test plan

- [x] `cargo nextest run -p jeod_runner -E 'test(tier3_battin)'` passes (bit-stable trajectory under original tolerances).
- [x] `cargo nextest run -p jeod_runner -E 'test(tier3_simulation_run4_3rd_body)'` passes (no regression in shared `sim_dyncomp` scaffold).
- [x] `cargo fmt --check` and `cargo clippy --workspace --tests -- -D warnings` clean.
- [ ] CI: `check`, `test`, `test-tier3` jobs green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)