### PR TITLE
[#222] Add proptest round-trip laws for jeod_quantities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,7 @@ name = "jeod_quantities"
 version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
+ "proptest",
  "thiserror 2.0.18",
  "typenum",
  "uom",
@@ -3366,10 +3367,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -3429,6 +3455,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -3632,6 +3667,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3963,6 +4010,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,6 +4280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4417,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/jeod_quantities/Cargo.toml
+++ b/crates/jeod_quantities/Cargo.toml
@@ -14,6 +14,9 @@ uom = { workspace = true }
 typenum = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+proptest = "1"
+
 [features]
 # Exposes test-only phantom markers (e.g. `TestVehicle`) so downstream crates
 # can write frame-composition tests without needing to implement sealed

--- a/crates/jeod_quantities/tests/proptest_round_trips.rs
+++ b/crates/jeod_quantities/tests/proptest_round_trips.rs
@@ -1,0 +1,192 @@
+//! Property-based round-trip tests for `jeod_quantities` algebraic laws.
+//!
+//! Three suites:
+//!   1. `FrameTransform` composition associativity:
+//!      `(a * b) * c ≈ a * (b * c)` when applied to a `Position`.
+//!   2. Quaternion normalization idempotency for both `NormalizedQuat::renormalize`
+//!      and `JeodQuat::normalize` (in-place).
+//!   3. `F64Ext` unit-conversion round-trips (km→m, deg→rad→deg, km/s→m/s, etc.).
+//!
+//! All `f64` strategies are bounded to non-NaN, non-inf, magnitudes in
+//! `1e-9..1e9` to keep the laws inside the regime where double-precision
+//! arithmetic is well-behaved.
+
+use glam::DVec3;
+use jeod_quantities::prelude::*;
+use proptest::prelude::*;
+use uom::si::{
+    angle::{degree, radian},
+    length::{kilometer, meter},
+    time::{hour, second},
+    velocity::{kilometer_per_second, meter_per_second},
+};
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+/// Finite, non-zero `f64` in a magnitude range that keeps round-trips stable
+/// (avoids subnormals and overflow).
+fn finite_scalar() -> impl Strategy<Value = f64> {
+    prop_oneof![
+        (1.0e-9_f64..1.0e9_f64),
+        (1.0e-9_f64..1.0e9_f64).prop_map(|x| -x),
+    ]
+}
+
+/// Arbitrary `JeodQuat` (scalar-first, left-transformation) built from four
+/// finite components. Guaranteed to have non-zero norm by component bounds.
+fn arbitrary_jeod_quat() -> impl Strategy<Value = JeodQuat> {
+    (
+        finite_scalar(),
+        finite_scalar(),
+        finite_scalar(),
+        finite_scalar(),
+    )
+        .prop_filter("non-zero, finite norm", |(a, b, c, d)| {
+            let n2 = a * a + b * b + c * c + d * d;
+            n2.is_finite() && n2 > 1.0e-18
+        })
+        .prop_map(|(a, b, c, d)| JeodQuat::from_array([a, b, c, d]))
+}
+
+/// A `NormalizedQuat<ScalarFirst, LeftTransform>` (i.e. a witnessed unit-norm
+/// JEOD quaternion) drawn from the arbitrary-`JeodQuat` strategy via
+/// `renormalize`.
+fn arbitrary_unit_jeod_quat() -> impl Strategy<Value = NormalizedQuat<ScalarFirst, LeftTransform>> {
+    arbitrary_jeod_quat().prop_filter_map("renormalize succeeds", NormalizedQuat::renormalize)
+}
+
+/// A `Position<F>` with finite, bounded components.
+fn arbitrary_position<F: Frame>() -> impl Strategy<Value = jeod_quantities::aliases::Position<F>> {
+    (finite_scalar(), finite_scalar(), finite_scalar())
+        .prop_map(|(x, y, z)| Qty3::from_raw_si(DVec3::new(x, y, z)))
+}
+
+// Property 1: FrameTransform composition associativity. Pick four distinct
+// frames A=Inertial, B=Ecef, C=PlanetFixed<Earth>, D=PlanetFixed<Moon> (all
+// sealed `Frame` impls reachable from the prelude) and assert
+// `(a * b) * c ≈ a * (b * c)` after applying to a `Position<A>`.
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+    #[test]
+    fn frame_transform_composition_is_associative(
+        qa in arbitrary_unit_jeod_quat(),
+        qb in arbitrary_unit_jeod_quat(),
+        qc in arbitrary_unit_jeod_quat(),
+        p in arbitrary_position::<Inertial>(),
+    ) {
+        type A = Inertial;
+        type B = Ecef;
+        type C = PlanetFixed<Earth>;
+        type D = PlanetFixed<Moon>;
+
+        let a: FrameTransform<A, B> = FrameTransform::from_quat(qa);
+        let b: FrameTransform<B, C> = FrameTransform::from_quat(qb);
+        let c: FrameTransform<C, D> = FrameTransform::from_quat(qc);
+
+        let left: FrameTransform<A, D> = (a * b) * c;
+        let right: FrameTransform<A, D> = a * (b * c);
+
+        let pl = left.apply(p).raw_si();
+        let pr = right.apply(p).raw_si();
+
+        // Tolerance scales with the input magnitude — three matrix
+        // multiplies on a unit rotation accumulate <1e-12 relative drift.
+        let scale = p.raw_si().length().max(1.0);
+        let diff = (pl - pr).length();
+        prop_assert!(
+            diff < 1.0e-12 * scale,
+            "associativity drift = {diff} (scale={scale})\n  pl = {pl:?}\n  pr = {pr:?}",
+        );
+    }
+}
+
+// Property 2: Quaternion normalization idempotency. For both
+// `NormalizedQuat::renormalize` (1/sqrt scaling) and `JeodQuat::normalize`
+// (JEOD Padé fast path with canonical hemisphere), the second pass agrees
+// with the first to within a few ULPs.
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+    #[test]
+    fn quat_normalize_is_idempotent(q in arbitrary_jeod_quat()) {
+        // --- Path 1: NormalizedQuat::renormalize ---
+        let n1 = NormalizedQuat::renormalize(q)
+            .expect("non-zero norm by strategy filter");
+        let n2 = NormalizedQuat::renormalize(n1.inner())
+            .expect("unit-norm quat re-normalizes");
+        let a = n1.inner().data;
+        let b = n2.inner().data;
+        for i in 0..4 {
+            prop_assert!(
+                (a[i] - b[i]).abs() <= 1.0e-15,
+                "renormalize idempotency failed at i={i}: {} vs {}",
+                a[i], b[i],
+            );
+        }
+        // The witnessed quaternion is unit-norm to within DEFAULT_TOLERANCE.
+        let n = n1.inner().norm();
+        prop_assert!(
+            (n - 1.0).abs() <= NormalizedQuat::<ScalarFirst, LeftTransform>::DEFAULT_TOLERANCE,
+            "renormalized quat not unit-norm: {n}",
+        );
+
+        // --- Path 2: JeodQuat::normalize (in-place, JEOD Padé fast path) ---
+        let mut j1 = q;
+        j1.normalize();
+        let mut j2 = j1;
+        j2.normalize();
+        for i in 0..4 {
+            prop_assert!(
+                (j1.data[i] - j2.data[i]).abs() <= 1.0e-15,
+                "JeodQuat::normalize idempotency failed at i={i}: {} vs {}",
+                j1.data[i], j2.data[i],
+            );
+        }
+        // JEOD normalization places result in canonical hemisphere (q0 >= 0).
+        prop_assert!(j1.data[0] >= 0.0, "canonical hemisphere violated: q0={}", j1.data[0]);
+    }
+}
+
+// Property 3: F64Ext unit-conversion round-trips. The construction methods
+// on `f64` produce `uom`-typed quantities; `.get::<base>()` must invert the
+// construction exactly for power-of-ten factors and within ~1e-13 relative
+// for irrational factors such as π/180.
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+    #[test]
+    fn unit_conversion_round_trips(x in finite_scalar()) {
+        let scale = x.abs().max(1.0);
+
+        // Power-of-ten conversions: x.km() → m and x.km_per_s() → m/s
+        // are exact factors of 1000; tolerate <1e-9 relative for fp.
+        prop_assert!(
+            (x.km().get::<meter>() - x * 1000.0).abs() <= 1.0e-9 * scale,
+            "km→m: got {}, expected {}", x.km().get::<meter>(), x * 1000.0,
+        );
+        prop_assert!(
+            (x.m().get::<kilometer>() - x * 0.001).abs() <= 1.0e-12 * scale,
+        );
+        prop_assert!(
+            (x.km_per_s().get::<meter_per_second>() - x * 1000.0).abs() <= 1.0e-9 * scale,
+        );
+        prop_assert!(
+            (x.km_per_s().get::<kilometer_per_second>() - x).abs() <= 1.0e-12 * scale,
+        );
+        // Time: 1 hour == 3600 s exactly; round-trip s → hour → s.
+        prop_assert!(
+            (x.hours().get::<second>() - x * 3600.0).abs() <= 1.0e-9 * scale,
+        );
+        prop_assert!(
+            (x.s().get::<hour>().hours().get::<second>() - x).abs() <= 1.0e-12 * scale,
+        );
+
+        // Irrational factor π/180: deg → rad → deg drifts within ~1e-13.
+        let round = x.deg().get::<radian>().rad().get::<degree>();
+        let rel = (round - x).abs() / scale;
+        prop_assert!(rel <= 1.0e-13, "deg↔rad rel drift {rel} (round={round}, x={x})");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #222 (PR9 of #213). Adds three property-based test suites covering the type-system algebraic laws, all confined to `jeod_quantities`:

- **`FrameTransform` composition associativity** — `(a * b) * c ≈ a * (b * c)` over four distinct frames (`Inertial`, `Ecef`, `PlanetFixed<Earth>`, `PlanetFixed<Moon>`).
- **Quaternion normalization idempotency** — for both `NormalizedQuat::renormalize` (1/sqrt scaling) and `JeodQuat::normalize` (JEOD Padé fast path with canonical hemisphere).
- **`F64Ext` unit-conversion round-trips** — `x.km().m() == x * 1000.0`, `x.deg().rad().deg() ≈ x` within ~1e-13 relative, plus km/s, hour↔s.

Adds `proptest = "1"` as a `[dev-dependencies]` entry on `jeod_quantities`. Each suite runs 256 cases (proptest default, configured explicitly) with `f64` strategies bounded to non-NaN, non-inf, magnitudes in `1e-9..1e9`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `cargo nextest run -p jeod_quantities --test proptest_round_trips` — 3 passed, 0 failed
- [x] All three properties pass with proptest's default 256 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)