### PR TITLE
[#233] Relocate JEOD .cc parser out of production jeod_gravity (#232 Wave 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,8 +2500,10 @@ name = "jeod_test_data"
 version = "0.1.0"
 dependencies = [
  "glam 0.30.10",
+ "jeod_gravity",
  "jeod_quantities",
  "regex",
+ "thiserror 2.0.18",
  "uom",
 ]
 

--- a/crates/jeod_gravity/src/coefficients.rs
+++ b/crates/jeod_gravity/src/coefficients.rs
@@ -14,7 +14,7 @@ use crate::spherical_harmonics_gravity_source::SphericalHarmonicsData;
 
 /// Errors from loading a binary spherical-harmonics coefficient blob.
 #[derive(Debug, thiserror::Error)]
-pub enum BinaryLoadError {
+pub enum CoeffLoadError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("invalid binary format: {0}")]
@@ -57,19 +57,19 @@ pub fn save_binary(
 }
 
 /// Load coefficients from the compact binary format.
-pub fn load_binary(path: &std::path::Path) -> Result<SphericalHarmonicsData, BinaryLoadError> {
+pub fn load_binary(path: &std::path::Path) -> Result<SphericalHarmonicsData, CoeffLoadError> {
     let buf = std::fs::read(path)?;
     load_binary_from_bytes(&buf)
 }
 
 /// Load coefficients from binary bytes (for embedded data).
-pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, BinaryLoadError> {
+pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, CoeffLoadError> {
     let mut pos = 0;
 
     // Bounds-checked read helpers (prevent panics on truncated/corrupted files)
-    let read_u32 = |pos: &mut usize| -> Result<u32, BinaryLoadError> {
+    let read_u32 = |pos: &mut usize| -> Result<u32, CoeffLoadError> {
         if *pos + 4 > buf.len() {
-            return Err(BinaryLoadError::InvalidFormat(format!(
+            return Err(CoeffLoadError::InvalidFormat(format!(
                 "truncated binary file at offset {}",
                 *pos
             )));
@@ -78,9 +78,9 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Bina
         *pos += 4;
         Ok(val)
     };
-    let read_f64 = |pos: &mut usize| -> Result<f64, BinaryLoadError> {
+    let read_f64 = |pos: &mut usize| -> Result<f64, CoeffLoadError> {
         if *pos + 8 > buf.len() {
-            return Err(BinaryLoadError::InvalidFormat(format!(
+            return Err(CoeffLoadError::InvalidFormat(format!(
                 "truncated binary file at offset {}",
                 *pos
             )));
@@ -89,9 +89,9 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Bina
         *pos += 8;
         Ok(val)
     };
-    let read_u8 = |pos: &mut usize| -> Result<u8, BinaryLoadError> {
+    let read_u8 = |pos: &mut usize| -> Result<u8, CoeffLoadError> {
         if *pos >= buf.len() {
-            return Err(BinaryLoadError::InvalidFormat(format!(
+            return Err(CoeffLoadError::InvalidFormat(format!(
                 "truncated binary file at offset {}",
                 *pos
             )));
@@ -103,19 +103,19 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Bina
 
     // Magic number
     if buf.len() < 8 {
-        return Err(BinaryLoadError::InvalidFormat(
+        return Err(CoeffLoadError::InvalidFormat(
             "binary coefficient file too short".into(),
         ));
     }
     if &buf[0..4] != b"JEOD" {
-        return Err(BinaryLoadError::InvalidFormat(
+        return Err(CoeffLoadError::InvalidFormat(
             "invalid magic in binary coefficient file".into(),
         ));
     }
     pos += 4;
     let version = read_u32(&mut pos)?;
     if version != 1 {
-        return Err(BinaryLoadError::InvalidFormat(format!(
+        return Err(CoeffLoadError::InvalidFormat(format!(
             "unsupported binary coefficient version {version}"
         )));
     }
@@ -125,12 +125,12 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Bina
 
     // Sanity checks to prevent unbounded memory allocation
     if degree > 10000 {
-        return Err(BinaryLoadError::InvalidFormat(format!(
+        return Err(CoeffLoadError::InvalidFormat(format!(
             "degree {degree} exceeds maximum supported (10000)"
         )));
     }
     if order > degree {
-        return Err(BinaryLoadError::InvalidFormat(format!(
+        return Err(CoeffLoadError::InvalidFormat(format!(
             "order ({order}) exceeds degree ({degree})"
         )));
     }
@@ -142,7 +142,7 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Bina
     let num_coeffs = (degree + 1) * (degree + 2) / 2;
     let expected_size = 41 + 2 * num_coeffs * 8;
     if buf.len() < expected_size {
-        return Err(BinaryLoadError::InvalidFormat(format!(
+        return Err(CoeffLoadError::InvalidFormat(format!(
             "binary file too short for degree {degree}: need {expected_size} bytes, have {}",
             buf.len()
         )));

--- a/crates/jeod_gravity/src/coefficients.rs
+++ b/crates/jeod_gravity/src/coefficients.rs
@@ -1,145 +1,24 @@
-//! Gravity coefficient loading from JEOD C++ data files.
+//! Compact binary serialization for gravity coefficients.
+//!
+//! Production gravity loads pre-built `.bin` blobs through
+//! [`load_binary`] / [`load_binary_from_bytes`]. The blobs are produced
+//! by [`save_binary`] from [`SphericalHarmonicsData`] values that test
+//! infrastructure assembles from JEOD's `.cc` source files.
+//!
+//! Parsing JEOD's `.cc` source files lives in
+//! `jeod_test_data::jeod_cc` (a dev/test-only crate). `jeod_gravity`
+//! itself does not know how to parse JEOD source — only how to consume
+//! the binary format derived from it.
 
 use crate::spherical_harmonics_gravity_source::SphericalHarmonicsData;
 
-/// Errors from loading gravity coefficient files.
+/// Errors from loading a binary spherical-harmonics coefficient blob.
 #[derive(Debug, thiserror::Error)]
-pub enum CoeffLoadError {
+pub enum BinaryLoadError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("missing field '{field}' in {path}")]
-    MissingField { field: &'static str, path: String },
     #[error("invalid binary format: {0}")]
     InvalidFormat(String),
-}
-
-/// Load only the gravitational parameter (mu) from a JEOD C++ gravity data file.
-///
-/// Works with any JEOD gravity file including spherical-only files (like
-/// `sun_spherical.cc`, `moon_spherical.cc`) that lack `degree`/`order` fields.
-///
-/// Returns mu in m³/s².
-pub fn load_mu_from_jeod_cc(path: &std::path::Path) -> Result<f64, CoeffLoadError> {
-    let content = std::fs::read_to_string(path)?;
-    let path_str = path.display().to_string();
-
-    for line in content.lines() {
-        if let Some(val) = extract_assign_f64(line.trim(), "mu") {
-            return Ok(val);
-        }
-    }
-
-    Err(CoeffLoadError::MissingField {
-        field: "mu",
-        path: path_str,
-    })
-}
-
-/// Load spherical harmonics coefficients from a JEOD C++ data file.
-///
-/// Parses files like `earth_GGM05C.cc` that contain lines of the form:
-/// ```text
-/// ...->degree = 360;
-/// ...->order = 360;
-/// ...->mu = 398600.44150E+09;
-/// ...->radius = 6378136.30;
-/// ...->tide_free = false;
-/// ...->tide_free_delta = 4.173E-9;
-/// ...->Cnm[2] = JEOD_ALLOC_PRIM_ARRAY(3, double);
-/// ...->Cnm[2][0] = -4.8416945732000E-04;
-/// ...->Snm[2][0] = 0.0;
-/// ```
-pub fn load_from_jeod_cc(path: &std::path::Path) -> Result<SphericalHarmonicsData, CoeffLoadError> {
-    let content = std::fs::read_to_string(path)?;
-    let path_str = path.display().to_string();
-
-    let mut degree: Option<usize> = None;
-    let mut order: Option<usize> = None;
-    let mut mu: Option<f64> = None;
-    let mut radius: Option<f64> = None;
-    let mut tide_free: Option<bool> = None;
-    let mut tide_free_delta: Option<f64> = None;
-
-    // First pass: extract metadata
-    for line in content.lines() {
-        let line = line.trim();
-        if let Some(val) = extract_assign_usize(line, "degree") {
-            degree = Some(val);
-        }
-        if let Some(val) = extract_assign_usize(line, "order") {
-            order = Some(val);
-        }
-        if let Some(val) = extract_assign_f64(line, "mu") {
-            mu = Some(val);
-        }
-        if let Some(val) = extract_assign_f64(line, "radius") {
-            radius = Some(val);
-        }
-        if line.contains("tide_free") && !line.contains("tide_free_delta") {
-            if line.contains("true") {
-                tide_free = Some(true);
-            } else if line.contains("false") {
-                tide_free = Some(false);
-            }
-        }
-        if let Some(val) = extract_assign_f64(line, "tide_free_delta") {
-            tide_free_delta = Some(val);
-        }
-    }
-
-    let degree = degree.ok_or_else(|| CoeffLoadError::MissingField {
-        field: "degree",
-        path: path_str.clone(),
-    })?;
-    let order = order.ok_or_else(|| CoeffLoadError::MissingField {
-        field: "order",
-        path: path_str.clone(),
-    })?;
-    let mu = mu.ok_or_else(|| CoeffLoadError::MissingField {
-        field: "mu",
-        path: path_str.clone(),
-    })?;
-    let radius = radius.ok_or(CoeffLoadError::MissingField {
-        field: "radius",
-        path: path_str,
-    })?;
-    let tide_free = tide_free.unwrap_or(true);
-    let tide_free_delta = tide_free_delta.unwrap_or(0.0);
-
-    // Allocate coefficient arrays
-    let mut cnm: Vec<Vec<f64>> = Vec::with_capacity(degree + 1);
-    let mut snm: Vec<Vec<f64>> = Vec::with_capacity(degree + 1);
-    for n in 0..=degree {
-        cnm.push(vec![0.0; n + 1]);
-        snm.push(vec![0.0; n + 1]);
-    }
-
-    // Second pass: extract coefficients
-    // Patterns: ->Cnm[n][m] = value; and ->Snm[n][m] = value;
-    for line in content.lines() {
-        let line = line.trim();
-        if let Some((n, m, val)) = extract_coeff(line, "Cnm") {
-            if n <= degree && m <= n {
-                cnm[n][m] = val;
-            }
-        }
-        if let Some((n, m, val)) = extract_coeff(line, "Snm") {
-            if n <= degree && m <= n {
-                snm[n][m] = val;
-            }
-        }
-    }
-
-    Ok(SphericalHarmonicsData::new(
-        degree,
-        order,
-        radius,
-        mu,
-        cnm,
-        snm,
-        tide_free,
-        tide_free_delta,
-    ))
 }
 
 /// Save coefficients to a compact binary format.
@@ -178,19 +57,19 @@ pub fn save_binary(
 }
 
 /// Load coefficients from the compact binary format.
-pub fn load_binary(path: &std::path::Path) -> Result<SphericalHarmonicsData, CoeffLoadError> {
+pub fn load_binary(path: &std::path::Path) -> Result<SphericalHarmonicsData, BinaryLoadError> {
     let buf = std::fs::read(path)?;
     load_binary_from_bytes(&buf)
 }
 
 /// Load coefficients from binary bytes (for embedded data).
-pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, CoeffLoadError> {
+pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, BinaryLoadError> {
     let mut pos = 0;
 
     // Bounds-checked read helpers (prevent panics on truncated/corrupted files)
-    let read_u32 = |pos: &mut usize| -> Result<u32, CoeffLoadError> {
+    let read_u32 = |pos: &mut usize| -> Result<u32, BinaryLoadError> {
         if *pos + 4 > buf.len() {
-            return Err(CoeffLoadError::InvalidFormat(format!(
+            return Err(BinaryLoadError::InvalidFormat(format!(
                 "truncated binary file at offset {}",
                 *pos
             )));
@@ -199,9 +78,9 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Coef
         *pos += 4;
         Ok(val)
     };
-    let read_f64 = |pos: &mut usize| -> Result<f64, CoeffLoadError> {
+    let read_f64 = |pos: &mut usize| -> Result<f64, BinaryLoadError> {
         if *pos + 8 > buf.len() {
-            return Err(CoeffLoadError::InvalidFormat(format!(
+            return Err(BinaryLoadError::InvalidFormat(format!(
                 "truncated binary file at offset {}",
                 *pos
             )));
@@ -210,9 +89,9 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Coef
         *pos += 8;
         Ok(val)
     };
-    let read_u8 = |pos: &mut usize| -> Result<u8, CoeffLoadError> {
+    let read_u8 = |pos: &mut usize| -> Result<u8, BinaryLoadError> {
         if *pos >= buf.len() {
-            return Err(CoeffLoadError::InvalidFormat(format!(
+            return Err(BinaryLoadError::InvalidFormat(format!(
                 "truncated binary file at offset {}",
                 *pos
             )));
@@ -224,19 +103,19 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Coef
 
     // Magic number
     if buf.len() < 8 {
-        return Err(CoeffLoadError::InvalidFormat(
+        return Err(BinaryLoadError::InvalidFormat(
             "binary coefficient file too short".into(),
         ));
     }
     if &buf[0..4] != b"JEOD" {
-        return Err(CoeffLoadError::InvalidFormat(
+        return Err(BinaryLoadError::InvalidFormat(
             "invalid magic in binary coefficient file".into(),
         ));
     }
     pos += 4;
     let version = read_u32(&mut pos)?;
     if version != 1 {
-        return Err(CoeffLoadError::InvalidFormat(format!(
+        return Err(BinaryLoadError::InvalidFormat(format!(
             "unsupported binary coefficient version {version}"
         )));
     }
@@ -246,12 +125,12 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Coef
 
     // Sanity checks to prevent unbounded memory allocation
     if degree > 10000 {
-        return Err(CoeffLoadError::InvalidFormat(format!(
+        return Err(BinaryLoadError::InvalidFormat(format!(
             "degree {degree} exceeds maximum supported (10000)"
         )));
     }
     if order > degree {
-        return Err(CoeffLoadError::InvalidFormat(format!(
+        return Err(BinaryLoadError::InvalidFormat(format!(
             "order ({order}) exceeds degree ({degree})"
         )));
     }
@@ -263,7 +142,7 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Coef
     let num_coeffs = (degree + 1) * (degree + 2) / 2;
     let expected_size = 41 + 2 * num_coeffs * 8;
     if buf.len() < expected_size {
-        return Err(CoeffLoadError::InvalidFormat(format!(
+        return Err(BinaryLoadError::InvalidFormat(format!(
             "binary file too short for degree {degree}: need {expected_size} bytes, have {}",
             buf.len()
         )));
@@ -302,86 +181,4 @@ pub fn load_binary_from_bytes(buf: &[u8]) -> Result<SphericalHarmonicsData, Coef
         tide_free,
         tide_free_delta,
     ))
-}
-
-// --- Helper functions ---
-
-fn extract_assign_usize(line: &str, key: &str) -> Option<usize> {
-    // Match: ->key = value; or ptr->key = value;
-    let pattern = format!("->{} = ", key);
-    if let Some(idx) = line.find(&pattern) {
-        let rest = &line[idx + pattern.len()..];
-        let val_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        val_str.parse().ok()
-    } else {
-        None
-    }
-}
-
-fn extract_assign_f64(line: &str, key: &str) -> Option<f64> {
-    // Match: ->key = value; with possible scientific notation or multiplication.
-    // Handles: `->mu = 398600.44150E+09;`
-    //          `->mu = 1000000000 * (4902.801076);`
-    let pattern = format!("->{} = ", key);
-    if let Some(idx) = line.find(&pattern) {
-        let rest = &line[idx + pattern.len()..];
-        // Extract up to semicolon, then evaluate
-        let expr: String = rest.chars().take_while(|c| *c != ';').collect();
-        eval_simple_expr(&expr)
-    } else {
-        None
-    }
-}
-
-/// Evaluate a simple numeric expression: a single f64, or `a * (b)` multiplication.
-fn eval_simple_expr(expr: &str) -> Option<f64> {
-    let expr = expr.trim();
-    // Try direct parse first
-    if let Ok(val) = expr.parse::<f64>() {
-        return Some(val);
-    }
-    // Try multiplication: "A * (B)" or "A * B"
-    if let Some(star_idx) = expr.find('*') {
-        let lhs = expr[..star_idx].trim();
-        let rhs = expr[star_idx + 1..]
-            .trim()
-            .trim_matches(|c| c == '(' || c == ')');
-        if let (Ok(a), Ok(b)) = (lhs.parse::<f64>(), rhs.trim().parse::<f64>()) {
-            return Some(a * b);
-        }
-    }
-    None
-}
-
-fn extract_coeff(line: &str, name: &str) -> Option<(usize, usize, f64)> {
-    // Match: ->Cnm[n][m] = value;
-    let prefix = format!("{}[", name);
-    let start = line.find(&prefix)?;
-    let rest = &line[start + prefix.len()..];
-
-    // Parse n
-    let n_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    let n: usize = n_str.parse().ok()?;
-
-    // Find ][m]
-    let bracket_pos = rest.find("][")?;
-    let after_bracket = &rest[bracket_pos + 2..];
-    let m_str: String = after_bracket
-        .chars()
-        .take_while(|c| c.is_ascii_digit())
-        .collect();
-    let m: usize = m_str.parse().ok()?;
-
-    // Find = value
-    let eq_pos = after_bracket.find('=')?;
-    let val_rest = after_bracket[eq_pos + 1..].trim();
-    let val_str: String = val_rest
-        .chars()
-        .take_while(|c| {
-            *c == '-' || *c == '+' || *c == '.' || *c == 'E' || *c == 'e' || c.is_ascii_digit()
-        })
-        .collect();
-    let val: f64 = val_str.parse().ok()?;
-
-    Some((n, m, val))
 }

--- a/crates/jeod_gravity/tests/j2_regression.rs
+++ b/crates/jeod_gravity/tests/j2_regression.rs
@@ -9,9 +9,8 @@
 
 use glam::DVec3;
 use jeod_dynamics::{rk4_translational_step, TranslationalState};
-use jeod_gravity::coefficients;
 use jeod_math::OrbitalElements;
-use jeod_test_data::jeod_path;
+use jeod_test_data::{jeod_cc, jeod_path};
 use std::f64::consts::PI;
 
 #[test]
@@ -20,7 +19,7 @@ fn j2_nodal_regression_rate() {
     assert!(root.exists(), "JEOD source not found");
 
     let ggm02c_path = root.join("models/environment/gravity/data/src/earth_GGM02C.cc");
-    let sh_data = coefficients::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C coefficients");
+    let sh_data = jeod_cc::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C coefficients");
     let mu = sh_data.mu;
     let r_eq = sh_data.radius;
 

--- a/crates/jeod_gravity/tests/tier2_grav_geospherical.rs
+++ b/crates/jeod_gravity/tests/tier2_grav_geospherical.rs
@@ -15,10 +15,10 @@
 //! Requires the JEOD source tree (via `JEOD_HOME` or `JEOD_PATH` env var).
 
 use glam::{DMat3, DVec3};
-use jeod_gravity::{coefficients, SphericalHarmonicsData};
+use jeod_gravity::SphericalHarmonicsData;
 use jeod_test_data::{
     gravity_verif::{load_gravity_test_cases, GravityTestCase},
-    jeod_path,
+    jeod_cc, jeod_path,
 };
 use std::path::{Path, PathBuf};
 
@@ -110,8 +110,7 @@ fn tier2_grav_geospherical_point_mass_sanity() {
     // Load mu directly from JEOD GGM02C (the file JEOD's grav_geospherical
     // test itself references). This matches `tier2_grav_geospherical_full_validation`
     // below and avoids a literal duplicate of the JEOD-source value.
-    let data =
-        coefficients::load_from_jeod_cc(&ggm02c_path(&root)).expect("load GGM02C coefficients");
+    let data = jeod_cc::load_from_jeod_cc(&ggm02c_path(&root)).expect("load GGM02C coefficients");
     let mu_earth = data.mu;
 
     for case in &cases {
@@ -252,7 +251,7 @@ fn tier2_grav_geospherical_full_validation() {
     // Load GGM02C (the test was built against GGM02C, not GGM05C).
     let path = ggm02c_path(&root);
     assert!(path.exists(), "GGM02C not found at {}", path.display());
-    let mut data = coefficients::load_from_jeod_cc(&path).expect("load GGM02C coefficients");
+    let mut data = jeod_cc::load_from_jeod_cc(&path).expect("load GGM02C coefficients");
     // JEOD test overrides tide_free = true (main.cc line 95).
     data.tide_free = true;
 
@@ -345,7 +344,7 @@ fn tier2_grav_geospherical_surface_gravity_ggm02c() {
         "GGM02C not found at {}. Requires JEOD source.",
         path.display()
     );
-    let data = coefficients::load_from_jeod_cc(&path).expect("load GGM02C coefficients");
+    let data = jeod_cc::load_from_jeod_cc(&path).expect("load GGM02C coefficients");
 
     // Equatorial surface.
     let pos_eq = DVec3::new(data.radius, 0.0, 0.0);

--- a/crates/jeod_runner/Cargo.toml
+++ b/crates/jeod_runner/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-jeod_sim = { path = "../jeod_sim", version = "0.1.0" }
+jeod_sim = { path = "../jeod_sim", version = "0.1.0", features = ["jeod-source"] }
 jeod_dynamics = { path = "../jeod_dynamics", version = "0.1.0" }
 jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
 jeod_time = { path = "../jeod_time", version = "0.1.0" }

--- a/crates/jeod_runner/src/run_verification/sim_derived_state.rs
+++ b/crates/jeod_runner/src/run_verification/sim_derived_state.rs
@@ -14,11 +14,12 @@ use jeod_sim::recipes::verification::{
     CsvReference, ExtrasComparator, InitialConditions, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    coefficients, default_leap_second_table, DerivedStateConfig, EulerSequence, GeodeticConfig,
-    GravityControl, GravityControls, GravityModel, GravitySource, GravitySourceEntry, JeodQuat,
-    MassProperties, RotationModel, RotationalState, SimulationBuilder, SimulationTime,
-    TranslationalState, VehicleConfig, EARTH,
+    default_leap_second_table, DerivedStateConfig, EulerSequence, GeodeticConfig, GravityControl,
+    GravityControls, GravityModel, GravitySource, GravitySourceEntry, JeodQuat, MassProperties,
+    RotationModel, RotationalState, SimulationBuilder, SimulationTime, TranslationalState,
+    VehicleConfig, EARTH,
 };
+use jeod_test_data::jeod_cc as coefficients;
 use uom::si::f64::Time;
 use uom::si::time::second;
 

--- a/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
@@ -17,11 +17,12 @@ use jeod_sim::recipes::verification::{
     CsvReference, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    coefficients::load_from_jeod_cc, default_leap_second_table, AtmosphereConfig, AtmosphereModel,
-    DragConfig, Ephemeris, EphemerisBody, GravityControl, GravityControls, GravityModel,
-    GravitySource, GravitySourceEntry, JeodQuat, MassProperties, MetAtmosphere, RotationModel,
-    RotationalState, SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig, EARTH,
+    default_leap_second_table, AtmosphereConfig, AtmosphereModel, DragConfig, Ephemeris,
+    EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource,
+    GravitySourceEntry, JeodQuat, MassProperties, MetAtmosphere, RotationModel, RotationalState,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig, EARTH,
 };
+use jeod_test_data::jeod_cc::load_from_jeod_cc;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -441,10 +442,10 @@ fn build_run4_3rd_body(init: &InitialConditions) -> SimulationBuilder {
     let earth_grav =
         load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth gravity");
     let mu_sun =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
             .expect("load Sun mu");
     let mu_moon =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
 
     // Initial Sun/Moon positions at the dyncomp epoch — re-queried each
@@ -592,10 +593,10 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> BattinSc
     let earth_grav =
         load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth gravity");
     let mu_sun =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
             .expect("load Sun mu");
     let mu_moon =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
 
     // Initial Sun/Moon state at the dyncomp epoch — refreshed each step
@@ -712,10 +713,10 @@ fn build_run7(
     let earth_grav =
         load_from_jeod_cc(&grav_data_dir.join("earth_GGM02C.cc")).expect("load Earth GGM02C");
     let mu_sun =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
             .expect("load Sun mu");
     let mu_moon =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
 
     let time = dyncomp_time();
@@ -922,7 +923,7 @@ fn build_run5(init: &InitialConditions, case: &str) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(
+    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu");
@@ -1220,7 +1221,7 @@ fn build_run5a_met(init: &InitialConditions) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(
+    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu");
@@ -1292,7 +1293,7 @@ fn build_run6b_aero_traj(init: &InitialConditions, t_struct_body: DMat3) -> Simu
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(
+    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu");

--- a/crates/jeod_runner/src/run_verification/sim_planetary.rs
+++ b/crates/jeod_runner/src/run_verification/sim_planetary.rs
@@ -32,7 +32,7 @@ fn load_mu_earth() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C")

--- a/crates/jeod_runner/src/run_verification/sim_polar_motion.rs
+++ b/crates/jeod_runner/src/run_verification/sim_polar_motion.rs
@@ -35,7 +35,7 @@ fn build_run2p_polar_motion(init: &InitialConditions) -> SimulationBuilder {
         jeod_root.display()
     );
 
-    let mu_earth = jeod_sim::coefficients::load_mu_from_jeod_cc(
+    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C");

--- a/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
+++ b/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
@@ -30,10 +30,11 @@ use jeod_sim::recipes::verification::{
     CsvReference, ExtrasComparator, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    coefficients, default_leap_second_table, DerivedStateConfig, Ephemeris, EphemerisBody,
-    GravityControl, GravityControls, GravityModel, GravitySource, GravitySourceEntry,
-    RotationModel, SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
+    default_leap_second_table, DerivedStateConfig, Ephemeris, EphemerisBody, GravityControl,
+    GravityControls, GravityModel, GravitySource, GravitySourceEntry, RotationModel,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
 };
+use jeod_test_data::jeod_cc as coefficients;
 use uom::si::f64::Time;
 use uom::si::time::second;
 

--- a/crates/jeod_runner/src/run_verification/sim_srp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_srp.rs
@@ -23,12 +23,12 @@ use jeod_sim::recipes::verification::{
     CsvReference, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    coefficients::load_mu_from_jeod_cc, default_leap_second_table, Ephemeris, EphemerisBody,
-    FlatPlate, FlatPlateParams, FlatPlateState, FlatPlateThermal, GravityControl, GravityControls,
-    GravityModel, GravitySource, GravitySourceEntry, MassProperties, RotationModel, ShadowBody,
-    SimulationBuilder, SimulationTime, SrpModel, ThermalIntegrationOrder, TranslationalState,
-    VehicleConfig, EARTH,
+    default_leap_second_table, Ephemeris, EphemerisBody, FlatPlate, FlatPlateParams,
+    FlatPlateState, FlatPlateThermal, GravityControl, GravityControls, GravityModel, GravitySource,
+    GravitySourceEntry, MassProperties, RotationModel, ShadowBody, SimulationBuilder,
+    SimulationTime, SrpModel, ThermalIntegrationOrder, TranslationalState, VehicleConfig, EARTH,
 };
+use jeod_test_data::jeod_cc::load_mu_from_jeod_cc;
 use uom::si::f64::Time;
 use uom::si::time::second;
 

--- a/crates/jeod_runner/src/run_verification/sim_tide_verif.rs
+++ b/crates/jeod_runner/src/run_verification/sim_tide_verif.rs
@@ -22,11 +22,11 @@ use jeod_sim::recipes::verification::{
     CsvReference, ExtrasComparator, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    coefficients::load_from_jeod_cc, default_leap_second_table, Ephemeris, EphemerisBody,
-    GravityControl, GravityControls, GravityModel, GravitySource, GravitySourceEntry, JeodQuat,
-    MassProperties, RotationModel, RotationalState, SimulationBuilder, SimulationTime,
-    TranslationalState, VehicleConfig,
+    default_leap_second_table, Ephemeris, EphemerisBody, GravityControl, GravityControls,
+    GravityModel, GravitySource, GravitySourceEntry, JeodQuat, MassProperties, RotationModel,
+    RotationalState, SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
 };
+use jeod_test_data::jeod_cc::load_from_jeod_cc;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -94,10 +94,10 @@ fn build_tide_run01(init: &InitialConditions) -> SimulationBuilder {
     let earth_mu = earth_grav.mu;
     let earth_radius = earth_grav.radius;
     let mu_sun =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
             .expect("load Sun mu");
     let mu_moon =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
 
     let time = dyncomp_time();

--- a/crates/jeod_runner/src/run_verification/sim_torque_simple.rs
+++ b/crates/jeod_runner/src/run_verification/sim_torque_simple.rs
@@ -28,11 +28,11 @@ use jeod_sim::recipes::verification::{
     CsvReference, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    coefficients, default_leap_second_table, Ephemeris, EphemerisBody, GravityControl,
-    GravityControls, GravityModel, GravitySource, GravitySourceEntry, MassProperties,
-    RotationModel, RotationalState, SimulationBuilder, SimulationTime, TranslationalState,
-    VehicleConfig,
+    default_leap_second_table, Ephemeris, EphemerisBody, GravityControl, GravityControls,
+    GravityModel, GravitySource, GravitySourceEntry, MassProperties, RotationModel,
+    RotationalState, SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
 };
+use jeod_test_data::jeod_cc as coefficients;
 use uom::si::f64::Time;
 use uom::si::time::second;
 

--- a/crates/jeod_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/jeod_runner/tests/pipeline_earth_lighting.rs
@@ -38,7 +38,7 @@ fn pipeline_earth_lighting_smoke() {
 
     let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
     let mu_earth =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
             .expect("load Earth mu");
 
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run9.rs
@@ -70,7 +70,7 @@ fn setup_run9(
 
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
     let mu_earth =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
             .expect("load Earth mu");
 
     let mass_init = jeod_test_data::mass_data::load_mass_from_file(

--- a/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
+++ b/crates/jeod_runner/tests/tier3_sim_earth_moon.rs
@@ -29,7 +29,7 @@ fn load_mu_earth() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C")
@@ -42,7 +42,7 @@ fn load_mu_sun() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
     )
     .expect("load Sun mu from sun_spherical")
@@ -119,7 +119,7 @@ fn tier3_simulation_earth_moon_clem() {
     let jeod_root = jeod_test_data::jeod_path();
     let lp150q_path = jeod_root.join("models/environment/gravity/data/src/moon_LP150Q.cc");
     let sh_data =
-        jeod_sim::coefficients::load_from_jeod_cc(&lp150q_path).expect("load LP150Q coefficients");
+        jeod_test_data::jeod_cc::load_from_jeod_cc(&lp150q_path).expect("load LP150Q coefficients");
     let moon_mu = sh_data.mu;
 
     // Moon rotation from DE421 BPC libration data, updated per step.

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_extended.rs
@@ -31,7 +31,7 @@ fn load_mu_earth() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C")

--- a/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mars_orbit.rs
@@ -21,7 +21,7 @@ fn load_mu_sun() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
     )
     .expect("load Sun mu from sun_spherical")
@@ -83,7 +83,7 @@ fn tier3_simulation_mars_dawn() {
     let jeod_root = jeod_test_data::jeod_path();
     let mro_path = jeod_root.join("models/environment/gravity/data/src/mars_MRO110B2.cc");
     let sh_data =
-        jeod_sim::coefficients::load_from_jeod_cc(&mro_path).expect("load MRO110B2 coefficients");
+        jeod_test_data::jeod_cc::load_from_jeod_cc(&mro_path).expect("load MRO110B2 coefficients");
     let mars_mu = sh_data.mu;
 
     // Dawn epoch: 2009-02-17 23:00:00 UTC

--- a/crates/jeod_runner/tests/tier3_sim_mercury.rs
+++ b/crates/jeod_runner/tests/tier3_sim_mercury.rs
@@ -25,7 +25,7 @@ fn load_mu_sun() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/sun_spherical.cc"),
     )
     .expect("load Sun mu from sun_spherical")

--- a/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem_comprehensive.rs
@@ -23,7 +23,7 @@ fn load_mu_earth() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C")

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_docker.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_docker.rs
@@ -101,7 +101,7 @@ fn assert_orbinit_match(
 ) {
     let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
     let mu_earth =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
             .expect("load Earth mu from earth_GGM05C.cc");
 
     // Load JEOD orbital elements input (from input.py -> Modified_data/*.py).

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_edge.rs
@@ -29,7 +29,7 @@ fn tier3_simulation_orbinit_cross_consistency() {
 
     let grav_data_dir = jeod_root.join("models/environment/gravity/data/src");
     let mu_earth =
-        jeod_sim::coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
             .expect("load Earth mu");
 
     let runs: Vec<(&str, &str)> = vec![

--- a/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_relative_extended.rs
@@ -37,7 +37,7 @@ fn load_mu_earth() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C")

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_extended.rs
@@ -36,7 +36,7 @@ fn load_mu_earth() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
     )
     .expect("load Earth mu from GGM05C")

--- a/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
+++ b/crates/jeod_runner/tests/tier3_sim_time_reversal.rs
@@ -22,7 +22,7 @@ fn load_mu_earth_gemt1() -> f64 {
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_sim::coefficients::load_mu_from_jeod_cc(
+    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
         &jeod_root.join("models/environment/gravity/data/src/earth_GEMT1.cc"),
     )
     .expect("load Earth mu from GEMT1")

--- a/crates/jeod_sim/Cargo.toml
+++ b/crates/jeod_sim/Cargo.toml
@@ -8,6 +8,16 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# `jeod-source` exposes verification helpers that read from a JEOD source
+# checkout (`$JEOD_HOME` / `$JEOD_PATH`) — currently the
+# `recipes::verification::reference_data` loaders that parse `.cc`
+# gravity files via `jeod_test_data::jeod_cc`. Off by default so
+# downstream mission crates don't pull `jeod_test_data` (a dev-flavored
+# crate) into their production build. Verification rigs in
+# `jeod_runner` enable this feature.
+jeod-source = ["dep:jeod_test_data"]
+
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
 jeod_math = { path = "../jeod_math", version = "0.1.0" }
@@ -19,6 +29,11 @@ jeod_atmosphere = { path = "../jeod_atmosphere", version = "0.1.0" }
 jeod_interactions = { path = "../jeod_interactions", version = "0.1.0" }
 jeod_ephemeris = { path = "../jeod_ephemeris", version = "0.1.0" }
 jeod_planet = { path = "../jeod_planet", version = "0.1.0" }
+# Optional: only pulled in when the `jeod-source` feature is enabled.
+# Used by `recipes::verification::reference_data` for parsing JEOD `.cc`
+# coefficient files. `jeod_test_data` is the dev/test-data crate; this
+# is the single non-dev consumer.
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0", optional = true }
 glam = { workspace = true }
 log = { workspace = true }
 uom = { workspace = true }

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -160,7 +160,10 @@ pub use jeod_frames::rotation_moon;
 // jeod_ephemeris: ephemeris data
 pub use jeod_ephemeris::{Ephemeris, EphemerisBody};
 
-// jeod_gravity: coefficient loading (for test/data infrastructure)
+// jeod_gravity: binary coefficient loading. The JEOD `.cc` source-file
+// parser (`load_from_jeod_cc`, `load_mu_from_jeod_cc`) lives in the
+// dev/test crate `jeod_test_data::jeod_cc` — production gravity does
+// not parse JEOD source.
 pub use jeod_gravity::coefficients;
 pub use jeod_gravity::relativistic;
 

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -26,6 +26,7 @@
 //! trait also dispatches on the [`CsvReference`] variant, calling the
 //! matching loader from `jeod_test_data::tier3_csv`.
 
+#[cfg(feature = "jeod-source")]
 pub mod reference_data;
 
 use glam::{DQuat, DVec3};

--- a/crates/jeod_sim/src/recipes/verification/mod.rs
+++ b/crates/jeod_sim/src/recipes/verification/mod.rs
@@ -27,7 +27,17 @@
 //! matching loader from `jeod_test_data::tier3_csv`.
 
 #[cfg(feature = "jeod-source")]
+#[path = "reference_data.rs"]
 pub mod reference_data;
+
+/// Stub `reference_data` module used when JEOD-source-backed loaders are
+/// unavailable.
+///
+/// Keeps the public `verification::reference_data` path present for
+/// rustdoc and intra-doc links in builds that do not enable the
+/// `jeod-source` feature.
+#[cfg(not(feature = "jeod-source"))]
+pub mod reference_data {}
 
 use glam::{DQuat, DVec3};
 use uom::si::f64::Time;

--- a/crates/jeod_sim/src/recipes/verification/reference_data.rs
+++ b/crates/jeod_sim/src/recipes/verification/reference_data.rs
@@ -15,8 +15,8 @@
 
 use std::path::{Path, PathBuf};
 
-use jeod_gravity::coefficients::load_from_jeod_cc;
 use jeod_gravity::SphericalHarmonicsData;
+use jeod_test_data::jeod_cc::load_from_jeod_cc;
 
 use crate::sources::GravitySourceEntry;
 use crate::{EARTH, MARS, MOON};

--- a/crates/jeod_test_data/Cargo.toml
+++ b/crates/jeod_test_data/Cargo.toml
@@ -10,6 +10,12 @@ repository.workspace = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }
+# `jeod_gravity` is a one-way dep here so the `jeod_cc` parser can return
+# `SphericalHarmonicsData`. `jeod_gravity` itself does NOT depend on
+# `jeod_test_data` (would be a cycle); the production crate is unaware
+# the parser exists.
+jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
 glam = { workspace = true }
 regex = "1"
+thiserror = { workspace = true }
 uom = { workspace = true }

--- a/crates/jeod_test_data/src/body_init_fixtures.rs
+++ b/crates/jeod_test_data/src/body_init_fixtures.rs
@@ -1,0 +1,1 @@
+// Populated by issue #235.

--- a/crates/jeod_test_data/src/gravity_fixtures.rs
+++ b/crates/jeod_test_data/src/gravity_fixtures.rs
@@ -1,0 +1,1 @@
+// Populated by issue #234.

--- a/crates/jeod_test_data/src/jeod_cc.rs
+++ b/crates/jeod_test_data/src/jeod_cc.rs
@@ -1,0 +1,237 @@
+//! JEOD C++ source file parsers for gravity coefficient files.
+//!
+//! These parsers exist exclusively to populate test fixtures and Tier 3
+//! verification data from a JEOD source checkout (`$JEOD_HOME` /
+//! `$JEOD_PATH`). Production gravity code in `jeod_gravity` consumes the
+//! compact binary format (`load_binary` / `load_binary_from_bytes`)
+//! produced by `save_binary`, which is generated from these parsers as a
+//! one-time test-data step.
+//!
+//! Parsing JEOD's `.cc` files is therefore a *test/data* concern, not a
+//! production capability — keeping it here preserves the principle that
+//! `jeod_gravity` is a self-contained physics crate with no knowledge of
+//! the original C++ source layout.
+
+use std::path::Path;
+
+use jeod_gravity::SphericalHarmonicsData;
+
+/// Errors from parsing a JEOD C++ gravity data file.
+#[derive(Debug, thiserror::Error)]
+pub enum CoeffLoadError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("missing field '{field}' in {path}")]
+    MissingField { field: &'static str, path: String },
+}
+
+/// Load only the gravitational parameter (mu) from a JEOD C++ gravity data file.
+///
+/// Works with any JEOD gravity file including spherical-only files (like
+/// `sun_spherical.cc`, `moon_spherical.cc`) that lack `degree`/`order` fields.
+///
+/// Returns mu in m³/s².
+pub fn load_mu_from_jeod_cc(path: &Path) -> Result<f64, CoeffLoadError> {
+    let content = std::fs::read_to_string(path)?;
+    let path_str = path.display().to_string();
+
+    for line in content.lines() {
+        if let Some(val) = extract_assign_f64(line.trim(), "mu") {
+            return Ok(val);
+        }
+    }
+
+    Err(CoeffLoadError::MissingField {
+        field: "mu",
+        path: path_str,
+    })
+}
+
+/// Load spherical harmonics coefficients from a JEOD C++ data file.
+///
+/// Parses files like `earth_GGM05C.cc` that contain lines of the form:
+/// ```text
+/// ...->degree = 360;
+/// ...->order = 360;
+/// ...->mu = 398600.44150E+09;
+/// ...->radius = 6378136.30;
+/// ...->tide_free = false;
+/// ...->tide_free_delta = 4.173E-9;
+/// ...->Cnm[2] = JEOD_ALLOC_PRIM_ARRAY(3, double);
+/// ...->Cnm[2][0] = -4.8416945732000E-04;
+/// ...->Snm[2][0] = 0.0;
+/// ```
+pub fn load_from_jeod_cc(path: &Path) -> Result<SphericalHarmonicsData, CoeffLoadError> {
+    let content = std::fs::read_to_string(path)?;
+    let path_str = path.display().to_string();
+
+    let mut degree: Option<usize> = None;
+    let mut order: Option<usize> = None;
+    let mut mu: Option<f64> = None;
+    let mut radius: Option<f64> = None;
+    let mut tide_free: Option<bool> = None;
+    let mut tide_free_delta: Option<f64> = None;
+
+    // First pass: extract metadata
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(val) = extract_assign_usize(line, "degree") {
+            degree = Some(val);
+        }
+        if let Some(val) = extract_assign_usize(line, "order") {
+            order = Some(val);
+        }
+        if let Some(val) = extract_assign_f64(line, "mu") {
+            mu = Some(val);
+        }
+        if let Some(val) = extract_assign_f64(line, "radius") {
+            radius = Some(val);
+        }
+        if line.contains("tide_free") && !line.contains("tide_free_delta") {
+            if line.contains("true") {
+                tide_free = Some(true);
+            } else if line.contains("false") {
+                tide_free = Some(false);
+            }
+        }
+        if let Some(val) = extract_assign_f64(line, "tide_free_delta") {
+            tide_free_delta = Some(val);
+        }
+    }
+
+    let degree = degree.ok_or_else(|| CoeffLoadError::MissingField {
+        field: "degree",
+        path: path_str.clone(),
+    })?;
+    let order = order.ok_or_else(|| CoeffLoadError::MissingField {
+        field: "order",
+        path: path_str.clone(),
+    })?;
+    let mu = mu.ok_or_else(|| CoeffLoadError::MissingField {
+        field: "mu",
+        path: path_str.clone(),
+    })?;
+    let radius = radius.ok_or(CoeffLoadError::MissingField {
+        field: "radius",
+        path: path_str,
+    })?;
+    let tide_free = tide_free.unwrap_or(true);
+    let tide_free_delta = tide_free_delta.unwrap_or(0.0);
+
+    // Allocate coefficient arrays
+    let mut cnm: Vec<Vec<f64>> = Vec::with_capacity(degree + 1);
+    let mut snm: Vec<Vec<f64>> = Vec::with_capacity(degree + 1);
+    for n in 0..=degree {
+        cnm.push(vec![0.0; n + 1]);
+        snm.push(vec![0.0; n + 1]);
+    }
+
+    // Second pass: extract coefficients
+    // Patterns: ->Cnm[n][m] = value; and ->Snm[n][m] = value;
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some((n, m, val)) = extract_coeff(line, "Cnm") {
+            if n <= degree && m <= n {
+                cnm[n][m] = val;
+            }
+        }
+        if let Some((n, m, val)) = extract_coeff(line, "Snm") {
+            if n <= degree && m <= n {
+                snm[n][m] = val;
+            }
+        }
+    }
+
+    Ok(SphericalHarmonicsData::new(
+        degree,
+        order,
+        radius,
+        mu,
+        cnm,
+        snm,
+        tide_free,
+        tide_free_delta,
+    ))
+}
+
+// --- Helper functions ---
+
+fn extract_assign_usize(line: &str, key: &str) -> Option<usize> {
+    // Match: ->key = value; or ptr->key = value;
+    let pattern = format!("->{} = ", key);
+    if let Some(idx) = line.find(&pattern) {
+        let rest = &line[idx + pattern.len()..];
+        let val_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        val_str.parse().ok()
+    } else {
+        None
+    }
+}
+
+fn extract_assign_f64(line: &str, key: &str) -> Option<f64> {
+    // Match: ->key = value; with possible scientific notation or multiplication.
+    // Handles: `->mu = 398600.44150E+09;`
+    //          `->mu = 1000000000 * (4902.801076);`
+    let pattern = format!("->{} = ", key);
+    if let Some(idx) = line.find(&pattern) {
+        let rest = &line[idx + pattern.len()..];
+        // Extract up to semicolon, then evaluate
+        let expr: String = rest.chars().take_while(|c| *c != ';').collect();
+        eval_simple_expr(&expr)
+    } else {
+        None
+    }
+}
+
+/// Evaluate a simple numeric expression: a single f64, or `a * (b)` multiplication.
+fn eval_simple_expr(expr: &str) -> Option<f64> {
+    let expr = expr.trim();
+    // Try direct parse first
+    if let Ok(val) = expr.parse::<f64>() {
+        return Some(val);
+    }
+    // Try multiplication: "A * (B)" or "A * B"
+    if let Some(star_idx) = expr.find('*') {
+        let lhs = expr[..star_idx].trim();
+        let rhs = expr[star_idx + 1..]
+            .trim()
+            .trim_matches(|c| c == '(' || c == ')');
+        if let (Ok(a), Ok(b)) = (lhs.parse::<f64>(), rhs.trim().parse::<f64>()) {
+            return Some(a * b);
+        }
+    }
+    None
+}
+
+fn extract_coeff(line: &str, name: &str) -> Option<(usize, usize, f64)> {
+    // Match: ->Cnm[n][m] = value;
+    let prefix = format!("{}[", name);
+    let start = line.find(&prefix)?;
+    let rest = &line[start + prefix.len()..];
+
+    // Parse n
+    let n_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let n: usize = n_str.parse().ok()?;
+
+    // Find ][m]
+    let bracket_pos = rest.find("][")?;
+    let after_bracket = &rest[bracket_pos + 2..];
+    let m_str: String = after_bracket
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let m: usize = m_str.parse().ok()?;
+
+    // Find = value
+    let eq_pos = after_bracket.find('=')?;
+    let val_rest = after_bracket[eq_pos + 1..].trim();
+    let val_str: String = val_rest
+        .chars()
+        .take_while(|c| {
+            *c == '-' || *c == '+' || *c == '.' || *c == 'E' || *c == 'e' || c.is_ascii_digit()
+        })
+        .collect();
+    let val: f64 = val_str.parse().ok()?;
+
+    Some((n, m, val))
+}

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -58,12 +58,16 @@ pub use jeod_quantities::prelude::*;
 
 pub mod apollo_mass_tree;
 pub mod atmosphere_verif;
+pub mod body_init_fixtures; // populated by issue #235
 pub mod crossval;
 pub mod dyncomp_csv;
 pub mod euler_test;
 pub mod gravity_control;
+pub mod gravity_fixtures; // populated by issue #234
 pub mod gravity_verif;
+pub mod jeod_cc;
 pub mod leap_second;
+pub mod mars_fixtures; // populated by issue #236
 pub mod mass_data;
 pub mod orbital_data;
 pub mod orbital_init;

--- a/crates/jeod_test_data/src/mars_fixtures.rs
+++ b/crates/jeod_test_data/src/mars_fixtures.rs
@@ -1,0 +1,1 @@
+// Populated by issue #236.

--- a/tests/bevy_parity_highfidelity.rs
+++ b/tests/bevy_parity_highfidelity.rs
@@ -35,7 +35,7 @@ fn tier3_bevy_sh4x4_rnp() {
         "GGM02C coefficients not found at {}",
         ggm02c_path.display()
     );
-    let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C");
+    let sh_data = jeod_test_data::jeod_cc::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C");
     let mu = sh_data.mu;
 
     let sh_source = GravitySource {
@@ -125,7 +125,7 @@ fn tier3_bevy_tidal_sh4x4() {
         "GGM02C coefficients not found at {}",
         ggm02c_path.display()
     );
-    let sh_data = jeod_sim::coefficients::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C");
+    let sh_data = jeod_test_data::jeod_cc::load_from_jeod_cc(&ggm02c_path).expect("load GGM02C");
     let mu = sh_data.mu;
     let radius = sh_data.radius;
 


### PR DESCRIPTION
## Summary

Foundation step for parent issue #232 (phase out `JEOD_HOME` from test runtime). Closes #233.

- Move `load_from_jeod_cc`, `load_mu_from_jeod_cc`, `CoeffLoadError`, and the private parsing helpers (`extract_assign_usize`, `extract_assign_f64`, `eval_simple_expr`, `extract_coeff`) from `crates/jeod_gravity/src/coefficients.rs` into a new `crates/jeod_test_data/src/jeod_cc.rs`. Production gravity no longer knows how to parse JEOD `.cc` source files.
- Production types stay put: `SphericalHarmonicsData`, `save_binary`, `load_binary`, `load_binary_from_bytes` remain in `jeod_gravity::coefficients`. The binary path (`load_binary_from_bytes`) is the production code path that consumes parser output.
- Update all callers (~28 files) across `jeod_gravity` tests, `jeod_runner` tests, the six `run_verification/sim_*.rs` rigs (`sim_derived_state`, `sim_dyncomp`, `sim_planetary`, `sim_polar_motion`, `sim_solar_beta`, `sim_srp`, `sim_tide_verif`, `sim_torque_simple`), `jeod_sim::recipes::verification::reference_data`, and `tests/bevy_parity_highfidelity.rs`.
- **Pre-create `pub mod` stubs** for `gravity_fixtures`, `body_init_fixtures`, `mars_fixtures` in `jeod_test_data/src/lib.rs` so Wave 1 sub-issues (#234, #235, #236) can develop in parallel worktrees without conflicting on `lib.rs`.
- No production gravity behavior changes; this is an import-rewiring refactor.

This is **Wave 0** of #232's parallel-worktree rollout. After this lands, Wave 1 (#234, #235, #236) can run as 3 parallel worktrees branched off `main`. Wave 2 (#237, #238) and Wave 3 (#239) follow.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 788 passed, 312 tier3 skipped (refactor preserves call signatures; tier3 will keep working since they call the same functions, just imported from a different path)
- [ ] CI runs the full Tier 3 suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)