### PR TITLE
[#221] Plumb --steps to examples and add test-examples CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Escape-hatch grep guard
         run: scripts/check_no_escape_hatches.sh
 
+  test-examples:
+    name: Smoke run examples
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run --example kepler_orbit -- --steps 10
+      - run: cargo run --example typed_mission -- --steps 10
+
   test-quantities:
     name: Test (jeod_quantities)
     runs-on: ubuntu-latest

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -105,7 +105,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tli_time = PARKING_ORBITS * parking_period;
     let separation_time = tli_time + 600.0;
 
-    println!("Apollo trans-lunar injection — 3-day trajectory");
+    let total_steps = parse_steps_arg((TOTAL_DURATION / DT).round() as usize);
+    let print_interval = 7_200.0;
+    let steps_per_print = (print_interval / DT).round() as usize;
+    // Derive the printed duration from `total_steps * DT` so headings/summary
+    // stay accurate when `--steps` overrides the nominal 3-day run length.
+    let elapsed_days = total_steps as f64 * DT / 86_400.0;
+
+    println!("Apollo trans-lunar injection — {elapsed_days:.2}-day trajectory");
     println!(
         "  Parking orbit: {:.0} km circular, {INCLINATION_DEG}° inclination",
         PARKING_ALT / 1000.0
@@ -122,10 +129,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Time (h)", "Alt (km)", "Dist Moon", "Speed (m/s)", "Mass (kg)", "Phase"
     );
     println!("{}", "-".repeat(76));
-
-    let total_steps = parse_steps_arg((TOTAL_DURATION / DT).round() as usize);
-    let print_interval = 7_200.0;
-    let steps_per_print = (print_interval / DT).round() as usize;
     let mut tli_applied = false;
     let mut separated = false;
 
@@ -192,9 +195,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         (final_body.trans.position - sim.source_position(apollo::MOON_IDX)).length();
     println!();
     println!(
-        "Final distance to Moon: {:.0} km after {:.1} days",
+        "Final distance to Moon: {:.0} km after {elapsed_days:.2} days",
         final_moon_dist / 1000.0,
-        TOTAL_DURATION / 86_400.0
     );
     Ok(())
 }

--- a/crates/jeod_runner/examples/apollo.rs
+++ b/crates/jeod_runner/examples/apollo.rs
@@ -38,6 +38,23 @@ const PARKING_ORBITS: f64 = 2.5;
 const DT: f64 = 60.0;
 const TOTAL_DURATION: f64 = 3.0 * 86_400.0;
 
+/// Parse `--steps N` from CLI args; fall back to `default` when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg(default: usize) -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    default
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Override scenario state with Apollo parking orbit, attach DE421
     // ephemeris, then build.
@@ -106,7 +123,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     println!("{}", "-".repeat(76));
 
-    let total_steps = (TOTAL_DURATION / DT).round() as usize;
+    let total_steps = parse_steps_arg((TOTAL_DURATION / DT).round() as usize);
     let print_interval = 7_200.0;
     let steps_per_print = (print_interval / DT).round() as usize;
     let mut tli_applied = false;

--- a/crates/jeod_runner/examples/batch_propagation.rs
+++ b/crates/jeod_runner/examples/batch_propagation.rs
@@ -19,6 +19,23 @@ fn eccentricity(mu: f64, position: DVec3, velocity: DVec3) -> f64 {
     e_vec.length()
 }
 
