### PR TITLE
[#214] Add root rustdoc landing, jeod_test_data //!, and missing_docs lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bevy = "0.18"
 bevy_jeod = "0.1"
 ```
 
-```rust
+```rust,no_run
 use bevy::prelude::*;
 use bevy_jeod::prelude::*;
 use bevy_jeod::recipes::{earth, orbital_elements, vehicle};

--- a/crates/jeod_quantities/src/diagnostics.rs
+++ b/crates/jeod_quantities/src/diagnostics.rs
@@ -51,6 +51,7 @@ impl<F: Frame> CompatibleFrames<F, F> for () {}
     note = "use `.m()`, `.km()`, `.cm()`, `.mm()`, `.ft()`, `.mi()`, or `.nmi()` to produce a `Length`"
 )]
 pub trait IntoLength {
+    /// Lift `self` into a typed [`Length`].
     fn into_length(self) -> Length;
 }
 
@@ -68,6 +69,7 @@ impl IntoLength for Length {
     note = "use `.rad()`, `.deg()`, `.arcmin()`, or `.arcsec()` to produce an `Angle`"
 )]
 pub trait IntoAngle {
+    /// Lift `self` into a typed [`Angle`].
     fn into_angle(self) -> Angle;
 }
 
@@ -85,6 +87,7 @@ impl IntoAngle for Angle {
     note = "use `.m3_per_s2()` or `.km3_per_s2()` to produce a `GravParam`"
 )]
 pub trait IntoGravParam {
+    /// Lift `self` into a typed [`GravParam`] (m³/s²).
     fn into_grav_param(self) -> GravParam;
 }
 
@@ -159,5 +162,7 @@ impl InertialOnly<crate::frame::Inertial> for () {}
     note = "use `.dot(other)` for scalar product (returns a scalar) or `.cross(other)` for vector product (returns a `Qty3`)"
 )]
 pub trait NoVectorVectorMul<D1, D2, F: Frame> {
+    /// Marker method — never called; exists only so the trait carries
+    /// its three type parameters into the compiler diagnostic.
     fn _do_not_call(&self) -> PhantomData<(D1, D2, F)>;
 }

--- a/crates/jeod_quantities/src/ext.rs
+++ b/crates/jeod_quantities/src/ext.rs
@@ -560,9 +560,13 @@ impl Vec3Ext for DVec3 {
 /// let r: Position<Inertial> = row.m_at::<Inertial>();
 /// ```
 pub trait Array3Ext: Copy {
+    /// Interpret `self` as a position in metres tagged with frame `F`.
     fn m_at<F: Frame>(self) -> crate::aliases::Position<F>;
+    /// Interpret `self` as a position in kilometres tagged with frame `F`.
     fn km_at<F: Frame>(self) -> crate::aliases::Position<F>;
+    /// Interpret `self` as a velocity in m/s tagged with frame `F`.
     fn m_per_s_at<F: Frame>(self) -> crate::aliases::Velocity<F>;
+    /// Interpret `self` as a velocity in km/s tagged with frame `F`.
     fn km_per_s_at<F: Frame>(self) -> crate::aliases::Velocity<F>;
 }
 

--- a/crates/jeod_quantities/src/frame.rs
+++ b/crates/jeod_quantities/src/frame.rs
@@ -55,6 +55,7 @@ pub trait Frame: FrameSealed + 'static {
 /// `impl Planet for X` outside the macro is technically possible but
 /// unsupported. Use the macro.
 pub trait Planet: PlanetSealed + 'static {
+    /// Human-readable name for error messages and debug output.
     const NAME: &'static str;
 }
 
@@ -69,6 +70,7 @@ pub trait Planet: PlanetSealed + 'static {
 /// Vehicle marker types are used with [`BodyFrame`], [`StructuralFrame`],
 /// [`Lvlh`], and [`Ned`].
 pub trait Vehicle: VehicleSealed + 'static {
+    /// Human-readable name for error messages and debug output.
     const NAME: &'static str;
 }
 

--- a/crates/jeod_quantities/src/frame_transform.rs
+++ b/crates/jeod_quantities/src/frame_transform.rs
@@ -221,9 +221,15 @@ pub enum FrameTransformError {
     NonFinite,
     /// Determinant is not within `1e-9` of `1.0`. A reflection
     /// (`det ≈ -1`) or a scaling (`|det| ≠ 1`) lands here.
-    DeterminantNotOne { determinant: f64 },
+    DeterminantNotOne {
+        /// The offending determinant value.
+        determinant: f64,
+    },
     /// `M · Mᵀ` differs from identity by more than `1e-9` in any element.
-    NotOrthonormal { drift: f64 },
+    NotOrthonormal {
+        /// Maximum element-wise drift of `M·Mᵀ` from the identity.
+        drift: f64,
+    },
     /// `glam::DQuat::from_mat3` produced a zero quaternion (degenerate input).
     ZeroQuaternion,
 }

