### PR TITLE
Pre-release cleanup: licensing, metadata, fail-loudly policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-28
+
+Initial public release. The original phased implementation plan
+(Phases 1–7) closed in April 2026; ongoing work tracks as GitHub issues.
+
+### Added
+
+- **Typed quantities** (`jeod_quantities`): phantom-tagged
+  `Position<F>`, `Velocity<F>`, `Acceleration<F>`,
+  `SecondsSince<S>`, `Quat<L, T>`, `NormalizedQuat`,
+  `FrameTransform<From, To>`, and the `F64Ext` facade
+  (`400.0.km()`, `51.6.deg()`, `420_000.0.kg()`). Compile-time
+  rejection of cross-frame mismatches and unit-dimensional errors.
+- **Mission API** (`bevy_jeod::prelude` + `bevy_jeod::recipes`):
+  typestate `VehicleBuilder` (no-state / no-integrator gates),
+  recipe modules for Earth/Moon/Sun/Mars, common orbital elements
+  (ISS, GEO, GTO, Molniya), and vehicle masses.
+- **Pipeline** (`jeod_sim`): nine-stage integration loop —
+  TimeUpdate, EphemerisUpdate, EnvironmentSet (gravity, atmosphere),
+  InteractionSet (aero, SRP, gravity torque, contact, shadow),
+  ForceCollectionSet, IntegrationSet, DerivedStateSet. Single API
+  surface for ECS adapters.
+- **Bevy adapter** (`bevy_jeod`): `JeodPlugin`, `JeodSet` system-set
+  enum, component bundles, and a thin systems layer that delegates
+  to `jeod_sim`.
+- **Standalone runner** (`jeod_runner`): `Simulation` propagator that
+  consumes the same `VehicleConfig` as the Bevy adapter — mission
+  code can swap between Bevy and the runner without rebuilding the
+  configuration.
+- **Physics models**: spherical-harmonics gravity (Gottlieb
+  algorithm), tides, third-body, RNP Earth rotation
+  (precession/nutation/polar motion), MET atmosphere, exponential
+  atmosphere, drag, SRP, gravity-gradient torque, contact, eclipse
+  shadow, Earth lighting.
+- **Time scales**: TAI, UTC, UT1, TDB, TT, GMST with leap-second
+  table from JEOD source.
+- **Integrators**: RK4, RKF45, ABM4, Gauss-Jackson 8th-order.
+- **Ephemerides**: DE4xx binary reader via `anise`.
+- **Verification**: three test tiers — Tier 1 unit tests, Tier 2
+  static reference vectors from JEOD source, Tier 3 trajectory
+  cross-validation against JEOD Trick simulations (committed
+  reference CSVs, Docker-based regeneration workflow).
+
+### Crates
+
+Thirteen crates published at this version:
+
+- `jeod_quantities`, `jeod_math`, `jeod_frames`, `jeod_time`,
+  `jeod_planet`, `jeod_ephemeris`, `jeod_gravity`, `jeod_atmosphere`,
+  `jeod_dynamics`, `jeod_interactions`, `jeod_sim`, `jeod_runner`,
+  `jeod_test_data`, plus the root `bevy_jeod` crate.
+
+[0.1.0]: https://github.com/simnaut/bevy_jeod/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,49 @@ The three verification tiers:
   through `Simulation::step()`, compare against JEOD Trick simulation output over
   hours/days
 
+## Fail Loudly (non-negotiable)
+
+Physics simulations have no graceful-degradation mode. A trajectory that
+silently propagates with a missing rotation matrix, an uninitialized mass,
+or a misconfigured gravity source is not "approximately right" — it is
+*wrong*, and downstream consumers (mission planners, GN&C developers,
+analysts) will treat the wrong answer as correct because nothing failed.
+The consequences range from wasted engineering time to mission-critical
+errors. Therefore:
+
+- **Misconfigurations and invalid physics must panic immediately.** A
+  vehicle configured for `MoonDE421` rotation without `EphemerisR`
+  loaded, an `AttachEvent` referencing an entity that isn't a mass body,
+  a gravity source with a non-positive `mu`, or a quaternion that drifts
+  past `NaN` — all of these must fail loudly with a diagnostic message
+  that names the misconfiguration and tells the caller how to fix it. Do
+  not `warn!` and continue; do not return a default; do not skip the
+  step. Surface the failure at the point of detection.
+- **Use `assert!` (and `assert_eq!`/`assert_ne!`), not `debug_assert!`.**
+  Invariants that protect physics correctness must hold in release
+  builds, where most simulation runs actually execute. `debug_assert!`
+  is silently a no-op under `--release` and gives a false sense of
+  safety. Reserve `debug_assert!` for invariants that are *purely
+  expensive performance checks* with no correctness consequence — those
+  are rare in this codebase.
+- **Diagnostic messages name the broken assumption.** A panic message
+  like `"unwrap on None"` is useless to a mission engineer. Write
+  messages that state which invariant was violated, which input
+  triggered it, and what the caller should change. The two patterns to
+  use are `expect("<noun phrase>: <what to fix>")` and
+  `unwrap_or_else(|err| panic!("<context with values>: {err:?}. <how to
+  fix>"))`.
+- **The exception**: deeply internal invariants that are unreachable by
+  construction may keep terse `expect()` messages — e.g.
+  `expect("stage 1 runs before stages 2-4")` inside a kernel that
+  already proved the precondition holds. These are documentation for
+  the next reader, not user-facing diagnostics.
+
+This rule is not in tension with the *No Half-Baked Implementations*
+rule above — it is its operational corollary. A test or implementation
+that compiles and runs but silently produces wrong physics is the
+half-baked failure mode the previous section forbids.
+
 ## Precision
 
 Use `f64` everywhere. Do NOT use Bevy's `Transform`/`GlobalTransform` (f32).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,30 @@
 [package]
 name = "bevy_jeod"