+/// Parse `--steps N` from CLI args; fall back to `default` when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg(default: usize) -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    default
+}
+
 fn main() {
     let mu_earth = constants::mu_ggm05c().value;
 
@@ -33,7 +50,7 @@ fn main() {
     let period = 2.0 * std::f64::consts::PI * (r0.powi(3) / mu_earth).sqrt();
     let n_orbits = 10;
     let dt = sim.dt;
-    let steps = (n_orbits as f64 * period / dt).ceil() as usize;
+    let steps = parse_steps_arg((n_orbits as f64 * period / dt).ceil() as usize);
 
     let initial = sim.body(0).trans;
     let initial_energy = specific_energy(mu_earth, initial.position, initial.velocity);

--- a/crates/jeod_runner/examples/batch_propagation.rs
+++ b/crates/jeod_runner/examples/batch_propagation.rs
@@ -48,9 +48,12 @@ fn main() {
 
     let r0 = sim.body(0).trans.position.length();
     let period = 2.0 * std::f64::consts::PI * (r0.powi(3) / mu_earth).sqrt();
-    let n_orbits = 10;
+    let nominal_orbits = 10;
     let dt = sim.dt;
-    let steps = parse_steps_arg((n_orbits as f64 * period / dt).ceil() as usize);
+    let steps = parse_steps_arg((nominal_orbits as f64 * period / dt).ceil() as usize);
+    // Derive the actual orbit count from `steps * dt / period` so the heading
+    // stays accurate when `--steps` overrides the nominal 10-orbit length.
+    let actual_orbits = steps as f64 * dt / period;
 
     let initial = sim.body(0).trans;
     let initial_energy = specific_energy(mu_earth, initial.position, initial.velocity);
@@ -58,9 +61,9 @@ fn main() {
     println!("Batch Kepler Orbit Propagation (no Bevy)");
     println!("=========================================");
     println!("Initial altitude: {:.1} km", (r0 - 6_378_137.0) / 1000.0);
-    println!("Orbital period:   {:.1} s", period);
-    println!("Timestep:         {:.1} s", dt);
-    println!("Propagating for:  {} orbits ({} steps)", n_orbits, steps);
+    println!("Orbital period:   {period:.1} s");
+    println!("Timestep:         {dt:.1} s");
+    println!("Propagating for:  {actual_orbits:.2} orbits ({steps} steps)");
     println!();
 
     let report_interval = (steps / 10).max(1);

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -121,10 +121,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut sim = sb.build().expect("earth_moon scenario must validate");
 
-    println!(
-        "Clementine lunar orbit — {:.0}-day propagation",
-        DURATION / 86_400.0
-    );
+    let print_interval = 7_200.0;
+    let total_steps = parse_steps_arg((DURATION / DT).round() as usize);
+    let steps_per_print = (print_interval / DT).round() as usize;
+    // Derive the printed duration from `total_steps * DT` so headings stay
+    // accurate when `--steps` overrides the nominal 1-day run length.
+    let elapsed_days = total_steps as f64 * DT / 86_400.0;
+
+    println!("Clementine lunar orbit — {elapsed_days:.2}-day propagation");
     println!("  Moon: LP150Q 60×60 SH | Earth + Sun 3rd-body | Cannonball SRP");
     println!("  Integrator: RK4 at dt={DT} s");
     println!();
@@ -133,10 +137,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Time (h)", "Alt (km)", "Speed (m/s)", "Period (h)", "Ecc"
     );
     println!("{}", "-".repeat(62));
-
-    let print_interval = 7_200.0;
-    let total_steps = parse_steps_arg((DURATION / DT).round() as usize);
-    let steps_per_print = (print_interval / DT).round() as usize;
 
     for step in 1..=total_steps {
         sim.step().expect("step failed");
@@ -161,9 +161,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     let final_body = sim.body(0);
     let final_alt = (final_body.trans.position.length() - R_MOON) / 1000.0;
-    println!(
-        "Final altitude: {final_alt:.1} km after {:.1} days",
-        DURATION / 86_400.0
-    );
+    println!("Final altitude: {final_alt:.1} km after {elapsed_days:.2} days");
     Ok(())
 }

--- a/crates/jeod_runner/examples/earth_moon.rs
+++ b/crates/jeod_runner/examples/earth_moon.rs
@@ -41,6 +41,23 @@ const DT: f64 = 1.0;
 const DURATION: f64 = 86_400.0;
 const R_MOON: f64 = 1_737_400.0;
 
+/// Parse `--steps N` from CLI args; fall back to `default` when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg(default: usize) -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    default
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load DE421 + Moon BPC libration (committed at test_data/).
     let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_data");
@@ -118,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "-".repeat(62));
 
     let print_interval = 7_200.0;
-    let total_steps = (DURATION / DT).round() as usize;
+    let total_steps = parse_steps_arg((DURATION / DT).round() as usize);
     let steps_per_print = (print_interval / DT).round() as usize;
 
     for step in 1..=total_steps {

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -96,7 +96,11 @@ fn main() {
     let final_e = eccentricity(mu_earth, final_state.position, final_state.velocity);
     let sma_decay = initial_a - final_a;
 
+    // Derive elapsed time from `steps * dt` so the summary stays accurate
+    // when `--steps` overrides the nominal 24-hour run length.
+    let elapsed_h = steps as f64 * dt / 3600.0;
+
     println!();
     println!("Final: a={:.3} km, e={:.6}", final_a / 1000.0, final_e);
-    println!("SMA decay: {:.1} m over 24h", sma_decay);
+    println!("SMA decay: {sma_decay:.1} m over {elapsed_h:.2}h");
 }

--- a/crates/jeod_runner/examples/leo_drag.rs
+++ b/crates/jeod_runner/examples/leo_drag.rs
@@ -22,6 +22,23 @@ fn eccentricity(mu: f64, position: DVec3, velocity: DVec3) -> f64 {
     e_vec.length()
 }
 
+/// Parse `--steps N` from CLI args; fall back to `default` when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg(default: usize) -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    default
+}
+
 fn main() {
     let mu_earth = constants::mu_ggm05c().value;
     let r_eq = 6_378_137.0;
@@ -53,8 +70,10 @@ fn main() {
 
     let dt = sim.dt;
     let total_time = 86_400.0;
-    let steps = (total_time / dt) as usize;
-    let print_interval = steps / 24;
+    let steps = parse_steps_arg((total_time / dt) as usize);
+    // Guard against `steps < 24` (e.g. CI smoke `--steps 10`) producing a
+    // zero divisor in `step % print_interval`.
+    let print_interval = (steps / 24).max(1);
 
     for step in 0..steps {
         sim.step().expect("step failed");

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -31,6 +31,23 @@ const DT: f64 = 10.0;
 const DURATION: f64 = 10_800.0;
 const R_MARS_EQ: f64 = 3_396_190.0;
 
+/// Parse `--steps N` from CLI args; fall back to `default` when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg(default: usize) -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    default
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_data");
     let bsp_path = data_dir.join("de421.bsp");
@@ -84,7 +101,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", "-".repeat(62));
 
     let print_interval = 900.0;
-    let total_steps = (DURATION / DT).round() as usize;
+    let total_steps = parse_steps_arg((DURATION / DT).round() as usize);
     let steps_per_print = (print_interval / DT).round() as usize;
 
     for step in 1..=total_steps {

--- a/crates/jeod_runner/examples/mars_orbit.rs
+++ b/crates/jeod_runner/examples/mars_orbit.rs
@@ -126,9 +126,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     let final_body = sim.body(0);
     let final_alt = (final_body.trans.position.length() - R_MARS_EQ) / 1000.0;
-    println!(
-        "Final altitude: {final_alt:.1} km after {:.0} minutes",
-        DURATION / 60.0
-    );
+    // Derive elapsed time from `total_steps * DT` so the summary stays
+    // accurate when `--steps` overrides the nominal duration.
+    let elapsed_min = total_steps as f64 * DT / 60.0;
+    println!("Final altitude: {final_alt:.1} km after {elapsed_min:.1} minutes");
     Ok(())
 }

--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -37,6 +37,8 @@ const DEFAULT_STEPS: usize = 560;
 
 /// Parse `--steps N` from CLI args; default to [`DEFAULT_STEPS`] when absent.
 /// Panics with a clear message on a malformed value (per fail-loudly policy).
+/// Rejects `0` because `MaxSteps(0)` would make `print_state` early-return on
+/// every tick without ever writing `AppExit` — the app would hang forever.
 fn parse_steps_arg() -> usize {
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -44,9 +46,16 @@ fn parse_steps_arg() -> usize {
             let val = args
                 .next()
                 .expect("--steps requires a value, e.g. --steps 10");
-            return val
-                .parse::<usize>()
+            let n: usize = val
+                .parse()
                 .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+            assert!(
+                n >= 1,
+                "--steps must be >= 1; got {n}. The example exits after writing \
+                 AppExit on step >= max_steps; with max_steps == 0 the app would \
+                 hang forever. Pass at least --steps 1.",
+            );
+            return n;
         }
     }
     DEFAULT_STEPS

--- a/examples/kepler_orbit.rs
+++ b/examples/kepler_orbit.rs
@@ -32,6 +32,26 @@ use uom::si::mass::kilogram;
 
 const MU_EARTH: f64 = 3.986_004_415e14;
 
+/// Default step count: ~one ISS orbit at dt=10s.
+const DEFAULT_STEPS: usize = 560;
+
+/// Parse `--steps N` from CLI args; default to [`DEFAULT_STEPS`] when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg() -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    DEFAULT_STEPS
+}
+
 /// Earth equatorial radius from `recipes::constants::r_eq_earth()`.
 /// Used to compute the printed altitude — keeps the example aligned
 /// with the rest of the recipe-based examples if the constant ever
@@ -47,6 +67,7 @@ fn eccentricity(mu: f64, position: DVec3, velocity: DVec3) -> f64 {
 }
 
 fn main() {
+    let max_steps = parse_steps_arg();
     App::new()
         .add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_millis(0))))
         .insert_resource(Time::<Fixed>::from_seconds(10.0))
@@ -54,11 +75,15 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, print_state.after(JeodSet::Integration))
         .insert_resource(StepCounter(0))
+        .insert_resource(MaxSteps(max_steps))
         .run();
 }
 
 #[derive(Resource)]
 struct StepCounter(usize);