--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -56,6 +56,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 mod sealed;
 

--- a/crates/jeod_quantities/src/qty3.rs
+++ b/crates/jeod_quantities/src/qty3.rs
@@ -15,8 +15,11 @@ use crate::frame::Frame;
 /// unit tests for the static size/align assertions.
 #[repr(C)]
 pub struct Qty3<D: ?Sized + Dimension, F: Frame> {
+    /// X component, dimension `D`, in SI base units.
     pub x: Quantity<D, SI<f64>, f64>,
+    /// Y component, dimension `D`, in SI base units.
     pub y: Quantity<D, SI<f64>, f64>,
+    /// Z component, dimension `D`, in SI base units.
     pub z: Quantity<D, SI<f64>, f64>,
     _f: PhantomData<F>,
 }

--- a/crates/jeod_quantities/src/quat.rs
+++ b/crates/jeod_quantities/src/quat.rs
@@ -24,6 +24,7 @@ use crate::sealed::QuatSealed;
 /// Sealed at the type-system level: only `jeod_quantities` can impl
 /// this trait (the seal trait `QuatSealed` is private to the crate).
 pub trait Layout: QuatSealed + 'static {
+    /// Human-readable name (`"ScalarFirst"` or `"ScalarLast"`).
     const NAME: &'static str;
 }
 
@@ -48,6 +49,7 @@ impl Layout for ScalarLast {
 /// Sealed at the type-system level: only `jeod_quantities` can impl
 /// this trait (the seal trait `QuatSealed` is private to the crate).
 pub trait Transform: QuatSealed + 'static {
+    /// Human-readable name (`"LeftTransform"` or `"RightTransform"`).
     const NAME: &'static str;
 }
 
@@ -160,8 +162,11 @@ impl From<DQuat> for Quat<ScalarLast, LeftTransform> {
 #[derive(Debug, thiserror::Error)]
 #[error("quaternion norm {norm} deviates from 1 by {deviation:.3e}, which exceeds tolerance {tolerance:.3e}")]
 pub struct NotNormalized {
+    /// Measured Euclidean norm of the offending quaternion.
     pub norm: f64,
+    /// Absolute deviation `|norm − 1|`.
     pub deviation: f64,
+    /// Tolerance against which `deviation` was checked.
     pub tolerance: f64,
 }
 

--- a/crates/jeod_quantities/src/sealed.rs
+++ b/crates/jeod_quantities/src/sealed.rs
@@ -18,8 +18,24 @@
 //! - `PlanetSealed`: gates `Planet` impls. Same treatment as
 //!   `VehicleSealed`.
 
+/// Sealed-trait bound for [`crate::frame::Frame`] impls. Closed —
+/// downstream crates cannot impl this trait, so they cannot impl
+/// `Frame` either.
 pub trait FrameSealed {}
+/// Sealed-trait bound for [`crate::frame::Vehicle`] impls. Re-exported
+/// via `__macro_support` so the `define_vehicle!` macro can satisfy
+/// the bound from downstream call sites. Convention-sealed: only the
+/// macro should produce impls.
 pub trait VehicleSealed {}
+/// Sealed-trait bound for [`crate::frame::Planet`] impls. Re-exported
+/// via `__macro_support` so the `define_planet!` macro can satisfy the
+/// bound from downstream call sites. Convention-sealed: only the macro
+/// should produce impls.
 pub trait PlanetSealed {}
+/// Sealed-trait bound for [`crate::time_scale::TimeScale`] impls.
+/// Closed — downstream crates cannot impl this trait.
 pub trait TimeScaleSealed {}
+/// Sealed-trait bound for [`crate::quat::Layout`] and
+/// [`crate::quat::Transform`] impls. Closed — the four standing
+/// quaternion conventions are exhaustive.
 pub trait QuatSealed {}

--- a/crates/jeod_runner/src/branded.rs
+++ b/crates/jeod_runner/src/branded.rs
@@ -101,6 +101,9 @@ pub struct BodyIdx<'sim> {
 }
 
 impl BodyIdx<'_> {
