### PR TITLE
[#216] Add recipe entry-point doctests and audit ignore blocks

### DIFF
--- a/crates/jeod_runner/src/branded.rs
+++ b/crates/jeod_runner/src/branded.rs
@@ -12,20 +12,27 @@
 //!
 //! This module ships the **opt-in** branded API:
 //!
-//! ```ignore
-//! use jeod_runner::{Simulation, SourceIdx};
+//! ```
+//! use jeod_runner::Simulation;
+//! use jeod_sim::{default_leap_second_table, F64Ext, SimulationTime};
+//! use jeod_sim::recipes::{earth, orbital_elements, vehicle};
+//! use jeod_sim::{GravityControl, VehicleBuilder};
 //!
-//! Simulation::run(time, dt, |mut sim| {
-//!     // `sim` has type `BrandedSimulation<'sim>` where `'sim` is fresh
-//!     // per `run` call (HRTB). Indices returned from `sim.add_source` /
-//!     // `sim.add_body` carry the matching `'sim` lifetime.
-//!     let earth: SourceIdx<'_> = sim.add_source("Earth", earth_entry);
-//!     let satellite = sim.add_body(vehicle_config);
-//!     for _ in 0..n_steps {
-//!         sim.step();
-//!     }
-//!     let final_pos = sim.body(satellite).trans.position;
+//! let time = SimulationTime::at_j2000(default_leap_second_table());
+//! let final_pos_x = Simulation::run(time, 60.0, |mut sim| {
+//!     // `sim` has type `BrandedSimulation<'sim>`; `earth_idx` carries
+//!     // the matching `'sim` lifetime so it cannot escape this closure.
+//!     let earth_idx = sim.add_source("Earth", earth::point_mass());
+//!     let cfg = VehicleBuilder::new()
+//!         .from_orbital_elements(orbital_elements::iss(), earth::point_mass().source.mu.m3_per_s2())
+//!         .three_dof_point_mass(vehicle::iss_mass())
+//!         .rk4()
+//!         .gravity(GravityControl::new_spherical(earth_idx.into_raw(), false))
+//!         .build();
+//!     let sat = sim.add_body(cfg);
+//!     sim.body(sat).trans.position.x
 //! });
+//! assert!(final_pos_x.abs() > 6_000_000.0);
 //! ```
 //!
 //! Two `Simulation::run` calls produce indices with **different** `'sim`
@@ -264,16 +271,28 @@ impl Simulation {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```
     /// use jeod_runner::Simulation;
-    /// use jeod_sim::SimulationTime;
+    /// use jeod_sim::{default_leap_second_table, F64Ext, SimulationTime};
+    /// use jeod_sim::recipes::{earth, orbital_elements, vehicle};
+    /// use jeod_sim::{GravityControl, VehicleBuilder};
     ///
-    /// Simulation::run(SimulationTime::at_j2000(/* ... */), 60.0, |mut sim| {
-    ///     let earth = sim.add_source("Earth", earth_entry);
-    ///     let satellite = sim.add_body(vehicle_config);
-    ///     sim.step();
-    ///     let final_pos = sim.body(satellite).trans.position;
+    /// let time = SimulationTime::at_j2000(default_leap_second_table());
+    /// let r = Simulation::run(time, 60.0, |mut sim| {
+    ///     let earth_idx = sim.add_source("Earth", earth::point_mass());
+    ///     let cfg = VehicleBuilder::new()
+    ///         .from_orbital_elements(
+    ///             orbital_elements::iss(),
+    ///             earth::point_mass().source.mu.m3_per_s2(),
+    ///         )
+    ///         .three_dof_point_mass(vehicle::iss_mass())
+    ///         .rk4()
+    ///         .gravity(GravityControl::new_spherical(earth_idx.into_raw(), false))
+    ///         .build();
+    ///     let sat = sim.add_body(cfg);
+    ///     sim.body(sat).trans.position.length()
     /// });
+    /// assert!(r > 6_000_000.0);
     /// ```
     pub fn run<F, R>(time: SimulationTime, dt: f64, f: F) -> R
     where

--- a/crates/jeod_runner/src/error.rs
+++ b/crates/jeod_runner/src/error.rs
@@ -50,7 +50,7 @@ use jeod_sim::EphemerisBody;
 /// is needed or accepted by the language). Downstream recovery logic can
 /// destructure freely:
 ///
-/// ```ignore
+/// ```
 /// use jeod_runner::StepError;
 ///
 /// fn handle(err: StepError) {

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -8,22 +8,14 @@
 //! functions from `jeod_sim` directly instead.
 //!
 //! # Example
-//! ```ignore
-//! use jeod_runner::{Simulation, VehicleConfig, GravitySourceEntry};
-//! use jeod_sim::{SimulationTime, EARTH};
+//! ```
+//! use jeod_runner::SimulationBuilderExt;
+//! use jeod_sim::recipes::Mission;
 //!
-//! let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
-//! let mut sim = Simulation::new(time, 10.0);
-//! let earth = sim.add_source(GravitySourceEntry::central_body(&EARTH));
-//! let vehicle = sim.add_body(VehicleConfig {
-//!     trans: initial_state,
-//!     gravity_controls: controls,
-//!     ..Default::default()
-//! });
-//! sim.validate().unwrap();
-//! sim.step_n(100);
-//! let output = sim.body(vehicle);
-//! println!("{:?}", output.trans.position);
+//! let mut sim = Mission::iss_leo().into_builder().build().unwrap();
+//! sim.step_n(10);
+//! let output = sim.body(0);
+//! assert!(output.trans.position.length() > 6_000_000.0);
 //! ```
 
 #![forbid(unsafe_code)]
@@ -373,17 +365,14 @@ impl SimBody {
 /// preconditions are programmer errors, not runtime conditions.
 ///
 /// # Example
-/// ```ignore
-/// let mut sim = Simulation::new(time, 10.0);
-/// let earth = sim.add_source("Earth", GravitySourceEntry::central_body(&EARTH));
-/// let vehicle = sim.add_body(VehicleConfig {
-///     trans: initial_state,
-///     gravity_controls: controls,
-///     ..Default::default()
-/// });
-/// sim.validate().unwrap();
-/// sim.step_n(100);
-/// let output = sim.body(vehicle);
+/// ```
+/// use jeod_runner::SimulationBuilderExt;
+/// use jeod_sim::recipes::Mission;
+///
+/// let mut sim = Mission::iss_leo().into_builder().build().unwrap();
+/// sim.step_n(10);
+/// let output = sim.body(0);
+/// assert!(output.trans.position.length() > 6_000_000.0);
 /// ```
 pub struct Simulation {
     /// Simulation time (TAI, UTC, TDB, GMST, etc.).

--- a/crates/jeod_runner/src/prelude.rs
+++ b/crates/jeod_runner/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Glob-import prelude for runner-side ergonomics.
 //!
-//! ```ignore
+//! ```
 //! use jeod_runner::prelude::*;
 //! ```
 //!

--- a/crates/jeod_runner/src/run_verification/mod.rs
+++ b/crates/jeod_runner/src/run_verification/mod.rs
@@ -15,6 +15,9 @@
 //! ([`sim_dyncomp`], etc.). Each test in `jeod_runner/tests/tier3_*.rs`
 //! collapses to a one-liner of the form:
 //!
+//! // reason: snippet declares a `#[test]` and depends on a JEOD reference
+//! // CSV being present on disk; the Tier 3 test files in
+//! // `crates/jeod_runner/tests/tier3_*.rs` are the runnable forms.
 //! ```ignore
 //! use jeod_runner::prelude::*;
 //! use jeod_runner::run_verification::sim_dyncomp;

--- a/crates/jeod_runner/src/run_verification/mod.rs
+++ b/crates/jeod_runner/src/run_verification/mod.rs
@@ -15,9 +15,7 @@
 //! ([`sim_dyncomp`], etc.). Each test in `jeod_runner/tests/tier3_*.rs`
 //! collapses to a one-liner of the form:
 //!
-//! // reason: snippet declares a `#[test]` and depends on a JEOD reference
-//! // CSV being present on disk; the Tier 3 test files in
-//! // `crates/jeod_runner/tests/tier3_*.rs` are the runnable forms.
+//! // reason: snippet declares a `#[test]` and depends on a JEOD reference CSV being present on disk; the Tier 3 test files in `crates/jeod_runner/tests/tier3_*.rs` are the runnable forms.
 //! ```ignore
 //! use jeod_runner::prelude::*;
 //! use jeod_runner::run_verification::sim_dyncomp;

--- a/crates/jeod_sim/src/atmosphere.rs
+++ b/crates/jeod_sim/src/atmosphere.rs
@@ -47,7 +47,7 @@ impl AtmosphereConfig {
     /// constants aren't scattered across multiple configuration sites.
     ///
     /// # Example
-    /// ```ignore
+    /// ```
     /// use jeod_sim::{AtmosphereConfig, AtmosphereModel, EARTH};
     /// use jeod_atmosphere::exponential::ExponentialAtmosphere;
     ///
@@ -55,6 +55,7 @@ impl AtmosphereConfig {
     ///     AtmosphereModel::Exponential(ExponentialAtmosphere::default()),
     ///     &EARTH,
     /// );
+    /// assert_eq!(config.r_eq, EARTH.shape.r_eq);
     /// ```
     pub fn from_planet(model: AtmosphereModel, planet: &PlanetConfig) -> Self {
         Self {

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -98,8 +98,7 @@ pub enum ThermalIntegrationOrder {
 /// [`crate::integrate_body_coupled`]). Construct with `..Default::default()`
 /// so the trait's snapshot scratch initializes empty:
 ///
-/// // reason: pattern fragment — `plates` and `n` are placeholders for
-/// // mission-specific values; the snippet documents the construction shape.
+/// // reason: pattern fragment — `plates` and `n` are placeholders for mission-specific values; the snippet documents the construction shape.
 /// ```ignore
 /// FlatPlateState {
 ///     plates,

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -98,6 +98,8 @@ pub enum ThermalIntegrationOrder {
 /// [`crate::integrate_body_coupled`]). Construct with `..Default::default()`
 /// so the trait's snapshot scratch initializes empty:
 ///
+/// // reason: pattern fragment — `plates` and `n` are placeholders for
+/// // mission-specific values; the snippet documents the construction shape.
 /// ```ignore
 /// FlatPlateState {
 ///     plates,

--- a/crates/jeod_sim/src/recipes/mod.rs
+++ b/crates/jeod_sim/src/recipes/mod.rs
@@ -23,6 +23,9 @@
 //!
 //! Mission code consumes recipes through whichever adapter it targets:
 //!
+//! // reason: doctest references downstream adapter crates (jeod_runner,
+//! // bevy_jeod) that jeod_sim cannot depend on without a circular
+//! // workspace dependency.
 //! ```ignore
 //! // Standalone runner
 //! use jeod_runner::SimulationBuilderExt;          // .build() terminal

--- a/crates/jeod_sim/src/recipes/mod.rs
+++ b/crates/jeod_sim/src/recipes/mod.rs
@@ -23,9 +23,7 @@
 //!
 //! Mission code consumes recipes through whichever adapter it targets:
 //!
-//! // reason: doctest references downstream adapter crates (jeod_runner,
-//! // bevy_jeod) that jeod_sim cannot depend on without a circular
-//! // workspace dependency.
+//! // reason: doctest references downstream adapter crates (jeod_runner, bevy_jeod) that jeod_sim cannot depend on without a circular workspace dependency.
 //! ```ignore
 //! // Standalone runner
 //! use jeod_runner::SimulationBuilderExt;          // .build() terminal

--- a/crates/jeod_sim/src/recipes/orbital_elements.rs
+++ b/crates/jeod_sim/src/recipes/orbital_elements.rs
@@ -38,6 +38,13 @@ fn from_pos_vel_with_mu(pos: glam::DVec3, vel: glam::DVec3, mu: GravParam) -> Or
 /// reference state vector (with all of Earth's perturbations baked in)
 /// constructs it directly from a CSV / Python preset; that's a Tier 3
 /// concern, not a recipe.
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::iss();
+/// assert!(oe.semi_major_axis > 6_700_000.0);
+/// assert!(oe.e_mag < 1e-6);
+/// ```
 pub fn iss() -> OrbitalElements {
     leo_400km_circular_iss_inclination()
 }
@@ -57,6 +64,13 @@ fn circular_orbit_with_mu(r: f64, inc: f64, mu: GravParam) -> OrbitalElements {
 }
 
 /// Geostationary circular orbit at 42164 km, inclination 0°.
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::geostationary();
+/// assert!((oe.semi_major_axis - 42_164_172.0).abs() < 1.0);
+/// assert!(oe.inclination.abs() < 1e-12);
+/// ```
 pub fn geostationary() -> OrbitalElements {
     circular_orbit_with_mu(42_164_172.0_f64, 0.0, mu_ggm05c())
 }
@@ -64,12 +78,26 @@ pub fn geostationary() -> OrbitalElements {
 /// 400 km circular LEO at 51.6° inclination — the simplest ISS-like
 /// orbit (analytic closed-form, vs. [`iss`] which is from the JEOD
 /// reference state).
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::leo_400km_circular_iss_inclination();
+/// assert!((oe.inclination - 51.6_f64.to_radians()).abs() < 1e-12);
+/// assert!(oe.e_mag < 1e-6);
+/// ```
 pub fn leo_400km_circular_iss_inclination() -> OrbitalElements {
     let r_eq = 6_378_137.0_f64;
     circular_orbit_with_mu(r_eq + 400_000.0, 51.6_f64.to_radians(), mu_ggm05c())
 }
 
 /// Polar circular LEO at 600 km altitude.
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::leo_polar_600km();
+/// assert!((oe.inclination - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+/// assert!(oe.semi_major_axis > 6_900_000.0 && oe.semi_major_axis < 7_000_000.0);
+/// ```
 pub fn leo_polar_600km() -> OrbitalElements {
     let r_eq = 6_378_137.0_f64;
     circular_orbit_with_mu(r_eq + 600_000.0, 90.0_f64.to_radians(), mu_ggm05c())
@@ -83,6 +111,13 @@ pub fn leo_polar_600km() -> OrbitalElements {
 /// ~58.98 km/s perpendicular. Matches the inlined initial state used
 /// by the GR perihelion-advance test (`tier3_sim_mercury`) and the
 /// existing `scenarios::mercury_relativistic` setup.
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::mercury_perihelion();
+/// // Mercury's eccentricity is ~0.2 — definitely non-circular.
+/// assert!(oe.e_mag > 0.1 && oe.e_mag < 0.3);
+/// ```
 pub fn mercury_perihelion() -> OrbitalElements {
     from_pos_vel_with_mu(
         glam::DVec3::new(46.0e9, 0.0, 0.0),
@@ -95,6 +130,13 @@ pub fn mercury_perihelion() -> OrbitalElements {
 /// inertial). Constants match `scenarios::mars_orbit` exactly so a
 /// custom-loop test can pull the same starting state without
 /// duplicating the literal vectors.
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::mars_dawn_orbit();
+/// // Dawn arrives at Mars on a hyperbolic flyby trajectory.
+/// assert!(oe.e_mag > 1.0);
+/// ```
 pub fn mars_dawn_orbit() -> OrbitalElements {
     from_pos_vel_with_mu(
         glam::DVec3::new(11_563_355.680_2, -14_356_668.897_7, 6_293_704.616_9),
@@ -107,6 +149,13 @@ pub fn mars_dawn_orbit() -> OrbitalElements {
 ///
 /// Used by Earth-orbit Apollo tests as the starting state before the
 /// trans-lunar burn.
+///
+/// ```
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::apollo_parking();
+/// assert!((oe.inclination - 32.5_f64.to_radians()).abs() < 1e-12);
+/// assert!(oe.e_mag < 1e-6);
+/// ```
 pub fn apollo_parking() -> OrbitalElements {
     let r_eq = 6_378_137.0_f64;
     circular_orbit_with_mu(r_eq + 185_000.0, 32.5_f64.to_radians(), mu_ggm05c())
@@ -119,6 +168,14 @@ pub fn apollo_parking() -> OrbitalElements {
 /// (e.g. `0.1.rad()` for an inclined-GEO study) and the function
 /// returns the orbital elements of a circular orbit at that
 /// inclination, with the line of nodes along the +x axis.
+///
+/// ```
+/// use jeod_quantities::ext::F64Ext;
+/// use jeod_sim::recipes::orbital_elements;
+/// let oe = orbital_elements::geo_inclined(0.1_f64.rad());
+/// assert!((oe.inclination - 0.1).abs() < 1e-12);
+/// assert!((oe.semi_major_axis - 42_164_172.0).abs() < 1.0);
+/// ```
 pub fn geo_inclined(inclination: uom::si::f64::Angle) -> OrbitalElements {
     use uom::si::angle::radian;
     circular_orbit_with_mu(42_164_172.0_f64, inclination.get::<radian>(), mu_ggm05c())

--- a/crates/jeod_sim/src/recipes/scenarios/apollo.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/apollo.rs
@@ -36,6 +36,14 @@ pub const SUN_IDX: usize = 2;
 /// The example then layers stage separation and an impulsive
 /// trans-lunar Δv burn on top of this scenario as inline maneuvers —
 /// those are mission-code-specific and not baked into the scenario.
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::apollo;
+/// let sb = apollo::apollo_translunar();
+/// // Earth + Moon + Sun gravity sources.
+/// assert_eq!(sb.sources.len(), 3);
+/// assert_eq!(sb.bodies.len(), 1);
+/// ```
 pub fn apollo_translunar() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), 60.0);
     let earth_idx = sb.add_source("Earth", earth::point_mass());

--- a/crates/jeod_sim/src/recipes/scenarios/clementine_lunar.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/clementine_lunar.rs
@@ -26,6 +26,14 @@ use crate::SimulationBuilder;
 /// `jeod_sim::recipes::verification::reference_data::moon_lp150q()` and
 /// adds a non-spherical control. That's appropriate only for Tier 3
 /// cross-validation (it requires `$JEOD_HOME`).
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::clementine_lunar;
+/// let sb = clementine_lunar::clementine_lunar();
+/// // Moon (central) + Earth (third-body) + Sun (third-body / SRP).
+/// assert_eq!(sb.sources.len(), 3);
+/// assert_eq!(sb.bodies.len(), 1);
+/// ```
 pub fn clementine_lunar() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::clementine_1994(), 1.0);
 

--- a/crates/jeod_sim/src/recipes/scenarios/earth_moon.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/earth_moon.rs
@@ -12,6 +12,12 @@ use crate::SimulationBuilder;
 /// Trans-lunar coast with Earth, Moon, and Sun. See
 /// [`clementine_lunar`](super::clementine_lunar::clementine_lunar) for
 /// the underlying setup.
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::earth_moon;
+/// let sb = earth_moon::earth_moon_translunar();
+/// assert_eq!(sb.sources.len(), 3);
+/// ```
 pub fn earth_moon_translunar() -> SimulationBuilder {
     super::clementine_lunar::clementine_lunar()
 }

--- a/crates/jeod_sim/src/recipes/scenarios/geostationary.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/geostationary.rs
@@ -14,6 +14,14 @@ use crate::SimulationBuilder;
 
 /// Geostationary point-mass satellite at 42164 km, 0° inclination.
 /// Earth point-mass gravity, RK4, J2000 epoch, 300 s step.
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::geostationary;
+/// let sb = geostationary::geo();
+/// assert_eq!(sb.sources.len(), 1);
+/// assert_eq!(sb.bodies.len(), 1);
+/// assert_eq!(sb.dt, 300.0);
+/// ```
 pub fn geo() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), 300.0);
     let earth_idx = sb.add_source("Earth", earth::point_mass());

--- a/crates/jeod_sim/src/recipes/scenarios/iss_leo.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/iss_leo.rs
@@ -19,6 +19,13 @@ use crate::SimulationBuilder;
 /// ([`crate::recipes::orbital_elements::iss`])
 /// initialized via the typestate vehicle builder. Step size is 60 s,
 /// epoch is J2000.
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::iss_leo;
+/// let sb = iss_leo::iss_leo();
+/// assert_eq!(sb.bodies.len(), 1);
+/// assert_eq!(sb.sources.len(), 1);
+/// ```
 pub fn iss_leo() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), 60.0);
     let earth_idx = sb.add_source("Earth", earth::point_mass());
@@ -38,6 +45,13 @@ pub fn iss_leo() -> SimulationBuilder {
 /// identity attitude (drag requires a rotational state for the
 /// inertial → structural frame transform — see JEOD_INV: IN.15).
 /// Demonstrates 24-hour altitude decay under solar-mean conditions.
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::iss_leo;
+/// let sb = iss_leo::iss_leo_drag();
+/// assert_eq!(sb.bodies.len(), 1);
+/// assert!(sb.atmosphere.is_some());
+/// ```
 pub fn iss_leo_drag() -> SimulationBuilder {
     use crate::recipes::atmosphere;
     use jeod_dynamics::{MassProperties, RotationalState};

--- a/crates/jeod_sim/src/recipes/scenarios/mars_orbit.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mars_orbit.rs
@@ -23,6 +23,14 @@ use crate::SimulationBuilder;
 /// accuracy substitutes the central-body source with
 /// `verification::reference_data::mars_mro110b2()` and adds a
 /// non-spherical [`GravityControl`].
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::mars_orbit;
+/// let sb = mars_orbit::mars_orbit();
+/// // Mars central + Sun third-body.
+/// assert_eq!(sb.sources.len(), 2);
+/// assert_eq!(sb.dt, 10.0);
+/// ```
 pub fn mars_orbit() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::dawn_mars_2009(), 10.0);
     let mars_idx = sb.add_source("Mars", mars::point_mass());

--- a/crates/jeod_sim/src/recipes/scenarios/mercury.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mercury.rs
@@ -17,6 +17,14 @@ use crate::SimulationBuilder;
 /// enabled — used to measure perihelion advance over many orbits.
 ///
 /// 100 s step. Initial state matches Mercury at perihelion.
+///
+/// ```
+/// use jeod_sim::recipes::scenarios::mercury;
+/// let sb = mercury::mercury_relativistic();
+/// assert_eq!(sb.sources.len(), 1);
+/// assert_eq!(sb.bodies.len(), 1);
+/// assert_eq!(sb.dt, 100.0);
+/// ```
 pub fn mercury_relativistic() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), 100.0);
     let sun_idx = sb.add_source("Sun", sun::point_mass());

--- a/crates/jeod_sim/src/recipes/scenarios/mod.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mod.rs
@@ -5,6 +5,9 @@
 //! scenarios as `Mission::iss_leo().into_builder()` rather than calling
 //! into these submodules directly.
 //!
+//! // reason: doctest references the downstream `jeod_runner` adapter
+//! // crate, which jeod_sim cannot depend on without a circular workspace
+//! // dependency.
 //! ```ignore
 //! use jeod_runner::SimulationBuilderExt;
 //! use jeod_sim::recipes::Mission;

--- a/crates/jeod_sim/src/recipes/scenarios/mod.rs
+++ b/crates/jeod_sim/src/recipes/scenarios/mod.rs
@@ -5,9 +5,7 @@
 //! scenarios as `Mission::iss_leo().into_builder()` rather than calling
 //! into these submodules directly.
 //!
-//! // reason: doctest references the downstream `jeod_runner` adapter
-//! // crate, which jeod_sim cannot depend on without a circular workspace
-//! // dependency.
+//! // reason: doctest references the downstream `jeod_runner` adapter crate, which jeod_sim cannot depend on without a circular workspace dependency.
 //! ```ignore
 //! use jeod_runner::SimulationBuilderExt;
 //! use jeod_sim::recipes::Mission;

--- a/crates/jeod_sim/src/recipes/vehicle.rs
+++ b/crates/jeod_sim/src/recipes/vehicle.rs
@@ -19,6 +19,12 @@ use uom::si::length::meter;
 use uom::si::mass::kilogram;
 
 /// ISS-class mass (~420 t) as a typed [`Mass`].
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::iss_mass().get::<kilogram>(), 420_000.0);
+/// ```
 pub fn iss_mass() -> Mass {
     420_000.0.kg()
 }
@@ -26,11 +32,23 @@ pub fn iss_mass() -> Mass {
 /// 1 kg unit-sphere test particle. Used by drag / SRP verification
 /// scenarios that match JEOD's "1 kg sphere in elliptical orbit"
 /// pattern.
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::unit_sphere_mass().get::<kilogram>(), 1.0);
+/// ```
 pub fn unit_sphere_mass() -> Mass {
     1.0.kg()
 }
 
 /// STS-114 (Discovery) mass at launch (~109 t).
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::sts114_mass().get::<kilogram>(), 109_000.0);
+/// ```
 pub fn sts114_mass() -> Mass {
     109_000.0.kg()
 }
@@ -41,22 +59,46 @@ pub fn sts114_mass() -> Mass {
 /// `tier3_sim_earth_moon` Tier 3 case asserts against this value. SRP
 /// acceleration scales with mass so missions cross-validating against
 /// JEOD must use 424 kg, not the 227 kg dry mass.
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::clementine_mass().get::<kilogram>(), 424.0);
+/// ```
 pub fn clementine_mass() -> Mass {
     424.0.kg()
 }
 
 /// Dawn spacecraft mass at Mars arrival (~1217 kg total).
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::dawn_mass().get::<kilogram>(), 1_217.0);
+/// ```
 pub fn dawn_mass() -> Mass {
     1_217.0.kg()
 }
 
 /// Apollo CSM mass (~30 t).
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::apollo_csm_mass().get::<kilogram>(), 30_000.0);
+/// ```
 pub fn apollo_csm_mass() -> Mass {
     30_000.0.kg()
 }
 
 /// Apollo Lunar Module mass (~14.7 t fueled / lunar-descent
 /// configuration).
+///
+/// ```
+/// use jeod_sim::recipes::vehicle;
+/// use uom::si::mass::kilogram;
+/// assert_eq!(vehicle::apollo_lm_mass().get::<kilogram>(), 14_700.0);
+/// ```
 pub fn apollo_lm_mass() -> Mass {
     14_700.0.kg()
 }
@@ -65,6 +107,15 @@ pub fn apollo_lm_mass() -> Mass {
 /// inertia `I = (2/5) m r²` along all body axes, CoM at structural
 /// origin. Inputs are typed so call sites stay unit-safe ergonomically:
 /// `vehicle::rigid_sphere(420_000.0.kg(), 5.0.m())`.
+///
+/// ```
+/// use jeod_quantities::ext::F64Ext;
+/// use jeod_sim::recipes::vehicle;
+/// let mp = vehicle::rigid_sphere(10.0.kg(), 1.0.m());
+/// // I = (2/5) m r² = 4.0
+/// assert!((mp.inertia.x_axis.x - 4.0).abs() < 1e-12);
+/// assert_eq!(mp.mass, 10.0);
+/// ```
 pub fn rigid_sphere(mass: Mass, radius: Length) -> MassProperties {
     let m = mass.get::<kilogram>();
     let r = radius.get::<meter>();

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -4,6 +4,8 @@
 //! CSV path, propagation duration, and per-component tolerances into a
 //! single declarative unit. Tier 3 tests in Phase 7/8 collapse to:
 //!
+//! // reason: `run_and_assert` is defined by `jeod_runner::VerificationCaseExt`,
+//! // which jeod_sim cannot depend on without a circular workspace dependency.
 //! ```ignore
 //! #[test]
 //! fn tier3_dyncomp_run2_3dof() {

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -4,8 +4,7 @@
 //! CSV path, propagation duration, and per-component tolerances into a
 //! single declarative unit. Tier 3 tests in Phase 7/8 collapse to:
 //!
-//! // reason: `run_and_assert` is defined by `jeod_runner::VerificationCaseExt`,
-//! // which jeod_sim cannot depend on without a circular workspace dependency.
+//! // reason: `run_and_assert` is defined by `jeod_runner::VerificationCaseExt`, which jeod_sim cannot depend on without a circular workspace dependency.
 //! ```ignore
 //! #[test]
 //! fn tier3_dyncomp_run2_3dof() {

--- a/crates/jeod_sim/src/vehicle_builder.rs
+++ b/crates/jeod_sim/src/vehicle_builder.rs
@@ -24,16 +24,18 @@
 //!
 //! # Happy path
 //!
-//! ```ignore
+//! ```
 //! use jeod_sim::vehicle_builder::VehicleBuilder;
+//! use jeod_sim::recipes::orbital_elements;
 //! use jeod_sim::EARTH;
 //! use jeod_quantities::ext::F64Ext;
 //!
 //! let cfg = VehicleBuilder::new()
-//!     .from_orbital_elements(elems, EARTH.mu_typed())
+//!     .from_orbital_elements(orbital_elements::iss(), EARTH.mu_typed())
 //!     .three_dof_point_mass(420_000.0.kg())
 //!     .rk4()
 //!     .build();
+//! assert!(cfg.mass.is_some());
 //! ```
 
 use core::marker::PhantomData;

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -15,11 +15,14 @@ use crate::components::*;
 /// rotation, and geodetic computation.
 ///
 /// # Example
-/// ```ignore
+/// ```
+/// use bevy::prelude::*;
 /// use bevy_jeod::PlanetBundle;
 /// use jeod_sim::EARTH;
 ///
-/// let earth = commands.spawn(PlanetBundle::point_mass("Earth", &EARTH)).id();
+/// let mut world = World::new();
+/// let earth = world.spawn(PlanetBundle::point_mass("Earth", &EARTH)).id();
+/// assert!(world.get_entity(earth).is_ok());
 /// ```
 #[derive(Bundle)]
 pub struct PlanetBundle {
@@ -69,10 +72,14 @@ impl PlanetBundle {
 /// by SRP and solar-beta systems.
 ///
 /// # Example
-/// ```ignore
+/// ```
+/// use bevy::prelude::*;
 /// use bevy_jeod::SunBundle;
+/// use jeod_sim::TranslationalState;
 ///
-/// commands.spawn(SunBundle::new(sun_state));
+/// let mut world = World::new();
+/// let sun = world.spawn(SunBundle::new(TranslationalState::default())).id();
+/// assert!(world.get_entity(sun).is_ok());
 /// ```
 #[derive(Bundle)]
 pub struct SunBundle {
@@ -97,10 +104,14 @@ impl SunBundle {
 /// by the earth lighting system.
 ///
 /// # Example
-/// ```ignore
+/// ```
+/// use bevy::prelude::*;
 /// use bevy_jeod::MoonBundle;
+/// use jeod_sim::TranslationalState;
 ///
-/// commands.spawn(MoonBundle::new(moon_state));
+/// let mut world = World::new();
+/// let moon = world.spawn(MoonBundle::new(TranslationalState::default())).id();
+/// assert!(world.get_entity(moon).is_ok());
 /// ```
 #[derive(Bundle)]
 pub struct MoonBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,23 +254,24 @@ pub fn register_jeod_component_types(app: &mut App) {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use bevy_jeod::{JeodPlugin, VehicleConfigBevyExt};
-/// use jeod_sim::recipes::{constants, orbital_elements};
-/// use jeod_sim::{GravityControl, VehicleBuilder};
-/// use jeod_quantities::ext::F64Ext;
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_jeod::{PlanetBundle, VehicleConfigBevyExt};
+/// use jeod_sim::recipes::{constants, orbital_elements, vehicle};
+/// use jeod_sim::{GravityControl, VehicleBuilder, EARTH};
 ///
-/// fn setup(mut commands: Commands) {
-///     let earth = commands.spawn(/* gravity-source bundle */).id();
+/// let mut app = App::new();
+/// app.add_systems(Startup, |mut commands: Commands| {
+///     let earth = commands.spawn(PlanetBundle::point_mass("Earth", &EARTH)).id();
 ///     let cfg = VehicleBuilder::new()
 ///         .from_orbital_elements(orbital_elements::iss(), constants::mu_ggm05c())
-///         .three_dof_point_mass(420_000.0.kg())
+///         .three_dof_point_mass(vehicle::iss_mass())
 ///         .rk4()
 ///         .gravity(GravityControl::new_spherical(0_usize, false))
 ///         .build();
-///     // Resolve source-index 0 to the earth entity.
 ///     cfg.spawn_bevy(&mut commands, &[earth]);
-/// }
+/// });
+/// app.update();
 /// ```
 pub trait VehicleConfigBevyExt {
     /// Spawn a Bevy entity carrying the core components implied by this

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,7 @@
 //! scenario-composition catalogue (`earth::point_mass()`,
 //! `orbital_elements::iss()`, `vehicle::iss_mass()`, …).
 //!
-//! ```ignore
+//! ```
 //! use bevy::prelude::*;
 //! use bevy_jeod::prelude::*;
 //! use bevy_jeod::recipes::*;
@@ -21,6 +21,7 @@
 //!     .rk4()
 //!     .gravity(GravityControl::new_spherical(0_usize, false))
 //!     .build();
+//! assert!(cfg.mass.is_some());
 //! ```
 
 pub use crate::{

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1247,13 +1247,25 @@ pub fn cannonball_srp_system(
 /// messages to have any effect.
 ///
 /// # Example
-/// ```ignore
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_jeod::DetachEvent;
+///
+/// // A user-defined system that emits a DetachEvent for a known booster
+/// // entity (e.g. one cached in a Resource).
+/// #[derive(Resource)]
+/// struct Booster(Entity);
+///
 /// fn detach_booster(
-///     mut detach_messages: bevy::ecs::message::MessageWriter<crate::DetachEvent>,
-///     booster_entity: Entity,
+///     booster: Res<Booster>,
+///     mut detach_messages: bevy::ecs::message::MessageWriter<DetachEvent>,
 /// ) {
-///     detach_messages.write(crate::DetachEvent { child: booster_entity });
+///     detach_messages.write(DetachEvent { child: booster.0 });
 /// }
+///
+/// let mut app = App::new();
+/// app.add_message::<DetachEvent>();
+/// app.add_systems(Update, detach_booster);
 /// ```
 pub fn staging_system(
     tree: Option<ResMut<crate::MassTreeR>>,


### PR DESCRIPTION
## Summary

Closes #216.

- Audit cuts workspace `ignore` doctest blocks from **19 → 5**. Every remaining `ignore` carries a one-line `// reason:` annotation: 4 of them sit in `jeod_sim` and reference the downstream `jeod_runner` / `bevy_jeod` adapters that `jeod_sim` cannot depend on without a circular workspace dep; the fifth is a partial struct-literal shape fragment in `interactions.rs` that needs unbound placeholders.
- Adds **17 runnable doctests** on the public surface: 8 in `recipes::orbital_elements` (`iss`, `geostationary`, `leo_400km_…`, `leo_polar_600km`, `mercury_perihelion`, `mars_dawn_orbit`, `apollo_parking`, `geo_inclined`), 8 in `recipes::vehicle` (`iss_mass`, `unit_sphere_mass`, `sts114_mass`, `clementine_mass`, `dawn_mass`, `apollo_csm_mass`, `apollo_lm_mass`, `rigid_sphere`), 9 in `recipes::scenarios::{apollo,clementine_lunar,earth_moon,geostationary,iss_leo,mars_orbit,mercury}` (`iss_leo` has two pub fns).
- Converts 14 of the previously-ignored examples into runnable doctests (recipe usage, `prelude`, `error::StepError`, `atmosphere::AtmosphereConfig::from_planet`, `branded` ×2, `jeod_runner::lib` ×2, `vehicle_builder` happy-path, `bevy_jeod::prelude`, `bundles::{PlanetBundle,SunBundle,MoonBundle}`, `VehicleConfigBevyExt`, `staging_system`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `cargo test --doc --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)