+
+#[derive(Resource)]
+struct MaxSteps(usize);
 
 fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
     time.set_relative_speed_f64(1e6);
@@ -122,9 +147,10 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
 fn print_state(
     query: Query<(&Name, &TranslationalStateC)>,
     mut counter: ResMut<StepCounter>,
+    max_steps: Res<MaxSteps>,
     mut exit: MessageWriter<AppExit>,
 ) {
-    if counter.0 >= 560 {
+    if counter.0 >= max_steps.0 {
         return;
     }
     counter.0 += 1;
@@ -148,8 +174,8 @@ fn print_state(
                 e_mag
             );
         }
-        if counter.0 >= 560 {
-            println!("Completed ~1 orbit. Exiting.");
+        if counter.0 >= max_steps.0 {
+            println!("Completed {} steps. Exiting.", max_steps.0);
             exit.write(AppExit::Success);
             return;
         }

--- a/examples/typed_mission.rs
+++ b/examples/typed_mission.rs
@@ -34,6 +34,8 @@ const DEFAULT_STEPS: usize = 560;
 
 /// Parse `--steps N` from CLI args; default to [`DEFAULT_STEPS`] when absent.
 /// Panics with a clear message on a malformed value (per fail-loudly policy).
+/// Rejects `0` because `MaxSteps(0)` would make `log_orbit` early-return on
+/// every tick without ever writing `AppExit` — the app would hang forever.
 fn parse_steps_arg() -> usize {
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
@@ -41,9 +43,16 @@ fn parse_steps_arg() -> usize {
             let val = args
                 .next()
                 .expect("--steps requires a value, e.g. --steps 10");
-            return val
-                .parse::<usize>()
+            let n: usize = val
+                .parse()
                 .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+            assert!(
+                n >= 1,
+                "--steps must be >= 1; got {n}. The example exits after writing \
+                 AppExit on step >= max_steps; with max_steps == 0 the app would \
+                 hang forever. Pass at least --steps 1.",
+            );
+            return n;
         }
     }
     DEFAULT_STEPS

--- a/examples/typed_mission.rs
+++ b/examples/typed_mission.rs
@@ -26,7 +26,31 @@ use jeod_sim::{F64Ext, GravityControl, VehicleBuilder};
 #[derive(Resource)]
 struct StepCounter(usize);
 
+#[derive(Resource)]
+struct MaxSteps(usize);
+
+/// Default step count: ~one ISS orbit at dt=10s.
+const DEFAULT_STEPS: usize = 560;
+
+/// Parse `--steps N` from CLI args; default to [`DEFAULT_STEPS`] when absent.
+/// Panics with a clear message on a malformed value (per fail-loudly policy).
+fn parse_steps_arg() -> usize {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            let val = args
+                .next()
+                .expect("--steps requires a value, e.g. --steps 10");
+            return val
+                .parse::<usize>()
+                .unwrap_or_else(|err| panic!("--steps value {val:?} is not a usize: {err}"));
+        }
+    }
+    DEFAULT_STEPS
+}
+
 fn main() {
+    let max_steps = parse_steps_arg();
     App::new()
         .add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_millis(0))))
         .insert_resource(Time::<Fixed>::from_seconds(10.0))
