### PR TITLE
[#235] Commit body_init + jeod_math reference fixtures (#232 Wave 1)

### DIFF
--- a/crates/jeod_dynamics/src/body_init.rs
+++ b/crates/jeod_dynamics/src/body_init.rs
@@ -391,20 +391,14 @@ mod tests {
 
     #[test]
     fn iss_reference_state_from_elements() {
-        let root = jeod_test_data::jeod_path();
-        assert!(
-            root.exists(),
-            "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
-            root.display()
-        );
-
+        // Inputs come from the committed `test_data/body_init/iss.json`
+        // fixture (regenerated via the `extract_body_init` binary), not
+        // `$JEOD_HOME` at runtime.
         let init = jeod_test_data::orbital_init::load_orbital_init(
-            &root,
             "ISS",
             "trans_Orbit_inertial_body_set01",
         );
-        let expected =
-            jeod_test_data::reference_state::load_reference_state(&root, "ISS", "inertial");
+        let expected = jeod_test_data::reference_state::load_reference_state("ISS", "inertial");
 
         // ISS set01 uses SmaEccIncAscnodeArgperTimeperi.
         let t_peri = init

--- a/crates/jeod_dynamics/tests/tier2_body_init.rs
+++ b/crates/jeod_dynamics/tests/tier2_body_init.rs
@@ -1,7 +1,9 @@
 //! Tier 2: Validate body initialization from orbital elements against
 //! ISS reference state from JEOD verification data.
 //!
-//! Requires JEOD_HOME (or JEOD_PATH) set to the JEOD source checkout.
+//! Inputs come from the committed `test_data/body_init/iss.json` fixture
+//! (regenerated via `cargo run -p jeod_test_data --bin extract_body_init`),
+//! so this test no longer requires `JEOD_HOME` / `JEOD_PATH` at runtime.
 //!
 //! Tests exercise three JEOD element set parameterizations, all describing
 //! the same ISS orbit at STS-114 MET 001:19:30:59.000:
@@ -22,21 +24,9 @@ use jeod_dynamics::{
 /// Sourced from `jeod_planet::presets::EARTH.mu`.
 const EARTH_MU: f64 = jeod_planet::presets::EARTH.mu;
 
-/// Load the JEOD path, panicking with a clear message if not available.
-fn jeod_root() -> std::path::PathBuf {
-    let root = jeod_test_data::jeod_path();
-    assert!(
-        root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH \
-         to the JEOD source checkout (e.g. ../jeod).",
-        root.display()
-    );
-    root
-}
-
 /// Load the ISS inertial reference state (position + velocity in ECI).
-fn load_iss_reference(root: &std::path::Path) -> TranslationalState {
-    let ref_state = jeod_test_data::reference_state::load_reference_state(root, "ISS", "inertial");
+fn load_iss_reference() -> TranslationalState {
+    let ref_state = jeod_test_data::reference_state::load_reference_state("ISS", "inertial");
     TranslationalState {
         position: ref_state.position,
         velocity: ref_state.velocity,
@@ -94,13 +84,9 @@ fn print_comparison(
 
 #[test]
 fn iss_set01_time_periapsis() {
-    let root = jeod_root();
-    let init = jeod_test_data::orbital_init::load_orbital_init(
-        &root,
-        "ISS",
-        "trans_Orbit_inertial_body_set01",
-    );
-    let expected = load_iss_reference(&root);
+    let init =
+        jeod_test_data::orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set01");
+    let expected = load_iss_reference();
 
     // set01 provides time_periapsis — use the dedicated ported function,
     // which matches JEOD dyn_body_init_orbit.cc:295 exactly.
@@ -149,13 +135,9 @@ fn iss_set01_time_periapsis() {
 
 #[test]
 fn iss_set02_mean_anomaly() {
-    let root = jeod_root();
-    let init = jeod_test_data::orbital_init::load_orbital_init(
-        &root,
-        "ISS",
-        "trans_Orbit_inertial_body_set02",
-    );
-    let expected = load_iss_reference(&root);
+    let init =
+        jeod_test_data::orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set02");
+    let expected = load_iss_reference();
 
     let mean_anomaly = init.mean_anomaly.expect("ISS set02 must have mean_anomaly");
 
@@ -200,13 +182,9 @@ fn iss_set02_mean_anomaly() {
 
 #[test]
 fn iss_set10_true_anomaly() {
-    let root = jeod_root();
-    let init = jeod_test_data::orbital_init::load_orbital_init(
-        &root,
-        "ISS",
-        "trans_Orbit_inertial_body_set10",
-    );
-    let expected = load_iss_reference(&root);
+    let init =
+        jeod_test_data::orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set10");
+    let expected = load_iss_reference();
 
     let true_anomaly = init.true_anomaly.expect("ISS set10 must have true_anomaly");
 
@@ -252,14 +230,9 @@ fn iss_set10_true_anomaly() {
 
 #[test]
 fn iss_element_sets_cross_consistent() {
-    let root = jeod_root();
-
     // set01: time_periapsis -> mean anomaly -> Cartesian (via the ported helper).
-    let init01 = jeod_test_data::orbital_init::load_orbital_init(
-        &root,
-        "ISS",
-        "trans_Orbit_inertial_body_set01",
-    );
+    let init01 =
+        jeod_test_data::orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set01");
     let state01 = init_from_time_periapsis(
         init01.semi_major_axis,
         init01.eccentricity,
@@ -271,11 +244,8 @@ fn iss_element_sets_cross_consistent() {
     );
 
     // set02: mean anomaly (directly) -> Cartesian
-    let init02 = jeod_test_data::orbital_init::load_orbital_init(
-        &root,
-        "ISS",
-        "trans_Orbit_inertial_body_set02",
-    );
+    let init02 =
+        jeod_test_data::orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set02");
     let state02 = init_from_mean_anomaly(
         init02.semi_major_axis,
         init02.eccentricity,
@@ -287,11 +257,8 @@ fn iss_element_sets_cross_consistent() {
     );
 
     // set10: true anomaly (directly) -> Cartesian
-    let init10 = jeod_test_data::orbital_init::load_orbital_init(
-        &root,
-        "ISS",
-        "trans_Orbit_inertial_body_set10",
-    );
+    let init10 =
+        jeod_test_data::orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set10");
     let state10 = init_from_orbital_elements(
         init10.semi_major_axis,
         init10.eccentricity,

--- a/crates/jeod_math/tests/jeod_validation.rs
+++ b/crates/jeod_math/tests/jeod_validation.rs
@@ -1,6 +1,10 @@
 //! Validate orbital elements and quaternion math against JEOD verification data.
 //!
-//! Requires the JEOD source tree (via `JEOD_HOME` or `JEOD_PATH` env var).
+//! The body-init tests (ISS reference state and orbital_init parser) read
+//! from the committed `test_data/body_init/iss.json` fixture and run without
+//! `$JEOD_HOME`. The orbital_data (5001-vector roundtrip) and euler_test
+//! tests still read JEOD source directly via `jeod_path()` and require
+//! `$JEOD_HOME` / `$JEOD_PATH`; their migration is tracked separately.
 
 use jeod_math::JeodQuat;
 use jeod_math::OrbitalElements;
@@ -16,15 +20,10 @@ const MU_EARTH: f64 = jeod_planet::presets::EARTH.mu;
 
 #[test]
 fn validate_iss_orbital_elements_to_cartesian() {
-    let root = jeod_path();
-    assert!(
-        root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
-        root.display()
-    );
-
-    let init = orbital_init::load_orbital_init(&root, "ISS", "trans_Orbit_inertial_body_set01");
-    let expected = reference_state::load_reference_state(&root, "ISS", "inertial");
+    // Inputs come from the committed `test_data/body_init/iss.json` fixture,
+    // not `$JEOD_HOME` at runtime.
+    let init = orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set01");
+    let expected = reference_state::load_reference_state("ISS", "inertial");
 
     // Verify parsed values are sensible
     assert!(
@@ -109,14 +108,9 @@ fn validate_iss_orbital_elements_to_cartesian() {
 
 #[test]
 fn validate_iss_reference_state_parsing() {
-    let root = jeod_path();
-    assert!(
-        root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
-        root.display()
-    );
-
-    let state = reference_state::load_reference_state(&root, "ISS", "inertial");
+    // Inputs come from the committed `test_data/body_init/iss.json` fixture,
+    // not `$JEOD_HOME` at runtime.
+    let state = reference_state::load_reference_state("ISS", "inertial");
 
     // Cross-check against known values from the file
     assert!(
@@ -393,14 +387,9 @@ fn validate_euler_matrix_from_jeod() {
 
 #[test]
 fn validate_orbital_init_parser() {
-    let root = jeod_path();
-    assert!(
-        root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
-        root.display()
-    );
-
-    let init = orbital_init::load_orbital_init(&root, "ISS", "trans_Orbit_inertial_body_set01");
+    // Inputs come from the committed `test_data/body_init/iss.json` fixture,
+    // not `$JEOD_HOME` at runtime.
+    let init = orbital_init::load_orbital_init("ISS", "trans_Orbit_inertial_body_set01");
 
     // Cross-check parsed values against known file contents
     let deg2rad = std::f64::consts::PI / 180.0;

--- a/crates/jeod_runner/tests/tier3_sim_orbinit_docker.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbinit_docker.rs
@@ -104,8 +104,9 @@ fn assert_orbinit_match(
         jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
             .expect("load Earth mu from earth_GGM05C.cc");
 
-    // Load JEOD orbital elements input (from input.py -> Modified_data/*.py).
-    let init = jeod_test_data::orbital_init::load_orbital_init(jeod_root, vehicle, init_name);
+    // Load JEOD orbital elements input from the committed body_init fixture
+    // (originally extracted from Modified_data/<vehicle>/<init_name>.py).
+    let init = jeod_test_data::orbital_init::load_orbital_init(vehicle, init_name);
 
     // JEOD input.py for set01 uses time_periapsis (M = n * t_peri).
     let t_peri = init
@@ -302,21 +303,12 @@ fn tier3_orbinit_docker_run0301_sts_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0401_sts_trans_state() {
-    let jeod_root = jeod_test_data::jeod_path();
-    assert!(
-        jeod_root.exists(),
-        "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
-        jeod_root.display()
-    );
-
     // RUN_0401 uses DynBodyInitTransState (direct Cartesian input in inertial).
     // The JEOD input.py sets position and velocity directly; initialization
-    // should be a pass-through to the body state.
-    let trans = jeod_test_data::orbital_init::load_trans_state(
-        &jeod_root,
-        "STS_114",
-        "trans_TransState_inertial_body",
-    );
+    // should be a pass-through to the body state. Inputs come from the
+    // committed `test_data/body_init/sts_114.json` fixture.
+    let trans =
+        jeod_test_data::orbital_init::load_trans_state("STS_114", "trans_TransState_inertial_body");
     let expected = TranslationalState {
         position: DVec3::from_array(trans.position),
         velocity: DVec3::from_array(trans.velocity),

--- a/crates/jeod_test_data/src/bin/extract_body_init.rs
+++ b/crates/jeod_test_data/src/bin/extract_body_init.rs
@@ -27,9 +27,11 @@
 //!   `trans_TransState_inertial_body.py`        — direct Cartesian (STS_114 only)
 //!
 //! Scenarios extracted: `ISS`, `STS_114`. Each scenario writes a single
-//! `test_data/body_init/<vehicle>.json` containing every record above
-//! that exists in the JEOD source tree (missing files are skipped without
-//! erroring — not every vehicle defines every record).
+//! `test_data/body_init/<vehicle>.json`. The `reference_inertial` and
+//! `trans_state` files listed in `SCENARIOS` are required and the binary
+//! errors loudly if they are missing (per CLAUDE.md "Fail Loudly"); the
+//! per-orbit `set01/set02/set10/pfix_set01` files are optional and skipped
+//! when absent (not every vehicle defines every orbit form).
 //!
 //! The schema follows the no-`serde_json` style used elsewhere in this
 //! crate (see `planet_geodetic_verif.rs`); the JSON is hand-written and
@@ -211,7 +213,6 @@ fn write_bundle(out: &mut std::fs::File, bundle: &ScenarioBundle) {
         bundle.vehicle,
     )
     .unwrap();
-    writeln!(out, "  \"jeod_version\": \"5.4\",").unwrap();
     writeln!(
         out,
         "  \"note\": \"Body initialization vectors. Regenerate with: cargo run -p jeod_test_data \

--- a/crates/jeod_test_data/src/bin/extract_body_init.rs
+++ b/crates/jeod_test_data/src/bin/extract_body_init.rs
@@ -1,0 +1,339 @@
+//! Extract JEOD `Modified_data/*.py` body-initialization vectors into
+//! committed fixtures under `test_data/body_init/<vehicle>.json`.
+//!
+//! This is a **regen-only** path: it reads `$JEOD_HOME` (or `$JEOD_PATH`,
+//! or an explicit `--jeod-home <PATH>` argument), parses the body-init
+//! Python files for each scenario, and writes the JSON consumed by
+//! `jeod_test_data::reference_state::*` and
+//! `jeod_test_data::orbital_init::*` at runtime.
+//!
+//! Run after a JEOD upgrade or whenever a scenario file is added/amended:
+//!
+//! ```bash
+//! cargo run -p jeod_test_data --bin extract_body_init -- \
+//!     --jeod-home /path/to/jeod
+//! ```
+//!
+//! ## Sources of record (audit list)
+//!
+//! Per scenario, the binary parses:
+//!
+//! - `models/dynamics/body_action/verif/SIM_orbinit/Modified_data/<vehicle>/`
+//!   `reference_inertial_trans_state.py`        — ECI reference state
+//!   `trans_Orbit_inertial_body_set01.py`       — orbit (sma/ecc/inc/raan/argp/t_peri)
+//!   `trans_Orbit_inertial_body_set02.py`       — orbit (mean anomaly)
+//!   `trans_Orbit_inertial_body_set10.py`       — orbit (true anomaly)
+//!   `trans_Orbit_pfix_body_set01.py`           — pfix orbit (set01 form)
+//!   `trans_TransState_inertial_body.py`        — direct Cartesian (STS_114 only)
+//!
+//! Scenarios extracted: `ISS`, `STS_114`. Each scenario writes a single
+//! `test_data/body_init/<vehicle>.json` containing every record above
+//! that exists in the JEOD source tree (missing files are skipped without
+//! erroring — not every vehicle defines every record).
+//!
+//! The schema follows the no-`serde_json` style used elsewhere in this
+//! crate (see `planet_geodetic_verif.rs`); the JSON is hand-written and
+//! parsed back via `body_init_fixtures::parse_*` helpers.
+
+use std::io::Write;
+
+use jeod_test_data::body_init_fixtures::{
+    OrbitalInitRecord, ReferenceStateRecord, TransStateRecord,
+};
+use jeod_test_data::orbital_init::{parse_orbital_init_py, parse_trans_state_py};
+use jeod_test_data::reference_state::parse_reference_state_py;
+
+/// Vehicles and the init records to extract for each.
+const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        vehicle: "ISS",
+        reference_inertial: true,
+        orbit_inits: &[
+            "trans_Orbit_inertial_body_set01",
+            "trans_Orbit_inertial_body_set02",
+            "trans_Orbit_inertial_body_set10",
+            "trans_Orbit_pfix_body_set01",
+        ],
+        trans_states: &[],
+    },
+    Scenario {
+        vehicle: "STS_114",
+        reference_inertial: true,
+        orbit_inits: &[
+            "trans_Orbit_inertial_body_set01",
+            "trans_Orbit_pfix_body_set01",
+        ],
+        trans_states: &["trans_TransState_inertial_body"],
+    },
+];
+
+struct Scenario {
+    vehicle: &'static str,
+    reference_inertial: bool,
+    orbit_inits: &'static [&'static str],
+    trans_states: &'static [&'static str],
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let jeod_root = resolve_jeod_root(&args).unwrap_or_else(|| {
+        eprintln!(
+            "extract_body_init: JEOD source not found.\n\
+             Pass `--jeod-home <PATH>` or set JEOD_HOME / JEOD_PATH \
+             (see CLAUDE.md \"Environment Setup\")."
+        );
+        std::process::exit(2);
+    });
+
+    let body_init_root = body_init_dir();
+    std::fs::create_dir_all(&body_init_root).unwrap_or_else(|e| {
+        panic!("Cannot create {}: {e}", body_init_root.display());
+    });
+
+    for scenario in SCENARIOS {
+        let mut bundle = ScenarioBundle::new(scenario.vehicle);
+
+        if scenario.reference_inertial {
+            let path = jeod_root.join(format!(
+                "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/\
+                 reference_inertial_trans_state.py",
+                scenario.vehicle,
+            ));
+            let content = read_required(&path);
+            let state = parse_reference_state_py(&content).unwrap_or_else(|e| {
+                panic!(
+                    "extract_body_init: failed to parse reference state in {}: {e}",
+                    path.display()
+                );
+            });
+            bundle.reference_inertial = Some(state);
+        }
+
+        for init_name in scenario.orbit_inits {
+            let path = jeod_root.join(format!(
+                "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/{}.py",
+                scenario.vehicle, init_name,
+            ));
+            if !path.exists() {
+                continue;
+            }
+            let content = read_required(&path);
+            let init = parse_orbital_init_py(&content).unwrap_or_else(|e| {
+                panic!(
+                    "extract_body_init: failed to parse orbital init in {}: {e}",
+                    path.display()
+                );
+            });
+            bundle.orbital_inits.push((init_name.to_string(), init));
+        }
+
+        for init_name in scenario.trans_states {
+            let path = jeod_root.join(format!(
+                "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/{}.py",
+                scenario.vehicle, init_name,
+            ));
+            if !path.exists() {
+                continue;
+            }
+            let content = read_required(&path);
+            let trans = parse_trans_state_py(&content).unwrap_or_else(|e| {
+                panic!(
+                    "extract_body_init: failed to parse trans state in {}: {e}",
+                    path.display()
+                );
+            });
+            bundle.trans_states.push((init_name.to_string(), trans));
+        }
+
+        let out_path =
+            body_init_root.join(format!("{}.json", scenario.vehicle.to_ascii_lowercase()));
+        let mut f = std::fs::File::create(&out_path)
+            .unwrap_or_else(|e| panic!("Cannot create {}: {e}", out_path.display()));
+        write_bundle(&mut f, &bundle);
+        println!(
+            "wrote {} (reference_inertial={}, orbital_inits={}, trans_states={})",
+            out_path.display(),
+            bundle.reference_inertial.is_some(),
+            bundle.orbital_inits.len(),
+            bundle.trans_states.len(),
+        );
+    }
+}
+
+fn resolve_jeod_root(args: &[String]) -> Option<std::path::PathBuf> {
+    if let Some(idx) = args.iter().position(|a| a == "--jeod-home") {
+        if let Some(p) = args.get(idx + 1) {
+            return Some(std::path::PathBuf::from(p));
+        }
+    }
+    if let Ok(p) = std::env::var("JEOD_PATH") {
+        return Some(std::path::PathBuf::from(p));
+    }
+    if let Ok(p) = std::env::var("JEOD_HOME") {
+        return Some(std::path::PathBuf::from(p));
+    }
+    None
+}
+
+fn body_init_dir() -> std::path::PathBuf {
+    jeod_test_data::tier3_csv::test_data_path("body_init")
+}
+
+fn read_required(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("Cannot read {}: {e}", path.display()))
+}
+
+struct ScenarioBundle {
+    vehicle: &'static str,
+    reference_inertial: Option<ReferenceStateRecord>,
+    orbital_inits: Vec<(String, OrbitalInitRecord)>,
+    trans_states: Vec<(String, TransStateRecord)>,
+}
+
+impl ScenarioBundle {
+    fn new(vehicle: &'static str) -> Self {
+        Self {
+            vehicle,
+            reference_inertial: None,
+            orbital_inits: Vec::new(),
+            trans_states: Vec::new(),
+        }
+    }
+}
+
+fn write_bundle(out: &mut std::fs::File, bundle: &ScenarioBundle) {
+    writeln!(out, "{{").unwrap();
+    writeln!(out, "  \"schema_version\": 1,").unwrap();
+    writeln!(out, "  \"vehicle\": \"{}\",", bundle.vehicle).unwrap();
+    writeln!(
+        out,
+        "  \"source\": \"models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/\",",
+        bundle.vehicle,
+    )
+    .unwrap();
+    writeln!(out, "  \"jeod_version\": \"5.4\",").unwrap();
+    writeln!(
+        out,
+        "  \"note\": \"Body initialization vectors. Regenerate with: cargo run -p jeod_test_data \
+         --bin extract_body_init -- --jeod-home $JEOD_HOME\","
+    )
+    .unwrap();
+
+    // reference_inertial: an object or null.
+    write!(out, "  \"reference_inertial\": ").unwrap();
+    match &bundle.reference_inertial {
+        Some(s) => writeln!(
+            out,
+            "{{\"position\": [{}, {}, {}], \"velocity\": [{}, {}, {}]}},",
+            fmt(s.position[0]),
+            fmt(s.position[1]),
+            fmt(s.position[2]),
+            fmt(s.velocity[0]),
+            fmt(s.velocity[1]),
+            fmt(s.velocity[2]),
+        ),
+        None => writeln!(out, "null,"),
+    }
+    .unwrap();
+
+    // orbital_inits: array of {name, ...}.
+    writeln!(out, "  \"orbital_inits\": [").unwrap();
+    for (i, (name, init)) in bundle.orbital_inits.iter().enumerate() {
+        let comma = if i + 1 < bundle.orbital_inits.len() {
+            ","
+        } else {
+            ""
+        };
+        writeln!(out, "    {{").unwrap();
+        writeln!(out, "      \"name\": \"{}\",", name).unwrap();
+        writeln!(
+            out,
+            "      \"semi_major_axis\": {},",
+            fmt(init.semi_major_axis)
+        )
+        .unwrap();
+        writeln!(out, "      \"eccentricity\": {},", fmt(init.eccentricity)).unwrap();
+        writeln!(out, "      \"inclination\": {},", fmt(init.inclination)).unwrap();
+        writeln!(
+            out,
+            "      \"ascending_node\": {},",
+            fmt(init.ascending_node)
+        )
+        .unwrap();
+        writeln!(out, "      \"arg_periapsis\": {},", fmt(init.arg_periapsis)).unwrap();
+        writeln!(
+            out,
+            "      \"time_periapsis\": {},",
+            fmt_opt(init.time_periapsis),
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "      \"mean_anomaly\": {},",
+            fmt_opt(init.mean_anomaly),
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "      \"true_anomaly\": {},",
+            fmt_opt(init.true_anomaly),
+        )
+        .unwrap();
+        writeln!(out, "      \"planet_name\": \"{}\",", init.planet_name).unwrap();
+        writeln!(
+            out,
+            "      \"reference_frame\": \"{}\"",
+            init.reference_frame
+        )
+        .unwrap();
+        writeln!(out, "    }}{}", comma).unwrap();
+    }
+    writeln!(out, "  ],").unwrap();
+
+    // trans_states: array of {name, ...}.
+    writeln!(out, "  \"trans_states\": [").unwrap();
+    for (i, (name, t)) in bundle.trans_states.iter().enumerate() {
+        let comma = if i + 1 < bundle.trans_states.len() {
+            ","
+        } else {
+            ""
+        };
+        writeln!(out, "    {{").unwrap();
+        writeln!(out, "      \"name\": \"{}\",", name).unwrap();
+        writeln!(
+            out,
+            "      \"position\": [{}, {}, {}],",
+            fmt(t.position[0]),
+            fmt(t.position[1]),
+            fmt(t.position[2]),
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "      \"velocity\": [{}, {}, {}],",
+            fmt(t.velocity[0]),
+            fmt(t.velocity[1]),
+            fmt(t.velocity[2]),
+        )
+        .unwrap();
+        writeln!(out, "      \"reference_frame\": \"{}\"", t.reference_frame).unwrap();
+        writeln!(out, "    }}{}", comma).unwrap();
+    }
+    writeln!(out, "  ]").unwrap();
+
+    writeln!(out, "}}").unwrap();
+}
+
+/// Round-trippable f64 representation; `{x:?}` always emits a decimal point
+/// or exponent so the JSON literal parses unambiguously back to the same
+/// `f64`. (`{x}` would print `1` for `1.0` which would parse as integer.)
+fn fmt(x: f64) -> String {
+    format!("{x:?}")
+}
+
+fn fmt_opt(x: Option<f64>) -> String {
+    match x {
+        Some(v) => fmt(v),
+        None => "null".to_string(),
+    }
+}

--- a/crates/jeod_test_data/src/body_init_fixtures.rs
+++ b/crates/jeod_test_data/src/body_init_fixtures.rs
@@ -112,12 +112,14 @@ pub struct BodyInitBundle {
 
 /// Load a vehicle's body-init bundle from `test_data/body_init/<vehicle>.json`.
 ///
-/// The result is cached per process; calls after the first are constant-time
-/// `Arc`-clone equivalents (an internal `OnceLock` per vehicle).
+/// The result is cached per process via an internal `OnceLock` per vehicle;
+/// calls after the first are constant-time and return the same shared
+/// `&'static` reference.
 ///
 /// # Panics
-/// Panics if the fixture is missing or malformed; the message names the
-/// regen command per CLAUDE.md "Fail Loudly".
+/// Panics if the fixture is missing or malformed, or if the parsed bundle's
+/// `vehicle` field does not match the requested vehicle. The message names
+/// the regen command per CLAUDE.md "Fail Loudly".
 pub fn load_vehicle_bundle(vehicle: &str) -> &'static BodyInitBundle {
     let cache = bundle_cache(vehicle);
     cache.get_or_init(|| {
@@ -130,13 +132,24 @@ pub fn load_vehicle_bundle(vehicle: &str) -> &'static BodyInitBundle {
                 path.display(),
             )
         });
-        parse_bundle_json(&content).unwrap_or_else(|e| {
+        let bundle = parse_bundle_json(&content).unwrap_or_else(|e| {
             panic!(
                 "Malformed body-init fixture {}: {e}. Regenerate with: \
                  cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME",
                 path.display(),
             )
-        })
+        });
+        assert_eq!(
+            bundle.vehicle,
+            vehicle,
+            "body-init fixture {} contains vehicle {:?} but {:?} was requested. \
+             Regenerate with: cargo run -p jeod_test_data --bin extract_body_init -- \
+             --jeod-home $JEOD_HOME",
+            path.display(),
+            bundle.vehicle,
+            vehicle,
+        );
+        bundle
     })
 }
 
@@ -156,9 +169,24 @@ fn bundle_cache(vehicle: &str) -> &'static OnceLock<BodyInitBundle> {
     }
 }
 
+/// Schema version this code understands. Bumped whenever the on-disk
+/// JSON shape changes in a way the parser cannot accept.
+const EXPECTED_SCHEMA_VERSION: u64 = 1;
+
 /// Hand-rolled JSON parser for a body-init bundle. Mirrors the
 /// no-`serde_json` style of `planet_geodetic_verif.rs`.
 pub(crate) fn parse_bundle_json(s: &str) -> Result<BodyInitBundle, String> {
+    let schema_version = parse_num_field(s, "schema_version")
+        .ok_or_else(|| "missing top-level \"schema_version\" key".to_string())?
+        as u64;
+    if schema_version != EXPECTED_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported schema_version {schema_version}; this build expects \
+             {EXPECTED_SCHEMA_VERSION}. Regenerate with: cargo run -p jeod_test_data \
+             --bin extract_body_init -- --jeod-home $JEOD_HOME"
+        ));
+    }
+
     let vehicle = parse_str_field(s, "vehicle")
         .ok_or_else(|| "missing top-level \"vehicle\" key".to_string())?;
 
@@ -486,11 +514,27 @@ mod tests {
 
     #[test]
     fn parses_null_reference_inertial() {
-        let json = r#"{"vehicle": "X", "reference_inertial": null,
+        let json = r#"{"schema_version": 1, "vehicle": "X", "reference_inertial": null,
 "orbital_inits": [], "trans_states": []}"#;
         let b = parse_bundle_json(json).unwrap();
         assert!(b.reference_inertial.is_none());
         assert!(b.orbital_inits.is_empty());
         assert!(b.trans_states.is_empty());
+    }
+
+    #[test]
+    fn rejects_missing_schema_version() {
+        let json = r#"{"vehicle": "X", "reference_inertial": null,
+"orbital_inits": [], "trans_states": []}"#;
+        let err = parse_bundle_json(json).unwrap_err();
+        assert!(err.contains("schema_version"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_unknown_schema_version() {
+        let json = r#"{"schema_version": 999, "vehicle": "X", "reference_inertial": null,
+"orbital_inits": [], "trans_states": []}"#;
+        let err = parse_bundle_json(json).unwrap_err();
+        assert!(err.contains("unsupported schema_version 999"), "got: {err}");
     }
 }

--- a/crates/jeod_test_data/src/body_init_fixtures.rs
+++ b/crates/jeod_test_data/src/body_init_fixtures.rs
@@ -1,1 +1,496 @@
-// Populated by issue #235.
+//! Body initialization fixtures (committed JSON).
+//!
+//! Each `test_data/body_init/<vehicle>.json` file contains the body-init
+//! vectors for one JEOD scenario (`ISS`, `STS_114`, ...) extracted once
+//! from the `Modified_data/<vehicle>/*.py` files under
+//! `models/dynamics/body_action/verif/SIM_orbinit/`. Tests load these
+//! fixtures via the higher-level helpers in
+//! [`crate::reference_state`] and [`crate::orbital_init`]; the present
+//! module owns the JSON schema, hand-rolled parser, and per-vehicle bundle
+//! cache.
+//!
+//! Regenerate with:
+//!
+//! ```bash
+//! cargo run -p jeod_test_data --bin extract_body_init -- \
+//!     --jeod-home $JEOD_HOME
+//! ```
+//!
+//! ## Schema
+//!
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "vehicle": "ISS",
+//!   "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/ISS/",
+//!   "jeod_version": "5.4",
+//!   "note": "Body initialization vectors. Regenerate with: ...",
+//!   "reference_inertial": {"position": [...], "velocity": [...]} | null,
+//!   "orbital_inits": [
+//!     {"name": "trans_Orbit_inertial_body_set01",
+//!      "semi_major_axis": ..., "eccentricity": ..., "inclination": ...,
+//!      "ascending_node": ..., "arg_periapsis": ...,
+//!      "time_periapsis": ... | null,
+//!      "mean_anomaly":  ... | null,
+//!      "true_anomaly":  ... | null,
+//!      "planet_name": "Earth",
+//!      "reference_frame": "Earth.inertial"},
+//!     ...
+//!   ],
+//!   "trans_states": [
+//!     {"name": "trans_TransState_inertial_body",
+//!      "position": [..., ..., ...], "velocity": [..., ..., ...],
+//!      "reference_frame": "Earth.inertial"},
+//!     ...
+//!   ]
+//! }
+//! ```
+//!
+//! The parser is hand-rolled (no `serde_json`) to match the project-wide
+//! pattern in `planet_geodetic_verif.rs`, `tier3_baseline_diff.rs`, and
+//! `tier3_report.rs`. All numeric fields use Rust's `{x:?}` round-trippable
+//! `f64` rendering so re-parsing is bit-identical.
+
+use std::sync::OnceLock;
+
+/// Errors raised while parsing JEOD `.py` files (regen path) or the
+/// committed JSON fixtures (runtime path).
+#[derive(Debug, thiserror::Error)]
+pub enum BodyInitFixtureError {
+    #[error("malformed body-init data: {0}")]
+    Malformed(String),
+}
+
+impl BodyInitFixtureError {
+    pub(crate) fn malformed<S: Into<String>>(s: S) -> Self {
+        Self::Malformed(s.into())
+    }
+}
+
+/// One reference-state record (ECI position / velocity).
+#[derive(Debug, Clone)]
+pub struct ReferenceStateRecord {
+    pub position: [f64; 3],
+    pub velocity: [f64; 3],
+}
+
+/// One orbital-element init record (the JSON form; `reference_state.rs` and
+/// `orbital_init.rs` wrap this with their existing `OrbitalInitData` /
+/// `ReferenceState` types for compatibility with downstream tests).
+#[derive(Debug, Clone)]
+pub struct OrbitalInitRecord {
+    pub name: String,
+    pub semi_major_axis: f64,
+    pub eccentricity: f64,
+    pub inclination: f64,
+    pub ascending_node: f64,
+    pub arg_periapsis: f64,
+    pub time_periapsis: Option<f64>,
+    pub mean_anomaly: Option<f64>,
+    pub true_anomaly: Option<f64>,
+    pub planet_name: String,
+    pub reference_frame: String,
+}
+
+/// One direct-Cartesian init record.
+#[derive(Debug, Clone)]
+pub struct TransStateRecord {
+    pub name: String,
+    pub position: [f64; 3],
+    pub velocity: [f64; 3],
+    pub reference_frame: String,
+}
+
+/// Per-vehicle bundle as parsed from the JSON fixture.
+#[derive(Debug, Clone)]
+pub struct BodyInitBundle {
+    pub vehicle: String,
+    pub reference_inertial: Option<ReferenceStateRecord>,
+    pub orbital_inits: Vec<OrbitalInitRecord>,
+    pub trans_states: Vec<TransStateRecord>,
+}
+
+/// Load a vehicle's body-init bundle from `test_data/body_init/<vehicle>.json`.
+///
+/// The result is cached per process; calls after the first are constant-time
+/// `Arc`-clone equivalents (an internal `OnceLock` per vehicle).
+///
+/// # Panics
+/// Panics if the fixture is missing or malformed; the message names the
+/// regen command per CLAUDE.md "Fail Loudly".
+pub fn load_vehicle_bundle(vehicle: &str) -> &'static BodyInitBundle {
+    let cache = bundle_cache(vehicle);
+    cache.get_or_init(|| {
+        let filename = format!("body_init/{}.json", vehicle.to_ascii_lowercase());
+        let path = crate::tier3_csv::test_data_path(&filename);
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!(
+                "Cannot read {}: {e}. Regenerate with: cargo run -p jeod_test_data \
+                 --bin extract_body_init -- --jeod-home $JEOD_HOME",
+                path.display(),
+            )
+        });
+        parse_bundle_json(&content).unwrap_or_else(|e| {
+            panic!(
+                "Malformed body-init fixture {}: {e}. Regenerate with: \
+                 cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME",
+                path.display(),
+            )
+        })
+    })
+}
+
+/// Per-vehicle `OnceLock`. Vehicle list is small (ISS, STS_114) so a static
+/// match is simpler than a global `Mutex<HashMap>`.
+fn bundle_cache(vehicle: &str) -> &'static OnceLock<BodyInitBundle> {
+    static ISS: OnceLock<BodyInitBundle> = OnceLock::new();
+    static STS_114: OnceLock<BodyInitBundle> = OnceLock::new();
+
+    match vehicle {
+        "ISS" => &ISS,
+        "STS_114" => &STS_114,
+        other => panic!(
+            "load_vehicle_bundle: unknown vehicle {other:?}. \
+             Add it to extract_body_init.rs SCENARIOS and to body_init_fixtures::bundle_cache."
+        ),
+    }
+}
+
+/// Hand-rolled JSON parser for a body-init bundle. Mirrors the
+/// no-`serde_json` style of `planet_geodetic_verif.rs`.
+pub(crate) fn parse_bundle_json(s: &str) -> Result<BodyInitBundle, String> {
+    let vehicle = parse_str_field(s, "vehicle")
+        .ok_or_else(|| "missing top-level \"vehicle\" key".to_string())?;
+
+    // reference_inertial: object or `null`.
+    let reference_inertial = parse_object_field(s, "reference_inertial")?
+        .map(|inner| -> Result<ReferenceStateRecord, String> {
+            let position = parse_array3_field(inner, "position")
+                .ok_or_else(|| "reference_inertial: missing position".to_string())?;
+            let velocity = parse_array3_field(inner, "velocity")
+                .ok_or_else(|| "reference_inertial: missing velocity".to_string())?;
+            Ok(ReferenceStateRecord { position, velocity })
+        })
+        .transpose()?;
+
+    let orbital_init_entries = parse_array_field_entries(s, "orbital_inits")?;
+    let mut orbital_inits = Vec::with_capacity(orbital_init_entries.len());
+    for entry in orbital_init_entries {
+        orbital_inits.push(parse_orbital_init_entry(entry)?);
+    }
+
+    let trans_state_entries = parse_array_field_entries(s, "trans_states")?;
+    let mut trans_states = Vec::with_capacity(trans_state_entries.len());
+    for entry in trans_state_entries {
+        trans_states.push(parse_trans_state_entry(entry)?);
+    }
+
+    Ok(BodyInitBundle {
+        vehicle,
+        reference_inertial,
+        orbital_inits,
+        trans_states,
+    })
+}
+
+fn parse_orbital_init_entry(entry: &str) -> Result<OrbitalInitRecord, String> {
+    let name = parse_str_field(entry, "name")
+        .ok_or_else(|| format!("orbital_inits entry missing \"name\": {entry}"))?;
+    let semi_major_axis = parse_num_field(entry, "semi_major_axis")
+        .ok_or_else(|| format!("orbital_inits[{name}]: missing semi_major_axis"))?;
+    let eccentricity = parse_num_field(entry, "eccentricity")
+        .ok_or_else(|| format!("orbital_inits[{name}]: missing eccentricity"))?;
+    let inclination = parse_num_field(entry, "inclination")
+        .ok_or_else(|| format!("orbital_inits[{name}]: missing inclination"))?;
+    let ascending_node = parse_num_field(entry, "ascending_node")
+        .ok_or_else(|| format!("orbital_inits[{name}]: missing ascending_node"))?;
+    let arg_periapsis = parse_num_field(entry, "arg_periapsis")
+        .ok_or_else(|| format!("orbital_inits[{name}]: missing arg_periapsis"))?;
+    let time_periapsis = parse_opt_num_field(entry, "time_periapsis");
+    let mean_anomaly = parse_opt_num_field(entry, "mean_anomaly");
+    let true_anomaly = parse_opt_num_field(entry, "true_anomaly");
+    let planet_name = parse_str_field(entry, "planet_name").unwrap_or_default();
+    let reference_frame = parse_str_field(entry, "reference_frame").unwrap_or_default();
+
+    Ok(OrbitalInitRecord {
+        name,
+        semi_major_axis,
+        eccentricity,
+        inclination,
+        ascending_node,
+        arg_periapsis,
+        time_periapsis,
+        mean_anomaly,
+        true_anomaly,
+        planet_name,
+        reference_frame,
+    })
+}
+
+fn parse_trans_state_entry(entry: &str) -> Result<TransStateRecord, String> {
+    let name = parse_str_field(entry, "name")
+        .ok_or_else(|| format!("trans_states entry missing \"name\": {entry}"))?;
+    let position = parse_array3_field(entry, "position")
+        .ok_or_else(|| format!("trans_states[{name}]: missing position"))?;
+    let velocity = parse_array3_field(entry, "velocity")
+        .ok_or_else(|| format!("trans_states[{name}]: missing velocity"))?;
+    let reference_frame = parse_str_field(entry, "reference_frame").unwrap_or_default();
+    Ok(TransStateRecord {
+        name,
+        position,
+        velocity,
+        reference_frame,
+    })
+}
+
+// ── tiny hand-rolled JSON helpers ──────────────────────────────────────────
+
+fn find_key_value_start<'a>(s: &'a str, key: &str) -> Option<&'a str> {
+    let needle = format!("\"{key}\"");
+    let idx = s.find(&needle)?;
+    let rest = &s[idx + needle.len()..];
+    let colon = rest.find(':')?;
+    Some(rest[colon + 1..].trim_start())
+}
+
+fn parse_str_field(s: &str, key: &str) -> Option<String> {
+    let after = find_key_value_start(s, key)?;
+    let bytes = after.as_bytes();
+    if bytes.is_empty() || bytes[0] != b'"' {
+        return None;
+    }
+    let end = after[1..].find('"')?;
+    Some(after[1..1 + end].to_string())
+}
+
+fn parse_num_field(s: &str, key: &str) -> Option<f64> {
+    let after = find_key_value_start(s, key)?;
+    if after.starts_with("null") {
+        return None;
+    }
+    let end = after
+        .find(|c: char| c == ',' || c == '}' || c == ']' || c.is_whitespace())
+        .unwrap_or(after.len());
+    after[..end].trim().parse().ok()
+}
+
+/// Returns `None` for `null`, `Some(v)` for a literal number, `None` if the
+/// key is absent.
+fn parse_opt_num_field(s: &str, key: &str) -> Option<f64> {
+    let after = find_key_value_start(s, key)?;
+    if after.starts_with("null") {
+        return None;
+    }
+    let end = after
+        .find(|c: char| c == ',' || c == '}' || c == ']' || c.is_whitespace())
+        .unwrap_or(after.len());
+    after[..end].trim().parse().ok()
+}
+
+fn parse_array3_field(s: &str, key: &str) -> Option<[f64; 3]> {
+    let after = find_key_value_start(s, key)?;
+    if !after.starts_with('[') {
+        return None;
+    }
+    let close = after.find(']')?;
+    let inner = &after[1..close];
+    let parts: Vec<f64> = inner
+        .split(',')
+        .map(|p| p.trim().parse::<f64>())
+        .collect::<Result<_, _>>()
+        .ok()?;
+    if parts.len() != 3 {
+        return None;
+    }
+    Some([parts[0], parts[1], parts[2]])
+}
+
+/// Parse an object-or-null field. Returns `Ok(None)` for `null` and
+/// `Ok(Some(inner))` for an object body, where `inner` is the substring
+/// between the matching `{` and `}` (exclusive).
+fn parse_object_field<'a>(s: &'a str, key: &str) -> Result<Option<&'a str>, String> {
+    let after =
+        find_key_value_start(s, key).ok_or_else(|| format!("missing top-level {key:?} key"))?;
+    if after.starts_with("null") {
+        return Ok(None);
+    }
+    if !after.starts_with('{') {
+        return Err(format!("{key} is not an object or null"));
+    }
+    let bytes = after.as_bytes();
+    let mut depth = 1_i32;
+    let mut i = 1;
+    let mut in_string = false;
+    while i < bytes.len() && depth > 0 {
+        let c = bytes[i];
+        if in_string {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => in_string = true,
+            b'{' | b'[' => depth += 1,
+            b'}' | b']' => depth -= 1,
+            _ => {}
+        }
+        i += 1;
+        if depth == 0 {
+            return Ok(Some(&after[1..i - 1]));
+        }
+    }
+    Err(format!("unterminated object value for {key}"))
+}
+
+/// Parse an array-of-objects field. Returns the substring of each entry
+/// (between matching `{` and `}`).
+fn parse_array_field_entries<'a>(s: &'a str, key: &str) -> Result<Vec<&'a str>, String> {
+    let after =
+        find_key_value_start(s, key).ok_or_else(|| format!("missing top-level {key:?} key"))?;
+    if !after.starts_with('[') {
+        return Err(format!("{key} is not an array"));
+    }
+    let bytes = after.as_bytes();
+    let mut depth = 1_i32; // we have already entered the outer `[`
+    let mut i = 1;
+    let mut in_string = false;
+    let mut entries = Vec::new();
+    let mut entry_start: Option<usize> = None;
+    while i < bytes.len() && depth > 0 {
+        let c = bytes[i];
+        if in_string {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' => in_string = true,
+            b'{' => {
+                if depth == 1 {
+                    entry_start = Some(i + 1);
+                }
+                depth += 1;
+            }
+            b'[' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 1 {
+                    let start = entry_start.take().ok_or_else(|| {
+                        format!("{key}: closing }} without a matching object opener")
+                    })?;
+                    entries.push(&after[start..i]);
+                }
+            }
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 0 {
+        return Err(format!("unterminated array for {key}"));
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_BUNDLE: &str = r#"{
+  "schema_version": 1,
+  "vehicle": "TEST",
+  "source": "test/path/",
+  "jeod_version": "5.4",
+  "note": "Test bundle.",
+  "reference_inertial": {"position": [1.0, 2.0, 3.0], "velocity": [4.0, 5.0, 6.0]},
+  "orbital_inits": [
+    {
+      "name": "set_a",
+      "semi_major_axis": 6.7e6,
+      "eccentricity": 0.001,
+      "inclination": 0.9,
+      "ascending_node": 0.86,
+      "arg_periapsis": 1.75,
+      "time_periapsis": 4581.96,
+      "mean_anomaly": null,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "set_b",
+      "semi_major_axis": 6.7e6,
+      "eccentricity": 0.001,
+      "inclination": 0.9,
+      "ascending_node": 0.86,
+      "arg_periapsis": 1.75,
+      "time_periapsis": null,
+      "mean_anomaly": 0.5,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.inertial"
+    }
+  ],
+  "trans_states": [
+    {
+      "name": "ts_a",
+      "position": [1.0e6, 2.0e6, 3.0e6],
+      "velocity": [-1.0, 2.0, -3.0],
+      "reference_frame": "Earth.inertial"
+    }
+  ]
+}
+"#;
+
+    #[test]
+    fn parses_full_bundle() {
+        let b = parse_bundle_json(SAMPLE_BUNDLE).unwrap();
+        assert_eq!(b.vehicle, "TEST");
+        let r = b.reference_inertial.unwrap();
+        assert_eq!(r.position, [1.0, 2.0, 3.0]);
+        assert_eq!(r.velocity, [4.0, 5.0, 6.0]);
+
+        assert_eq!(b.orbital_inits.len(), 2);
+        let a = &b.orbital_inits[0];
+        assert_eq!(a.name, "set_a");
+        assert_eq!(a.time_periapsis, Some(4581.96));
+        assert_eq!(a.mean_anomaly, None);
+        let bb = &b.orbital_inits[1];
+        assert_eq!(bb.name, "set_b");
+        assert_eq!(bb.time_periapsis, None);
+        assert_eq!(bb.mean_anomaly, Some(0.5));
+
+        assert_eq!(b.trans_states.len(), 1);
+        let t = &b.trans_states[0];
+        assert_eq!(t.name, "ts_a");
+        assert_eq!(t.position, [1.0e6, 2.0e6, 3.0e6]);
+        assert_eq!(t.velocity, [-1.0, 2.0, -3.0]);
+    }
+
+    #[test]
+    fn parses_null_reference_inertial() {
+        let json = r#"{"vehicle": "X", "reference_inertial": null,
+"orbital_inits": [], "trans_states": []}"#;
+        let b = parse_bundle_json(json).unwrap();
+        assert!(b.reference_inertial.is_none());
+        assert!(b.orbital_inits.is_empty());
+        assert!(b.trans_states.is_empty());
+    }
+}

--- a/crates/jeod_test_data/src/orbital_init.rs
+++ b/crates/jeod_test_data/src/orbital_init.rs
@@ -1,12 +1,34 @@
+//! Orbital-element and direct-Cartesian initialization records.
+//!
+//! Originally extracted from JEOD `Modified_data/<vehicle>/`
+//! `trans_Orbit_*_body_*.py` and `trans_TransState_*_body.py` (in
+//! `models/dynamics/body_action/verif/SIM_orbinit/`), the records are now
+//! committed to `test_data/body_init/<vehicle>.json` and read back here
+//! without touching the JEOD source tree at runtime.
+//!
+//! Regenerate with:
+//!
+//! ```bash
+//! cargo run -p jeod_test_data --bin extract_body_init -- \
+//!     --jeod-home $JEOD_HOME
+//! ```
+//!
+//! The Python parsers still live here (`parse_orbital_init_py`,
+//! `parse_trans_state_py`) and are invoked exclusively by the regen
+//! binary; runtime test paths never call them.
+
 use regex::Regex;
 use std::f64::consts::PI;
 
-/// Orbital element initialization data from a JEOD Trick input file.
+use crate::body_init_fixtures::{
+    load_vehicle_bundle, BodyInitFixtureError, OrbitalInitRecord, TransStateRecord,
+};
+
+/// Orbital element initialization data, originally from a JEOD Trick input file.
 ///
-/// Parsed from files like:
+/// JEOD source files like
 /// `models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{vehicle}/trans_Orbit_{frame}_body_{init_name}.py`
-///
-/// These files contain Python assignments in two forms:
+/// contain Python assignments in two forms:
 /// - `key = trick.attach_units("unit", value)` (with unit conversion)
 /// - `key = value` (bare numeric)
 ///
@@ -28,28 +50,57 @@ pub struct OrbitalInitData {
     pub reference_frame: String,
 }
 
-/// Load orbital element initialization data from a JEOD Trick input file.
+/// Load orbital element initialization data from the committed
+/// `test_data/body_init/<vehicle>.json` fixture.
 ///
 /// # Arguments
-/// * `jeod_root` - Path to the JEOD source tree root.
-/// * `vehicle` - Vehicle directory name (e.g. `"ISS"`).
-/// * `init_name` - Init file identifier (e.g. `"trans_Orbit_inertial_body_set01"`).
+/// * `vehicle` - Vehicle directory name (e.g. `"ISS"`, `"STS_114"`).
+/// * `init_name` - Init file identifier without `.py`
+///   (e.g. `"trans_Orbit_inertial_body_set01"`).
 ///
 /// # Panics
-/// Panics if the file cannot be read, or required fields (semi_major_axis, eccentricity,
-/// inclination, ascending_node, arg_periapsis) are missing.
-pub fn load_orbital_init(
-    jeod_root: &std::path::Path,
-    vehicle: &str,
-    init_name: &str,
-) -> OrbitalInitData {
-    let path = jeod_root.join(format!(
-        "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/{}.py",
-        vehicle, init_name
-    ));
-    let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Cannot read {}: {}", path.display(), e));
+/// Panics if the fixture is missing, malformed, or doesn't contain the
+/// requested `init_name`. The panic message names the regen command per
+/// the CLAUDE.md "Fail Loudly" rule.
+pub fn load_orbital_init(vehicle: &str, init_name: &str) -> OrbitalInitData {
+    let bundle = load_vehicle_bundle(vehicle);
+    let rec = bundle
+        .orbital_inits
+        .iter()
+        .find(|r| r.name == init_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "body_init fixture for {vehicle} is missing orbital_init {init_name:?}. \
+                 Add the scenario to extract_body_init.rs SCENARIOS and regenerate with: \
+                 cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME"
+            )
+        });
+    OrbitalInitData::from(rec)
+}
 
+impl From<&OrbitalInitRecord> for OrbitalInitData {
+    fn from(rec: &OrbitalInitRecord) -> Self {
+        OrbitalInitData {
+            semi_major_axis: rec.semi_major_axis,
+            eccentricity: rec.eccentricity,
+            inclination: rec.inclination,
+            ascending_node: rec.ascending_node,
+            arg_periapsis: rec.arg_periapsis,
+            time_periapsis: rec.time_periapsis,
+            mean_anomaly: rec.mean_anomaly,
+            true_anomaly: rec.true_anomaly,
+            planet_name: rec.planet_name.clone(),
+            reference_frame: rec.reference_frame.clone(),
+        }
+    }
+}
+
+/// Parse the body of a JEOD `trans_Orbit_*_body_*.py` file into an
+/// [`OrbitalInitRecord`] (the canonical JSON-serializable form).
+///
+/// Regen-only path: the runtime [`load_orbital_init`] reads the committed
+/// fixture and never invokes this parser.
+pub fn parse_orbital_init_py(content: &str) -> Result<OrbitalInitRecord, BodyInitFixtureError> {
     // Match: key = trick.attach_units( "unit", value)
     let units_re =
         Regex::new(r#"\.(\w+)\s*=\s*trick\.attach_units\(\s*"(\w+)"\s*,\s*([-\d.eE+]+)\s*\)"#)
@@ -80,9 +131,11 @@ pub fn load_orbital_init(
         if let Some(cap) = units_re.captures(line) {
             let key = &cap[1];
             let unit = &cap[2];
-            let raw_val: f64 = cap[3].parse().unwrap();
+            let raw_val: f64 = cap[3]
+                .parse()
+                .map_err(|e| BodyInitFixtureError::malformed(format!("parse {key}: {e}")))?;
 
-            let val = convert_units(raw_val, unit);
+            let val = convert_units(raw_val, unit)?;
 
             match key {
                 "semi_major_axis" => semi_major_axis = Some(val),
@@ -101,7 +154,9 @@ pub fn load_orbital_init(
         // Try bare value pattern
         if let Some(cap) = bare_re.captures(line) {
             let key = &cap[1];
-            let val: f64 = cap[2].parse().unwrap();
+            let val: f64 = cap[2]
+                .parse()
+                .map_err(|e| BodyInitFixtureError::malformed(format!("parse {key}: {e}")))?;
 
             match key {
                 "semi_major_axis" => semi_major_axis = Some(val * 1000.0), // assume km
@@ -129,44 +184,47 @@ pub fn load_orbital_init(
         }
     }
 
-    OrbitalInitData {
-        semi_major_axis: semi_major_axis
-            .unwrap_or_else(|| panic!("Missing semi_major_axis in {}", path.display())),
+    Ok(OrbitalInitRecord {
+        name: String::new(), // filled in by extract_body_init
+        semi_major_axis: semi_major_axis.ok_or_else(|| {
+            BodyInitFixtureError::malformed("missing semi_major_axis".to_string())
+        })?,
         eccentricity: eccentricity
-            .unwrap_or_else(|| panic!("Missing eccentricity in {}", path.display())),
+            .ok_or_else(|| BodyInitFixtureError::malformed("missing eccentricity".to_string()))?,
         inclination: inclination
-            .unwrap_or_else(|| panic!("Missing inclination in {}", path.display())),
+            .ok_or_else(|| BodyInitFixtureError::malformed("missing inclination".to_string()))?,
         ascending_node: ascending_node
-            .unwrap_or_else(|| panic!("Missing ascending_node in {}", path.display())),
+            .ok_or_else(|| BodyInitFixtureError::malformed("missing ascending_node".to_string()))?,
         arg_periapsis: arg_periapsis
-            .unwrap_or_else(|| panic!("Missing arg_periapsis in {}", path.display())),
+            .ok_or_else(|| BodyInitFixtureError::malformed("missing arg_periapsis".to_string()))?,
         time_periapsis,
         mean_anomaly,
         true_anomaly,
         planet_name,
         reference_frame,
-    }
+    })
 }
 
 /// Convert a raw value from the given unit string to SI (meters, radians, seconds).
-fn convert_units(val: f64, unit: &str) -> f64 {
+fn convert_units(val: f64, unit: &str) -> Result<f64, BodyInitFixtureError> {
     match unit {
-        "degree" => val * PI / 180.0,
-        "km" => val * 1000.0,
-        "s" => val,
-        "m" => val,
-        "rad" => val,
-        other => panic!("Unknown unit: {}", other),
+        "degree" => Ok(val * PI / 180.0),
+        "km" => Ok(val * 1000.0),
+        "s" => Ok(val),
+        "m" => Ok(val),
+        "rad" => Ok(val),
+        other => Err(BodyInitFixtureError::malformed(format!(
+            "unknown unit: {other:?}"
+        ))),
     }
 }
 
-/// Direct Cartesian translational-state initialization data from a JEOD
-/// `trans_TransState_*.py` file.
+/// Direct Cartesian translational-state initialization data, originally from a
+/// JEOD `trans_TransState_*.py` file.
 ///
-/// Parsed from files like:
+/// JEOD source files like
 /// `models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{vehicle}/trans_TransState_{frame}_body.py`
-///
-/// Contains position/velocity vectors with `trick.attach_units("m", [...])` and
+/// contain position/velocity vectors with `trick.attach_units("m", [...])` and
 /// `trick.attach_units("m/s", [...])` wrappers.
 #[derive(Debug, Clone)]
 pub struct TransStateData {
@@ -175,29 +233,43 @@ pub struct TransStateData {
     pub reference_frame: String,
 }
 
-/// Load a direct Cartesian translational-state init file.
+/// Load a direct Cartesian translational-state init record from the
+/// committed `test_data/body_init/<vehicle>.json` fixture.
 ///
 /// # Arguments
-/// * `jeod_root` - Path to the JEOD source tree root.
 /// * `vehicle` - Vehicle directory name (e.g. `"STS_114"`).
-/// * `init_name` - Init file identifier without `.py` (e.g. `"trans_TransState_inertial_body"`).
+/// * `init_name` - Init file identifier without `.py`
+///   (e.g. `"trans_TransState_inertial_body"`).
 ///
 /// # Panics
-/// Panics if the file cannot be read; if `position` or `velocity` entries are
-/// missing or have an unexpected unit (must be `"m"` and `"m/s"` respectively);
-/// or if `reference_ref_frame_name` is missing.
-pub fn load_trans_state(
-    jeod_root: &std::path::Path,
-    vehicle: &str,
-    init_name: &str,
-) -> TransStateData {
-    let path = jeod_root.join(format!(
-        "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/{}.py",
-        vehicle, init_name
-    ));
-    let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Cannot read {}: {}", path.display(), e));
+/// Panics if the fixture is missing, malformed, or doesn't contain the
+/// requested `init_name`. The panic message names the regen command.
+pub fn load_trans_state(vehicle: &str, init_name: &str) -> TransStateData {
+    let bundle = load_vehicle_bundle(vehicle);
+    let rec = bundle
+        .trans_states
+        .iter()
+        .find(|r| r.name == init_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "body_init fixture for {vehicle} is missing trans_state {init_name:?}. \
+                 Add the scenario to extract_body_init.rs SCENARIOS and regenerate with: \
+                 cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME"
+            )
+        });
+    TransStateData {
+        position: rec.position,
+        velocity: rec.velocity,
+        reference_frame: rec.reference_frame.clone(),
+    }
+}
 
+/// Parse the body of a JEOD `trans_TransState_*.py` file into a
+/// [`TransStateRecord`].
+///
+/// Regen-only path: the runtime [`load_trans_state`] reads the committed
+/// fixture and never invokes this parser.
+pub fn parse_trans_state_py(content: &str) -> Result<TransStateRecord, BodyInitFixtureError> {
     // Match: .position = trick.attach_units( "m", [  x,  y,  z])
     // Match: .velocity = trick.attach_units( "m/s", [  vx,  vy,  vz])
     let vec3_re = Regex::new(
@@ -216,27 +288,31 @@ pub fn load_trans_state(
         if let Some(cap) = vec3_re.captures(line) {
             let field = &cap[1];
             let unit = &cap[2];
-            let x: f64 = cap[3].parse().unwrap();
-            let y: f64 = cap[4].parse().unwrap();
-            let z: f64 = cap[5].parse().unwrap();
+            let x: f64 = cap[3]
+                .parse()
+                .map_err(|e| BodyInitFixtureError::malformed(format!("parse {field}.x: {e}")))?;
+            let y: f64 = cap[4]
+                .parse()
+                .map_err(|e| BodyInitFixtureError::malformed(format!("parse {field}.y: {e}")))?;
+            let z: f64 = cap[5]
+                .parse()
+                .map_err(|e| BodyInitFixtureError::malformed(format!("parse {field}.z: {e}")))?;
             // Validate unit per field — no scale conversion needed for SI.
             match field {
                 "position" => {
-                    assert!(
-                        unit == "m",
-                        "Unexpected unit '{}' for position in {} (expected \"m\")",
-                        unit,
-                        path.display()
-                    );
+                    if unit != "m" {
+                        return Err(BodyInitFixtureError::malformed(format!(
+                            "unexpected unit {unit:?} for position (expected \"m\")"
+                        )));
+                    }
                     position = Some([x, y, z]);
                 }
                 "velocity" => {
-                    assert!(
-                        unit == "m/s",
-                        "Unexpected unit '{}' for velocity in {} (expected \"m/s\")",
-                        unit,
-                        path.display()
-                    );
+                    if unit != "m/s" {
+                        return Err(BodyInitFixtureError::malformed(format!(
+                            "unexpected unit {unit:?} for velocity (expected \"m/s\")"
+                        )));
+                    }
                     velocity = Some([x, y, z]);
                 }
                 _ => {}
@@ -248,10 +324,64 @@ pub fn load_trans_state(
         }
     }
 
-    TransStateData {
-        position: position.unwrap_or_else(|| panic!("Missing position in {}", path.display())),
-        velocity: velocity.unwrap_or_else(|| panic!("Missing velocity in {}", path.display())),
-        reference_frame: reference_frame
-            .unwrap_or_else(|| panic!("Missing reference_ref_frame_name in {}", path.display())),
+    Ok(TransStateRecord {
+        name: String::new(), // filled in by extract_body_init
+        position: position
+            .ok_or_else(|| BodyInitFixtureError::malformed("missing position".to_string()))?,
+        velocity: velocity
+            .ok_or_else(|| BodyInitFixtureError::malformed("missing velocity".to_string()))?,
+        reference_frame: reference_frame.ok_or_else(|| {
+            BodyInitFixtureError::malformed("missing reference_ref_frame_name".to_string())
+        })?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_orbital_init_py_attach_units() {
+        let py = r#"
+vehicle.set01.subject.semi_major_axis = trick.attach_units("km", 6732.90120152)
+vehicle.set01.subject.eccentricity   = trick.attach_units("rad", 0.00129073350)
+vehicle.set01.subject.inclination    = trick.attach_units("degree", 51.670450765)
+vehicle.set01.subject.ascending_node = trick.attach_units("degree", 49.708417385)
+vehicle.set01.subject.arg_periapsis  = trick.attach_units("degree", 100.582445989)
+vehicle.set01.subject.time_periapsis = trick.attach_units("s", 4581.96167293)
+vehicle.set01.subject.planet_name    = "Earth"
+vehicle.set01.subject.orbit_frame_name = "Earth.inertial"
+"#;
+        let rec = parse_orbital_init_py(py).unwrap();
+        assert!((rec.semi_major_axis - 6_732_901.201_52).abs() < 1e-6);
+        assert!((rec.eccentricity - 0.00129073350).abs() < 1e-12);
+        let deg2rad = PI / 180.0;
+        assert!((rec.inclination - 51.670450765 * deg2rad).abs() < 1e-12);
+        assert_eq!(rec.planet_name, "Earth");
+        assert_eq!(rec.reference_frame, "Earth.inertial");
+        assert!((rec.time_periapsis.unwrap() - 4581.96167293).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_trans_state_py_attach_units() {
+        let py = r#"
+sts114.trans.subject.position = trick.attach_units("m", [1.0e6, 2.0e6, 3.0e6])
+sts114.trans.subject.velocity = trick.attach_units("m/s", [-1.0, 2.0, -3.0])
+sts114.trans.subject.reference_ref_frame_name = "Earth.inertial"
+"#;
+        let rec = parse_trans_state_py(py).unwrap();
+        assert_eq!(rec.position, [1.0e6, 2.0e6, 3.0e6]);
+        assert_eq!(rec.velocity, [-1.0, 2.0, -3.0]);
+        assert_eq!(rec.reference_frame, "Earth.inertial");
+    }
+
+    #[test]
+    fn parse_trans_state_py_rejects_wrong_units() {
+        let py = r#"sts114.trans.subject.position = trick.attach_units("km", [1.0, 2.0, 3.0])
+sts114.trans.subject.velocity = trick.attach_units("m/s", [-1.0, 2.0, -3.0])
+sts114.trans.subject.reference_ref_frame_name = "Earth.inertial"
+"#;
+        let err = parse_trans_state_py(py).unwrap_err();
+        assert!(format!("{err}").contains("position"));
     }
 }

--- a/crates/jeod_test_data/src/reference_state.rs
+++ b/crates/jeod_test_data/src/reference_state.rs
@@ -110,15 +110,15 @@ pub fn parse_reference_state_py(
 
     let mut arrays: Vec<[f64; 3]> = Vec::new();
     for cap in array_re.captures_iter(content) {
-        let x: f64 = cap[1].parse().map_err(|e| {
-            BodyInitFixtureError::malformed(format!("parse position component: {e}"))
-        })?;
-        let y: f64 = cap[2].parse().map_err(|e| {
-            BodyInitFixtureError::malformed(format!("parse position component: {e}"))
-        })?;
-        let z: f64 = cap[3].parse().map_err(|e| {
-            BodyInitFixtureError::malformed(format!("parse position component: {e}"))
-        })?;
+        let x: f64 = cap[1]
+            .parse()
+            .map_err(|e| BodyInitFixtureError::malformed(format!("parse array component: {e}")))?;
+        let y: f64 = cap[2]
+            .parse()
+            .map_err(|e| BodyInitFixtureError::malformed(format!("parse array component: {e}")))?;
+        let z: f64 = cap[3]
+            .parse()
+            .map_err(|e| BodyInitFixtureError::malformed(format!("parse array component: {e}")))?;
         arrays.push([x, y, z]);
     }
 

--- a/crates/jeod_test_data/src/reference_state.rs
+++ b/crates/jeod_test_data/src/reference_state.rs
@@ -1,17 +1,30 @@
+//! ISS / STS-114 reference translational-state vectors.
+//!
+//! Originally extracted from JEOD `Modified_data/<vehicle>/`
+//! `reference_inertial_trans_state.py` (e.g.
+//! `models/dynamics/body_action/verif/SIM_orbinit/Modified_data/ISS/reference_inertial_trans_state.py`),
+//! the reference state is now committed to
+//! `test_data/body_init/<vehicle>.json` and read back here without
+//! touching the JEOD source tree at runtime.
+//!
+//! Regenerate with:
+//!
+//! ```bash
+//! cargo run -p jeod_test_data --bin extract_body_init -- \
+//!     --jeod-home $JEOD_HOME
+//! ```
+//!
+//! The Python parser still lives here (`parse_reference_state_py`) and is
+//! invoked exclusively by the regen binary; runtime test paths never
+//! call it.
+
 use glam::DVec3;
 use jeod_quantities::prelude::*;
 use regex::Regex;
 
-/// ISS reference translational state from JEOD verification data.
-///
-/// Parsed from files like:
-/// `models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{vehicle}/reference_{frame}_trans_state.py`
-///
-/// These files contain Python assignments of the form:
-/// ```python
-///   vehicle_reference.expected_state.trans.position  = [      1244540.53,   5655938.85,   3425643.22]
-///   vehicle_reference.expected_state.trans.velocity  = [    -6003.833051, -1469.496044,  4590.511776]
-/// ```
+use crate::body_init_fixtures::{load_vehicle_bundle, BodyInitFixtureError, ReferenceStateRecord};
+
+/// ISS / STS-114 reference translational state from JEOD verification data.
 ///
 /// Frame: inertial (ICRF) — JEOD's `reference_inertial_trans_state.py` files
 /// specify the state in the inertial frame. Use [`ReferenceState::position_typed`]
@@ -40,49 +53,86 @@ impl ReferenceState {
     }
 }
 
-/// Load an ISS reference translational state from JEOD's verification data.
+/// Load a vehicle's reference translational state from the committed
+/// `test_data/body_init/<vehicle>.json` fixture.
 ///
 /// # Arguments
-/// * `jeod_root` - Path to the JEOD source tree root.
-/// * `vehicle` - Vehicle directory name (e.g. `"ISS"`).
-/// * `frame` - Reference frame name used in filename (e.g. `"inertial"`).
+/// * `vehicle` - Vehicle directory name (e.g. `"ISS"`, `"STS_114"`).
+/// * `frame` - Reference frame name. Only `"inertial"` is currently
+///   committed; other values will panic with a clear regen-command
+///   message.
 ///
 /// # Panics
-/// Panics if the file cannot be read or does not contain at least two 3-element arrays
-/// (position and velocity).
-pub fn load_reference_state(
-    jeod_root: &std::path::Path,
-    vehicle: &str,
-    frame: &str,
-) -> ReferenceState {
-    let path = jeod_root.join(format!(
-        "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/{}/reference_{}_trans_state.py",
-        vehicle, frame
-    ));
-    let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Cannot read {}: {}", path.display(), e));
+/// Panics if the fixture is missing, malformed, or doesn't include the
+/// requested frame. The panic message names the regen command per the
+/// CLAUDE.md "Fail Loudly" rule.
+pub fn load_reference_state(vehicle: &str, frame: &str) -> ReferenceState {
+    let bundle = load_vehicle_bundle(vehicle);
+    match frame {
+        "inertial" => match &bundle.reference_inertial {
+            Some(state) => ReferenceState {
+                position: DVec3::new(state.position[0], state.position[1], state.position[2]),
+                velocity: DVec3::new(state.velocity[0], state.velocity[1], state.velocity[2]),
+            },
+            None => panic!(
+                "body_init fixture for {vehicle} is missing `reference_inertial`. \
+                 Regenerate with: cargo run -p jeod_test_data --bin extract_body_init \
+                 -- --jeod-home $JEOD_HOME"
+            ),
+        },
+        other => panic!(
+            "load_reference_state: only \"inertial\" frame is committed (got {other:?} \
+             for vehicle {vehicle}). Add the new frame to extract_body_init.rs and \
+             regenerate the fixture."
+        ),
+    }
+}
 
+/// Parse `reference_inertial_trans_state.py` content into a
+/// [`ReferenceStateRecord`] suitable for JSON serialization.
+///
+/// This is the regen-only path: the runtime [`load_reference_state`] reads
+/// the committed fixture and never invokes this parser.
+///
+/// JEOD's `reference_*_trans_state.py` files contain Python assignments of
+/// the form:
+/// ```python
+///   vehicle_reference.expected_state.trans.position  = [      1244540.53,   5655938.85,   3425643.22]
+///   vehicle_reference.expected_state.trans.velocity  = [    -6003.833051, -1469.496044,  4590.511776]
+/// ```
+///
+/// Returns the first two 3-element arrays found, interpreted as `(position, velocity)`.
+pub fn parse_reference_state_py(
+    content: &str,
+) -> Result<ReferenceStateRecord, BodyInitFixtureError> {
     let array_re =
         Regex::new(r"\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]").unwrap();
 
-    let mut arrays: Vec<DVec3> = Vec::new();
-    for cap in array_re.captures_iter(&content) {
-        let x: f64 = cap[1].parse().unwrap();
-        let y: f64 = cap[2].parse().unwrap();
-        let z: f64 = cap[3].parse().unwrap();
-        arrays.push(DVec3::new(x, y, z));
+    let mut arrays: Vec<[f64; 3]> = Vec::new();
+    for cap in array_re.captures_iter(content) {
+        let x: f64 = cap[1].parse().map_err(|e| {
+            BodyInitFixtureError::malformed(format!("parse position component: {e}"))
+        })?;
+        let y: f64 = cap[2].parse().map_err(|e| {
+            BodyInitFixtureError::malformed(format!("parse position component: {e}"))
+        })?;
+        let z: f64 = cap[3].parse().map_err(|e| {
+            BodyInitFixtureError::malformed(format!("parse position component: {e}"))
+        })?;
+        arrays.push([x, y, z]);
     }
 
-    assert!(
-        arrays.len() >= 2,
-        "Expected at least 2 arrays (position, velocity) in {}",
-        path.display()
-    );
+    if arrays.len() < 2 {
+        return Err(BodyInitFixtureError::malformed(format!(
+            "expected at least 2 arrays (position, velocity), got {}",
+            arrays.len()
+        )));
+    }
 
-    ReferenceState {
+    Ok(ReferenceStateRecord {
         position: arrays[0],
         velocity: arrays[1],
-    }
+    })
 }
 
 #[cfg(test)]
@@ -134,5 +184,21 @@ mod tests {
         let v = state.velocity_typed();
         assert_eq!(p.raw_si(), state.position);
         assert_eq!(v.raw_si(), state.velocity);
+    }
+
+    #[test]
+    fn parse_reference_state_py_picks_first_two_arrays() {
+        let py = "vehicle_reference.expected_state.trans.position  = [1.0, 2.0, 3.0]\n\
+                  vehicle_reference.expected_state.trans.velocity  = [4.0, 5.0, 6.0]\n";
+        let rec = parse_reference_state_py(py).unwrap();
+        assert_eq!(rec.position, [1.0, 2.0, 3.0]);
+        assert_eq!(rec.velocity, [4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn parse_reference_state_py_rejects_too_few_arrays() {
+        let py = "x = [1.0, 2.0, 3.0]";
+        let err = parse_reference_state_py(py).unwrap_err();
+        assert!(format!("{err}").contains("at least 2 arrays"));
     }
 }

--- a/test_data/body_init/iss.json
+++ b/test_data/body_init/iss.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "vehicle": "ISS",
+  "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/ISS/",
+  "jeod_version": "5.4",
+  "note": "Body initialization vectors. Regenerate with: cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME",
+  "reference_inertial": {"position": [1244540.53, 5655938.85, 3425643.22], "velocity": [-6003.833051, -1469.496044, 4590.511776]},
+  "orbital_inits": [
+    {
+      "name": "trans_Orbit_inertial_body_set01",
+      "semi_major_axis": 6732901.20152,
+      "eccentricity": 0.0012907335,
+      "inclination": 0.9018194918388728,
+      "ascending_node": 0.8675755493238396,
+      "arg_periapsis": 1.755494852217414,
+      "time_periapsis": 4581.96167293,
+      "mean_anomaly": null,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "trans_Orbit_inertial_body_set02",
+      "semi_major_axis": 6732901.20152,
+      "eccentricity": 0.0012907335,
+      "inclination": 0.9018194918388728,
+      "ascending_node": 0.8675755493238396,
+      "arg_periapsis": 1.755494852217414,
+      "time_periapsis": null,
+      "mean_anomaly": 5.236209017533277,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "trans_Orbit_inertial_body_set10",
+      "semi_major_axis": 6732901.20152,
+      "eccentricity": 0.0012907335,
+      "inclination": 0.9018194918388728,
+      "ascending_node": 0.8675755493238396,
+      "arg_periapsis": 1.755494852217414,
+      "time_periapsis": null,
+      "mean_anomaly": null,
+      "true_anomaly": 5.2339718836974285,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "trans_Orbit_pfix_body_set01",
+      "semi_major_axis": 6732901.205250001,
+      "eccentricity": 0.00129073426,
+      "inclination": 0.9014390876767299,
+      "ascending_node": 5.429530680701693,
+      "arg_periapsis": 1.7559744228809693,
+      "time_periapsis": 4581.96222432,
+      "mean_anomaly": null,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.pfix"
+    }
+  ],
+  "trans_states": [
+  ]
+}

--- a/test_data/body_init/iss.json
+++ b/test_data/body_init/iss.json
@@ -2,7 +2,6 @@
   "schema_version": 1,
   "vehicle": "ISS",
   "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/ISS/",
-  "jeod_version": "5.4",
   "note": "Body initialization vectors. Regenerate with: cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME",
   "reference_inertial": {"position": [1244540.53, 5655938.85, 3425643.22], "velocity": [-6003.833051, -1469.496044, 4590.511776]},
   "orbital_inits": [

--- a/test_data/body_init/sts_114.json
+++ b/test_data/body_init/sts_114.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "vehicle": "STS_114",
+  "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/STS_114/",
+  "jeod_version": "5.4",
+  "note": "Body initialization vectors. Regenerate with: cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME",
+  "reference_inertial": {"position": [1244471.94, 5655811.8, 3425518.88], "velocity": [-6003.553468, -1469.321965, 4590.57723]},
+  "orbital_inits": [
+    {
+      "name": "trans_Orbit_inertial_body_set01",
+      "semi_major_axis": 6732163.59764,
+      "eccentricity": 0.00122446354,
+      "inclination": 0.9018261209658911,
+      "ascending_node": 0.8675961322535078,
+      "arg_periapsis": 1.801291139680453,
+      "time_periapsis": 4541.07695545,
+      "mean_anomaly": null,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "trans_Orbit_pfix_body_set01",
+      "semi_major_axis": 6732163.61166,
+      "eccentricity": 0.00122446412,
+      "inclination": 0.9014457086530604,
+      "ascending_node": 5.429551274731655,
+      "arg_periapsis": 1.8017698046402992,
+      "time_periapsis": 4541.07829767,
+      "mean_anomaly": null,
+      "true_anomaly": null,
+      "planet_name": "Earth",
+      "reference_frame": "Earth.pfix"
+    }
+  ],
+  "trans_states": [
+    {
+      "name": "trans_TransState_inertial_body",
+      "position": [1244471.94, 5655811.8, 3425518.88],
+      "velocity": [-6003.553468, -1469.321965, 4590.57723],
+      "reference_frame": "Earth.inertial"
+    }
+  ]
+}

--- a/test_data/body_init/sts_114.json
+++ b/test_data/body_init/sts_114.json
@@ -2,7 +2,6 @@
   "schema_version": 1,
   "vehicle": "STS_114",
   "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/STS_114/",
-  "jeod_version": "5.4",
   "note": "Body initialization vectors. Regenerate with: cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME",
   "reference_inertial": {"position": [1244471.94, 5655811.8, 3425518.88], "velocity": [-6003.553468, -1469.321965, 4590.57723]},
   "orbital_inits": [


### PR DESCRIPTION
## Summary

Closes #235 (Wave 1 of #232). Replaces `JEOD_HOME`-at-test-time loading of body-init Python files with committed JSON fixtures.

- New regen binary `extract_body_init` parses `Modified_data/<vehicle>/*.py` via the existing helpers and writes `test_data/body_init/<vehicle>.json`.
- `jeod_test_data::reference_state::load_reference_state` and `jeod_test_data::orbital_init::{load_orbital_init,load_trans_state}` now read the committed JSON; their `jeod_root` argument is gone, the runtime path no longer calls `jeod_path()`.
- `jeod_test_data::body_init_fixtures` (the stub that Wave 0 pre-created) now hosts the JSON schema, the hand-rolled parser (matching the project's no-`serde_json` style), and the per-vehicle `OnceLock` cache.
- Migrated tests (all pass with `JEOD_HOME` / `JEOD_PATH` unset):
    - `crates/jeod_dynamics/tests/tier2_body_init.rs` (4 tests)
    - `crates/jeod_dynamics/src/body_init.rs::tests::iss_reference_state_from_elements`
    - `crates/jeod_math/tests/jeod_validation.rs` body-init callsites at lines 19, 112, 396
- `jeod_runner/tests/tier3_sim_orbinit_docker.rs` callsites updated mechanically to the new arity (no behaviour change).

## Depends on

#241 (#233 Wave 0). PR is opened against `main`; rebase / merge once Wave 0 lands.

## Committed fixtures

```
test_data/body_init/iss.json      (ISS: reference_inertial + 4 orbit inits)
test_data/body_init/sts_114.json  (STS_114: reference_inertial + 2 orbit inits + 1 trans state)
```

Regenerate after a JEOD upgrade with:

```bash
cargo run -p jeod_test_data --bin extract_body_init -- --jeod-home $JEOD_HOME
```

## Out of scope (intentionally untouched)

- `crates/jeod_math/tests/jeod_validation.rs` lines 170, 248, 301, 462 — those callsites use `orbital_data` (5001-vector roundtrip) and `euler_test` (`euler_derived_state_ut.cc`), which are different JEOD source files belonging to sibling waves.
- `crates/jeod_test_data/src/{leap_second,mass_data,gravity_verif}.rs` — different files, different sub-issues.
- `crates/jeod_runner/` deeper migration — owned by #237 / #238.
- `jeod_path()` itself — owned by #239.

## Test plan

```
cargo fmt --check                                                  # PASS
cargo clippy --workspace --tests -- -D warnings                    # PASS
cargo nextest run --workspace -E 'not test(tier3_)'                # 811/811 PASS

env -u JEOD_HOME -u JEOD_PATH cargo nextest run -p jeod_dynamics --test tier2_body_init
# 4/4 PASS

env -u JEOD_HOME -u JEOD_PATH cargo nextest run -p jeod_dynamics \
  -E 'test(iss_reference_state_from_elements)'
# 1/1 PASS

env -u JEOD_HOME -u JEOD_PATH cargo nextest run -p jeod_math \
  -E 'test(validate_iss_orbital_elements_to_cartesian) | \
      test(validate_iss_reference_state_parsing) | \
      test(validate_orbital_init_parser)'
# 3/3 PASS
```

- [x] All migrated tests pass with `JEOD_HOME` and `JEOD_PATH` unset.
- [x] Workspace fmt + clippy clean.
- [x] Full unit + Tier 2 suite (`-E 'not test(tier3_)'`) green.
- [x] Regen binary produces deterministic JSON via `{x:?}` round-trippable f64 rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)