### PR TITLE
[#215] Add module //! docs to 8 physics crates + expand jeod_math

### DIFF
--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -32,8 +32,9 @@
 //! [`AtmosphereState`] exposes typed accessors (`density_typed`,
 //! `temperature_typed`, `pressure_typed`, `wind_typed`) that wrap the raw
 //! `f64`/`DVec3` fields in `uom`/`jeod_quantities` SI types for use across
-//! frame-tagged public APIs. JEOD source paths used: `models/environment/
-//! atmosphere/MET/` and the broader atmosphere model directory.
+//! frame-tagged public APIs. JEOD source paths used:
+//! `models/environment/atmosphere/MET/` and the broader
+//! `models/environment/atmosphere/` model directory.
 
 #![forbid(unsafe_code)]
 

--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -1,3 +1,40 @@
+//! Neutral-atmosphere density, temperature, pressure, and wind models.
+//!
+//! Pure-Rust port of JEOD's atmosphere models from
+//! `models/environment/atmosphere/`. All evaluations are framed by the
+//! [`AtmosphereState`] return type — density (kg/m^3), temperature (K),
+//! pressure (Pa), and inertial-frame wind velocity (m/s). The crate has zero
+//! Bevy dependency; orchestration lives in `jeod_sim`.
+//!
+//! ## Models
+//!
+//! - [`exponential`] — `rho = rho_0 * exp(-(h - h_0) / H)`. A simple,
+//!   single-parameter scale-height model intended as a fallback and as a
+//!   sanity-check baseline for tests. Not physically accurate above ~100 km
+//!   where diffusive equilibrium takes over.
+//! - [`met`] — Marshall Engineering Thermosphere model. Faithful port of
+//!   JEOD's MET implementation, which is built on the Jacchia 1970/1971
+//!   thermosphere papers (SAO Special Reports No. 313 and 332). MET combines
+//!   temperature-profile integration via Gauss quadrature with seasonal-
+//!   latitude density corrections and is the production model for LEO drag.
+//!
+//! ## Co-rotation wind
+//!
+//! [`compute_corotation_wind`] (and its typed sibling
+//! [`compute_corotation_wind_typed`]) implement JEOD's
+//! `WindVelocity::update_wind()` for a planet whose angular velocity points
+//! along the inertial Z axis: `wind = omega × r`. Aerodynamic drag computes
+//! its relative velocity against this co-rotating wind, not against the bare
+//! inertial frame.
+//!
+//! ## Typed quantities
+//!
+//! [`AtmosphereState`] exposes typed accessors (`density_typed`,
+//! `temperature_typed`, `pressure_typed`, `wind_typed`) that wrap the raw
+//! `f64`/`DVec3` fields in `uom`/`jeod_quantities` SI types for use across
+//! frame-tagged public APIs. JEOD source paths used: `models/environment/
+//! atmosphere/MET/` and the broader atmosphere model directory.
+
 #![forbid(unsafe_code)]
 
 pub use jeod_quantities::prelude::*;

--- a/crates/jeod_dynamics/src/lib.rs
+++ b/crates/jeod_dynamics/src/lib.rs
@@ -1,3 +1,33 @@
+//! Rigid-body dynamics: state, mass properties, forces, and integration.
+//!
+//! This crate is the JEOD-faithful port of the dynamics half of
+//! `models/dynamics/`. It owns the per-vehicle state types
+//! ([`TranslationalState`], [`RotationalState`], [`SixDofState`]), the rigid-
+//! body mass model ([`MassProperties`], [`MassBody`], [`MassPoint`],
+//! [`MassTree`], [`point_mass_inertia`]), the force-collection pipeline
+//! ([`collect_forces`], [`ForceContributions`], [`TotalForce`],
+//! [`GravityAcceleration`], [`compute_translational_acceleration`],
+//! [`compute_translational_derivatives`], [`compute_frame_derivatives`],
+//! [`compute_t_inertial_struct`]), and a battery of integrators
+//! ([`rk4_translational_step`], [`rk4_sixdof_step`], adaptive RKF4(5) in
+//! [`rkf45`], multistep [`abm4`]/Adams–Bashforth–Moulton, and
+//! [`gauss_jackson`]).
+//!
+//! Initial-condition machinery in [`body_init`] mirrors JEOD's
+//! `BodyAction` subclasses: [`init_from_orbital_elements`],
+//! [`init_from_mean_anomaly`], [`init_from_time_periapsis`],
+//! [`init_from_lvlh`], [`init_from_ned`], and [`compute_ned_rotation`].
+//! Frame propagation lives in [`propagation`]: [`propagate_body_frames`],
+//! [`propagate_forward`], [`propagate_reverse`]. Holonomic constraints
+//! ([`HolonomicConstraint`], [`PendulumConstraint`], [`BaumgarteSolver`],
+//! [`apply_constraint`]) port the constraint-stabilization layer used by
+//! tethers and articulated structures.
+//!
+//! JEOD source: `models/dynamics/dyn_body/`, `models/dynamics/mass/`,
+//! `models/dynamics/body_action/`, and `models/utils/integration/`. Pure
+//! Rust, zero Bevy dependency — orchestration lives in `jeod_sim` and ECS
+//! wiring lives in the `bevy_jeod` root crate.
+
 #![forbid(unsafe_code)]
 
 pub mod abm4;

--- a/crates/jeod_ephemeris/src/lib.rs
+++ b/crates/jeod_ephemeris/src/lib.rs
@@ -1,3 +1,31 @@
+//! Planetary ephemerides backed by JPL DE-series SPK files.
+//!
+//! Pure-Rust replacement for JEOD's `models/environment/ephemerides/` DE4xx
+//! reader. Where JEOD links a hand-rolled binary loader to JPL DE405/DE421
+//! kernels, this crate delegates the file format and Chebyshev evaluation to
+//! the `anise` crate (a Rust SPICE/NAIF reimplementation) and exposes a
+//! thin, frame-tagged API on top.
+//!
+//! ## Public surface
+//!
+//! - [`Ephemeris`] — owns an `anise::Almanac` and answers position/velocity
+//!   queries from `.bsp` files (e.g., `de421.bsp`, `de440.bsp`). All vectors
+//!   are returned in J2000 ICRF, in meters and m/s, wrapped as
+//!   `Position<Inertial>` / `Velocity<Inertial>` from `jeod_quantities`.
+//! - [`EphemerisBody`] — the body-identifier enum that maps JEOD's
+//!   `EphemerisBody` constants to `anise`'s NAIF integer IDs (Sun, Moon,
+//!   Earth, the planets and barycenters needed by Tier 3 tests).
+//! - [`EphemerisError`] — fail-loudly error type for missing files,
+//!   unsupported bodies, or out-of-range epochs.
+//!
+//! ## Role in the pipeline
+//!
+//! The ephemeris populates third-body positions for gravity (Sun and Moon
+//! perturbations on Earth orbits, planet-on-planet perturbations on
+//! interplanetary trajectories) and for radiation-pressure / shadow geometry
+//! in `jeod_interactions`. JEOD source: `models/environment/ephemerides/`.
+//! Pure Rust, zero Bevy dependency.
+
 #![forbid(unsafe_code)]
 
 pub use jeod_quantities::prelude::*;

--- a/crates/jeod_frames/src/lib.rs
+++ b/crates/jeod_frames/src/lib.rs
@@ -1,3 +1,36 @@
+//! Reference frames, frame tree, and Earth/Mars/Moon rotation models.
+//!
+//! Port of JEOD's `models/utils/ref_frames/` (the `RefFrame` tree that is the
+//! backbone of every coordinate system in JEOD) and `models/environment/RNP/`
+//! (precession, nutation, polar motion). The crate is pure Rust with zero
+//! Bevy dependency.
+//!
+//! ## Frame tree
+//!
+//! - [`FrameTree`], [`FrameNode`], [`FrameId`] — an arena-based hierarchy
+//!   that mirrors JEOD's `RefFrame` parent/child links. Each node stores
+//!   state **relative to its parent** (translation, velocity, orientation,
+//!   angular velocity); relative states between arbitrary frames are
+//!   computed by walking to the common ancestor and composing/negating
+//!   states. The arena is a flat `Vec` with parallel `Option<FrameId>`
+//!   parent pointers, which keeps lookups cache-friendly and avoids the
+//!   pointer chasing of JEOD's intrusive linked lists.
+//! - [`RefFrameState`], [`RefFrameStateTyped`], [`RefFrameTrans`],
+//!   [`RefFrameRot`], [`RefFrameKind`] — the per-node state structs
+//!   (re-exported from [`ref_frame_state`]). Quaternions are JEOD-convention
+//!   scalar-first, left-transformation, matching `jeod_math::JeodQuat`.
+//!
+//! ## Earth / Mars / Moon rotation
+//!
+//! - [`rotation_j2000`], [`precession_j2000`], [`nutation_j2000`],
+//!   [`data_nutation_j2000`] — Earth precession + IAU-1980 nutation series
+//!   (the `data_nutation_j2000` table is the 106-term series ported from
+//!   JEOD's `RNP_J2000` data files).
+//! - [`rotation_mars`], [`rotation_moon`] — body-fixed rotation models for
+//!   the Mars and Moon target bodies used by JEOD verification sims.
+//!
+//! JEOD source: `models/utils/ref_frames/` and `models/environment/RNP/`.
+
 #![forbid(unsafe_code)]
 
 pub mod data_nutation_j2000;

--- a/crates/jeod_gravity/src/lib.rs
+++ b/crates/jeod_gravity/src/lib.rs
@@ -1,3 +1,40 @@
+//! Gravity: spherical, spherical harmonics (Gottlieb), tides, and relativistic terms.
+//!
+//! Pure-Rust port of JEOD's `models/environment/gravity/`. The crate produces
+//! gravitational acceleration, the gravity-gradient tensor, and the
+//! gravitational potential at a body's position, given a configured set of
+//! gravity sources.
+//!
+//! ## Public surface
+//!
+//! - **Spherical (point-mass) gravity**: [`calc_spherical`], [`gravitation`],
+//!   and [`gravitation_with_scratch`] from [`compute`]. Output is a
+//!   `jeod_dynamics::GravityAcceleration` containing acceleration, gradient,
+//!   and potential — gradient and potential are filled even for the point-
+//!   mass case so downstream consumers (gravity-gradient torque, energy
+//!   diagnostics) have what they need.
+//! - **Spherical harmonics**: [`calc_nonspherical`],
+//!   [`calc_nonspherical_typed`], [`calc_nonspherical_with_scratch`], and
+//!   [`GottliebScratch`] from [`spherical_harmonics_calc_nonspherical`].
+//!   This is the ported Gottlieb algorithm from JEOD
+//!   `models/environment/gravity/src/spherical_harmonics_calc_nonspherical.cc`
+//!   — a numerically stable normalized Legendre recursion that scales to
+//!   high degree and order without the underflow/overflow problems of the
+//!   classical formulation.
+//! - **Configuration types**: [`GravitySource`], [`GravityModel`],
+//!   gravity-controls re-exports from [`gravity_controls`] and
+//!   [`spherical_harmonics_gravity_controls`], and the
+//!   [`SphericalHarmonicsData`] coefficient container.
+//! - **Tides and relativistic corrections**: [`tides`] and [`relativistic`]
+//!   carry the small post-Newtonian and luni-solar tide terms.
+//!
+//! JEOD coefficient data lives in
+//! `models/environment/gravity/data/include/earth_GGM05C.hh` (and similar
+//! per-body files); [`coefficients`] contains the parsing logic that turns
+//! the C++ array headers into `Vec<Vec<f64>>` C and S coefficient tables.
+//! Coefficients are normalized as in JEOD; the recursion expects normalized
+//! input. Pure Rust, zero Bevy dependency.
+
 #![forbid(unsafe_code)]
 
 pub mod coefficients;

--- a/crates/jeod_interactions/src/lib.rs
+++ b/crates/jeod_interactions/src/lib.rs
@@ -1,3 +1,43 @@
+//! Surface interactions: aerodynamics, radiation pressure, contact, lighting, torques.
+//!
+//! Pure-Rust port of JEOD's `models/interactions/` plus the surface-model and
+//! shadow geometry that those interactions depend on. Each module produces a
+//! force, torque, or environmental scalar at a vehicle position; the
+//! orchestration that sums these into a body's `jeod_dynamics::TotalForce`
+//! lives in `jeod_sim`.
+//!
+//! ## Public surface
+//!
+//! - **Aerodynamic drag**: [`aero_drag`] (port of JEOD
+//!   `models/interactions/aerodynamics/`) provides scalar-Cd drag against a
+//!   ballistic-coefficient body. [`flat_plate_aero`] adds the per-facet
+//!   panel-method drag/lift used for articulated spacecraft.
+//! - **Radiation pressure**: [`radiation_pressure`] ports JEOD
+//!   `models/interactions/radiation_pressure/` — solar flux against a
+//!   surface model with absorption / specular / diffuse coefficients,
+//!   shadow-corrected via the [`shadow`] module's umbra/penumbra geometry
+//!   and via [`compute_earth_lighting`] for Earth-albedo and Earth-IR
+//!   contributions ([`EarthLightingState`], [`LightingBody`],
+//!   [`LightingParams`]).
+//! - **Gravity-gradient torque**: [`compute_gravity_torque`] and its typed
+//!   sibling [`compute_gravity_torque_typed`] port JEOD
+//!   `models/interactions/gravity_torque/` — the cross product of the
+//!   inertia tensor and the gravity-gradient tensor projected through the
+//!   body attitude.
+//! - **Surface model**: [`SurfaceFacet`], [`ArticulatedFacet`],
+//!   [`ArticulationState`], [`SurfaceShape`] in [`surface_model`] are the
+//!   per-facet geometry inputs that aero, SRP, contact, and thermal share.
+//! - **Contact**: [`compute_contact_force`],
+//!   [`compute_contact_force_from_geometry`], [`compute_contact_geometry`],
+//!   [`ContactFacet`], [`ContactForce`], [`ContactGeometry`],
+//!   [`ContactMaterial`], [`ContactShape`] for collision/contact response.
+//! - **Thermal**: [`compute_thermal_power_balance`],
+//!   [`ThermalEnvironment`], [`ThermalFacet`], [`ThermalPowerBalance`] —
+//!   per-facet power balance for thermal-rider models.
+//!
+//! JEOD source: `models/interactions/` and surrounding utilities. Pure Rust,
+//! zero Bevy dependency.
+
 #![forbid(unsafe_code)]
 
 pub mod aero_drag;

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -1,10 +1,54 @@
 //! `jeod_math` — JEOD-faithful math kernels.
 //!
+//! Pure-Rust port of the standalone math utilities under JEOD
+//! `models/utils/`: quaternions, Euler angles, orbital elements, geodetic
+//! coordinates, the LVLH frame, the solar beta angle, and the small but
+//! load-bearing collection of vector/matrix helpers that mirror JEOD's
+//! `Vector3`/`Matrix3x3` inline functions.
+//!
 //! Phase 2 of the type-system refactor (#104) unifies the quaternion type
-//! with [`jeod_quantities`]. `JeodQuat` is now a re-export of
+//! with `jeod_quantities`. [`JeodQuat`] is now a re-export of
 //! `jeod_quantities::JeodQuat` (the canonical `Quat<ScalarFirst,
 //! LeftTransform>` type alias), and all algebraic/conversion methods live
 //! on that unified type so there is only one quaternion in the workspace.
+//! [`Quat`], [`NormalizedQuat`], the [`Layout`] tags ([`ScalarFirst`],
+//! [`ScalarLast`]) and the [`Transform`] tags ([`LeftTransform`],
+//! [`RightTransform`]) are re-exported so kernel code can name its inputs
+//! at the JEOD convention without reaching into upstream crates directly.
+//!
+//! ## Public surface
+//!
+//! - [`orbital_elements::OrbitalElements`] — Cartesian↔Keplerian conversion
+//!   ported from `models/utils/orbital_elements/src/orbital_elements.cc`.
+//!   Holds semi-major axis, eccentricity, inclination, RAAN, argument of
+//!   periapsis, and the three anomalies (true, mean, orbital), plus
+//!   energy/angular-momentum diagnostics.
+//! - [`euler_angles`] — port of JEOD `models/utils/orientation/`:
+//!   [`EulerSequence`], [`ALL_SEQUENCES`], and the
+//!   `compute_*_typed`/`quaternion_to_matrix_normalized` helpers.
+//! - [`geodetic`] — port of `models/utils/planet_fixed/`:
+//!   [`cartesian_to_geodetic_typed`], [`geodetic_to_cartesian_typed`],
+//!   [`GeodeticState`], [`GeodeticStateTyped`].
+//! - [`lvlh`] — port of `models/utils/lvlh_frame/`:
+//!   [`compute_lvlh_frame_typed`], [`LvlhFrame`].
+//! - [`solar_beta::solar_beta_angle_typed`] — solar beta angle for an
+//!   orbit, used in eclipse-fraction and thermal calculations.
+//! - [`quaternion`] — JEOD-convention quaternion algebra on the unified
+//!   [`JeodQuat`] type.
+//!
+//! ## Vector / matrix helpers
+//!
+//! [`types`] re-exports `glam`'s [`DMat3`] / [`DQuat`] / [`DVec3`] and adds
+//! the [`mat3_from_rows`] constructor (JEOD source is row-major while
+//! `glam` is column-major, so this lets ports read top-to-bottom against
+//! the C++ source) plus the inline `Vector3::*` / `Matrix3x3::*` operators
+//! ported from `models/utils/math/include/vector3_inline.hh` and
+//! `matrix3x3_inline.hh` (e.g., `vector3_transform`,
+//! `vector3_transform_transpose`, `matrix3x3_transform_matrix`,
+//! `matrix3x3_transpose_transform_matrix`,
+//! `matrix3x3_product_transpose_transpose`).
+//!
+//! Pure Rust, zero Bevy dependency.
 
 #![forbid(unsafe_code)]
 

--- a/crates/jeod_planet/src/lib.rs
+++ b/crates/jeod_planet/src/lib.rs
@@ -1,3 +1,32 @@
+//! Planetary shape and standard preset bodies.
+//!
+//! Pure-Rust port of JEOD's `models/environment/planet/` — the per-body
+//! reference-ellipsoid parameters (gravitational parameter, equatorial and
+//! polar radii, flattening) consumed by gravity, geodetic, atmospheric, and
+//! frame-rotation code.
+//!
+//! ## Public surface
+//!
+//! - [`PlanetShape`] (re-exported from [`planet`]) — the JEOD `Planet`
+//!   struct equivalent. Stores `name`, `mu` (m^3/s^2), `r_eq` (m),
+//!   `r_pol` (m), and `flat_coeff` along with derived helpers
+//!   (`flat_inv`, `e_ellipsoid`).
+//! - [`presets`] — canonical body constants matching JEOD source data
+//!   files. Earth uses WGS84 geometry from `planet/data/src/earth.cc`
+//!   together with the GGM05C gravitational parameter
+//!   `mu = 398_600.441_50e9 m^3/s^2` (which differs from IERS 2010 by
+//!   3e6 m^3/s^2; we follow JEOD's value to keep cross-validation faithful).
+//!   Additional presets cover the other bodies the JEOD verification sims
+//!   exercise.
+//!
+//! ## Role in the pipeline
+//!
+//! `PlanetShape` is the shared parameter block consumed by
+//! `jeod_math::geodetic` for ellipsoidal coordinate conversions, by
+//! `jeod_gravity` when the gravity model needs the reference radius, and
+//! by `jeod_frames` for body-fixed rotation models. Pure Rust, zero Bevy
+//! dependency.
+
 #![forbid(unsafe_code)]
 
 pub use jeod_quantities::prelude::*;

--- a/crates/jeod_time/src/lib.rs
+++ b/crates/jeod_time/src/lib.rs
@@ -28,8 +28,9 @@
 //!   one of JEOD's `TimeConverter_*` classes. GMST in particular drives
 //!   Earth's body-fixed rotation in `jeod_frames`.
 //!
-//! JEOD source: `models/environment/time/` and `models/environment/time/
-//! data/`. Pure Rust, zero Bevy dependency.
+//! JEOD source: `models/environment/time/` (and the
+//! `models/environment/time/data/` subdirectory for `Leap_Second.dat`). Pure
+//! Rust, zero Bevy dependency.
 
 #![forbid(unsafe_code)]
 

--- a/crates/jeod_time/src/lib.rs
+++ b/crates/jeod_time/src/lib.rs
@@ -1,3 +1,36 @@
+//! Time scales, leap seconds, calendar dates, and the time manager.
+//!
+//! Pure-Rust port of JEOD's `models/environment/time/`. The crate models the
+//! standard astronomical and engineering time scales (TAI, UTC, UT1, TT,
+//! TDB, GPS, GMST), the leap-second table that ties UTC to TAI, and the
+//! per-simulation user-defined epoch (UDE) and mission-elapsed time (MET)
+//! that mission code typically logs against.
+//!
+//! ## Public surface
+//!
+//! - [`TimeManager`] and [`TimeScaleId`] — the orchestrator that owns the
+//!   currently registered time scales and answers conversions between
+//!   them. Mirrors JEOD's `TimeManager`.
+//! - [`SimulationTime`] — the resource the integration loop advances each
+//!   step; downstream consumers (gravity, ephemeris, atmosphere) read from
+//!   it rather than tracking their own clocks.
+//! - [`DynamicTime`] — the dynamics-frame time state passed through the
+//!   integrator.
+//! - [`LeapSecondTable`] — parser/lookup for JEOD's
+//!   `models/environment/time/data/Leap_Second.dat`. Required for any
+//!   simulation that hits a UTC↔TAI conversion.
+//! - **Calendar / epoch types**: [`CalendarDate`] and [`UTC_EPOCH_TAI_TJT`]
+//!   from [`time_utc`], [`UserDefinedEpoch`] from [`time_ude`],
+//!   [`MissionElapsedTime`] from [`time_met`], [`GpsTimeComponents`] and
+//!   [`TAI_GPS_OFFSET`] from [`time_gps`], plus the [`epoch`] module.
+//! - **Per-pair time converters**: [`time_converter_tai_tdb`],
+//!   [`time_converter_tai_tt`], and [`time_converter_ut1_gmst`] each port
+//!   one of JEOD's `TimeConverter_*` classes. GMST in particular drives
+//!   Earth's body-fixed rotation in `jeod_frames`.
+//!
+//! JEOD source: `models/environment/time/` and `models/environment/time/
+//! data/`. Pure Rust, zero Bevy dependency.
+
 #![forbid(unsafe_code)]
 
 pub use jeod_quantities::prelude::*;


### PR DESCRIPTION
## Summary

Closes #215. Adds crate-level `//!` documentation to 8 physics crates that previously had **zero** doc-comment lines (so docs.rs renders a blank landing page) and expands the existing 7-line block in `jeod_math` to mention the `orbital_elements` sub-module and the `mat3_from_rows`-style JEOD math helpers.

This is PR1 of the 9-PR rollout for issue #213. PR2 will turn on `#![warn(missing_docs)]` per crate now that each one has a real module-level entry point.

Each block follows the shape of `jeod_sim/src/lib.rs:1–35`: physics role of the crate, top public types/functions actually re-exported, and the JEOD `models/...` source path the port is faithful to.

Files modified:
- `crates/jeod_atmosphere/src/lib.rs`
- `crates/jeod_dynamics/src/lib.rs`
- `crates/jeod_ephemeris/src/lib.rs`
- `crates/jeod_frames/src/lib.rs`
- `crates/jeod_gravity/src/lib.rs`
- `crates/jeod_interactions/src/lib.rs`
- `crates/jeod_math/src/lib.rs` (expanded, not new)
- `crates/jeod_planet/src/lib.rs`
- `crates/jeod_time/src/lib.rs`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --doc --workspace`
- [ ] Visual check: `cargo doc --open -p jeod_gravity` (or any of the 9) renders the new landing-page prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)