@@ -34,6 +58,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, log_orbit.after(JeodSet::Integration))
         .insert_resource(StepCounter(0))
+        .insert_resource(MaxSteps(max_steps))
         .run();
 }
 
@@ -98,9 +123,10 @@ fn log_orbit(
         Option<&TotalForceC>,
     )>,
     mut counter: ResMut<StepCounter>,
+    max_steps: Res<MaxSteps>,
     mut exit: MessageWriter<AppExit>,
 ) {
-    if counter.0 >= 560 {
+    if counter.0 >= max_steps.0 {
         return;
     }
     counter.0 += 1;
@@ -121,8 +147,8 @@ fn log_orbit(
                 v
             );
         }
-        if counter.0 >= 560 {
-            println!("Completed ~1 orbit. Exiting.");
+        if counter.0 >= max_steps.0 {
+            println!("Completed {} steps. Exiting.", max_steps.0);
             exit.write(AppExit::Success);
             return;
         }


### PR DESCRIPTION
## Summary

Closes #221.

- Adds a `--steps N` CLI argument to all seven example binaries (zero new deps; tiny inline `parse_steps_arg` helper per file using `std::env::args`). Default is the existing hardcoded step count, so manual usage is unchanged.
- Adds a `test-examples` CI job to `.github/workflows/ci.yml`, gated on `check`, that runs `cargo run --example kepler_orbit -- --steps 10` and `cargo run --example typed_mission -- --steps 10` so the "public API broke but the doctest is `ignore`" failure mode is finally caught.

Files touched:
- `examples/kepler_orbit.rs` (default 560 steps)
- `examples/typed_mission.rs` (default 560 steps)
- `crates/jeod_runner/examples/apollo.rs` (default `(TOTAL_DURATION / DT).round()`)
- `crates/jeod_runner/examples/batch_propagation.rs` (default `(n_orbits * period / dt).ceil()`)
- `crates/jeod_runner/examples/earth_moon.rs` (default `(DURATION / DT).round()`)
- `crates/jeod_runner/examples/leo_drag.rs` (default `(total_time / dt) as usize`; also `print_interval = (steps / 24).max(1)` so `--steps 10` doesn't divide by zero)
- `crates/jeod_runner/examples/mars_orbit.rs` (default `(DURATION / DT).round()`)
- `.github/workflows/ci.yml` (`test-examples` job appended after `check`)

Per the issue, only `kepler_orbit` and `typed_mission` are wired into the new CI job; the runner examples get the `--steps` arg for parity but stay out of CI for now.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `cargo run --example kepler_orbit -- --steps 10` — exits cleanly after step 10
- [x] `cargo run --example typed_mission -- --steps 10` — exits cleanly after step 10
- [x] `cargo run --example kepler_orbit` (no arg) — runs full default 560 steps, exits with `Completed 560 steps. Exiting.`
- [x] `cargo run -p jeod_runner --example batch_propagation -- --steps 10` — runs end-to-end
- [x] `JEOD_HOME=… cargo run -p jeod_runner --example leo_drag -- --steps 10` — runs end-to-end (needs `JEOD_HOME` for the MET atmosphere data; same as before this PR)
- Other runner examples (`apollo`, `earth_moon`, `mars_orbit`) compile cleanly under `cargo build -p jeod_runner --examples` and require external data (`test_data/de421.bsp`, `$JEOD_HOME` reference data) to actually run, unchanged from before this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>