-version = "0.1.0"
-edition = "2021"
+description = "Bevy ECS adapter for the JEOD orbital-dynamics port"
+keywords = ["bevy", "orbital-mechanics", "simulation", "aerospace", "jeod"]
+categories = ["science", "simulation", "aerospace"]
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_sim = { path = "crates/jeod_sim" }
+jeod_sim = { path = "crates/jeod_sim", version = "0.1.0" }
 glam = { workspace = true }
 bevy = { workspace = true }
 bevy_reflect = { workspace = true }
 
 [dev-dependencies]
 glam = { workspace = true }
-jeod_test_data = { path = "crates/jeod_test_data" }
-jeod_sim = { path = "crates/jeod_sim" }
-jeod_runner = { path = "crates/jeod_runner" }
+jeod_test_data = { path = "crates/jeod_test_data", version = "0.1.0" }
+jeod_sim = { path = "crates/jeod_sim", version = "0.1.0" }
+jeod_runner = { path = "crates/jeod_runner", version = "0.1.0" }
 # Examples consume `recipes::orbital_elements` and convert into the
 # Bevy components, which requires the typed orbital-init helper plus
 # uom unit constructors.
-jeod_dynamics = { path = "crates/jeod_dynamics" }
-jeod_quantities = { path = "crates/jeod_quantities" }
+jeod_dynamics = { path = "crates/jeod_dynamics", version = "0.1.0" }
+jeod_quantities = { path = "crates/jeod_quantities", version = "0.1.0" }
 uom = { workspace = true }
 
 [workspace]
