### PR TITLE
[#219] Add jeod_planet inline tests + Tier 2 ECEF↔geodetic round-trips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,7 @@ jobs:
             models/environment/time/data \
             models/dynamics/body_action/verif/SIM_orbinit/Modified_data \
             models/dynamics/derived_state/verif/unit_tests \
-            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
-            models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF
+            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data
           git checkout
       - uses: taiki-e/install-action@nextest
       - name: Run tests (skip Tier 3 trajectory validation)
@@ -134,7 +133,6 @@ jobs:
             models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
             models/environment/time/verif/SIM_7_time_reversal \
             models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
-            models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF \
             verif/SIM_dyncomp
           git checkout
       - uses: taiki-e/install-action@nextest
@@ -181,7 +179,6 @@ jobs:
             models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
             models/environment/time/verif/SIM_7_time_reversal \
             models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
-            models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF \
             verif/SIM_dyncomp
           git checkout
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,8 @@ jobs:
             models/environment/time/data \
             models/dynamics/body_action/verif/SIM_orbinit/Modified_data \
             models/dynamics/derived_state/verif/unit_tests \
-            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data
+            models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
+            models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF
           git checkout
       - uses: taiki-e/install-action@nextest
       - name: Run tests (skip Tier 3 trajectory validation)
@@ -133,6 +134,7 @@ jobs:
             models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
             models/environment/time/verif/SIM_7_time_reversal \
             models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
+            models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF \
             verif/SIM_dyncomp
           git checkout
       - uses: taiki-e/install-action@nextest
@@ -179,6 +181,7 @@ jobs:
             models/interactions/radiation_pressure/verif/SIM_2A_SHADOW_CALC \
             models/environment/time/verif/SIM_7_time_reversal \
             models/utils/orbital_elements/verif/SIM_orb_elem/Modified_data \
+            models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF \
             verif/SIM_dyncomp
           git checkout
       - uses: taiki-e/install-action@nextest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,7 +2438,10 @@ dependencies = [
 name = "jeod_planet"
 version = "0.1.0"
 dependencies = [
+ "glam 0.30.10",
+ "jeod_math",
  "jeod_quantities",
+ "jeod_test_data",
  "uom",
 ]
 

--- a/crates/jeod_planet/Cargo.toml
+++ b/crates/jeod_planet/Cargo.toml
@@ -11,3 +11,8 @@ repository.workspace = true
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 uom = { workspace = true }
+
+[dev-dependencies]
+glam = { workspace = true }
+jeod_math = { path = "../jeod_math", version = "0.1.0" }
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }

--- a/crates/jeod_planet/src/planet.rs
+++ b/crates/jeod_planet/src/planet.rs
@@ -152,4 +152,105 @@ mod tests {
             assert!(e > 0.0 && e < 1.0, "{}: e={}", planet.name, e);
         }
     }
+
+    // -----------------------------------------------------------------
+    // PR6 (#219): basic accessor coverage. The pre-existing tests above
+    // cover typed accessors and aggregate sanity; the cases below pin
+    // the field-level semantics of `PlanetShape` for a hand-constructed
+    // value, so that downstream callers can rely on the struct surface
+    // without depending on the `presets` module.
+    // -----------------------------------------------------------------
+
+    use crate::planet::PlanetShape;
+
+    /// Hand-built minimal planet, so the test does not depend on preset
+    /// constants (which are exercised separately).
+    const TEST_SHAPE: PlanetShape = PlanetShape {
+        name: "Testopia",
+        mu: 1.5e14,
+        r_eq: 6_400_000.0,
+        r_pol: 6_400_000.0 * (1.0 - 1.0 / 300.0),
+        flat_coeff: 1.0 / 300.0,
+    };
+
+    #[test]
+    fn shape_struct_field_access_round_trip() {
+        // The struct has no methods that mutate state — direct field
+        // access must return the literal we stored.
+        assert_eq!(TEST_SHAPE.name, "Testopia");
+        assert_eq!(TEST_SHAPE.mu, 1.5e14);
+        assert_eq!(TEST_SHAPE.r_eq, 6_400_000.0);
+        assert_eq!(TEST_SHAPE.flat_coeff, 1.0 / 300.0);
+    }
+
+    #[test]
+    fn radius_accessors_distinct_and_consistent() {
+        // r_eq > r_pol for any oblate body (f > 0). The const above has
+        // flat_coeff = 1/300 > 0, so the relation must hold for every
+        // preset and our hand-built shape. We reach for the values via
+        // a non-const accessor expression so clippy doesn't fold the
+        // comparison to a literal.
+        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS] {
+            assert!(
+                planet.r_eq > planet.r_pol,
+                "{}: r_eq={} not > r_pol={}",
+                planet.name,
+                planet.r_eq,
+                planet.r_pol
+            );
+            let derived_pol = planet.r_eq * (1.0 - planet.flat_coeff);
+            let err = (derived_pol - planet.r_pol).abs();
+            assert!(
+                err < 1.0,
+                "{}: r_pol drifted by {err} m from r_eq*(1-f)",
+                planet.name
+            );
+        }
+    }
+
+    #[test]
+    fn flattening_inverse_round_trip() {
+        // flat_inv() must invert flat_coeff exactly (within f64 ULP).
+        let f = TEST_SHAPE.flat_coeff;
+        let inv = TEST_SHAPE.flat_inv();
+        assert!(
+            (inv * f - 1.0).abs() < 1e-14,
+            "flat_inv({f}) * f != 1: got {}",
+            inv * f
+        );
+    }
+
+    #[test]
+    fn mu_accessor_matches_typed_and_preserves_value() {
+        // The typed getter must round-trip the raw f64 mu without loss.
+        // GravParam stores its value in base SI (m³/s²).
+        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS] {
+            assert_eq!(planet.mu_typed().value, planet.mu);
+        }
+    }
+
+    #[test]
+    fn eccentricity_squared_matches_definition() {
+        // e_ellip_sq = 2f - f^2; e_ellipsoid is its sqrt.
+        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS] {
+            let f = planet.flat_coeff;
+            let expected = 2.0 * f - f * f;
+            assert!((planet.e_ellip_sq() - expected).abs() < 1e-15);
+            let e = planet.e_ellipsoid();
+            assert!((e * e - planet.e_ellip_sq()).abs() < 1e-15);
+        }
+    }
+
+    #[test]
+    fn shape_struct_is_copy() {
+        // The Copy bound matters for ergonomic use as a const — assert
+        // it implicitly via a copy through a function boundary.
+        fn take_by_value(s: PlanetShape) -> f64 {
+            s.r_eq
+        }
+        let s = TEST_SHAPE;
+        assert_eq!(take_by_value(s), TEST_SHAPE.r_eq);
+        // Verify the original is still usable post-copy.
+        assert_eq!(s.name, "Testopia");
+    }
 }

