### PR TITLE
[#238] Audit verification rigs: migrate or feature-gate sim_*.rs (#232 Wave 2)

### DIFF
--- a/crates/jeod_runner/Cargo.toml
+++ b/crates/jeod_runner/Cargo.toml
@@ -53,3 +53,16 @@ path = "examples/batch_propagation.rs"
 [[example]]
 name = "leo_drag"
 path = "examples/leo_drag.rs"
+
+# Examples that consume the JEOD-source-backed verification reference data
+# (`jeod_sim::recipes::verification::reference_data::*`) require the same
+# `verification` feature that gates the rest of `run_verification`.
+[[example]]
+name = "earth_moon"
+path = "examples/earth_moon.rs"
+required-features = ["verification"]
+
+[[example]]
+name = "mars_orbit"
+path = "examples/mars_orbit.rs"
+required-features = ["verification"]

--- a/crates/jeod_runner/Cargo.toml
+++ b/crates/jeod_runner/Cargo.toml
@@ -8,8 +8,22 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# Default-on: enables the `run_verification` module and its
+# `VerificationCaseExt` extension trait. Tier 3 tests
+# (`crates/jeod_runner/tests/tier3_*.rs`) require this feature; CI runs
+# with the default feature set so they pick it up automatically.
+#
+# Production / mission consumers that don't need the verification rigs
+# can opt out with `--no-default-features`. That build excludes the
+# `run_verification` module and drops the `jeod_test_data` /
+# `jeod_sim/jeod-source` dependencies entirely, leaving `jeod_runner`
+# JEOD-source-free.
+default = ["verification"]
+verification = ["dep:jeod_test_data", "jeod_sim/jeod-source"]
+
 [dependencies]
-jeod_sim = { path = "../jeod_sim", version = "0.1.0", features = ["jeod-source"] }
+jeod_sim = { path = "../jeod_sim", version = "0.1.0" }
 jeod_dynamics = { path = "../jeod_dynamics", version = "0.1.0" }
 jeod_gravity = { path = "../jeod_gravity", version = "0.1.0" }
 jeod_time = { path = "../jeod_time", version = "0.1.0" }
@@ -17,16 +31,20 @@ jeod_frames = { path = "../jeod_frames", version = "0.1.0" }
 jeod_interactions = { path = "../jeod_interactions", version = "0.1.0" }
 jeod_math = { path = "../jeod_math", version = "0.1.0" }
 # `jeod_test_data` powers `run_verification::*` (Tier 3 verification-case
-# machinery). It is lightweight (regex + glam + uom) and pulls in no physics
-# crates, so promoting it from a dev-dep to a regular dep keeps the public
-# `VerificationCaseExt` reachable from any consumer of `jeod_runner`.
-jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
+# machinery). Optional and gated behind the `verification` feature so a
+# `--no-default-features` build of `jeod_runner` ships JEOD-source-free.
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0", optional = true }
 glam = { workspace = true }
 log = { workspace = true }
 uom = { workspace = true }
 
 [dev-dependencies]
 jeod_atmosphere = { path = "../jeod_atmosphere", version = "0.1.0" }
+# Tier 3 tests under `tests/tier3_*.rs` use `jeod_test_data` directly
+# (e.g. for `tier3_csv` loaders); kept as an explicit dev-dep so
+# disabling the `verification` feature does not also disable the test
+# harness's CSV ingestion.
+jeod_test_data = { path = "../jeod_test_data", version = "0.1.0" }
 
 [[example]]
 name = "batch_propagation"

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -41,6 +41,7 @@ pub mod branded;
 pub mod builder;
 pub mod error;
 pub mod prelude;
+#[cfg(feature = "verification")]
 pub mod run_verification;
 
 pub use branded::{BodyIdx, BrandedSimulation, SourceIdx};
@@ -54,6 +55,7 @@ pub use jeod_sim::RotationModel;
 pub use builder::SimulationBuilderExt;
 
 // Re-export the Phase-7 Tier 3 verification-case extension trait.
+#[cfg(feature = "verification")]
 pub use run_verification::VerificationCaseExt;
 
 // Re-exports of types relocated from jeod_runner to jeod_sim in Phase 6 of

--- a/crates/jeod_runner/src/prelude.rs
+++ b/crates/jeod_runner/src/prelude.rs
@@ -9,7 +9,9 @@
 //!   [`jeod_sim::SimulationBuilder`].
 //! - [`crate::VerificationCaseExt`] — terminal
 //!   `.run_and_assert()` on
-//!   [`jeod_sim::recipes::verification::VerificationCase`].
+//!   [`jeod_sim::recipes::verification::VerificationCase`]. Available
+//!   only when the default `verification` feature is enabled.
 
 pub use crate::SimulationBuilderExt;
+#[cfg(feature = "verification")]
 pub use crate::VerificationCaseExt;

--- a/crates/jeod_runner/src/run_verification/sim_derived_state.rs
+++ b/crates/jeod_runner/src/run_verification/sim_derived_state.rs
@@ -19,7 +19,6 @@ use jeod_sim::{
     RotationModel, RotationalState, SimulationBuilder, SimulationTime, TranslationalState,
     VehicleConfig, EARTH,
 };
-use jeod_test_data::jeod_cc as coefficients;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -47,11 +46,11 @@ fn jeod_root() -> PathBuf {
 }
 
 fn load_mu_earth() -> f64 {
-    let jeod = jeod_root();
-    coefficients::load_mu_from_jeod_cc(
-        &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu from GGM05C")
+    // Earth mu sourced from the committed `test_data/gravity/ggm05c.bin`
+    // fixture (Wave 1 of #232). Matches the value in JEOD's
+    // `models/environment/gravity/data/src/earth_GGM05C.cc` exactly so
+    // baselines stay bit-stable.
+    jeod_test_data::gravity_fixtures::load_ggm05c().mu
 }
 
 fn point_mass_earth(mu: f64, with_rnp: bool) -> GravitySourceEntry {

--- a/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
@@ -22,7 +22,6 @@ use jeod_sim::{
     GravitySourceEntry, JeodQuat, MassProperties, MetAtmosphere, RotationModel, RotationalState,
     SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig, EARTH,
 };
-use jeod_test_data::jeod_cc::load_from_jeod_cc;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -91,13 +90,12 @@ fn build_run2_3dof(init: &InitialConditions) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let earth_grav =
-        load_from_jeod_cc(&jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"))
-            .expect("load Earth gravity");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
 
     let time = SimulationTime::at_j2000(default_leap_second_table());
     let mut sb = SimulationBuilder::new(time, dt);
-    let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_mu));
     sb.add_body(VehicleConfig {
         trans: trans_from(init),
         gravity_controls: GravityControls {
@@ -112,9 +110,8 @@ fn build_run2_6dof(init: &InitialConditions) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let earth_grav =
-        load_from_jeod_cc(&jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"))
-            .expect("load Earth gravity");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
     let mass_init = jeod_test_data::mass_data::load_mass_from_file(
         &sim_dir.join("Modified_data/mass.py"),
         Some("set_mass_iss"),
@@ -145,7 +142,7 @@ fn build_run2_6dof(init: &InitialConditions) -> SimulationBuilder {
 
     let time = SimulationTime::at_j2000(default_leap_second_table());
     let mut sb = SimulationBuilder::new(time, dt);
-    let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_mu));
     sb.add_body(VehicleConfig {
         trans: trans_from(init),
         rot: Some(rot_from(init, "run2_6dof")),
@@ -279,10 +276,8 @@ fn dyncomp_time() -> SimulationTime {
 /// with the EarthRNP rotation model so the planet-fixed frame updates each
 /// step. Used by the RUN_3A / RUN_3B / RUN_5* / RUN_6* configurations.
 fn earth_sh_with_rnp() -> GravitySourceEntry {
-    let jeod = jeod_root();
-    let sh_data =
-        load_from_jeod_cc(&jeod.join("models/environment/gravity/data/src/earth_GGM02C.cc"))
-            .expect("load GGM02C");
+    // GGM02C SH coefficients from the committed fixture (Wave 1 of #232).
+    let sh_data = jeod_test_data::gravity_fixtures::load_ggm02c();
     GravitySourceEntry {
         source: GravitySource {
             mu: sh_data.mu,
@@ -439,11 +434,10 @@ fn build_run4_3rd_body(init: &InitialConditions) -> SimulationBuilder {
     let grav_data_dir = jeod.join("models/environment/gravity/data/src");
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
 
-    let earth_grav =
-        load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth gravity");
-    let mu_sun =
-        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
-            .expect("load Sun mu");
+    // Earth GGM05C mu and Sun mu from committed fixtures (Wave 1 of #232);
+    // Moon GRAIL150 has no fixture yet, loaded from JEOD source.
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
+    let mu_sun = jeod_test_data::mars_fixtures::load_sun_spherical_mu();
     let mu_moon =
         jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
@@ -461,7 +455,7 @@ fn build_run4_3rd_body(init: &InitialConditions) -> SimulationBuilder {
         .expect("Moon position at epoch");
 
     let mut sb = SimulationBuilder::new(time, dt);
-    let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_mu));
     let sun = sb.add_source("Sun", third_body_source(mu_sun, sun_t0.raw_si()));
     let moon = sb.add_source("Moon", third_body_source(mu_moon, moon_t0.raw_si()));
     debug_assert_eq!(
@@ -590,11 +584,10 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> BattinSc
     let jeod = jeod_root();
     let grav_data_dir = jeod.join("models/environment/gravity/data/src");
 
-    let earth_grav =
-        load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth gravity");
-    let mu_sun =
-        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
-            .expect("load Sun mu");
+    // Earth GGM05C mu and Sun mu from committed fixtures (Wave 1 of #232);
+    // Moon GRAIL150 has no fixture yet, loaded from JEOD source.
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
+    let mu_sun = jeod_test_data::mars_fixtures::load_sun_spherical_mu();
     let mu_moon =
         jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
@@ -612,7 +605,7 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> BattinSc
         .expect("Moon state at epoch");
 
     let mut sb = SimulationBuilder::new(time, BATTIN_DT);
-    let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_mu));
     let sun_idx = sb.add_source(
         "Sun",
         third_body_source_with_state(mu_sun, sun_pos_t0.raw_si(), sun_vel_t0.raw_si()),
@@ -710,11 +703,10 @@ fn build_run7(
     let grav_file_refs: Vec<&std::path::Path> = grav_files.iter().map(|p| p.as_path()).collect();
     let grav_cfg = jeod_test_data::gravity_control::load_gravity_control(&grav_file_refs);
 
-    let earth_grav =
-        load_from_jeod_cc(&grav_data_dir.join("earth_GGM02C.cc")).expect("load Earth GGM02C");
-    let mu_sun =
-        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
-            .expect("load Sun mu");
+    // Earth GGM02C SH and Sun mu from committed fixtures (Wave 1 of #232);
+    // Moon GRAIL150 has no fixture yet, loaded from JEOD source.
+    let earth_grav = jeod_test_data::gravity_fixtures::load_ggm02c();
+    let mu_sun = jeod_test_data::mars_fixtures::load_sun_spherical_mu();
     let mu_moon =
         jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");
@@ -923,10 +915,8 @@ fn build_run5(init: &InitialConditions, case: &str) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
-        &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let mu_earth = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
     let mass_props = iss_mass_properties();
 
     let time = SimulationTime::at_j2000(default_leap_second_table());
@@ -1011,13 +1001,12 @@ fn build_run6_drag(
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let earth_grav =
-        load_from_jeod_cc(&jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"))
-            .expect("load Earth gravity");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
     let mass_props = sphere_mass_properties();
 
     let mut sb = SimulationBuilder::new(dyncomp_time(), dt);
-    let earth = sb.add_source("Earth", earth_pm_with_rnp(earth_grav.mu));
+    let earth = sb.add_source("Earth", earth_pm_with_rnp(earth_mu));
     sb = sb.atmosphere(
         AtmosphereConfig {
             model: AtmosphereModel::Met(met_solar_mean()),
@@ -1141,14 +1130,13 @@ fn build_run10(init: &InitialConditions, case: &str) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let earth_grav =
-        load_from_jeod_cc(&jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"))
-            .expect("load Earth gravity");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
     let mass_props = cylinder_mass_properties();
 
     let time = SimulationTime::at_j2000(default_leap_second_table());
     let mut sb = SimulationBuilder::new(time, dt);
-    let earth = sb.add_source("Earth", point_mass_earth_source(earth_grav.mu));
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_mu));
     sb.add_body(VehicleConfig {
         trans: trans_from(init),
         rot: Some(rot_from(init, case)),
@@ -1221,10 +1209,8 @@ fn build_run5a_met(init: &InitialConditions) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
-        &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let mu_earth = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
     let mass_props = iss_mass_properties();
 
     // RUN_5A: minimum solar activity (F10.7 = 70, Ap = 0)
@@ -1293,10 +1279,8 @@ fn build_run6b_aero_traj(init: &InitialConditions, t_struct_body: DMat3) -> Simu
     let jeod = jeod_root();
     let sim_dir = jeod.join(SIM_DYNCOMP);
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
-        &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let mu_earth = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
 
     let mut sb = SimulationBuilder::new(dyncomp_time(), dt);
     let earth = sb.add_source("Earth", earth_pm_with_rnp(mu_earth));

--- a/crates/jeod_runner/src/run_verification/sim_planetary.rs
+++ b/crates/jeod_runner/src/run_verification/sim_planetary.rs
@@ -26,20 +26,17 @@ use uom::si::time::second;
 const SIM_PLANETARY: &str = "models/dynamics/derived_state/verif/SIM_Planetary";
 
 fn load_mu_earth() -> f64 {
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    jeod_test_data::gravity_fixtures::load_ggm05c().mu
+}
+
+fn build_planetary(init: &InitialConditions) -> SimulationBuilder {
     let jeod_root = jeod_test_data::jeod_path();
     assert!(
         jeod_root.exists(),
         "JEOD source not found at {}. Set JEOD_HOME or JEOD_PATH.",
         jeod_root.display()
     );
-    jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
-        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu from GGM05C")
-}
-
-fn build_planetary(init: &InitialConditions) -> SimulationBuilder {
-    let jeod_root = jeod_test_data::jeod_path();
     let dt =
         jeod_test_data::s_define::load_dynamics_dt(&jeod_root.join(SIM_PLANETARY).join("S_define"));
     let mu_earth = load_mu_earth();

--- a/crates/jeod_runner/src/run_verification/sim_polar_motion.rs
+++ b/crates/jeod_runner/src/run_verification/sim_polar_motion.rs
@@ -35,10 +35,8 @@ fn build_run2p_polar_motion(init: &InitialConditions) -> SimulationBuilder {
         jeod_root.display()
     );
 
-    let mu_earth = jeod_test_data::jeod_cc::load_mu_from_jeod_cc(
-        &jeod_root.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu from GGM05C");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let mu_earth = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
 
     let dt =
         jeod_test_data::s_define::load_dynamics_dt(&jeod_root.join("verif/SIM_dyncomp/S_define"));

--- a/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
+++ b/crates/jeod_runner/src/run_verification/sim_solar_beta.rs
@@ -34,7 +34,6 @@ use jeod_sim::{
     GravityControls, GravityModel, GravitySource, GravitySourceEntry, RotationModel,
     SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
 };
-use jeod_test_data::jeod_cc as coefficients;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -75,11 +74,8 @@ fn bsp_path() -> PathBuf {
 }
 
 fn load_mu_earth() -> f64 {
-    let jeod = jeod_root();
-    coefficients::load_mu_from_jeod_cc(
-        &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu from GGM05C")
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    jeod_test_data::gravity_fixtures::load_ggm05c().mu
 }
 
 fn earth_point_mass(mu: f64) -> GravitySourceEntry {
@@ -270,11 +266,8 @@ fn sim_solar_beta_dt() -> f64 {
 }
 
 fn build_solar_beta_equ(init: &InitialConditions) -> SimulationBuilder {
-    let jeod = jeod_root();
-    let mu_earth = coefficients::load_mu_from_jeod_cc(
-        &jeod.join("models/environment/gravity/data/src/earth_GGM05C.cc"),
-    )
-    .expect("load Earth mu");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let mu_earth = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
 
     let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
     let (sun_t0, _) = ephemeris
@@ -332,10 +325,8 @@ pub fn solar_beta_equ() -> VerificationCase {
 }
 
 fn build_solar_beta_obliquity(init: &InitialConditions) -> SimulationBuilder {
-    let jeod = jeod_root();
-    let grav_data_dir = jeod.join("models/environment/gravity/data/src");
-    let sh_data = coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
-        .expect("load Earth GGM05C");
+    // Earth GGM05C SH from the committed fixture (Wave 1 of #232).
+    let sh_data = jeod_test_data::gravity_fixtures::load_ggm05c();
     let mu_earth = sh_data.mu;
 
     let ephemeris = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");

--- a/crates/jeod_runner/src/run_verification/sim_srp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_srp.rs
@@ -28,7 +28,6 @@ use jeod_sim::{
     GravitySourceEntry, MassProperties, RotationModel, ShadowBody, SimulationBuilder,
     SimulationTime, SrpModel, ThermalIntegrationOrder, TranslationalState, VehicleConfig, EARTH,
 };
-use jeod_test_data::jeod_cc::load_mu_from_jeod_cc;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -207,11 +206,10 @@ fn build_srp(
 ) -> SimulationBuilder {
     let jeod = jeod_root();
     let sim_dir = jeod.join(sim_subdir);
-    let grav_data_dir = jeod.join("models/environment/gravity/data/src");
 
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
-    let earth_mu =
-        load_mu_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth mu");
+    // Earth mu from the committed GGM05C fixture (Wave 1 of #232).
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
 
     let time = srp_time(sim_subdir);
     let epoch_tai_tjt = time.tai_tjt_at_epoch;

--- a/crates/jeod_runner/src/run_verification/sim_tide_verif.rs
+++ b/crates/jeod_runner/src/run_verification/sim_tide_verif.rs
@@ -26,7 +26,6 @@ use jeod_sim::{
     GravityModel, GravitySource, GravitySourceEntry, JeodQuat, MassProperties, RotationModel,
     RotationalState, SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
 };
-use jeod_test_data::jeod_cc::load_from_jeod_cc;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -89,13 +88,12 @@ fn build_tide_run01(init: &InitialConditions) -> SimulationBuilder {
     let grav_data_dir = jeod.join("models/environment/gravity/data/src");
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
 
-    let earth_grav =
-        load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc")).expect("load Earth GGM05C");
+    // Earth GGM05C SH and Sun mu from committed fixtures (Wave 1 of #232);
+    // Moon GRAIL150 has no fixture yet, loaded from JEOD source.
+    let earth_grav = jeod_test_data::gravity_fixtures::load_ggm05c();
     let earth_mu = earth_grav.mu;
     let earth_radius = earth_grav.radius;
-    let mu_sun =
-        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
-            .expect("load Sun mu");
+    let mu_sun = jeod_test_data::mars_fixtures::load_sun_spherical_mu();
     let mu_moon =
         jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
             .expect("load Moon mu");

--- a/crates/jeod_runner/src/run_verification/sim_torque_simple.rs
+++ b/crates/jeod_runner/src/run_verification/sim_torque_simple.rs
@@ -32,7 +32,6 @@ use jeod_sim::{
     GravityModel, GravitySource, GravitySourceEntry, MassProperties, RotationModel,
     RotationalState, SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
 };
-use jeod_test_data::jeod_cc as coefficients;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -132,12 +131,13 @@ fn build_torque_simple(init: &InitialConditions, cfg: RunConfig) -> SimulationBu
     let grav_data_dir = jeod.join("models/environment/gravity/data/src");
     let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
 
-    let earth_grav = coefficients::load_from_jeod_cc(&grav_data_dir.join("earth_GGM05C.cc"))
-        .expect("load Earth GGM05C");
-    let mu_sun = coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("sun_spherical.cc"))
-        .expect("load Sun mu");
-    let mu_moon = coefficients::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
-        .expect("load Moon mu");
+    // Earth GGM05C SH and Sun mu from committed fixtures (Wave 1 of #232);
+    // Moon GRAIL150 has no fixture yet, loaded from JEOD source.
+    let earth_grav = jeod_test_data::gravity_fixtures::load_ggm05c();
+    let mu_sun = jeod_test_data::mars_fixtures::load_sun_spherical_mu();
+    let mu_moon =
+        jeod_test_data::jeod_cc::load_mu_from_jeod_cc(&grav_data_dir.join("moon_GRAIL150.cc"))
+            .expect("load Moon mu");
 
     let needs_pfix = cfg.earth_nonspherical || cfg.gradient_degree > 0;
     let earth_source = if needs_pfix {

--- a/crates/jeod_runner/tests/pre_step_smoke.rs
+++ b/crates/jeod_runner/tests/pre_step_smoke.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Smoke test for the `VerificationCase::pre_step` factory hook (#156).
 //!
 //! Builds a minimal `VerificationCase` whose pre-step closure stamps the

--- a/crates/jeod_runner/tests/tier3_sim_battin.rs
+++ b/crates/jeod_runner/tests/tier3_sim_battin.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: Battin's method vs direct subtraction for third-body gravity
 //!
 //! Verifies that Battin's method for differential (third-body) gravity

--- a/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_rot_verif.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_6B with non-identity structural-to-body rotation
 //!
 //! Same scenario as `tier3_sim_drag_verif` (1 kg sphere, elliptical orbit,

--- a/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_drag_verif.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_6B — aerodynamic drag via Simulation pipeline
 //!
 //! Propagates a 1 kg sphere in elliptical orbit with point-mass gravity, MET

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run10.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run10.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_10A/10C/10D — Gravity gradient torque
 //!
 //! All simulation parameters (mu, step size, mass) are loaded from JEOD source

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run2.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run2.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_2 — Point-mass gravity (3-DOF and 6-DOF)
 //!
 //! All simulation parameters (mu, step size, mass) are loaded from JEOD source

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run3.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run3.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_3A/3B — Spherical harmonics gravity (4x4 / 8x8 + RNP)
 //!
 //! All simulation parameters (epoch, step size, gravity degree/order) are loaded

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run4.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_4 — Spherical Earth + Sun/Moon third-body.
 //!
 //! Migrated from a 280-line bespoke per-step ephemeris-update loop to

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run5.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run5.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_5B/5C — Elliptical orbit, 6-DOF (ISS mass)
 //!
 //! JEOD labels these "atmosphere comparison" runs, but drag is disabled

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run6.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_6A/6B — Drag (constant density and MET atmosphere)
 //!
 //! All simulation parameters (epoch, step size, mu, mass) are loaded from JEOD

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run7.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_7A–7D — Spherical harmonics + Sun/Moon
 //! third-body (± drag).
 //!

--- a/crates/jeod_runner/tests/tier3_sim_euler.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_Euler cross-validation (derived_state/verif/SIM_Euler)
 //!
 //! Uses the RUN_2 point-mass 6-DOF trajectory (which has quaternion data)

--- a/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_euler_edge.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_Euler edge-case cross-validation
 //!
 //! RUN_ecc: Eccentric orbit (400 km x 8000 km altitude) — varying orbital rate

--- a/crates/jeod_runner/tests/tier3_sim_lvlh.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_LVLH cross-validation (derived_state/verif/SIM_LVLH)
 //!
 //! Point-mass gravity, 400 km circular LEO (i=45 deg), 24h.

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_edge.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_LVLH edge-case cross-validation
 //!
 //! RUN_ecc: Eccentric orbit (400 km x 8000 km) — varying orbital rate

--- a/crates/jeod_runner/tests/tier3_sim_met.rs
+++ b/crates/jeod_runner/tests/tier3_sim_met.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_dyncomp RUN_5A — MET atmosphere via Simulation pipeline
 //!
 //! Propagates an ISS-like elliptical orbit with point-mass gravity and MET

--- a/crates/jeod_runner/tests/tier3_sim_ned.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_NED cross-validation (derived_state/verif/SIM_NED)
 //!
 //! Matches the JEOD SIM_NED configuration:

--- a/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ned_edge.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_NED edge-case cross-validation
 //!
 //! RUN_ell_polar: Polar orbit on ellipsoidal Earth — geodetic singularity at poles

--- a/crates/jeod_runner/tests/tier3_sim_orbelem.rs
+++ b/crates/jeod_runner/tests/tier3_sim_orbelem.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_OrbElem cross-validation (derived_state/verif/SIM_OrbElem)
 //!
 //! Point-mass gravity, eccentric orbit (e=0.36), 24h, dt=0.03125s.

--- a/crates/jeod_runner/tests/tier3_sim_planetary.rs
+++ b/crates/jeod_runner/tests/tier3_sim_planetary.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_Planetary — derived state trajectory in 5 orbit regimes.
 //!
 //! Validates Simulation trajectory against JEOD SIM_Planetary reference CSVs

--- a/crates/jeod_runner/tests/tier3_sim_polar_motion.rs
+++ b/crates/jeod_runner/tests/tier3_sim_polar_motion.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: Polar motion regression check (point-mass gravity).
 //!
 //! Validates that enabling `Simulation::polar_motion` does not break

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: ISS LEO trajectory cross-validation against SIM_dyncomp RUN_2,
 //! with the Sun source registered + DE421-driven each step so
 //! `body.solar_beta` is computed throughout. Sun has mu=0 — the Sun

--- a/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
+++ b/crates/jeod_runner/tests/tier3_sim_solar_beta_edge.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_SolarBeta edge-case cross-validation via Simulation pipeline.
 //!
 //! - `RUN_incl_0` — equatorial orbit (i=0), point-mass gravity. Beta tracks

--- a/crates/jeod_runner/tests/tier3_sim_srp.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_3_ORBIT — flat-plate SRP + conical Earth shadow, GEO
 //! orbit, ~23 days.
 //!

--- a/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
+++ b/crates/jeod_runner/tests/tier3_sim_srp_1st_order.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_3_ORBIT_1st_ORDER cross-validation.
 //!
 //! Migrated from a 287-line bespoke per-step ephemeris-update loop to

--- a/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
+++ b/crates/jeod_runner/tests/tier3_sim_tide_verif.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_tide_verif RUN_01 — solid body tides cross-validation.
 //!
 //! Migrated from a 290-line bespoke per-step ephemeris-update loop to

--- a/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
+++ b/crates/jeod_runner/tests/tier3_sim_torque_simple.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "verification")]
+
 //! Tier 3: SIM_torque_compare_simple — six runs of progressive
 //! gravity + gravity-gradient complexity.
 //!

--- a/crates/jeod_sim/src/recipes/verification/reference_data.rs
+++ b/crates/jeod_sim/src/recipes/verification/reference_data.rs
@@ -55,9 +55,11 @@ fn jeod_grav_data(file: &str) -> PathBuf {
     // Routes through `jeod_test_data::jeod_path()` (the canonical
     // JEOD-source resolver in this workspace) instead of the previous
     // duplicate copy that lived here. Wave 2 of #232 collapsed the two
-    // helpers into one. The canonical resolver returns a sentinel path
-    // when neither `JEOD_PATH` nor `JEOD_HOME` is set; the subsequent
-    // `load_from_jeod_cc` panics with a "Set JEOD_HOME or JEOD_PATH"
+    // helpers into one. `jeod_test_data::jeod_path()` prefers
+    // `JEOD_PATH` over `JEOD_HOME` and returns a sentinel path when
+    // neither is set; downstream callers (e.g. `load_grav_cc`) surface
+    // the resulting I/O error from `load_from_jeod_cc`'s `Result` via
+    // `unwrap_or_else`, panicking with a "Set JEOD_HOME or JEOD_PATH"
     // diagnostic identical in spirit to the original behaviour.
     jeod_test_data::jeod_path()
         .join("models/environment/gravity/data/src")

--- a/crates/jeod_sim/src/recipes/verification/reference_data.rs
+++ b/crates/jeod_sim/src/recipes/verification/reference_data.rs
@@ -13,7 +13,7 @@
 //! rotation data as standalone Rust assets is tracked as a separate
 //! follow-up issue.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use jeod_gravity::SphericalHarmonicsData;
 use jeod_test_data::jeod_cc::load_from_jeod_cc;
@@ -52,25 +52,14 @@ fn load_grav_cc(file: &str) -> SphericalHarmonicsData {
 }
 
 fn jeod_grav_data(file: &str) -> PathBuf {
-    jeod_path()
+    // Routes through `jeod_test_data::jeod_path()` (the canonical
+    // JEOD-source resolver in this workspace) instead of the previous
+    // duplicate copy that lived here. Wave 2 of #232 collapsed the two
+    // helpers into one. The canonical resolver returns a sentinel path
+    // when neither `JEOD_PATH` nor `JEOD_HOME` is set; the subsequent
+    // `load_from_jeod_cc` panics with a "Set JEOD_HOME or JEOD_PATH"
+    // diagnostic identical in spirit to the original behaviour.
+    jeod_test_data::jeod_path()
         .join("models/environment/gravity/data/src")
         .join(file)
-}
-
-/// Resolve `$JEOD_HOME` or `$JEOD_PATH`. Panics with a helpful message
-/// if neither is set — verification cases require JEOD source data and
-/// must not silently skip.
-pub fn jeod_path() -> PathBuf {
-    if let Ok(p) = std::env::var("JEOD_HOME") {
-        Path::new(&p).to_path_buf()
-    } else if let Ok(p) = std::env::var("JEOD_PATH") {
-        Path::new(&p).to_path_buf()
-    } else {
-        panic!(
-            "JEOD_HOME / JEOD_PATH not set. Verification reference loaders \
-             require a JEOD source checkout. Clone https://github.com/nasa/jeod \
-             alongside this repo and set JEOD_HOME=../jeod (or copy \
-             .cargo/config.toml.example to .cargo/config.toml)."
-        )
-    }
 }


### PR DESCRIPTION
Closes #238. Wave 2 of #232's parallel rollout. Depends on #233 / #234 / #235 / #236 (all merged).

## Summary

Per-file audit of every `run_verification/sim_*.rs` rig and `jeod_sim::recipes::verification::reference_data`. Two coordinated moves:

1. **Feature-gate the rigs** behind a new default-on `verification` cargo feature on `jeod_runner`. Production builds (`cargo build -p jeod_runner --no-default-features`) skip the entire `run_verification` module and drop `jeod_test_data` / `jeod_sim/jeod-source` from the dep closure — the runner ships JEOD-source-free.
2. **Migrate calls to committed fixtures** wherever they exist (Earth GGM05C / GGM02C, Sun mu — all from Wave 1). Remaining JEOD-source loads (Moon GRAIL150, Modified_data/{time,mass,grav_controls}.py, S_define dt) only run under the gated module.

## Per-file decisions

| File | Decision | Rationale |
|---|---|---|
| `jeod_runner/Cargo.toml` | Add `default = ["verification"]`; gate `dep:jeod_test_data` + `jeod_sim/jeod-source` behind it. Keep `jeod_test_data` as explicit dev-dep so `tests/tier3_*.rs` still compile when the feature is off in unusual configs. | Cleanest split: opt-out for production, default-on for Tier 3. |
| `jeod_runner/src/{lib,prelude}.rs` | `#[cfg(feature = "verification")]` on `run_verification` module + `VerificationCaseExt` re-exports. | Preserves library API surface with the feature on. |
| `sim_derived_state.rs` | Migrated Earth GGM05C mu to `gravity_fixtures::load_ggm05c().mu`. | Fixture exists. Helper still loads S_define / time.py from JEOD source under the feature gate. |
| `sim_dyncomp.rs` | Migrated Earth GGM05C / GGM02C SH and Sun mu to `gravity_fixtures::*` and `mars_fixtures::load_sun_spherical_mu()` across all 12 callsites. | All Earth + Sun fixtures already committed; cuts ~12 `load_*_from_jeod_cc` calls. |
| `sim_planetary.rs` | Migrated Earth GGM05C mu to fixture; moved JEOD-source assert into `build_planetary` so the fixture-only helper is independent. | Fixture exists. |
| `sim_polar_motion.rs` | Migrated Earth GGM05C mu to fixture. | Fixture exists. |
| `sim_solar_beta.rs` | Migrated Earth GGM05C mu **and** SH (obliquity case uses full SH) to fixture. Removed unused `coefficients` import. | Fixture exists. |
| `sim_srp.rs` | Migrated Earth GGM05C mu to fixture. Removed unused `load_mu_from_jeod_cc` import. | Fixture exists. |
| `sim_tide_verif.rs` | Migrated Earth GGM05C SH **and** Sun mu to fixtures. Moon mu kept JEOD-source. Removed unused `load_from_jeod_cc` import. | Earth + Sun fixtures exist; Moon does not. |
| `sim_torque_simple.rs` | Migrated Earth GGM05C SH **and** Sun mu to fixtures. Moon mu kept JEOD-source. Removed unused `coefficients` import. | Earth + Sun fixtures exist; Moon does not. |
| `jeod_sim/.../reference_data.rs` | Removed duplicate local `jeod_path()` helper; routes through `jeod_test_data::jeod_path()`. | Consolidates to one resolver per workspace. |

Moon GRAIL150 mu, Modified_data/*.py, and S_define dt remain JEOD-source-loaded under the gated module. Adding fixtures for them is tracked as follow-up under #239.

## New feature flag

- `jeod_runner` now has `verification` (default-on). Opt out:
  ```bash
  cargo build -p jeod_runner --no-default-features   # JEOD-source-free
  cargo build -p jeod_runner --features verification # rigs available
  cargo build -p jeod_runner                         # default → rigs available
  ```

## Verification gates

- `cargo fmt --check` passes (after `cargo fmt` rewrap of the multi-line `mu_moon` declaration).
- `cargo clippy --workspace --tests -- -D warnings` passes.
- `cargo nextest run --workspace -E 'not test(tier3_)'`: 813 passed, 312 skipped.
- `cargo build --workspace --all-targets`: clean.
- `cargo build -p jeod_runner --no-default-features`: clean. `cargo tree -p jeod_runner --no-default-features --edges normal | grep test_data` is empty — confirmation that production builds drop `jeod_test_data` entirely.
- `cargo build -p jeod_runner --features verification`: clean.
- Sanity-tested `JEOD_HOME=… cargo nextest run -p jeod_runner --test tier3_sim_dyncomp_run2`: 2/2 pass after migration (RUN_2 3-DOF + 6-DOF), confirming the GGM05C fixture mu matches the bit-for-bit JEOD-source value.

## Test plan

- [ ] CI `check` (fmt + clippy + escape-hatch grep) passes.
- [ ] CI `test` (unit + tier 2) passes.
- [ ] CI `test-tier3` (tier 3 fast set) passes — exercises every migrated rig with the new fixtures.
- [ ] CI `test-tier3-full` on main passes — includes the long earth_moon test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)