@@ -39,6 +45,12 @@ members = [
     "crates/jeod_runner",
     "xtask",
 ]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/simnaut/bevy_jeod"
 
 [workspace.dependencies]
 glam = { version = "0.30", features = ["std"] }

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 The bevy_jeod Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The bevy_jeod Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,127 @@
+# bevy_jeod
+
+A Rust port of [NASA JEOD](https://github.com/nasa/jeod) (JSC Engineering
+Orbital Dynamics, v5.4) with [Bevy ECS](https://bevy.org) wiring on top.
+
+`bevy_jeod` reimplements JEOD's spacecraft dynamics — spherical-harmonics
+gravity, Earth rotation (precession/nutation/polar motion), atmospheric
+drag, solar radiation pressure, gravity-gradient torque, multi-step
+integrators, time-scale conversion (TAI/UTC/UT1/TDB/TT/GMST), DE4xx
+ephemerides — as pure Rust crates, then exposes them through a thin Bevy
+adapter so they slot into any Bevy app.
+
+**Status:** pre-1.0. Tier 3 cross-validated against JEOD Trick simulations
+(see [`docs/tier3_regeneration.md`](docs/tier3_regeneration.md)). API may
+change before 1.0.
+
+## Architecture
+
+Three layers, separated by hard dependency rules:
+
+- `jeod_*` — pure Rust physics crates, **zero Bevy dependency**. Math,
+  integrators, frame transforms, gravity, time scales, ephemerides.
+- `jeod_sim` — orchestration and recipes. Composes `jeod_*` into a
+  pipeline; the single API surface for any ECS adapter. Zero Bevy
+  dependency.
+- `bevy_jeod` (this crate) — thin Bevy glue. Components, systems that
+  delegate to `jeod_sim`, plugin registration. Depends only on
+  `jeod_sim` + `bevy`.
+
+See [`STRATEGY.md`](STRATEGY.md) for architecture detail and
+[`docs/type_system.md`](docs/type_system.md) for the typed-quantity layer.
+
+## Quick start
+
+```toml
+[dependencies]
+bevy = "0.18"
+bevy_jeod = "0.1"
+```
+
+```rust
+use bevy::prelude::*;
+use bevy_jeod::prelude::*;
+use bevy_jeod::recipes::{earth, orbital_elements, vehicle};
+
+fn setup(mut commands: Commands) {
+    let earth_recipe = earth::point_mass();
+    let mu = earth_recipe.source.mu.m3_per_s2();
+    let earth_entity = commands
+        .spawn((
+            GravitySourceC(earth_recipe.source),
+            SourceInertialPositionC::default(),
+            TranslationalStateC::default(),
+        ))
+        .id();
+
+    let cfg = VehicleBuilder::new()
+        .from_orbital_elements(orbital_elements::iss(), mu)
+        .three_dof_point_mass(vehicle::iss_mass())
+        .rk4()
+        .gravity(GravityControl::new_spherical(0_usize, false))
+        .build();
+
+    cfg.spawn_bevy(&mut commands, &[earth_entity]);
+}
+
+fn main() {
+    App::new()
+        .add_plugins((MinimalPlugins, JeodPlugin))
+        .insert_resource(Time::<Fixed>::from_seconds(10.0))
+        .add_systems(Startup, setup)
+        .run();
+}
+```
+
+The typestate `VehicleBuilder` rejects misuse at compile time
+(no integrator chosen, no state set, mismatched coordinate frames).
+Errors render in physics language — *"expected `Position<Inertial>`,
+found `Position<Ecef>` — apply a `FrameTransform<Ecef, Inertial>` first"* —
+not as `PhantomData` mismatches.
+
+A full worked example lives in
+[`examples/typed_mission.rs`](examples/typed_mission.rs).
+
+## Verification
+
+Three test tiers, all part of the definition of done for every release:
+
+- **Tier 1** — unit tests on pure functions (round-trips, convergence).
+- **Tier 2** — comparison against static reference vectors extracted from
+  JEOD source files (gravity test cases, Euler angle tables).
+- **Tier 3** — end-to-end trajectory cross-validation: propagate from the
+  same initial conditions as a JEOD Trick simulation and compare position,
+  velocity, attitude, and angular velocity over hours or days. Reference
+  CSVs are committed to the repo.
+
+```bash
+cargo nextest run --workspace -E 'not test(tier3_)'   # fast: Tier 1 + 2
+cargo nextest run --workspace -E 'test(tier3_)'       # Tier 3
+```
+
+Set `JEOD_HOME` to a JEOD source checkout for tests that load JEOD data
+files. See [`CLAUDE.md`](CLAUDE.md) for the full build and test workflow.
+
+## Documentation
+
+- [`STRATEGY.md`](STRATEGY.md) — architecture and phase history.
+- [`docs/type_system.md`](docs/type_system.md) — typed quantities,
+  phantom-tag pattern, adding new dimensions.
+- [`docs/JEOD_invariants.md`](docs/JEOD_invariants.md) — catalog of JEOD
+  C++ invariants and where each is enforced in our Rust port.
+- [`docs/tier3_regeneration.md`](docs/tier3_regeneration.md) — regenerating
+  Tier 3 reference CSVs in Docker.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+NASA JEOD itself is distributed under NASA's open-source license and is
+not redistributed by this project.

--- a/crates/jeod_atmosphere/Cargo.toml
+++ b/crates/jeod_atmosphere/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "jeod_atmosphere"
-version = "0.1.0"
-edition = "2021"
+description = "Atmospheric density models (exponential, MET) for bevy_jeod"
+keywords = ["atmosphere", "drag", "orbital-mechanics", "aerospace"]
+categories = ["science", "aerospace"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 glam = { workspace = true }
 uom = { workspace = true }

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -1,19 +1,24 @@
 [package]
 name = "jeod_dynamics"
-version = "0.1.0"
-edition = "2021"
+description = "Rigid-body dynamics, integrators (RK4, RKF45, GJ, ABM4), mass tree, and body initialization"
+keywords = ["orbital-mechanics", "dynamics", "integrator", "aerospace", "simulation"]
+categories = ["science", "aerospace", "simulation"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_frames = { path = "../jeod_frames" }
-jeod_math = { path = "../jeod_math" }
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_frames = { path = "../jeod_frames", version = "0.1.0" }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 glam = { workspace = true }
 uom = { workspace = true }
 
 [dev-dependencies]
-jeod_math = { path = "../jeod_math", features = ["test-utils"] }
-jeod_quantities = { path = "../jeod_quantities", features = ["test-utils"] }
-jeod_test_data = { path = "../jeod_test_data" }
-jeod_gravity = { path = "../jeod_gravity" }
-jeod_planet = { path = "../jeod_planet" }
+jeod_math = { path = "../jeod_math", version = "0.1.0", features = ["test-utils"] }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0", features = ["test-utils"] }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
+jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
+jeod_planet = { path = "../jeod_planet", version = "0.1.0" }
 sha2 = "0.10"

--- a/crates/jeod_dynamics/src/gauss_jackson/ratio128.rs
+++ b/crates/jeod_dynamics/src/gauss_jackson/ratio128.rs
@@ -64,6 +64,8 @@ impl Ratio128 {
 
     /// Construct from unsigned numerator and denominator with sign.
     /// JEOD: `Ratio128(unsigned long long num_in, unsigned long long den_in, int sign_in)`.
+    /// Faithful port of the JEOD constructor; currently exercised only by
+    /// the unit tests in this module.
     #[allow(dead_code)]
     pub fn new(num: u128, den: u128, sign: i8) -> Self {
         assert!(den != 0, "Ratio128: zero denominator");

--- a/crates/jeod_ephemeris/Cargo.toml
+++ b/crates/jeod_ephemeris/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "jeod_ephemeris"
-version = "0.1.0"
-edition = "2021"
+description = "DE4xx binary ephemeris reader and body positions for bevy_jeod"
+keywords = ["ephemeris", "de440", "spice", "orbital-mechanics", "aerospace"]
+categories = ["science", "aerospace"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 anise = "0.9"
 glam = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/jeod_frames/Cargo.toml
+++ b/crates/jeod_frames/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
 name = "jeod_frames"
-version = "0.1.0"
-edition = "2021"
+description = "Reference frame tree and Earth rotation (RNP, nutation, precession) for bevy_jeod"
+keywords = ["reference-frame", "earth-rotation", "orbital-mechanics", "aerospace", "geodesy"]
+categories = ["science", "aerospace"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_math = { path = "../jeod_math" }
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 glam = { workspace = true }
 
 [dev-dependencies]
-jeod_math = { path = "../jeod_math", features = ["test-utils"] }
-jeod_test_data = { path = "../jeod_test_data" }
-jeod_time = { path = "../jeod_time" }
+jeod_math = { path = "../jeod_math", version = "0.1.0", features = ["test-utils"] }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
+jeod_time = { path = "../jeod_time", version = "0.1.0" }

--- a/crates/jeod_frames/tests/rnp_comparison.rs
+++ b/crates/jeod_frames/tests/rnp_comparison.rs
@@ -76,7 +76,8 @@ fn max_matrix_error(a: &DMat3, b: &DMat3) -> f64 {
     max_err
 }
 
-/// JEOD RNP CSV record at one timestep.
+/// JEOD RNP CSV record at one timestep. Mirrors the CSV column layout;
+/// not every field is consumed by every assertion.
 #[allow(dead_code)]
 struct RnpRecord {
     time: f64,

--- a/crates/jeod_gravity/Cargo.toml
+++ b/crates/jeod_gravity/Cargo.toml
@@ -1,18 +1,23 @@
 [package]
 name = "jeod_gravity"
-version = "0.1.0"
-edition = "2021"
+description = "Spherical-harmonics gravity (Gottlieb), tides, and third-body for bevy_jeod"
+keywords = ["gravity", "spherical-harmonics", "orbital-mechanics", "aerospace", "physics"]
+categories = ["science", "aerospace"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_math = { path = "../jeod_math" }
-jeod_dynamics = { path = "../jeod_dynamics" }
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
+jeod_dynamics = { path = "../jeod_dynamics", version = "0.1.0" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 glam = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 uom = { workspace = true }
 
 [dev-dependencies]
-jeod_test_data = { path = "../jeod_test_data" }
-jeod_time = { path = "../jeod_time" }
-jeod_frames = { path = "../jeod_frames" }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
+jeod_time = { path = "../jeod_time", version = "0.1.0" }
+jeod_frames = { path = "../jeod_frames", version = "0.1.0" }

--- a/crates/jeod_interactions/Cargo.toml
+++ b/crates/jeod_interactions/Cargo.toml
@@ -1,20 +1,25 @@
 [package]
 name = "jeod_interactions"
-version = "0.1.0"
-edition = "2021"
+description = "Aerodynamic drag, SRP, gravity-gradient torque, shadow, and contact for bevy_jeod"
+keywords = ["drag", "srp", "gravity-gradient", "orbital-mechanics", "aerospace"]
+categories = ["science", "aerospace"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 glam = { workspace = true }
-jeod_atmosphere = { path = "../jeod_atmosphere" }
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_atmosphere = { path = "../jeod_atmosphere", version = "0.1.0" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 uom = { workspace = true }
 
 [dev-dependencies]
-jeod_dynamics = { path = "../jeod_dynamics" }
-jeod_ephemeris = { path = "../jeod_ephemeris" }
-jeod_gravity = { path = "../jeod_gravity" }
-jeod_math = { path = "../jeod_math" }
-jeod_planet = { path = "../jeod_planet" }
-jeod_quantities = { path = "../jeod_quantities", features = ["test-utils"] }
-jeod_test_data = { path = "../jeod_test_data" }
-jeod_time = { path = "../jeod_time" }
+jeod_dynamics = { path = "../jeod_dynamics", version = "0.1.0" }
+jeod_ephemeris = { path = "../jeod_ephemeris", version = "0.1.0" }
+jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
+jeod_planet = { path = "../jeod_planet", version = "0.1.0" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0", features = ["test-utils"] }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
+jeod_time = { path = "../jeod_time", version = "0.1.0" }

--- a/crates/jeod_interactions/tests/tier2_earth_lighting.rs
+++ b/crates/jeod_interactions/tests/tier2_earth_lighting.rs
@@ -16,6 +16,8 @@
 use jeod_interactions::earth_lighting::calc_lighting_params;
 use std::path::Path;
 
+/// JEOD lighting CSV record. Mirrors the full CSV column layout; only the
+/// subset relevant to each assertion is read.
 #[allow(dead_code)]
 struct LightingRecord {
     time: f64,

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "jeod_math"
-version = "0.1.0"
-edition = "2021"
+description = "Quaternion, Euler, geodetic, orbital-element, and LVLH math kernels for bevy_jeod"
+keywords = ["orbital-mechanics", "math", "quaternion", "geodetic", "aerospace"]
+categories = ["science", "aerospace", "mathematics"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 glam = { workspace = true }
 thiserror = { workspace = true }
 uom = { workspace = true }
@@ -13,10 +18,9 @@ uom = { workspace = true }
 test-utils = []
 
 [dev-dependencies]
-jeod_test_data = { path = "../jeod_test_data" }
-jeod_ephemeris = { path = "../jeod_ephemeris" }
-jeod_planet = { path = "../jeod_planet" }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
+jeod_ephemeris = { path = "../jeod_ephemeris", version = "0.1.0" }
+jeod_planet = { path = "../jeod_planet", version = "0.1.0" }
 # `test-utils` exposes `jeod_quantities::frame::TestVehicle` for inline tests
 # that need a phantom vehicle tag (Vehicle is sealed in production).
-jeod_quantities = { path = "../jeod_quantities", features = ["test-utils"] }
-
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0", features = ["test-utils"] }

--- a/crates/jeod_planet/Cargo.toml
+++ b/crates/jeod_planet/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "jeod_planet"
-version = "0.1.0"
-edition = "2021"
+description = "Planet definitions and presets (Earth, Moon, Sun, Mars) for bevy_jeod"
+keywords = ["planet", "ephemeris", "orbital-mechanics", "aerospace"]
+categories = ["science", "aerospace"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 uom = { workspace = true }

--- a/crates/jeod_quantities/Cargo.toml
+++ b/crates/jeod_quantities/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "jeod_quantities"
-version = "0.1.0"
-edition = "2021"
-description = "Dimensional-analysis and phantom-tag types for bevy_jeod (frames, time scales, quaternions)"
-license = "Apache-2.0"
+description = "Phantom-tagged typed quantities (Position, Velocity, ...) for orbital dynamics"
+keywords = ["orbital-mechanics", "physics", "type-system", "aerospace"]
+categories = ["science", "aerospace", "data-structures"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 glam = { workspace = true }

--- a/crates/jeod_runner/Cargo.toml
+++ b/crates/jeod_runner/Cargo.toml
@@ -1,27 +1,32 @@
 [package]
 name = "jeod_runner"
-version = "0.1.0"
-edition = "2021"
+description = "Standalone simulation runner and Tier 3 verification harness for bevy_jeod"
+keywords = ["orbital-mechanics", "simulation", "propagator", "aerospace", "verification"]
+categories = ["science", "aerospace", "simulation"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_sim = { path = "../jeod_sim" }
-jeod_dynamics = { path = "../jeod_dynamics" }
-jeod_gravity = { path = "../jeod_gravity" }
-jeod_time = { path = "../jeod_time" }
-jeod_frames = { path = "../jeod_frames" }
-jeod_interactions = { path = "../jeod_interactions" }
-jeod_math = { path = "../jeod_math" }
+jeod_sim = { path = "../jeod_sim", version = "0.1.0" }
+jeod_dynamics = { path = "../jeod_dynamics", version = "0.1.0" }
+jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
+jeod_time = { path = "../jeod_time", version = "0.1.0" }
+jeod_frames = { path = "../jeod_frames", version = "0.1.0" }
+jeod_interactions = { path = "../jeod_interactions", version = "0.1.0" }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
 # `jeod_test_data` powers `run_verification::*` (Tier 3 verification-case
 # machinery). It is lightweight (regex + glam + uom) and pulls in no physics
 # crates, so promoting it from a dev-dep to a regular dep keeps the public
 # `VerificationCaseExt` reachable from any consumer of `jeod_runner`.
-jeod_test_data = { path = "../jeod_test_data" }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
 glam = { workspace = true }
 log = { workspace = true }
 uom = { workspace = true }
 
 [dev-dependencies]
-jeod_atmosphere = { path = "../jeod_atmosphere" }
+jeod_atmosphere = { path = "../jeod_atmosphere", version = "0.1.0" }
 
 [[example]]
 name = "batch_propagation"

--- a/crates/jeod_runner/src/branded.rs
+++ b/crates/jeod_runner/src/branded.rs
@@ -318,6 +318,7 @@ impl Simulation {
 ///     sim_b.set_source_position(idx_a, DVec3::ZERO);
 /// });
 /// ```
+// Anchor for the compile_fail doctest above; never called at runtime.
 #[allow(dead_code)]
 fn _doc_compile_fail_marker() {}
 

--- a/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
+++ b/crates/jeod_runner/tests/tier3_sim_attach_mass.rs
@@ -116,26 +116,6 @@ fn mass_struct_cg_spec(mass: f64, position: DVec3, inertia_struct: DMat3) -> Mas
     MassProperties::with_inertia(mass, inertia_struct, position)
 }
 
-/// Build `MassProperties` using JEOD's `Spec` inertia spec: the inertia is
-/// given in a user-specified frame about a user-specified origin. Shift to
-/// CoM via `inertia_offset` and rotate by `inertia_orientation`.
-///
-/// JEOD's `Matrix3x3::transform_matrix(trans, mat, prod)` computes
-/// `prod = trans * mat * trans^T` (matrix3x3_inline.hh:510).
-#[allow(dead_code)]
-fn mass_spec_spec(
-    mass: f64,
-    position: DVec3,
-    inertia_user: DMat3,
-    inertia_offset: DVec3,
-    inertia_orientation: DMat3,
-) -> MassProperties {
-    let offset_inertia = point_mass_inertia(mass, inertia_offset);
-    let shifted = inertia_user - offset_inertia;
-    let body_inertia = inertia_orientation * shifted * inertia_orientation.transpose();
-    MassProperties::with_inertia(mass, body_inertia, position)
-}
-
 // ════════════════════════════════════════════════════════════════════
 // Baseline mass bodies (ported from JEOD Modified_data/*.py)
 // ════════════════════════════════════════════════════════════════════
@@ -166,7 +146,6 @@ fn child2_default() -> MassProperties {
 }
 
 /// `child3_mass_default()`: Body spec, diag(0.3333, 0.4167, 0.0833) about CoM.
-#[allow(dead_code)]
 fn child3_default() -> MassProperties {
     let inertia = DMat3::from_cols(
         DVec3::new(0.33333333, 0.0, 0.0),

--- a/crates/jeod_runner/tests/tier3_sim_relative.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative.rs
@@ -13,6 +13,8 @@ use jeod_sim::{
     compute_relative_state, MassProperties, RotationalState, SimulationTime, TranslationalState,
 };
 
+/// SIM_Relative CSV record. Mirrors the full column layout; not every
+/// field is consumed by every assertion.
 #[allow(dead_code)]
 struct RelativeRecord {
     time: f64,

--- a/crates/jeod_runner/tests/tier3_sim_timescale.rs
+++ b/crates/jeod_runner/tests/tier3_sim_timescale.rs
@@ -11,6 +11,8 @@ use jeod_sim::SimulationTime;
 
 const SECONDS_PER_DAY: f64 = 86400.0;
 
+/// SIM_5_all_inclusive timescale CSV record. Mirrors the full column
+/// layout; not every field is consumed by every assertion.
 #[allow(dead_code)]
 struct TimescaleRecord {
     time: f64,

--- a/crates/jeod_sim/Cargo.toml
+++ b/crates/jeod_sim/Cargo.toml
@@ -1,22 +1,27 @@
 [package]
 name = "jeod_sim"
-version = "0.1.0"
-edition = "2021"
+description = "Pipeline orchestration, VehicleBuilder, and recipes — single API surface for ECS adapters"
+keywords = ["orbital-mechanics", "simulation", "aerospace", "ecs", "physics"]
+categories = ["science", "aerospace", "simulation"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
-jeod_math = { path = "../jeod_math" }
-jeod_dynamics = { path = "../jeod_dynamics" }
-jeod_gravity = { path = "../jeod_gravity" }
-jeod_time = { path = "../jeod_time" }
-jeod_frames = { path = "../jeod_frames" }
-jeod_atmosphere = { path = "../jeod_atmosphere" }
-jeod_interactions = { path = "../jeod_interactions" }
-jeod_ephemeris = { path = "../jeod_ephemeris" }
-jeod_planet = { path = "../jeod_planet" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
+jeod_dynamics = { path = "../jeod_dynamics", version = "0.1.0" }
+jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
+jeod_time = { path = "../jeod_time", version = "0.1.0" }
+jeod_frames = { path = "../jeod_frames", version = "0.1.0" }
+jeod_atmosphere = { path = "../jeod_atmosphere", version = "0.1.0" }
+jeod_interactions = { path = "../jeod_interactions", version = "0.1.0" }
+jeod_ephemeris = { path = "../jeod_ephemeris", version = "0.1.0" }
+jeod_planet = { path = "../jeod_planet", version = "0.1.0" }
 glam = { workspace = true }
 log = { workspace = true }
 uom = { workspace = true }
 
 [dev-dependencies]
-jeod_test_data = { path = "../jeod_test_data" }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }

--- a/crates/jeod_test_data/Cargo.toml
+++ b/crates/jeod_test_data/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "jeod_test_data"
-version = "0.1.0"
-edition = "2021"
+description = "JEOD reference-data parsers and Tier 3 baseline tooling for bevy_jeod"
+keywords = ["jeod", "test-data", "verification", "aerospace"]
+categories = ["science", "aerospace", "development-tools"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 glam = { workspace = true }
 regex = "1"
 uom = { workspace = true }

--- a/crates/jeod_time/Cargo.toml
+++ b/crates/jeod_time/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "jeod_time"
-version = "0.1.0"
-edition = "2021"
+description = "Time scales (TAI/UTC/UT1/TDB/TT/GMST) and converters for bevy_jeod"
+keywords = ["time", "timescale", "tai", "utc", "aerospace"]
+categories = ["science", "aerospace", "date-and-time"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-jeod_quantities = { path = "../jeod_quantities" }
+jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 log = { workspace = true }
 uom = { workspace = true }

--- a/examples/typed_mission.rs
+++ b/examples/typed_mission.rs
@@ -134,7 +134,7 @@ fn log_orbit(
 // constructions. The example itself uses recipe presets, but the
 // import demonstrates the available surface — mission authors should
 // consume units via this facade instead of importing `uom::si::*`
-// directly.
+// directly. This function is documentation-only; never called.
 #[allow(dead_code)]
 fn _showcase_f64_ext() {
     let _mass = 420_000.0.kg();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -81,25 +81,22 @@ pub fn planet_fixed_rotation_system(
                 );
             }
             jeod_sim::RotationModel::MoonDE421 => {
-                let Some(eph) = ephemeris.as_ref() else {
-                    warn!(
-                        "RotationModel::MoonDE421 requires the EphemerisR resource with a BPC loaded; \
-                         leaving PlanetFixedRotationC unchanged"
-                    );
-                    continue;
-                };
+                let eph = ephemeris.as_ref().expect(
+                    "RotationModel::MoonDE421 requires the EphemerisR resource with a BPC \
+                     loaded. Insert EphemerisR before stepping the simulation, or switch the \
+                     body to RotationModel::MoonIAU.",
+                );
                 let tdb_jd = sim_time.tdb_julian_date();
-                match eph.get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd) {
-                    Ok(matrix) => {
-                        rot.0 = jeod_sim::FrameTransform::from_matrix(matrix);
-                    }
-                    Err(err) => {
-                        warn!(
-                            "Moon DE421 BPC rotation query failed at TDB JD {tdb_jd}: {err:?}; \
-                             leaving PlanetFixedRotationC unchanged"
-                        );
-                    }
-                }
+                let matrix = eph
+                    .get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd)
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "Moon DE421 BPC rotation query failed at TDB JD {tdb_jd}: {err:?}. \
+                             The loaded BPC kernel does not cover this epoch; load a kernel \
+                             whose coverage includes the simulation epoch."
+                        )
+                    });
+                rot.0 = jeod_sim::FrameTransform::from_matrix(matrix);
             }
         }
     }
@@ -1274,33 +1271,45 @@ pub fn staging_system(
     let mut changed_ids: Vec<jeod_sim::MassBodyId> = Vec::new();
 
     for evt in attach_events.read() {
-        let Ok(child_id) = bodies.get(evt.child).map(|(id, _)| id.0) else {
-            warn!(
-                "AttachEvent child entity {:?} missing MassBodyIdC or MassPropertiesC; skipping",
-                evt.child
-            );
-            continue;
-        };
-        let Ok(parent_id) = bodies.get(evt.parent).map(|(id, _)| id.0) else {
-            warn!(
-                "AttachEvent parent entity {:?} missing MassBodyIdC or MassPropertiesC; skipping",
-                evt.parent
-            );
-            continue;
-        };
+        let child_id = bodies
+            .get(evt.child)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "AttachEvent.child = {:?} is not a mass body — entity is missing MassBodyIdC \
+                 and/or MassPropertiesC. Spawn the body via the mass-tree API before attaching.",
+                    evt.child
+                )
+            })
+            .0
+             .0;
+        let parent_id = bodies
+            .get(evt.parent)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "AttachEvent.parent = {:?} is not a mass body — entity is missing MassBodyIdC \
+                 and/or MassPropertiesC. Spawn the parent via the mass-tree API before attaching.",
+                    evt.parent
+                )
+            })
+            .0
+             .0;
         tree.attach(child_id, parent_id, evt.offset, evt.t_parent_child);
         changed_ids.push(child_id);
         changed_ids.push(parent_id);
     }
 
     for evt in detach_events.read() {
-        let Ok(child_id) = bodies.get(evt.child).map(|(id, _)| id.0) else {
-            warn!(
-                "DetachEvent child entity {:?} missing MassBodyIdC or MassPropertiesC; skipping",
-                evt.child
-            );
-            continue;
-        };
+        let child_id = bodies
+            .get(evt.child)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "DetachEvent.child = {:?} is not a mass body — entity is missing MassBodyIdC \
+                 and/or MassPropertiesC.",
+                    evt.child
+                )
+            })
+            .0
+             .0;
         if let Some(parent_id) = tree.parent(child_id) {
             changed_ids.push(parent_id);
         }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -81,14 +81,25 @@ pub fn planet_fixed_rotation_system(
                 );
             }
             jeod_sim::RotationModel::MoonDE421 => {
-                let eph = ephemeris
-                    .as_ref()
-                    .expect("MoonDE421 rotation requires EphemerisR resource with BPC loaded.");
+                let Some(eph) = ephemeris.as_ref() else {
+                    warn!(
+                        "RotationModel::MoonDE421 requires the EphemerisR resource with a BPC loaded; \
+                         leaving PlanetFixedRotationC unchanged"
+                    );
+                    continue;
+                };
                 let tdb_jd = sim_time.tdb_julian_date();
-                rot.0 = jeod_sim::FrameTransform::from_matrix(
-                    eph.get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd)
-                        .expect("Moon DE421 BPC rotation query failed"),
-                );
+                match eph.get_body_rotation(jeod_sim::EphemerisBody::Moon, tdb_jd) {
+                    Ok(matrix) => {
+                        rot.0 = jeod_sim::FrameTransform::from_matrix(matrix);
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Moon DE421 BPC rotation query failed at TDB JD {tdb_jd}: {err:?}; \
+                             leaving PlanetFixedRotationC unchanged"
+                        );
+                    }
+                }
             }
         }
     }
@@ -1263,27 +1274,33 @@ pub fn staging_system(
     let mut changed_ids: Vec<jeod_sim::MassBodyId> = Vec::new();
 
     for evt in attach_events.read() {
-        let child_id = bodies
-            .get(evt.child)
-            .expect("AttachEvent child entity missing MassBodyIdC or MassPropertiesC")
-            .0
-             .0;
-        let parent_id = bodies
-            .get(evt.parent)
-            .expect("AttachEvent parent entity missing MassBodyIdC or MassPropertiesC")
-            .0
-             .0;
+        let Ok(child_id) = bodies.get(evt.child).map(|(id, _)| id.0) else {
+            warn!(
+                "AttachEvent child entity {:?} missing MassBodyIdC or MassPropertiesC; skipping",
+                evt.child
+            );
+            continue;
+        };
+        let Ok(parent_id) = bodies.get(evt.parent).map(|(id, _)| id.0) else {
+            warn!(
+                "AttachEvent parent entity {:?} missing MassBodyIdC or MassPropertiesC; skipping",
+                evt.parent
+            );
+            continue;
+        };
         tree.attach(child_id, parent_id, evt.offset, evt.t_parent_child);
         changed_ids.push(child_id);
         changed_ids.push(parent_id);
     }
 
     for evt in detach_events.read() {
-        let child_id = bodies
-            .get(evt.child)
-            .expect("DetachEvent child entity missing MassBodyIdC or MassPropertiesC")
-            .0
-             .0;
+        let Ok(child_id) = bodies.get(evt.child).map(|(id, _)| id.0) else {
+            warn!(
+                "DetachEvent child entity {:?} missing MassBodyIdC or MassPropertiesC; skipping",
+                evt.child
+            );
+            continue;
+        };
         if let Some(parent_id) = tree.parent(child_id) {
             changed_ids.push(parent_id);
         }


### PR DESCRIPTION
## Summary

Pre-release cleanup sweep. The codebase was already free of dev debris and lint-clean; this PR adds the mechanical paperwork required for `cargo publish` and tightens the panic policy on the Bevy adapter.

## Changes

### Licensing & top-level docs

- `LICENSE-MIT` and `LICENSE-APACHE` at the repo root (dual-licensed).
- `README.md`: tagline, status, architecture summary, quick-start snippet (lifted from `examples/typed_mission.rs`), links to `STRATEGY.md` and the docs.
- `CHANGELOG.md`: single `[0.1.0] - 2026-04-28` entry summarizing what shipped (typed quantities, `VehicleBuilder`, 9-stage pipeline, Tier 1/2/3 verification, 13 published crates).

### Crate metadata (14 manifests)

- New `[workspace.package]` block with `version = "0.1.0"`, `edition = "2021"`, `license = "MIT OR Apache-2.0"`, `repository = "https://github.com/simnaut/bevy_jeod"`. Each crate inherits via `field.workspace = true`.
- Per-crate `description`, `keywords`, and `categories` chosen for crates.io discoverability.
- Every path dependency now carries `version = "0.1.0"` so `cargo publish --dry-run` resolves them.
- `jeod_quantities` license updated from `Apache-2.0` to `MIT OR Apache-2.0` for consistency.

### Fail-loudly policy

A physics simulation has no graceful-degradation mode — a trajectory that silently propagates with a missing rotation matrix or an unattached body produces wrong physics that downstream consumers will treat as correct. This PR establishes the policy and tightens five sites in `src/systems.rs`:

- `MoonDE421` rotation when `EphemerisR` is missing → panic with a message naming the missing resource and the alternative (`MoonIAU`).
- `MoonDE421` rotation when the BPC kernel doesn't cover the simulation epoch → panic with the failing TDB JD and the underlying error.
- `AttachEvent.child` / `AttachEvent.parent` / `DetachEvent.child` referencing entities that aren't mass bodies → panic naming the offending entity and the missing components.

Two genuinely-internal invariants (`stage_inputs_and_order` post-condition, `k1_temp_dots` populated by stage 1) keep their terse `expect()` messages — they are unreachable by construction.

`CLAUDE.md` gains a new **Fail Loudly (non-negotiable)** section that documents the policy: panic at the detection site, prefer `assert!` over `debug_assert!` (which is a no-op under `--release`), and diagnostic messages must name the broken invariant and the fix.

### Hygiene

- Audited 13 `#[allow(dead_code)]` sites: deleted the unused `mass_spec_spec` helper in `tier3_sim_attach_mass.rs`, removed a stale allow on `child3_default` (which is in fact called), and added one-line justifications to the legitimate CSV-record / doctest-marker / `F64Ext` showcase sites.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo build --workspace --tests --examples`
- [x] `cargo test --workspace --lib` (all 14 lib suites green; Tier 2 / Tier 3 tests that need `JEOD_HOME` skipped — not a regression)
- [ ] CI: lint & format, docs, unit + Tier 2, Tier 3 fast, compile-time budget
- [ ] `cargo publish --dry-run -p <crate>` for each crate (run before tagging the release)

https://claude.ai/code/session_01T2pVS8f4wPUt24FFRPPLCz