+    /// Strip the `'sim` brand and return the raw `usize` body index that
+    /// `Simulation` uses internally. The result outlives the brand and
+    /// can no longer be checked against the originating `Simulation`.
     #[inline]
     pub fn into_raw(self) -> usize {
         self.raw

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -27,6 +27,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 use glam::{DMat3, DVec3};
 

--- a/crates/jeod_sim/src/atmosphere.rs
+++ b/crates/jeod_sim/src/atmosphere.rs
@@ -1,3 +1,8 @@
+//! Atmosphere stage: configuration and the per-body
+//! [`evaluate_atmosphere`] / [`evaluate_atmosphere_typed`] orchestration
+//! that converts inertial position to geodetic coordinates and queries
+//! the configured density / temperature / wind model.
+
 use glam::{DMat3, DVec3};
 use jeod_atmosphere::exponential::ExponentialAtmosphere;
 use jeod_atmosphere::met::MetAtmosphere;

--- a/crates/jeod_sim/src/forces.rs
+++ b/crates/jeod_sim/src/forces.rs
@@ -1,3 +1,7 @@
+//! Force-collection stage: composes per-body external + interaction +
+//! gravity contributions into the integrator's `FrameDerivatives` (linear
+//! and angular accelerations expressed in the integration frame).
+
 use glam::{DMat3, DVec3};
 use jeod_dynamics::forces::{FrameDerivativesTyped, GravityAccelerationTyped, TotalForceTyped};
 use jeod_dynamics::{

--- a/crates/jeod_sim/src/gravity.rs
+++ b/crates/jeod_sim/src/gravity.rs
@@ -1,3 +1,7 @@
+//! Gravity stage: per-body gravity accumulation across multiple sources
+//! (point-mass, spherical-harmonics with optional tides, plus optional
+//! relativistic post-Newtonian corrections).
+
 use glam::{DMat3, DVec3};
 use jeod_dynamics::forces::GravityAccelerationTyped;
 use jeod_dynamics::GravityAcceleration;

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -1,3 +1,8 @@
+//! Integration stage: stepping per-body translational + rotational state
+//! by one timestep using the configured integrator (RK4, ABM4, or
+//! Gauss-Jackson). Includes the contact-coupled multi-body RK4 entry
+//! points used when contact pairs are registered.
+
 use glam::DVec3;
 use jeod_dynamics::state::TranslationalStateTyped;
 use jeod_dynamics::{

--- a/crates/jeod_sim/src/interactions.rs
+++ b/crates/jeod_sim/src/interactions.rs
@@ -1,3 +1,7 @@
+//! Interaction stage: the per-body force / torque computations between
+//! the gravity and force-collection stages — drag, flat-plate and
+//! cannonball SRP, gravity-gradient torque, and contact pairs.
+
 use glam::{DMat3, DVec3};
 use jeod_dynamics::{MassProperties, RotationalState, TranslationalState};
 use jeod_interactions::{
@@ -603,8 +607,11 @@ pub fn compute_cannonball_srp_typed(
 /// phantom).
 #[derive(Debug, Clone, Copy)]
 pub struct FlatPlateStageInputsTyped {
+    /// Sun position in the inertial frame.
     pub sun_position: Position<Inertial>,
+    /// Dimensionless illumination factor (0–1) accounting for shadow.
     pub illum_factor: Ratio,
+    /// Body center of gravity in the structural frame (m).
     pub center_grav: DVec3,
 }
 

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -35,6 +35,7 @@
 //! execution order that any adapter must respect.
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 pub mod atmosphere;
 pub mod derived;

--- a/crates/jeod_sim/src/pipeline.rs
+++ b/crates/jeod_sim/src/pipeline.rs
@@ -1,3 +1,9 @@
+//! Canonical pipeline stage ordering shared by every JEOD adapter.
+//!
+//! Adapters that schedule per-stage system calls (the Bevy plugin, the
+//! standalone runner, batch tools) all consult [`PIPELINE_ORDER`] for the
+//! authoritative sequence so the order cannot drift between adapters.
+
 /// Pipeline stages mirroring JEOD's init/update ordering.
 ///
 /// JEOD's simulation loop runs these stages in strict order every timestep.

--- a/crates/jeod_sim/src/recipes/helpers/attach_detach_helpers.rs
+++ b/crates/jeod_sim/src/recipes/helpers/attach_detach_helpers.rs
@@ -16,6 +16,7 @@ pub struct AttachDetachEvent<E> {
 }
 
 impl<E> AttachDetachEvent<E> {
+    /// Build an event firing at `time` (s) carrying the user tag `event`.
     pub fn new(time: f64, event: E) -> Self {
         Self { time, event }
     }

--- a/crates/jeod_sim/src/recipes/helpers/force_torque_profiles.rs
+++ b/crates/jeod_sim/src/recipes/helpers/force_torque_profiles.rs
@@ -20,12 +20,16 @@ pub fn step_input(amplitude: DVec3, t_on: f64, t: f64) -> DVec3 {
 /// onwards, linear interpolation in between.
 #[derive(Debug, Clone, Copy)]
 pub struct RampInput {
+    /// Final amplitude reached at `t_on + duration`.
     pub amplitude: DVec3,
+    /// Time the ramp begins (s).
     pub t_on: f64,
+    /// Ramp duration (s).
     pub duration: f64,
 }
 
 impl RampInput {
+    /// Evaluate the ramp at simulation time `t` (s).
     pub fn evaluate(&self, t: f64) -> DVec3 {
         if t < self.t_on {
             DVec3::ZERO
@@ -42,12 +46,16 @@ impl RampInput {
 /// `t >= t_on`, zero before.
 #[derive(Debug, Clone, Copy)]
 pub struct SinusoidInput {
+    /// Sinusoid amplitude.
     pub amplitude: DVec3,
+    /// Frequency (Hz).
     pub frequency_hz: f64,
+    /// Time the sinusoid begins (s); zero before this time.
     pub t_on: f64,
 }
 
 impl SinusoidInput {
+    /// Evaluate the sinusoid at simulation time `t` (s).
     pub fn evaluate(&self, t: f64) -> DVec3 {
         if t < self.t_on {
             return DVec3::ZERO;

--- a/crates/jeod_sim/src/recipes/helpers/orbinit_case.rs
+++ b/crates/jeod_sim/src/recipes/helpers/orbinit_case.rs
@@ -14,12 +14,16 @@ use jeod_math::OrbitalElements;
 /// why test code (not this struct) owns tolerance values.
 #[derive(Debug, Clone)]
 pub struct OrbInitCase {
+    /// Test-case identifier used in assertion messages.
     pub label: &'static str,
+    /// Starting Keplerian orbital elements.
     pub elements: OrbitalElements,
+    /// Position roundtrip tolerance in metres for the assertion.
     pub position_tol_m: f64,
 }
 
 impl OrbInitCase {
+    /// Build a case from its label, elements, and position tolerance.
     pub fn new(label: &'static str, elements: OrbitalElements, position_tol_m: f64) -> Self {
         Self {
             label,

--- a/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
+++ b/crates/jeod_sim/src/recipes/helpers/periapsis_detection.rs
@@ -39,6 +39,9 @@ impl Default for PeriapsisDetector {
 }
 
 impl PeriapsisDetector {
+    /// Construct a fresh detector. The first sample seeds the previous
+    /// radial-rate value; periapsis crossings are reported from the
+    /// second sample onwards.
     pub fn new() -> Self {
         Self {
             prev_rdot: 0.0,

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -222,10 +222,20 @@ impl CsvReference {
 /// almost always a configuration mistake.
 #[derive(Clone, Debug)]
 pub struct Tolerances {
+    /// Per-axis position tolerance (m). All-zero opts out of the
+    /// position assertion entirely.
     pub position_m: [f64; 3],
+    /// Per-axis velocity tolerance (m/s). All-zero opts out of the
+    /// velocity assertion entirely.
     pub velocity_m_s: [f64; 3],
+    /// Scalar quaternion-angle tolerance (rad). Zero opts out of the
+    /// attitude assertion entirely.
     pub quat_angle_rad: f64,
+    /// Per-axis angular-velocity tolerance (rad/s). All-zero opts out of
+    /// the angular-velocity assertion entirely.
     pub ang_vel_rad_s: [f64; 3],
+    /// Family-specific extras: `(name, abs-tolerance)` pairs that the
+    /// runner asserts against `report.add_extra(name, ...)` outputs.
     pub extras: &'static [(&'static str, f64)],
 }
 
@@ -252,7 +262,11 @@ pub enum ExtrasComparator {
     /// Geodetic state: 3 extras (`altitude`, `latitude`, `longitude`).
     /// `spherical=true` compares against the spherical-Earth columns;
     /// `false` (default) compares against ellipsoidal columns.
-    Ned { spherical: bool },
+    Ned {
+        /// `true` compares against the spherical-Earth NED columns;
+        /// `false` (default) compares against the ellipsoidal columns.
+        spherical: bool,
+    },
     /// Euler angles: 3 extras (`euler_roll`, `euler_pitch`, `euler_yaw`)
     /// computed against JEOD's logged quaternion via our own port of the
     /// Euler-from-matrix conversion (self-consistency check of our Euler
@@ -277,7 +291,11 @@ pub enum ExtrasComparator {
     /// `dC20` column logged by JEOD's SIM_tide_verif. Pairs with
     /// [`CsvReference::Tide`]. The recipe carries the Earth source
     /// index because dC20 is per-source, not per-body.
-    TideDc20 { earth_source_idx: usize },
+    TideDc20 {
+        /// Index (in the simulation's source table) of the Earth source
+        /// whose ΔC20 series the comparator will sample.
+        earth_source_idx: usize,
+    },
 }
 
 /// A single Tier 3 verification case.

--- a/crates/jeod_sim/src/rotation_model.rs
+++ b/crates/jeod_sim/src/rotation_model.rs
@@ -1,3 +1,7 @@
+//! Rotation-model selector that drives a planet's per-step
+//! `T_inertial→pfix` update (Earth RNP, Mars principal-axis, lunar DE421
+//! libration, or static identity).
+
 /// Rotation model for a gravity source's planet-fixed frame.
 ///
 /// Determines how `t_inertial_pfix` is updated each step. Each planet has its

--- a/crates/jeod_sim/src/simulation_builder.rs
+++ b/crates/jeod_sim/src/simulation_builder.rs
@@ -45,16 +45,29 @@ pub struct MassTreeAttachment {
 ///
 /// See module docs for the consumer-side terminal methods.
 pub struct SimulationBuilder {
+    /// Initial simulation time.
     pub time: SimulationTime,
+    /// Fixed integrator timestep in seconds.
     pub dt: f64,
+    /// Optional atmosphere configuration (model + radii + wind).
     pub atmosphere: Option<AtmosphereConfig>,
+    /// Source index of the planet whose rotation drives geodetic conversion
+    /// for atmospheric evaluation. `None` when [`Self::atmosphere`] is `None`.
     pub atmosphere_planet_source: Option<usize>,
+    /// Optional DE4xx ephemeris used to update source positions per step.
     pub ephemeris: Option<Ephemeris>,
+    /// Optional polar-motion `(xp, yp)` in radians applied to Earth rotation.
     pub polar_motion: Option<(f64, f64)>,
+    /// Source index of the Sun, when needed for SRP / solar beta / lighting.
     pub sun_source: Option<usize>,
+    /// Source index of the Moon, when needed for Earth lighting.
     pub moon_source: Option<usize>,
+    /// Gravity sources keyed by name in declaration order.
     pub sources: Vec<(String, GravitySourceEntry)>,
+    /// Per-source `(body, parent)` ephemeris bodies; index matches
+    /// [`Self::sources`]. `None` for sources that do not move via DE4xx.
     pub source_ephem_bodies: Vec<Option<(EphemerisBody, EphemerisBody)>>,
+    /// Vehicles in declaration order. Body index = position in this vec.
     pub bodies: Vec<VehicleConfig>,
     /// Body names for mass tree registration (index matches `bodies`).
     pub mass_tree_names: Vec<Option<String>>,

--- a/crates/jeod_sim/src/validation.rs
+++ b/crates/jeod_sim/src/validation.rs
@@ -1,3 +1,10 @@
+//! Per-body and whole-scenario validation: cross-checks vehicle
+//! configuration, gravity / atmosphere / SRP wiring, integrator
+//! compatibility, and contact-pair consistency. Adapters call
+//! [`validate_body`] before stepping; misconfigurations surface as
+//! [`ValidationError`] variants instead of silently producing bad
+//! physics.
+
 use jeod_dynamics::{DynamicsConfig, MassProperties, TranslationalState};
 use jeod_gravity::{GravityControls, GravitySource};
 
@@ -6,6 +13,12 @@ use jeod_gravity::{GravityControls, GravitySource};
 /// Returned by [`validate_body`] instead of panicking, so callers can decide
 /// how to handle errors. The Bevy adapter wraps these and panics with entity
 /// context; standalone users can log or handle gracefully.
+///
+/// Each variant carries diagnostic context (offending indices, lengths,
+/// detail strings) intended for the [`Display`](std::fmt::Display) impl. The
+/// per-field `usize` payloads are self-explanatory in that context, so the
+/// `#[allow(missing_docs)]` is applied at the enum level.
+#[allow(missing_docs)]
 #[derive(Debug, Clone)]
 pub enum ValidationError {
     /// `GravityControls` present but no gravity acceleration storage.

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -1,3 +1,57 @@
+//! Shared test-only fixtures, parsers, and verification helpers for the
+//! `bevy_jeod` workspace.
+//!
+//! This crate is the single home for code that reads JEOD source files
+//! (Modified_data Python, S_define text, gravity coefficient C++ headers,
+//! `Leap_Second.dat`, `verif_out.txt`) and Trick CSV/`.bsp` outputs. Every
+//! other crate in the workspace consumes those parsed fixtures through this
+//! crate so the parsing logic exists in exactly one place. Production code
+//! (`jeod_*`, `jeod_sim`, `bevy_jeod`) never depends on this crate — only
+//! tests, examples, and the cross-validation report binaries do.
+//!
+//! ## Top-level modules
+//!
+//! - [`crossval`] — `CrossvalReport` builder used by Tier 3 trajectory tests
+//!   to compute and assert per-component max errors against JEOD CSVs.
+//! - [`gravity_verif`] — parser for JEOD's
+//!   `grav_geospherical/data/verif_out.txt` (40 acceleration / gradient /
+//!   potential test vectors).
+//! - [`tier3_csv`] — generic loader for `log_state_ASCII.csv` Trick logs
+//!   produced by `verif/SIM_*` runs (time, position, velocity, attitude,
+//!   angular velocity columns).
+//! - [`dyncomp_csv`] — typed helpers around the `SIM_dyncomp` family of
+//!   reference CSVs used by the ISS-orbit Tier 3 tests.
+//! - [`apollo_mass_tree`] — fixture wiring for the multi-body Apollo
+//!   `MassTree` used by attach/detach staging tests.
+//! - [`euler_test`] — six-case rotation-matrix → Euler-angle table lifted
+//!   from `euler_derived_state_ut.cc`.
+//! - [`leap_second`], [`time_config`] — JEOD `Leap_Second.dat` and
+//!   time-scale configuration parsers.
+//! - [`mass_data`], [`orbital_data`], [`orbital_init`], [`reference_state`],
+//!   [`s_define`], [`gravity_control`] — Modified_data Python and S_define
+//!   parsers that turn `trick.attach_units(...)` literals into typed Rust
+//!   values.
+//!
+//! ## Binaries
+//!
+//! Two helper binaries live in `src/bin/`:
+//!
+//! - `tier3_report` — runs the full Tier 3 suite, scrapes per-test
+//!   tolerance literals from test source, and emits JSON / Markdown
+//!   cross-validation reports plus an optional baseline freeze
+//!   (`--freeze-baselines`).
+//! - `tier3_baseline_diff` — diffs a fresh report against
+//!   `test_data/baselines.json` to detect baseline drift on
+//!   refactor-only PRs.
+//!
+//! ## Environment
+//!
+//! Every parser that resolves JEOD source paths goes through
+//! [`jeod_path`], which checks `JEOD_PATH` first and then `JEOD_HOME`
+//! (the standard JEOD/Trick convention). [`trick_path`] does the same
+//! for `TRICK_HOME`. Tests that need JEOD source data assert (panic)
+//! when neither variable is set; they never skip silently.
+
 #![forbid(unsafe_code)]
 
 pub use jeod_quantities::prelude::*;

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -23,12 +23,20 @@ use crate::components::*;
 /// ```
 #[derive(Bundle)]
 pub struct PlanetBundle {
+    /// Bevy `Name` used for debug output.
     pub name: Name,
+    /// Gravity source (point-mass or spherical-harmonics).
     pub source: GravitySourceC,
+    /// Inertial-frame position of the source (m).
     pub position: SourceInertialPositionC,
+    /// Translational state used by per-step systems.
     pub trans: TranslationalStateC,
+    /// `T_inertial→pfix` rotation, updated each step by
+    /// `planet_fixed_rotation_system` per the chosen [`RotationModelC`].
     pub rotation: PlanetFixedRotationC,
+    /// Selector that drives [`Self::rotation`] each step.
     pub rotation_model: RotationModelC,
+    /// Planet shape (radii, mu, flattening).
     pub shape: PlanetC,
 }
 
@@ -76,12 +84,16 @@ impl PlanetBundle {
 /// ```
 #[derive(Bundle)]
 pub struct SunBundle {
+    /// Bevy `Name`, defaults to `"Sun"`.
     pub name: Name,
+    /// Discriminator queried by SRP / solar-beta / lighting systems.
     pub marker: SunMarker,
+    /// Inertial position used by the same systems.
     pub trans: TranslationalStateC,
 }
 
 impl SunBundle {
+    /// Build a Sun bundle from an inertial translational state.
     pub fn new(state: jeod_sim::TranslationalState) -> Self {
         Self {
             name: Name::new("Sun"),
@@ -104,12 +116,16 @@ impl SunBundle {
 /// ```
 #[derive(Bundle)]
 pub struct MoonBundle {
+    /// Bevy `Name`, defaults to `"Moon"`.
     pub name: Name,
+    /// Discriminator queried by the earth-lighting system.
     pub marker: MoonMarker,
+    /// Inertial position used by the earth-lighting system.
     pub trans: TranslationalStateC,
 }
 
 impl MoonBundle {
+    /// Build a Moon bundle from an inertial translational state.
     pub fn new(state: jeod_sim::TranslationalState) -> Self {
         Self {
             name: Name::new("Moon"),

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,3 +1,8 @@
+//! Bevy `Component` newtypes wrapping `jeod_sim` typed siblings (state,
+//! mass, gravity controls, interactions, derived states). Each component
+//! is `#[reflect(opaque, Component)]` so it appears in Bevy's type
+//! registry as a leaf of its `jeod_*` inner type.
+
 use bevy::prelude::*;
 use glam::DVec3;
 use jeod_sim::{
@@ -26,6 +31,10 @@ use jeod_sim::{
 // from an untyped `TranslationalState` switches to
 // `TranslationalStateC::from(state)` without other changes.
 
+/// Inertial translational state (position, velocity, acceleration) for
+/// the body being integrated. Wraps the typed
+/// [`TranslationalStateTyped<Inertial>`] sibling so frame is enforced
+/// at the type level.
 // JEOD_INV: DB.24 — default integrated_frame is composite_body (we integrate composite_body state)
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
 #[reflect(opaque, Component)]
@@ -52,6 +61,8 @@ impl From<TranslationalState> for TranslationalStateC {
     }
 }
 
+/// Rotational state (attitude quaternion + body-frame angular
+/// velocity / acceleration) for the body being integrated.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
 #[reflect(opaque, Component)]
 pub struct RotationalStateC(pub RotationalStateTyped<SelfRef>);
@@ -80,6 +91,9 @@ impl From<RotationalState> for RotationalStateC {
     }
 }
 
+/// Body mass, center of mass, and inertia tensor (with cached
+/// inverses). Required on any entity that produces a force or torque
+/// requiring acceleration conversion.
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
 #[reflect(opaque, Component)]
 pub struct MassPropertiesC(pub MassPropertiesTyped<SelfRef>);
@@ -104,6 +118,9 @@ impl From<MassProperties> for MassPropertiesC {
     }
 }
 
+/// Per-step gravitational acceleration accumulator, populated by
+/// `gravity_computation_system` and consumed by
+/// `force_collection_system`.
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
 #[reflect(opaque, Component)]
 pub struct GravityAccelerationC(pub GravityAccelerationTyped<Inertial>);
@@ -115,6 +132,9 @@ impl From<GravityAcceleration> for GravityAccelerationC {
     }
 }
 
+/// Per-step accumulator of structure-frame forces / torques
+/// resolved into the inertial frame; consumed by the integration
+/// system.
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
 #[reflect(opaque, Component)]
 pub struct TotalForceC(pub TotalForceTyped<SelfRef, Inertial>);
@@ -126,6 +146,8 @@ impl From<TotalForce> for TotalForceC {
     }
 }
 
+/// Linear and angular accelerations passed to the integrator each
+/// stage. Populated by `force_collection_system`.
 #[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Default, Reflect)]
 #[reflect(opaque, Component)]
 pub struct FrameDerivativesC(pub FrameDerivativesTyped<Inertial, SelfRef>);
@@ -137,6 +159,8 @@ impl From<FrameDerivatives> for FrameDerivativesC {
     }
 }
 
+/// Per-body dynamics flags (translational on, rotational on, three-DOF
+/// override). Required on every dynamic body.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
 #[reflect(opaque, Component)]
 #[require(FrameDerivativesC)]
@@ -168,11 +192,17 @@ pub struct GaussJacksonStateC(pub jeod_sim::GaussJacksonState);
 #[reflect(opaque, Component)]
 pub struct Abm4StateC(pub jeod_sim::Abm4State);
 
+/// Per-body list of gravity controls keyed by source [`Entity`]. Each
+/// control selects the model (point-mass / spherical-harmonics) and
+/// which body it represents (central, third, etc.).
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(opaque, Component)]
 #[require(GravityAccelerationC, TotalForceC)]
 pub struct GravityControlsC(pub GravityControls<Entity>);
 
+/// Gravity source attached to a planet entity (mu plus optional
+/// spherical-harmonics coefficients). Queried by gravity controls
+/// targeting this entity.
 #[derive(Component, Debug, Clone, Deref, DerefMut, Reflect)]
 #[reflect(opaque, Component)]
 pub struct GravitySourceC(pub GravitySource);
@@ -216,7 +246,9 @@ pub struct SourceInertialVelocityC(pub Velocity<Inertial>);
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
 #[reflect(opaque, Component)]
 pub struct AerodynamicForceC {
+    /// Force in the body structural frame (N).
     pub force: DVec3,
+    /// Torque about the body structural origin (N·m).
     pub torque: DVec3,
 }
 
@@ -230,7 +262,9 @@ pub struct AerodynamicForceC {
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
 #[reflect(opaque, Component)]
 pub struct RadiationForceC {
+    /// Force in the body structural frame (N).
     pub force: DVec3,
+    /// Torque about the body structural origin (N·m).
     pub torque: DVec3,
 }
 
@@ -491,6 +525,7 @@ pub struct PlanetC(pub PlanetShape);
 #[reflect(opaque, Component)]
 #[require(OrbitalElementsC)]
 pub struct OrbitalElementsConfigC {
+    /// Gravity source entity supplying `mu` for the conversion.
     pub gravity_source: Entity,
 }
 
@@ -502,6 +537,7 @@ pub struct OrbitalElementsConfigC {
 #[reflect(opaque, Component)]
 #[require(EulerAnglesC)]
 pub struct EulerAnglesConfigC {
+    /// Euler-angle decomposition convention (e.g., 3-2-1 yaw/pitch/roll).
     pub sequence: jeod_sim::EulerSequence,
 }
 
@@ -515,6 +551,8 @@ pub struct EulerAnglesConfigC {
 #[reflect(opaque, Component)]
 #[require(GeodeticStateC)]
 pub struct GeodeticConfigC {
+    /// Planet entity supplying ellipsoid radii (`PlanetC`) and
+    /// `T_inertial→pfix` (`PlanetFixedRotationC`).
     pub planet: Entity,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
 
 pub mod bundles;
 pub mod components;

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -1,5 +1,11 @@
+//! [`JeodSet`] — the Bevy `SystemSet` partition that mirrors JEOD's
+//! per-step pipeline.
+
 use bevy::prelude::*;
 
+/// Bevy system-set partition mirroring JEOD's per-step pipeline. Stages
+/// run in declaration order; `JeodPlugin` configures the ordering at
+/// `App::build` time.
 // JEOD_INV: DM.04 — system set ordering mirrors JEOD init/update pipeline
 // JEOD_INV: DM.13 — EphemerisUpdate before Environment ensures ephemeris is current for gravity
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -4,8 +4,8 @@
 use bevy::prelude::*;
 
 /// Bevy system-set partition mirroring JEOD's per-step pipeline. Stages
-/// run in declaration order; `JeodPlugin` configures the ordering at
-/// `App::build` time.
+/// run in declaration order; `JeodPlugin::build` configures the ordering
+/// when the plugin is added to the app.
 // JEOD_INV: DM.04 — system set ordering mirrors JEOD init/update pipeline
 // JEOD_INV: DM.13 — EphemerisUpdate before Environment ensures ephemeris is current for gravity
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,3 +1,8 @@
+//! Bevy `Systems` that delegate per-body work to `jeod_sim` per-body
+//! orchestration functions. Each system queries the relevant components,
+//! calls into `jeod_sim`, and writes the result back. No physics
+//! algorithms live here.
+
 use bevy::prelude::*;
 use glam::DVec3;
 use jeod_sim::{
@@ -11,6 +16,9 @@ use crate::SimulationTimeR;
 
 // ── Time ──
 
+/// Advance every JEOD-tracked time scale by the Bevy `Time<Fixed>` delta
+/// each step (TAI/UTC/UT1/TDB/TT/GMST). Runs in
+/// [`JeodSet::TimeUpdate`](crate::JeodSet::TimeUpdate).
 // JEOD_INV: TM.03 — time types updated in dependency order (delegates to SimulationTime::advance)
 pub fn time_advance_system(mut sim_time: ResMut<SimulationTimeR>, time: Res<Time<Fixed>>) {
     let dt = time.delta_secs_f64();


### PR DESCRIPTION
## Summary

Closes #214 (the last sub-issue under #213).

- Root crate `bevy_jeod` (`src/lib.rs`) now uses
  `#![doc = include_str!("../README.md")]`, so the README is the rustdoc
  landing page and the Quick-start example becomes a real doctest. The
  Quick-start fence is `rust,no_run` because the example wires
  `App::new().run()`, which is not appropriate to execute under the
  doctest harness.
- `crates/jeod_test_data/src/lib.rs` gains a ~25-sentence `//!` block
  covering its role as the workspace's single home for JEOD/Trick fixture
  parsers and Tier 3 helpers, the top-level public modules (`crossval`,
  `gravity_verif`, `tier3_csv`, `dyncomp_csv`, `apollo_mass_tree`,
  `euler_test`, `leap_second`, `time_config`, `mass_data`,
  `orbital_data`, `orbital_init`, `reference_state`, `s_define`,
  `gravity_control`), the two binaries (`tier3_report` and
  `tier3_baseline_diff` in `src/bin/`), and the
  `JEOD_HOME` / `JEOD_PATH` environment requirement. (The `atmosphere_verif`
  and `planet_geodetic_verif` modules referenced in #214's text do not
  exist on the branch yet — those modules will land with PRs #229 and #230;
  the listing reflects what is actually present.)
- `#![warn(missing_docs)]` added to exactly four `lib.rs` files:
  `src/lib.rs` (root `bevy_jeod`), `crates/jeod_sim/src/lib.rs`,
  `crates/jeod_runner/src/lib.rs`, and
  `crates/jeod_quantities/src/lib.rs`.
- Backfilled `///` docs across those four crates so that
  `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` runs clean.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `cargo test --doc --workspace` (README Quick-start now compiles as
  a doctest under `bevy_jeod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)