### PR TITLE
Add GitHub Pages deployment for workspace rustdoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,12 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    # Guard: only main can publish to the live Pages site. `workflow_dispatch`
+    # lets a user pick a non-main branch from the Actions UI, and we don't
+    # want a feature branch to overwrite the published docs with stale
+    # output. The build job above still runs on any branch (useful as a
+    # smoke test); only the deploy step is gated.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+name: Deploy rustdoc to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one in-flight Pages deployment at a time, but do not cancel a running
+# deploy if a newer commit lands while it is publishing — interrupting halfway
+# can leave the site in a partially-updated state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build workspace docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo doc --workspace --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps
+
+      - name: Add root index.html redirect to bevy_jeod
+        run: |
+          cat > target/doc/index.html <<'EOF'
+          <!DOCTYPE html>
+          <meta charset="utf-8">
+          <title>bevy_jeod docs</title>
+          <meta http-equiv="refresh" content="0; url=bevy_jeod/index.html">
+          <link rel="canonical" href="bevy_jeod/index.html">
+          <p>Redirecting to <a href="bevy_jeod/index.html">bevy_jeod</a>…</p>
+          EOF
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/docs.yml` builds `cargo doc --workspace --no-deps` (with the same `RUSTDOCFLAGS=-D warnings` already enforced by `docs-enforce`) and deploys `target/doc/` to GitHub Pages on every push to `main`.
- Adds a root `index.html` redirect so the Pages root lands on `bevy_jeod/index.html`.
- After PR #231 merges, that landing page will render the README via `#![doc = include_str!("../README.md")]`, so first-time visitors see the project intro before drilling into per-crate APIs.

## Manual setup required before the first deploy

The workflow uses the modern Actions-based Pages deployment (`actions/deploy-pages@v4`), which needs Pages enabled with the right source:

1. Repo **Settings → Pages → Build and deployment → Source** = `GitHub Actions`.
2. The `github-pages` environment is auto-created on first deploy. Optionally restrict it to the `main` branch via Settings → Environments.

Once enabled, the docs land at `https://simnaut.github.io/bevy_jeod/` and refresh on every main-branch push. A README link can follow in a small follow-up once the URL is verified.

## Test plan

- [ ] Merge this PR.
- [ ] Enable Pages (Settings → Pages → Source = GitHub Actions).
- [ ] Trigger the workflow once via Actions tab → "Deploy rustdoc to GitHub Pages" → Run workflow, OR push any commit to `main`.
- [ ] Visit `https://simnaut.github.io/bevy_jeod/` — should redirect to the `bevy_jeod` crate page and render the README.
- [ ] Confirm sidebar lists all 13 workspace crates plus `bevy_jeod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)