--- a/crates/jeod_planet/tests/tier2_planet_geodetic.rs
+++ b/crates/jeod_planet/tests/tier2_planet_geodetic.rs
@@ -1,0 +1,356 @@
+//! Tier 2: ECEF↔geodetic (and ECEF↔spherical) round-trip closure for the
+//! `PlanetShape` ellipsoid + `jeod_math::geodetic` conversion kernels,
+//! seeded by the three explicit test points from JEOD's
+//! `SIM_PFIXPOSN_VERIF` Trick verification sim.
+//!
+//! ## Reference
+//!
+//! - JEOD source: `models/utils/planet_fixed/planet_fixed_posn/verif/
+//!   SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`. Three
+//!   `add_read` blocks define a Cartesian seed, a spherical seed, and an
+//!   elliptical seed.
+//! - JEOD verification methodology (random vector sweep) is in
+//!   `verif/unit_tests/Cartesian_to_AltLatLong_to_Cartesian/main.cc`,
+//!   which checks Cartesian closure of `cart -> spher -> cart` and
+//!   `cart -> ellip -> cart`. We mirror that methodology against the
+//!   SIM's deterministic seeds so the inputs are sourced from JEOD
+//!   itself.
+//! - `Planet` defaults (`r_eq = 6_378.137 km`, `flat_inv = 298.257223563`)
+//!   come from `environment/planet/data/include/earth.hh`.
+//!
+//! ## What is checked
+//!
+//! For every seed we exercise the identical Cartesian-closure invariant
+//! that JEOD's own unit test asserts (`vmag(cart_in - cart_out) < tol`).
+//! For the spherical seed and the elliptical seed we *additionally* run
+//! the angle-space round-trip — but only when the seed's latitude lies
+//! inside the principal range `(-π/2, +π/2)` so that the inverse is
+//! well-defined. The first `Spherical` seed in `input.py` is `lat=3.1416`
+//! (an aliased value used to stress the `sin/cos` numerical path in
+//! JEOD's verification log; it intentionally exits the principal range
+//! and so cannot be recovered angularly). For that case we limit the
+//! check to Cartesian closure, matching JEOD's own treatment.
+//!
+//! ## Polar handling
+//!
+//! Per CLAUDE.md "Common Pitfalls / Geodetic longitude at the poles",
+//! geodetic longitude is geometrically undefined as latitude approaches
+//! ±π/2 because all meridians converge. None of the three SIM seeds
+//! places us at the pole (closest is the Cartesian seed which sits on
+//! the equator at +x, latitude 0). No degraded longitude tolerance is
+//! required.
+//!
+//! ## Tolerance policy
+//!
+//! Per CLAUDE.md "Cross-validation tolerances", each tolerance is set
+//! to the observed max error * 1.05, then rounded up to a clean
+//! literal. Since both inputs and code are deterministic, the observed
+//! errors are fixed numbers.
+
+use glam::DVec3;
+use jeod_math::geodetic::{
+    cartesian_to_geodetic_typed, cartesian_to_spherical, geodetic_to_cartesian_typed,
+    spherical_to_cartesian, GeodeticState, GeodeticStateTyped, SphericalState,
+};
+use jeod_planet::EARTH;
+use jeod_quantities::aliases::Position;
+use jeod_quantities::ext::F64Ext;
+use jeod_quantities::frame::{Earth, PlanetFixed};
+use jeod_quantities::qty3::Qty3;
+use jeod_test_data::{
+    jeod_path,
+    planet_geodetic_verif::{load_planet_fixed_verif_cases, PlanetFixedSeed},
+};
+use uom::si::angle::radian;
+use uom::si::length::meter;
+
+/// Resolve the geodetic kernels through the typed surface (and back) so
+/// the bare-`f64` impls that the typed wrappers delegate to are exercised
+/// indirectly. Returns the recovered Cartesian position.
+fn geodetic_round_trip(cart: DVec3) -> (DVec3, GeodeticState) {
+    let pos: Position<PlanetFixed<Earth>> = Qty3::from_raw_si(cart);
+    let geo = cartesian_to_geodetic_typed(pos, EARTH.r_eq.m(), EARTH.r_pol.m());
+    let back: Position<PlanetFixed<Earth>> =
+        geodetic_to_cartesian_typed(geo, EARTH.r_eq.m(), EARTH.r_pol.m());
+    (back.raw_si(), geo.into_raw())
+}
+
+fn spherical_round_trip(cart: DVec3) -> (DVec3, SphericalState) {
+    let sph = cartesian_to_spherical(cart, EARTH.r_eq);
+    let back = spherical_to_cartesian(&sph, EARTH.r_eq);
+    (back, sph)
+}
+
+#[derive(Default)]
+struct MaxErrors {
+    cart_sphere_m: f64,
+    cart_ellip_m: f64,
+    sphere_lat_rad: f64,
+    sphere_lon_rad: f64,
+    sphere_alt_m: f64,
+    geo_lat_rad: f64,
+    geo_lon_rad: f64,
+    geo_alt_m: f64,
+}
+
+impl MaxErrors {
+    fn record_cart(&mut self, sphere: f64, ellip: f64) {
+        self.cart_sphere_m = self.cart_sphere_m.max(sphere);
+        self.cart_ellip_m = self.cart_ellip_m.max(ellip);
+    }
+
+    fn record_sphere_angles(&mut self, lat: f64, lon: f64, alt: f64) {
+        self.sphere_lat_rad = self.sphere_lat_rad.max(lat);
+        self.sphere_lon_rad = self.sphere_lon_rad.max(lon);
+        self.sphere_alt_m = self.sphere_alt_m.max(alt);
+    }
+
+    fn record_geo_angles(&mut self, lat: f64, lon: f64, alt: f64) {
+        self.geo_lat_rad = self.geo_lat_rad.max(lat);
+        self.geo_lon_rad = self.geo_lon_rad.max(lon);
+        self.geo_alt_m = self.geo_alt_m.max(alt);
+    }
+}
+
+/// Smallest absolute longitude difference modulo 2π. `atan2` returns in
+/// `(-π, +π]`, so a seed value at +π comes back as -π even though they
+/// represent the same meridian. Both branches are mathematically valid;
+/// the test must compare on the circle, not on the line.
+fn wrap_lon_diff(a: f64, b: f64) -> f64 {
+    let two_pi = std::f64::consts::TAU;
+    let mut d = (a - b).rem_euclid(two_pi);
+    if d > std::f64::consts::PI {
+        d = two_pi - d;
+    }
+    d.abs()
+}
+
+fn assert_jeod_source_present() -> std::path::PathBuf {
+    let root = jeod_path();
+    assert!(
+        root.exists(),
+        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH to the JEOD checkout \
+         (see CLAUDE.md \"Environment Setup\").",
+        root.display(),
+    );
+    root
+}
+
+/// Cartesian-closure for every seed plus angle-space closure where the
+/// seed angles live inside the principal range.
+#[test]
+fn tier2_planet_geodetic_round_trip_sim_pfixposn_seeds() {
+    let root = assert_jeod_source_present();
+    let cases = load_planet_fixed_verif_cases(&root);
+    assert_eq!(cases.len(), 3, "SIM_PFIXPOSN_VERIF has three seeds");
+
+    let mut max = MaxErrors::default();
+
+    for (idx, case) in cases.iter().enumerate() {
+        match *case {
+            PlanetFixedSeed::Cartesian { cart_m, .. } => {
+                // Forward+back through both branches.
+                let (back_geo, geo) = geodetic_round_trip(cart_m);
+                let (back_sph, _sph) = spherical_round_trip(cart_m);
+
+                let err_geo = (back_geo - cart_m).length();
+                let err_sph = (back_sph - cart_m).length();
+                max.record_cart(err_sph, err_geo);
+
+                // Also confirm: a second forward into the same lat/lon/alt
+                // is bit-stable (the iteration converged).
+                let (back2, geo2) = geodetic_round_trip(back_geo);
+                assert_eq!(geo2, geo, "case {idx} (cart): geodetic not idempotent");
+                assert!(
+                    (back2 - back_geo).length() < 1e-6,
+                    "case {idx} (cart): second round-trip drifted",
+                );
+            }
+            PlanetFixedSeed::Spherical {
+                altitude_m,
+                latitude_rad,
+                longitude_rad,
+                ..
+            } => {
+                let seed = SphericalState {
+                    altitude: altitude_m,
+                    latitude: latitude_rad,
+                    longitude: longitude_rad,
+                };
+                let cart = spherical_to_cartesian(&seed, EARTH.r_eq);
+                let (back_sph_cart, recovered) = spherical_round_trip(cart);
+                let err_cart = (back_sph_cart - cart).length();
+                max.cart_sphere_m = max.cart_sphere_m.max(err_cart);
+
+                if latitude_rad.abs() < std::f64::consts::FRAC_PI_2 {
+                    // Angle-space inverse exists.
+                    let dlat = (recovered.latitude - latitude_rad).abs();
+                    let dlon = wrap_lon_diff(recovered.longitude, longitude_rad);
+                    let dalt = (recovered.altitude - altitude_m).abs();
+                    max.record_sphere_angles(dlat, dlon, dalt);
+                }
+                // Note: the SIM's first spherical seed uses lat=3.1416
+                // (out-of-range) to stress the sin/cos numerical path;
+                // angle recovery is not meaningful there. JEOD's own
+                // unit test checks Cartesian closure only — we mirror
+                // that behaviour.
+            }
+            PlanetFixedSeed::Elliptical {
+                altitude_m,
+                latitude_rad,
+                longitude_rad,
+                ..
+            } => {
+                let seed = GeodeticState {
+                    altitude: altitude_m,
+                    latitude: latitude_rad,
+                    longitude: longitude_rad,
+                };
+                let typed_seed = GeodeticStateTyped::from_raw(seed);
+                let cart_typed: Position<PlanetFixed<Earth>> =
+                    geodetic_to_cartesian_typed(typed_seed, EARTH.r_eq.m(), EARTH.r_pol.m());
+                let cart = cart_typed.raw_si();
+
+                let (back_cart, recovered) = geodetic_round_trip(cart);
+                let err_cart = (back_cart - cart).length();
+                max.cart_ellip_m = max.cart_ellip_m.max(err_cart);
+
+                if latitude_rad.abs() < std::f64::consts::FRAC_PI_2 {
+                    let dlat = (recovered.latitude - latitude_rad).abs();
+                    let dlon = wrap_lon_diff(recovered.longitude, longitude_rad);
+                    let dalt = (recovered.altitude - altitude_m).abs();
+                    max.record_geo_angles(dlat, dlon, dalt);
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "tier2_planet_geodetic_round_trip_sim_pfixposn_seeds: \
+         max cart_sphere = {:.3e} m, max cart_ellip = {:.3e} m, \
+         max sphere lat/lon/alt = {:.3e}/{:.3e}/{:.3e}, \
+         max geo lat/lon/alt = {:.3e}/{:.3e}/{:.3e}",
+        max.cart_sphere_m,
+        max.cart_ellip_m,
+        max.sphere_lat_rad,
+        max.sphere_lon_rad,
+        max.sphere_alt_m,
+        max.geo_lat_rad,
+        max.geo_lon_rad,
+        max.geo_alt_m,
+    );
+
+    // Tolerances per CLAUDE.md "Tolerance policy" (observed max * 1.05,
+    // rounded up to a clean literal).
+    //
+    // Observed (Apr 2026) on x86_64-linux for the three SIM_PFIXPOSN_VERIF
+    // seeds:
+    //   cart_sphere = 9.313e-10 m  (Cartesian closure of cart->spher->cart;
+    //                               first SIM seed lives on the +x axis at
+    //                               r=6 778 136.3 m, error is ULP-level)
+    //   cart_ellip  = 6.880e-10 m  (cart->ellip->cart over the same point
+    //                               and the third seed reconstructed via
+    //                               update_from_ellip)
+    //   sphere lat/lon/alt = 0/0/0 (only sampled when the spherical seed
+    //                               has a principal-range latitude; the
+    //                               SIM seed is intentionally out-of-range
+    //                               so this field is never written)
+    //   geo lat/lon = 0/0          (third SIM seed lat=1.0 rad, lon=π;
+    //                               longitude wrap handled by wrap_lon_diff)
+    //   geo alt    = 9.140e-11 m
+    //
+    // The 1e-9 metric tolerances are the closest clean literal above
+    // observed*1.05 and absorb a small amount of ULP jitter on
+    // alternative targets (aarch64 etc.).
+    assert!(
+        max.cart_sphere_m < 1.0e-9,
+        "cart->spher->cart closure {:.3e} m exceeds 1.0e-9 m tolerance",
+        max.cart_sphere_m,
+    );
+    assert!(
+        max.cart_ellip_m < 1.0e-9,
+        "cart->ellip->cart closure {:.3e} m exceeds 1.0e-9 m tolerance",
+        max.cart_ellip_m,
+    );
+    assert!(
+        max.sphere_lat_rad < 1.0e-12,
+        "spherical lat closure {:.3e} rad exceeds 1.0e-12 rad tolerance",
+        max.sphere_lat_rad,
+    );
+    assert!(
+        max.sphere_lon_rad < 1.0e-12,
+        "spherical lon closure {:.3e} rad exceeds 1.0e-12 rad tolerance",
+        max.sphere_lon_rad,
+    );
+    assert!(
+        max.sphere_alt_m < 1.0e-6,
+        "spherical alt closure {:.3e} m exceeds 1.0e-6 m tolerance",
+        max.sphere_alt_m,
+    );
+    assert!(
+        max.geo_lat_rad < 1.0e-12,
+        "geodetic lat closure {:.3e} rad exceeds 1.0e-12 rad tolerance",
+        max.geo_lat_rad,
+    );
+    assert!(
+        max.geo_lon_rad < 1.0e-12,
+        "geodetic lon closure {:.3e} rad exceeds 1.0e-12 rad tolerance",
+        max.geo_lon_rad,
+    );
+    assert!(
+        max.geo_alt_m < 1.0e-10,
+        "geodetic alt closure {:.3e} m exceeds 1.0e-10 m tolerance",
+        max.geo_alt_m,
+    );
+}
+
+/// The `PlanetShape::r_pol` value derived from `r_eq` and `flat_coeff`
+/// must drive the same Cartesian point as JEOD's `Planet` initialization
+/// (which computes `r_pol = r_eq * (1 - 1/flat_inv)`). Verifies our
+/// preset is bit-identical to JEOD for the seed coordinates.
+#[test]
+fn tier2_planet_geodetic_earth_preset_matches_jeod_default() {
+    // JEOD: planet/data/include/earth.hh — r_eq = 6378.137 km, flat_inv = 298.257223563.
+    let jeod_r_eq_m = 6_378_137.0_f64;
+    let jeod_flat_inv = 298.257_223_563_f64;
+    let jeod_r_pol_m = jeod_r_eq_m * (1.0 - 1.0 / jeod_flat_inv);
+
+    assert_eq!(EARTH.r_eq, jeod_r_eq_m);
+    assert!(
+        (EARTH.flat_inv() - jeod_flat_inv).abs() < 1e-12,
+        "flat_inv differs by {}",
+        (EARTH.flat_inv() - jeod_flat_inv).abs(),
+    );
+    assert!(
+        (EARTH.r_pol - jeod_r_pol_m).abs() < 1e-9,
+        "r_pol differs by {} m",
+        (EARTH.r_pol - jeod_r_pol_m).abs(),
+    );
+}
+
+/// Exercise the typed surface end-to-end: typed seed in, typed result
+/// out, drive the kernel through `cartesian_to_geodetic_typed` /
+/// `geodetic_to_cartesian_typed`. Mirrors the SIM's third (elliptical)
+/// seed inside the principal latitude range.
+#[test]
+fn tier2_planet_geodetic_typed_round_trip_iss_inclined() {
+    // ISS-like, but distinctly off-pole so longitude is well-defined.
+    let seed = GeodeticStateTyped {
+        latitude: 51.6.deg(),
+        longitude: 30.0.deg(),
+        altitude: 408_000.0.m(),
+    };
+    let r_eq = EARTH.r_eq.m();
+    let r_pol = EARTH.r_pol.m();
+
+    let cart: Position<PlanetFixed<Earth>> = geodetic_to_cartesian_typed(seed, r_eq, r_pol);
+    let recovered = cartesian_to_geodetic_typed(cart, r_eq, r_pol);
+
+    let lat_err = (recovered.latitude.get::<radian>() - seed.latitude.get::<radian>()).abs();
+    let lon_err = (recovered.longitude.get::<radian>() - seed.longitude.get::<radian>()).abs();
+    let alt_err = (recovered.altitude.get::<meter>() - seed.altitude.get::<meter>()).abs();
+
+    assert!(lat_err < 1e-14, "ISS-inclined lat err = {lat_err} rad");
+    assert!(lon_err < 1e-14, "ISS-inclined lon err = {lon_err} rad");
+    assert!(alt_err < 1e-9, "ISS-inclined alt err = {alt_err} m");
+}

--- a/crates/jeod_planet/tests/tier2_planet_geodetic.rs
+++ b/crates/jeod_planet/tests/tier2_planet_geodetic.rs
@@ -57,10 +57,7 @@ use jeod_quantities::aliases::Position;
 use jeod_quantities::ext::F64Ext;
 use jeod_quantities::frame::{Earth, PlanetFixed};
 use jeod_quantities::qty3::Qty3;
-use jeod_test_data::{
-    jeod_path,
-    planet_geodetic_verif::{load_planet_fixed_verif_cases, PlanetFixedSeed},
-};
+use jeod_test_data::planet_geodetic_verif::{load_planet_fixed_verif_cases, PlanetFixedSeed};
 use uom::si::angle::radian;
 use uom::si::length::meter;
 
@@ -125,23 +122,11 @@ fn wrap_lon_diff(a: f64, b: f64) -> f64 {
     d.abs()
 }
 
-fn assert_jeod_source_present() -> std::path::PathBuf {
-    let root = jeod_path();
-    assert!(
-        root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH to the JEOD checkout \
-         (see CLAUDE.md \"Environment Setup\").",
-        root.display(),
-    );
-    root
-}
-
 /// Cartesian-closure for every seed plus angle-space closure where the
 /// seed angles live inside the principal range.
 #[test]
 fn tier2_planet_geodetic_round_trip_sim_pfixposn_seeds() {
-    let root = assert_jeod_source_present();
-    let cases = load_planet_fixed_verif_cases(&root);
+    let cases = load_planet_fixed_verif_cases();
     assert_eq!(cases.len(), 3, "SIM_PFIXPOSN_VERIF has three seeds");
 
     let mut max = MaxErrors::default();

--- a/crates/jeod_planet/tests/tier2_planet_geodetic.rs
+++ b/crates/jeod_planet/tests/tier2_planet_geodetic.rs
@@ -158,9 +158,29 @@ fn tier2_planet_geodetic_round_trip_sim_pfixposn_seeds() {
                 max.record_cart(err_sph, err_geo);
 
                 // Also confirm: a second forward into the same lat/lon/alt
-                // is bit-stable (the iteration converged).
+                // is convergent — the iterative `cartesian_to_geodetic`
+                // solver returns the same lat/lon/alt (within the kernel's
+                // own tolerance) when re-fed its own Cartesian output.
+                // We compare on a tolerance, not bit-exact, because the
+                // second pass starts from `back_geo` which already carries
+                // ULP-level round-trip error from pass one. Tolerances
+                // mirror those used in `jeod_math/src/geodetic.rs` tests.
                 let (back2, geo2) = geodetic_round_trip(back_geo);
-                assert_eq!(geo2, geo, "case {idx} (cart): geodetic not idempotent");
+                let dlat = (geo2.latitude - geo.latitude).abs();
+                let dlon = (geo2.longitude - geo.longitude).abs();
+                let dalt = (geo2.altitude - geo.altitude).abs();
+                assert!(
+                    dlat < 1e-12,
+                    "case {idx} (cart): geodetic lat not idempotent (Δ = {dlat:.3e} rad)",
+                );
+                assert!(
+                    dlon < 1e-12,
+                    "case {idx} (cart): geodetic lon not idempotent (Δ = {dlon:.3e} rad)",
+                );
+                assert!(
+                    dalt < 1e-6,
+                    "case {idx} (cart): geodetic alt not idempotent (Δ = {dalt:.3e} m)",
+                );
                 assert!(
                     (back2 - back_geo).length() < 1e-6,
                     "case {idx} (cart): second round-trip drifted",

--- a/crates/jeod_test_data/src/bin/extract_planet_pfixposn.rs
+++ b/crates/jeod_test_data/src/bin/extract_planet_pfixposn.rs
@@ -1,0 +1,242 @@
+//! Extract `SIM_PFIXPOSN_VERIF` seeds from a JEOD source checkout into
+//! `test_data/planet_pfixposn_seeds.json`.
+//!
+//! This is a **regen-only** path: it reads `$JEOD_HOME` (or
+//! `$JEOD_PATH`, or an explicit `--jeod-home <PATH>` argument), parses the
+//! three `add_read` blocks from
+//! `models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`,
+//! and writes the committed JSON consumed by
+//! `jeod_test_data::planet_geodetic_verif::load_planet_fixed_verif_cases`.
+//!
+//! Run after a JEOD upgrade or whenever the SIM's input is amended:
+//!
+//! ```bash
+//! cargo run -p jeod_test_data --bin extract_planet_pfixposn -- \
+//!     --jeod-home /path/to/jeod
+//! ```
+//!
+//! The binary prints the destination path on success.
+
+use std::io::Write;
+
+use regex::Regex;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let jeod_root = resolve_jeod_root(&args).unwrap_or_else(|| {
+        eprintln!(
+            "extract_planet_pfixposn: JEOD source not found.\n\
+             Pass `--jeod-home <PATH>` or set JEOD_HOME / JEOD_PATH \
+             (see CLAUDE.md \"Environment Setup\")."
+        );
+        std::process::exit(2);
+    });
+
+    let input_py = jeod_root.join(
+        "models/utils/planet_fixed/planet_fixed_posn/\
+         verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py",
+    );
+    let content = std::fs::read_to_string(&input_py).unwrap_or_else(|e| {
+        panic!(
+            "Cannot read {} (under JEOD_HOME = {}): {e}",
+            input_py.display(),
+            jeod_root.display(),
+        )
+    });
+
+    let cases = parse_input_py(&content);
+    assert!(
+        cases.len() >= 3,
+        "expected three add_read blocks in {}, found {}",
+        input_py.display(),
+        cases.len(),
+    );
+
+    let out_path = jeod_test_data::tier3_csv::test_data_path("planet_pfixposn_seeds.json");
+    let mut f = std::fs::File::create(&out_path)
+        .unwrap_or_else(|e| panic!("Cannot create {}: {e}", out_path.display()));
+    write_json(&mut f, &cases);
+    println!("wrote {} ({} cases)", out_path.display(), cases.len());
+}
+
+fn resolve_jeod_root(args: &[String]) -> Option<std::path::PathBuf> {
+    if let Some(idx) = args.iter().position(|a| a == "--jeod-home") {
+        if let Some(p) = args.get(idx + 1) {
+            return Some(std::path::PathBuf::from(p));
+        }
+    }
+    if let Ok(p) = std::env::var("JEOD_PATH") {
+        return Some(std::path::PathBuf::from(p));
+    }
+    if let Ok(p) = std::env::var("JEOD_HOME") {
+        return Some(std::path::PathBuf::from(p));
+    }
+    None
+}
+
+#[derive(Debug)]
+enum Case {
+    Cart {
+        read_time: f64,
+        cart_m: [f64; 3],
+    },
+    Spher {
+        read_time: f64,
+        altitude_m: f64,
+        latitude_rad: f64,
+        longitude_rad: f64,
+    },
+    Ellip {
+        read_time: f64,
+        altitude_m: f64,
+        latitude_rad: f64,
+        longitude_rad: f64,
+    },
+}
+
+fn parse_input_py(content: &str) -> Vec<Case> {
+    let block_re = Regex::new(
+        r#"(?ms)read\s*=\s*([0-9eE+.\-]+)\s*\n\s*trick\.add_read\s*\(\s*read\s*,\s*"""(?P<body>.*?)"""\s*\)"#,
+    )
+    .expect("regex for add_read block");
+    let mut cases = Vec::new();
+    for caps in block_re.captures_iter(content) {
+        let read_time: f64 = caps[1]
+            .parse()
+            .unwrap_or_else(|e| panic!("malformed read time {:?}: {e}", &caps[1]));
+        let body = &caps["body"];
+        if body.contains("update_from_cart") {
+            let xyz = parse_array3(body, r"earth\.cartesian_pos\s*=\s*\[([^\]]+)\]")
+                .unwrap_or_else(|| panic!("cartesian_pos not parseable in:\n{body}"));
+            cases.push(Case::Cart {
+                read_time,
+                cart_m: xyz,
+            });
+        } else if body.contains("update_from_spher") {
+            cases.push(Case::Spher {
+                read_time,
+                altitude_m: parse_assign(
+                    body,
+                    r"earth\.spherical_pos\.altitude\s*=\s*([\-0-9eE+.]+)",
+                ),
+                latitude_rad: parse_assign(
+                    body,
+                    r"earth\.spherical_pos\.latitude\s*=\s*([\-0-9eE+.]+)",
+                ),
+                longitude_rad: parse_assign(
+                    body,
+                    r"earth\.spherical_pos\.longitude\s*=\s*([\-0-9eE+.]+)",
+                ),
+            });
+        } else if body.contains("update_from_ellip") {
+            cases.push(Case::Ellip {
+                read_time,
+                altitude_m: parse_assign(
+                    body,
+                    r"earth\.elliptical_pos\.altitude\s*=\s*([\-0-9eE+.]+)",
+                ),
+                latitude_rad: parse_assign(
+                    body,
+                    r"earth\.elliptical_pos\.latitude\s*=\s*([\-0-9eE+.]+)",
+                ),
+                longitude_rad: parse_assign(
+                    body,
+                    r"earth\.elliptical_pos\.longitude\s*=\s*([\-0-9eE+.]+)",
+                ),
+            });
+        }
+    }
+    cases
+}
+
+fn parse_array3(text: &str, pattern: &str) -> Option<[f64; 3]> {
+    let re = Regex::new(pattern).ok()?;
+    let caps = re.captures(text)?;
+    let parts: Vec<f64> = caps[1]
+        .split(',')
+        .map(|s| s.trim().parse::<f64>())
+        .collect::<Result<_, _>>()
+        .ok()?;
+    if parts.len() != 3 {
+        return None;
+    }
+    Some([parts[0], parts[1], parts[2]])
+}
+
+fn parse_assign(text: &str, pattern: &str) -> f64 {
+    let re = Regex::new(pattern).expect("valid regex");
+    let caps = re
+        .captures(text)
+        .unwrap_or_else(|| panic!("pattern {pattern:?} did not match in:\n{text}"));
+    caps[1]
+        .parse()
+        .unwrap_or_else(|e| panic!("failed to parse {:?}: {e}", &caps[1]))
+}
+
+fn write_json(out: &mut std::fs::File, cases: &[Case]) {
+    writeln!(out, "{{").unwrap();
+    writeln!(out, "  \"schema_version\": 1,").unwrap();
+    writeln!(
+        out,
+        "  \"source\": \"models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py\","
+    )
+    .unwrap();
+    writeln!(out, "  \"jeod_version\": \"5.4\",").unwrap();
+    writeln!(
+        out,
+        "  \"note\": \"PlanetFixedPosition verification seeds. Regenerate with: cargo run -p jeod_test_data --bin extract_planet_pfixposn -- --jeod-home $JEOD_HOME\","
+    )
+    .unwrap();
+    writeln!(out, "  \"cases\": [").unwrap();
+    for (i, c) in cases.iter().enumerate() {
+        let comma = if i + 1 < cases.len() { "," } else { "" };
+        match c {
+            Case::Cart { read_time, cart_m } => writeln!(
+                out,
+                "    {{\"kind\": \"cartesian\",  \"read_time\": {}, \"cart_m\":   [{}, {}, {}]}}{}",
+                fmt(*read_time),
+                fmt(cart_m[0]),
+                fmt(cart_m[1]),
+                fmt(cart_m[2]),
+                comma,
+            ),
+            Case::Spher {
+                read_time,
+                altitude_m,
+                latitude_rad,
+                longitude_rad,
+            } => writeln!(
+                out,
+                "    {{\"kind\": \"spherical\",  \"read_time\": {}, \"altitude_m\": {}, \"latitude_rad\": {}, \"longitude_rad\": {}}}{}",
+                fmt(*read_time),
+                fmt(*altitude_m),
+                fmt(*latitude_rad),
+                fmt(*longitude_rad),
+                comma,
+            ),
+            Case::Ellip {
+                read_time,
+                altitude_m,
+                latitude_rad,
+                longitude_rad,
+            } => writeln!(
+                out,
+                "    {{\"kind\": \"elliptical\", \"read_time\": {}, \"altitude_m\": {},  \"latitude_rad\": {},    \"longitude_rad\": {}}}{}",
+                fmt(*read_time),
+                fmt(*altitude_m),
+                fmt(*latitude_rad),
+                fmt(*longitude_rad),
+                comma,
+            ),
+        }
+        .unwrap();
+    }
+    writeln!(out, "  ]").unwrap();
+    writeln!(out, "}}").unwrap();
+}
+
+fn fmt(x: f64) -> String {
+    // Round-trippable f64 representation; trims unnecessary fractional zeros.
+    let s = format!("{x:?}");
+    s
+}

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -12,6 +12,7 @@ pub mod leap_second;
 pub mod mass_data;
 pub mod orbital_data;
 pub mod orbital_init;
+pub mod planet_geodetic_verif;
 pub mod reference_state;
 pub mod s_define;
 pub mod tier3_csv;

--- a/crates/jeod_test_data/src/planet_geodetic_verif.rs
+++ b/crates/jeod_test_data/src/planet_geodetic_verif.rs
@@ -1,0 +1,184 @@
+//! JEOD `PlanetFixedPosition` verification cases.
+//!
+//! Parses the three explicit test points defined in
+//! `models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`.
+//!
+//! The JEOD SIM exercises [`PlanetFixedPosition`] using the WGS84 default
+//! Earth shape (`r_eq = 6378.137 km`, `flat_inv = 298.257223563`, set in
+//! `environment/planet/data/include/earth.hh`). It triggers three
+//! `add_read` snapshots:
+//!
+//! 1. `update_from_cart` with a Cartesian PCPF position.
+//! 2. `update_from_spher` with a spherical altitude/latitude/longitude.
+//! 3. `update_from_ellip` with an elliptical altitude/latitude/longitude.
+//!
+//! JEOD's verification methodology for these conversions is round-trip
+//! closure (see `verif/unit_tests/Cartesian_to_AltLatLong_to_Cartesian/main.cc`,
+//! which sweeps random vectors and checks `cart -> spher -> cart` and
+//! `cart -> ellip -> cart` magnitude errors). We mirror that methodology
+//! against the SIM's three explicit input points so the test inputs are
+//! sourced from JEOD itself (per CLAUDE.md "Tier 3 Cross-Validation"
+//! guidance: initial conditions may come from JEOD source files).
+
+use glam::DVec3;
+use regex::Regex;
+
+/// One verification case from `SIM_PFIXPOSN_VERIF`.
+///
+/// Each variant carries the `add_read` time tag from `input.py` for
+/// traceability, plus the seed coordinates used to drive the conversion.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PlanetFixedSeed {
+    /// `update_from_cart`: Cartesian PCPF position (m).
+    Cartesian { read_time: f64, cart_m: DVec3 },
+    /// `update_from_spher`: Spherical altitude (m), latitude (rad),
+    /// longitude (rad).
+    Spherical {
+        read_time: f64,
+        altitude_m: f64,
+        latitude_rad: f64,
+        longitude_rad: f64,
+    },
+    /// `update_from_ellip`: Elliptical (geodetic) altitude (m),
+    /// latitude (rad), longitude (rad).
+    Elliptical {
+        read_time: f64,
+        altitude_m: f64,
+        latitude_rad: f64,
+        longitude_rad: f64,
+    },
+}
+
+/// Load all three `SIM_PFIXPOSN_VERIF` seed cases from JEOD source.
+///
+/// # Panics
+/// Panics if the `input.py` cannot be read or fewer than three cases parse.
+pub fn load_planet_fixed_verif_cases(jeod_root: &std::path::Path) -> Vec<PlanetFixedSeed> {
+    let path = jeod_root.join(
+        "models/utils/planet_fixed/planet_fixed_posn/\
+         verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py",
+    );
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Cannot read {}: {}", path.display(), e));
+
+    // Each `add_read` block is structured like:
+    //   read = <time>
+    //   trick.add_read(read, """
+    //   <body>
+    //   """)
+    // We capture the time and the body and then sniff the body for which
+    // update_from_* call lives inside it.
+    let block_re = Regex::new(
+        r#"(?ms)read\s*=\s*([0-9eE+.\-]+)\s*\n\s*trick\.add_read\s*\(\s*read\s*,\s*"""(?P<body>.*?)"""\s*\)"#,
+    )
+    .expect("regex for add_read block");
+
+    let mut cases = Vec::new();
+    for caps in block_re.captures_iter(&content) {
+        let read_time: f64 = caps[1].parse().unwrap_or_else(|e| {
+            panic!("malformed read time {:?}: {e}", &caps[1]);
+        });
+        let body = &caps["body"];
+
+        if body.contains("update_from_cart") {
+            let xyz = parse_array3(body, r"earth\.cartesian_pos\s*=\s*\[([^\]]+)\]")
+                .unwrap_or_else(|| panic!("cartesian_pos not parseable in:\n{body}"));
+            cases.push(PlanetFixedSeed::Cartesian {
+                read_time,
+                cart_m: DVec3::new(xyz[0], xyz[1], xyz[2]),
+            });
+        } else if body.contains("update_from_spher") {
+            let alt = parse_assign(body, r"earth\.spherical_pos\.altitude\s*=\s*([\-0-9eE+.]+)");
+            let lat = parse_assign(body, r"earth\.spherical_pos\.latitude\s*=\s*([\-0-9eE+.]+)");
+            let lon = parse_assign(
+                body,
+                r"earth\.spherical_pos\.longitude\s*=\s*([\-0-9eE+.]+)",
+            );
+            cases.push(PlanetFixedSeed::Spherical {
+                read_time,
+                altitude_m: alt,
+                latitude_rad: lat,
+                longitude_rad: lon,
+            });
+        } else if body.contains("update_from_ellip") {
+            let alt = parse_assign(
+                body,
+                r"earth\.elliptical_pos\.altitude\s*=\s*([\-0-9eE+.]+)",
+            );
+            let lat = parse_assign(
+                body,
+                r"earth\.elliptical_pos\.latitude\s*=\s*([\-0-9eE+.]+)",
+            );
+            let lon = parse_assign(
+                body,
+                r"earth\.elliptical_pos\.longitude\s*=\s*([\-0-9eE+.]+)",
+            );
+            cases.push(PlanetFixedSeed::Elliptical {
+                read_time,
+                altitude_m: alt,
+                latitude_rad: lat,
+                longitude_rad: lon,
+            });
+        }
+    }
+
+    assert!(
+        cases.len() >= 3,
+        "expected three cases in {}, found {}",
+        path.display(),
+        cases.len()
+    );
+    cases
+}
+
+fn parse_array3(text: &str, pattern: &str) -> Option<[f64; 3]> {
+    let re = Regex::new(pattern).ok()?;
+    let caps = re.captures(text)?;
+    let parts: Vec<f64> = caps[1]
+        .split(',')
+        .map(|s| s.trim().parse::<f64>())
+        .collect::<Result<_, _>>()
+        .ok()?;
+    if parts.len() != 3 {
+        return None;
+    }
+    Some([parts[0], parts[1], parts[2]])
+}
+
+fn parse_assign(text: &str, pattern: &str) -> f64 {
+    let re = Regex::new(pattern).expect("valid regex");
+    let caps = re
+        .captures(text)
+        .unwrap_or_else(|| panic!("pattern {pattern:?} did not match in:\n{text}"));
+    caps[1]
+        .parse()
+        .unwrap_or_else(|e| panic!("failed to parse {:?}: {e}", &caps[1]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jeod_path;
+
+    #[test]
+    fn loads_three_cases_from_jeod_source() {
+        let root = jeod_path();
+        if !root.exists() {
+            // Loader is exercised by the Tier 2 test harness; this guard
+            // mirrors the convention used by other jeod_test_data loaders.
+            return;
+        }
+        let cases = load_planet_fixed_verif_cases(&root);
+        assert_eq!(cases.len(), 3, "SIM_PFIXPOSN_VERIF defines three reads");
+
+        // Sanity-check the first case (the Cartesian seed at ISS-ish radius).
+        match cases[0] {
+            PlanetFixedSeed::Cartesian { cart_m, .. } => {
+                assert!((cart_m.x - 6_778_136.3).abs() < 1e-6);
+                assert_eq!(cart_m.y, 0.0);
+                assert_eq!(cart_m.z, 0.0);
+            }
+            _ => panic!("first case must be Cartesian: {:?}", cases[0]),
+        }
+    }
+}

--- a/crates/jeod_test_data/src/planet_geodetic_verif.rs
+++ b/crates/jeod_test_data/src/planet_geodetic_verif.rs
@@ -1,27 +1,28 @@
-//! JEOD `PlanetFixedPosition` verification cases.
+//! JEOD `PlanetFixedPosition` verification seeds (committed JSON).
 //!
-//! Parses the three explicit test points defined in
-//! `models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`.
-//!
-//! The JEOD SIM exercises `PlanetFixedPosition` using the WGS84 default
-//! Earth shape (`r_eq = 6378.137 km`, `flat_inv = 298.257223563`, set in
-//! `environment/planet/data/include/earth.hh`). It triggers three
+//! The three explicit test points originate in JEOD's
+//! `models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`,
+//! which exercises `PlanetFixedPosition` against the WGS84 default Earth
+//! shape (`r_eq = 6378.137 km`, `flat_inv = 298.257223563`, set in
+//! `environment/planet/data/include/earth.hh`). The SIM triggers three
 //! `add_read` snapshots:
 //!
 //! 1. `update_from_cart` with a Cartesian PCPF position.
 //! 2. `update_from_spher` with a spherical altitude/latitude/longitude.
 //! 3. `update_from_ellip` with an elliptical altitude/latitude/longitude.
 //!
+//! The seeds were extracted once, committed at `test_data/planet_pfixposn_seeds.json`,
+//! and read back here without touching JEOD source. Regenerate with
+//! `cargo run -p jeod_test_data --bin extract_planet_pfixposn -- --jeod-home $JEOD_HOME`.
+//!
 //! JEOD's verification methodology for these conversions is round-trip
 //! closure (see `verif/unit_tests/Cartesian_to_AltLatLong_to_Cartesian/main.cc`,
 //! which sweeps random vectors and checks `cart -> spher -> cart` and
 //! `cart -> ellip -> cart` magnitude errors). We mirror that methodology
 //! against the SIM's three explicit input points so the test inputs are
-//! sourced from JEOD itself (per CLAUDE.md "Tier 3 Cross-Validation"
-//! guidance: initial conditions may come from JEOD source files).
+//! sourced from JEOD itself.
 
 use glam::DVec3;
-use regex::Regex;
 
 /// One verification case from `SIM_PFIXPOSN_VERIF`.
 ///
@@ -49,94 +50,169 @@ pub enum PlanetFixedSeed {
     },
 }
 
-/// Load all three `SIM_PFIXPOSN_VERIF` seed cases from JEOD source.
+/// Load the three `SIM_PFIXPOSN_VERIF` seed cases from the committed
+/// `test_data/planet_pfixposn_seeds.json`.
 ///
 /// # Panics
-/// Panics if the `input.py` cannot be read or fewer than three cases parse.
-pub fn load_planet_fixed_verif_cases(jeod_root: &std::path::Path) -> Vec<PlanetFixedSeed> {
-    let path = jeod_root.join(
-        "models/utils/planet_fixed/planet_fixed_posn/\
-         verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py",
-    );
-    let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Cannot read {}: {}", path.display(), e));
-
-    // Each `add_read` block is structured like:
-    //   read = <time>
-    //   trick.add_read(read, """
-    //   <body>
-    //   """)
-    // We capture the time and the body and then sniff the body for which
-    // update_from_* call lives inside it.
-    let block_re = Regex::new(
-        r#"(?ms)read\s*=\s*([0-9eE+.\-]+)\s*\n\s*trick\.add_read\s*\(\s*read\s*,\s*"""(?P<body>.*?)"""\s*\)"#,
-    )
-    .expect("regex for add_read block");
-
-    let mut cases = Vec::new();
-    for caps in block_re.captures_iter(&content) {
-        let read_time: f64 = caps[1].parse().unwrap_or_else(|e| {
-            panic!("malformed read time {:?}: {e}", &caps[1]);
-        });
-        let body = &caps["body"];
-
-        if body.contains("update_from_cart") {
-            let xyz = parse_array3(body, r"earth\.cartesian_pos\s*=\s*\[([^\]]+)\]")
-                .unwrap_or_else(|| panic!("cartesian_pos not parseable in:\n{body}"));
-            cases.push(PlanetFixedSeed::Cartesian {
-                read_time,
-                cart_m: DVec3::new(xyz[0], xyz[1], xyz[2]),
-            });
-        } else if body.contains("update_from_spher") {
-            let alt = parse_assign(body, r"earth\.spherical_pos\.altitude\s*=\s*([\-0-9eE+.]+)");
-            let lat = parse_assign(body, r"earth\.spherical_pos\.latitude\s*=\s*([\-0-9eE+.]+)");
-            let lon = parse_assign(
-                body,
-                r"earth\.spherical_pos\.longitude\s*=\s*([\-0-9eE+.]+)",
-            );
-            cases.push(PlanetFixedSeed::Spherical {
-                read_time,
-                altitude_m: alt,
-                latitude_rad: lat,
-                longitude_rad: lon,
-            });
-        } else if body.contains("update_from_ellip") {
-            let alt = parse_assign(
-                body,
-                r"earth\.elliptical_pos\.altitude\s*=\s*([\-0-9eE+.]+)",
-            );
-            let lat = parse_assign(
-                body,
-                r"earth\.elliptical_pos\.latitude\s*=\s*([\-0-9eE+.]+)",
-            );
-            let lon = parse_assign(
-                body,
-                r"earth\.elliptical_pos\.longitude\s*=\s*([\-0-9eE+.]+)",
-            );
-            cases.push(PlanetFixedSeed::Elliptical {
-                read_time,
-                altitude_m: alt,
-                latitude_rad: lat,
-                longitude_rad: lon,
-            });
-        }
-    }
-
-    assert!(
-        cases.len() >= 3,
-        "expected three cases in {}, found {}",
-        path.display(),
-        cases.len()
-    );
-    cases
+/// Panics if the JSON file is missing or malformed; the panic names the
+/// regen command per CLAUDE.md "Fail Loudly".
+pub fn load_planet_fixed_verif_cases() -> Vec<PlanetFixedSeed> {
+    let path = crate::tier3_csv::test_data_path("planet_pfixposn_seeds.json");
+    let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "Cannot read {}: {e}. Regenerate with `cargo run -p jeod_test_data \
+             --bin extract_planet_pfixposn -- --jeod-home $JEOD_HOME`.",
+            path.display(),
+        )
+    });
+    parse_seeds_json(&content).unwrap_or_else(|e| {
+        panic!(
+            "Malformed seeds in {}: {e}. Regenerate with `cargo run -p jeod_test_data \
+             --bin extract_planet_pfixposn -- --jeod-home $JEOD_HOME`.",
+            path.display(),
+        )
+    })
 }
 
-fn parse_array3(text: &str, pattern: &str) -> Option<[f64; 3]> {
-    let re = Regex::new(pattern).ok()?;
-    let caps = re.captures(text)?;
-    let parts: Vec<f64> = caps[1]
+/// Hand-rolled JSON parser for the `cases` array. Mirrors the
+/// no-`serde_json` style used by `tier3_baseline_diff` and `tier3_report`.
+fn parse_seeds_json(s: &str) -> Result<Vec<PlanetFixedSeed>, String> {
+    let cases_idx = s
+        .find("\"cases\"")
+        .ok_or_else(|| "missing top-level \"cases\" key".to_string())?;
+    let after = &s[cases_idx..];
+    let arr_start = after
+        .find('[')
+        .ok_or_else(|| "no opening `[` after \"cases\"".to_string())?;
+    let bytes = after.as_bytes();
+    // Walk to the matching `]` tracking depth so commas inside nested
+    // objects/arrays do not split entries.
+    let mut depth = 1_i32;
+    let mut i = arr_start + 1;
+    let mut entry_starts = vec![i];
+    let mut entries: Vec<&str> = Vec::new();
+    let mut in_string = false;
+    while i < bytes.len() && depth > 0 {
+        let c = bytes[i];
+        if in_string {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => in_string = true,
+            b'[' | b'{' => depth += 1,
+            b']' | b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let last_start = *entry_starts.last().unwrap();
+                    entries.push(&after[last_start..i]);
+                    break;
+                }
+            }
+            b',' if depth == 1 => {
+                let last_start = *entry_starts.last().unwrap();
+                entries.push(&after[last_start..i]);
+                entry_starts.push(i + 1);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 0 {
+        return Err("unterminated cases array".into());
+    }
+
+    let mut out = Vec::with_capacity(entries.len());
+    for raw in entries {
+        let entry = raw.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        out.push(parse_single_case(entry)?);
+    }
+    Ok(out)
+}
+
+fn parse_single_case(entry: &str) -> Result<PlanetFixedSeed, String> {
+    let kind = parse_str_field(entry, "kind")
+        .ok_or_else(|| format!("missing \"kind\" in entry: {entry}"))?;
+    let read_time = parse_num_field(entry, "read_time")
+        .ok_or_else(|| format!("missing \"read_time\" in entry: {entry}"))?;
+    match kind.as_str() {
+        "cartesian" => {
+            let xyz = parse_array3_field(entry, "cart_m")
+                .ok_or_else(|| format!("missing \"cart_m\" in entry: {entry}"))?;
+            Ok(PlanetFixedSeed::Cartesian {
+                read_time,
+                cart_m: DVec3::new(xyz[0], xyz[1], xyz[2]),
+            })
+        }
+        "spherical" => Ok(PlanetFixedSeed::Spherical {
+            read_time,
+            altitude_m: parse_num_field(entry, "altitude_m")
+                .ok_or_else(|| format!("missing altitude_m in {entry}"))?,
+            latitude_rad: parse_num_field(entry, "latitude_rad")
+                .ok_or_else(|| format!("missing latitude_rad in {entry}"))?,
+            longitude_rad: parse_num_field(entry, "longitude_rad")
+                .ok_or_else(|| format!("missing longitude_rad in {entry}"))?,
+        }),
+        "elliptical" => Ok(PlanetFixedSeed::Elliptical {
+            read_time,
+            altitude_m: parse_num_field(entry, "altitude_m")
+                .ok_or_else(|| format!("missing altitude_m in {entry}"))?,
+            latitude_rad: parse_num_field(entry, "latitude_rad")
+                .ok_or_else(|| format!("missing latitude_rad in {entry}"))?,
+            longitude_rad: parse_num_field(entry, "longitude_rad")
+                .ok_or_else(|| format!("missing longitude_rad in {entry}"))?,
+        }),
+        other => Err(format!("unknown kind \"{other}\" in entry: {entry}")),
+    }
+}
+
+fn parse_str_field(s: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\"");
+    let idx = s.find(&needle)?;
+    let rest = &s[idx + needle.len()..];
+    let colon = rest.find(':')?;
+    let after_colon = rest[colon + 1..].trim_start();
+    let bytes = after_colon.as_bytes();
+    if bytes.is_empty() || bytes[0] != b'"' {
+        return None;
+    }
+    // Find closing quote (no escapes expected for kind/source values used here).
+    let end = after_colon[1..].find('"')?;
+    Some(after_colon[1..1 + end].to_string())
+}
+
+fn parse_num_field(s: &str, key: &str) -> Option<f64> {
+    let needle = format!("\"{key}\"");
+    let idx = s.find(&needle)?;
+    let rest = &s[idx + needle.len()..];
+    let colon = rest.find(':')?;
+    let after_colon = rest[colon + 1..].trim_start();
+    let end = after_colon
+        .find(|c: char| c == ',' || c == '}' || c == ']' || c.is_whitespace())
+        .unwrap_or(after_colon.len());
+    after_colon[..end].trim().parse().ok()
+}
+
+fn parse_array3_field(s: &str, key: &str) -> Option<[f64; 3]> {
+    let needle = format!("\"{key}\"");
+    let idx = s.find(&needle)?;
+    let rest = &s[idx + needle.len()..];
+    let lb = rest.find('[')?;
+    let rb = rest[lb..].find(']')?;
+    let inner = &rest[lb + 1..lb + rb];
+    let parts: Vec<f64> = inner
         .split(',')
-        .map(|s| s.trim().parse::<f64>())
+        .map(|p| p.trim().parse::<f64>())
         .collect::<Result<_, _>>()
         .ok()?;
     if parts.len() != 3 {
@@ -145,39 +221,22 @@ fn parse_array3(text: &str, pattern: &str) -> Option<[f64; 3]> {
     Some([parts[0], parts[1], parts[2]])
 }
 
-fn parse_assign(text: &str, pattern: &str) -> f64 {
-    let re = Regex::new(pattern).expect("valid regex");
-    let caps = re
-        .captures(text)
-        .unwrap_or_else(|| panic!("pattern {pattern:?} did not match in:\n{text}"));
-    caps[1]
-        .parse()
-        .unwrap_or_else(|e| panic!("failed to parse {:?}: {e}", &caps[1]))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::jeod_path;
 
     #[test]
-    fn loads_three_cases_from_jeod_source() {
-        let root = jeod_path();
-        assert!(
-            root.exists(),
-            "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH \
-             (see CLAUDE.md \"Environment Setup\").",
-            root.display(),
-        );
-        let cases = load_planet_fixed_verif_cases(&root);
+    fn loads_three_cases_from_committed_json() {
+        let cases = load_planet_fixed_verif_cases();
         assert_eq!(cases.len(), 3, "SIM_PFIXPOSN_VERIF defines three reads");
 
         // Sanity-check the first case (the Cartesian seed at ISS-ish radius).
         match cases[0] {
-            PlanetFixedSeed::Cartesian { cart_m, .. } => {
+            PlanetFixedSeed::Cartesian { cart_m, read_time } => {
                 assert!((cart_m.x - 6_778_136.3).abs() < 1e-6);
                 assert_eq!(cart_m.y, 0.0);
                 assert_eq!(cart_m.z, 0.0);
+                assert_eq!(read_time, 1.0);
             }
             _ => panic!("first case must be Cartesian: {:?}", cases[0]),
         }

--- a/crates/jeod_test_data/src/planet_geodetic_verif.rs
+++ b/crates/jeod_test_data/src/planet_geodetic_verif.rs
@@ -3,7 +3,7 @@
 //! Parses the three explicit test points defined in
 //! `models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`.
 //!
-//! The JEOD SIM exercises [`PlanetFixedPosition`] using the WGS84 default
+//! The JEOD SIM exercises `PlanetFixedPosition` using the WGS84 default
 //! Earth shape (`r_eq = 6378.137 km`, `flat_inv = 298.257223563`, set in
 //! `environment/planet/data/include/earth.hh`). It triggers three
 //! `add_read` snapshots:
@@ -163,11 +163,12 @@ mod tests {
     #[test]
     fn loads_three_cases_from_jeod_source() {
         let root = jeod_path();
-        if !root.exists() {
-            // Loader is exercised by the Tier 2 test harness; this guard
-            // mirrors the convention used by other jeod_test_data loaders.
-            return;
-        }
+        assert!(
+            root.exists(),
+            "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH \
+             (see CLAUDE.md \"Environment Setup\").",
+            root.display(),
+        );
         let cases = load_planet_fixed_verif_cases(&root);
         assert_eq!(cases.len(), 3, "SIM_PFIXPOSN_VERIF defines three reads");
 

--- a/test_data/planet_pfixposn_seeds.json
+++ b/test_data/planet_pfixposn_seeds.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "source": "models/utils/planet_fixed/planet_fixed_posn/verif/SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py",
+  "jeod_version": "5.4",
+  "note": "PlanetFixedPosition verification seeds. Regenerate with: cargo run -p jeod_test_data --bin extract_planet_pfixposn -- --jeod-home $JEOD_HOME",
+  "cases": [
+    {"kind": "cartesian",  "read_time": 1.0, "cart_m":   [6778136.3, 0.0, 0.0]},
+    {"kind": "spherical",  "read_time": 2.0, "altitude_m": 1000.0, "latitude_rad": 3.1416, "longitude_rad": 1.0},
+    {"kind": "elliptical", "read_time": 3.0, "altitude_m": 500.0,  "latitude_rad": 1.0,    "longitude_rad": 3.1416}
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #219.

`jeod_planet` had no `tests/` directory and only sparse inline coverage despite owning shape/radius/flattening. This PR adds two complementary test layers, both rooted in JEOD source data:

- **Inline (planet.rs)**: 6 new accessor tests — hand-built `PlanetShape` field round-trip; r_eq / r_pol distinct & consistent with `flat_coeff`; exact `flat_inv` ↔ `flat_coeff` inversion; `mu_typed` accessor parity across every preset; `e_ellip_sq` / `e_ellipsoid` agreement; `Copy` semantics through a function boundary. (Existing 7 inline tests retained → 13 total.)
- **Tier 2 (`crates/jeod_planet/tests/tier2_planet_geodetic.rs`)**: 3 tests driving ECEF↔geodetic / ECEF↔spherical round-trips, seeded by the three `add_read` test points from JEOD's `SIM_PFIXPOSN_VERIF/SET_test/RUN_pfixposn_test/input.py`. Loader at `jeod_test_data::planet_geodetic_verif` mirrors the `gravity_verif.rs` pattern.

## Data source

JEOD ships no pre-extractable geodetic test vectors. `SIM_PFIXPOSN_VERIF` defines three fixed seeds (Cartesian, spherical, elliptical) inside its `input.py`; JEOD's own unit test (`Cartesian_to_AltLatLong_to_Cartesian/main.cc`) verifies those conversions via random-vector Cartesian closure. Our Tier 2 mirrors that methodology against the SIM's deterministic seeds — inputs come from JEOD source files, not from JEOD output.

## Observed max round-trip errors (x86_64-linux)

| Metric | Observed | Tolerance |
|---|---|---|
| cart→spher→cart | 9.31e-10 m | 1.0e-9 m |
| cart→ellip→cart | 6.88e-10 m | 1.0e-9 m |
| geodetic latitude | 0 | 1.0e-12 rad |
| geodetic longitude | 0 (after wrap) | 1.0e-12 rad |
| geodetic altitude | 9.14e-11 m | 1.0e-10 m |
| spherical lat / lon / alt | 0 / 0 / 0 | 1e-12 / 1e-12 / 1e-6 |

Tolerances follow CLAUDE.md "Tolerance policy" (observed × 1.05 → clean literal).

## Polar-handling note

Per CLAUDE.md *Common Pitfalls / Geodetic longitude at the poles*, longitude is geometrically undefined as `|lat| → π/2`. None of the three SIM seeds is at the pole, so no degraded longitude tolerance is required. The principal-range gate `|lat| < π/2` automatically excludes the SIM's intentionally-aliased `lat=3.1416` spherical seed (which JEOD itself only checks for Cartesian closure). Longitude diffs use a `wrap_lon_diff` helper because `atan2 ∈ (-π, +π]` returns `-π` for the SIM's `lon=π` elliptical seed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `JEOD_HOME=/home/user/git/jeod cargo nextest run -p jeod_planet` (16/16 pass: 13 inline + 3 Tier 2)
- [x] `JEOD_HOME=/home/user/git/jeod cargo nextest run -p jeod_test_data` (20/20 pass — new loader test included)
- [x] `cargo build --workspace --tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)