### PR TITLE
[#100] Roll out deny(missing_docs) + README + docs.rs metadata across all jeod_* crates

### DIFF
--- a/crates/jeod_atmosphere/Cargo.toml
+++ b/crates/jeod_atmosphere/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_atmosphere"
 description = "Atmospheric density models (exponential, MET) for bevy_jeod"
+readme = "README.md"
 keywords = ["atmosphere", "drag", "orbital-mechanics", "aerospace"]
 categories = ["science", "aerospace"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }

--- a/crates/jeod_atmosphere/README.md
+++ b/crates/jeod_atmosphere/README.md
@@ -1,0 +1,46 @@
+# jeod_atmosphere
+
+Neutral-atmosphere density, temperature, pressure, and wind models for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/environment/atmosphere/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/atmosphere/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod), including the
+Marshall Engineering Thermosphere (MET) implementation in
+[`models/environment/atmosphere/MET/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/atmosphere/MET/).
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_atmosphere  ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_quantities  (typed mass density, pressure, velocity)
+```
+
+`jeod_atmosphere` is part of the `jeod_*` physics layer — pure Rust with
+no Bevy dependency.
+
+## Public surface
+
+- `AtmosphereState` — density / temperature / pressure / inertial-frame
+  wind, returned by every model evaluation.
+- `exponential` — `rho = rho_0 * exp(-(h - h_0) / H)`. Single-parameter
+  scale-height fallback and unit-test baseline.
+- `met` — Marshall Engineering Thermosphere model (Jacchia 1970/1971).
+  Production model for LEO drag.
+- `compute_corotation_wind` / `compute_corotation_wind_typed` — `omega ×
+  r` co-rotation wind for planets whose angular velocity points along
+  the inertial Z axis.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `AT.*`
+  invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_atmosphere/>

--- a/crates/jeod_atmosphere/README.md
+++ b/crates/jeod_atmosphere/README.md
@@ -38,9 +38,9 @@ no Bevy dependency.
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `AT.*`
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `AT.*`
   invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_atmosphere/>

--- a/crates/jeod_atmosphere/src/lib.rs
+++ b/crates/jeod_atmosphere/src/lib.rs
@@ -37,6 +37,7 @@
 //! `models/environment/atmosphere/` model directory.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub use jeod_quantities::prelude::*;
 

--- a/crates/jeod_dynamics/Cargo.toml
+++ b/crates/jeod_dynamics/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_dynamics"
 description = "Rigid-body dynamics, integrators (RK4, RKF45, GJ, ABM4), mass tree, and body initialization"
+readme = "README.md"
 keywords = ["orbital-mechanics", "dynamics", "integrator", "aerospace", "simulation"]
 categories = ["science", "aerospace", "simulation"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_frames = { path = "../jeod_frames", version = "0.1.0" }

--- a/crates/jeod_dynamics/README.md
+++ b/crates/jeod_dynamics/README.md
@@ -1,0 +1,55 @@
+# jeod_dynamics
+
+Rigid-body dynamics, integrators (RK4, RKF45, Gauss-Jackson, ABM4), the
+mass tree, and body initialization for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/dynamics/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/dynamics/)
+and
+[`models/utils/integration/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/integration/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod). Decomposes JEOD's
+1200-line `DynBody` god-class into ~10 narrow components.
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes)
+   ↓
+jeod_dynamics    ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_math, jeod_frames, jeod_quantities
+```
+
+## Public surface
+
+- `state::TranslationalState`, `rotational::RotationalState`,
+  `rotational::SixDofState` — body state in the integration frame.
+- `mass::MassProperties` — mass, inertia, CoM offset, plus the
+  parallel-axis (Steiner) composition for mass-tree subtrees.
+- `forces::TotalForce`, `forces::FrameDerivatives`,
+  `forces::DynamicsConfig`, `forces::GravityAcceleration` — per-step
+  force / derivative accumulators.
+- `integration::IntegrationMethod` — RK4 / RKF45 / GJ / ABM4 dispatch.
+- `propagation`, `subtree`, `attach`, `body_init`, `constraints`,
+  `mass_body` — the rest of the `DynBody` decomposition.
+
+## JEOD conventions
+
+- Translational state is stored in the **integration frame** (typically
+  J2000 ECI), absolute (not parent-frame-relative).
+- Quaternions are scalar-first left-transformation
+  (`jeod_math::JeodQuat`).
+- `inverse_mass` and `inverse_inertia` are pre-computed once per step
+  to keep the inner loop multiply-only.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `DB.*`,
+  `MS.*`, `IN.*`, `RK.*`, `AB.*`, `GJ.*` invariants.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_dynamics/>

--- a/crates/jeod_dynamics/README.md
+++ b/crates/jeod_dynamics/README.md
@@ -47,9 +47,9 @@ jeod_math, jeod_frames, jeod_quantities
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `DB.*`,
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `DB.*`,
   `MS.*`, `IN.*`, `RK.*`, `AB.*`, `GJ.*` invariants.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_dynamics/>

--- a/crates/jeod_dynamics/src/forces.rs
+++ b/crates/jeod_dynamics/src/forces.rs
@@ -1,3 +1,13 @@
+//! Per-body force / torque accumulators consumed by the integrator.
+//!
+//! Mirrors the force-collection step of JEOD's
+//! [`models/dynamics/dyn_body/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/dynamics/dyn_body/)
+//! pipeline (v5.4.0). Interactions push contributions into these
+//! accumulators; the integrator reads them in the `ForceCollectionSet`
+//! schedule slot. Holds [`GravityAcceleration`], [`TotalForce`], the
+//! per-frame typed siblings, and helpers like
+//! `accumulate_gravity` and [`compute_translational_acceleration`].
+
 use core::marker::PhantomData;
 
 use glam::{DMat3, DVec3};
@@ -45,8 +55,12 @@ impl Default for GravityAcceleration {
 /// and never composed across frames in the dynamics layer.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GravityAccelerationTyped<F: Frame = Inertial> {
+    /// Gravitational acceleration in frame `F`.
     pub grav_accel: Acceleration<F>,
+    /// Gravity-gradient tensor (`1/s²`).
     pub grav_grad: DMat3,
+    /// Gravitational potential (`m²/s²`, JEOD sign convention is
+    /// positive for bound orbits).
     pub grav_pot: f64,
 }
 
@@ -84,10 +98,16 @@ impl<F: Frame> GravityAccelerationTyped<F> {
     }
 }
 
+/// Net body force / torque, the integrator's input each step.
+///
+/// Force is expressed in the integration frame (typically J2000 ECI);
+/// torque is in the body frame.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct TotalForce {
-    pub force: DVec3,  // N, in integration frame
-    pub torque: DVec3, // N*m, in body frame
+    /// Net force in newtons, in the integration frame.
+    pub force: DVec3,
+    /// Net torque in N·m, in the body frame.
+    pub torque: DVec3,
 }
 
 /// Typed sibling of [`TotalForce`].
@@ -101,7 +121,9 @@ pub struct TotalForce {
 /// vehicle marker exists yet (Phase 5 territory).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TotalForceTyped<V: Vehicle, F: Frame = Inertial> {
+    /// Net force in the integration frame `F`.
     pub force: Force<F>,
+    /// Net torque about the body-frame origin of vehicle `V`.
     pub torque: Torque<BodyFrame<V>>,
     _v: PhantomData<V>,
 }
@@ -139,10 +161,15 @@ impl<V: Vehicle, F: Frame> TotalForceTyped<V, F> {
     }
 }
 
+/// Frame-state derivatives: translational and rotational
+/// acceleration. The integrator's per-step output.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct FrameDerivatives {
-    pub trans_accel: DVec3, // m/s^2
-    pub rot_accel: DVec3,   // rad/s^2
+    /// Translational acceleration in m/s², in the integration frame.
+    pub trans_accel: DVec3,
+    /// Rotational acceleration (angular acceleration) in rad/s²,
+    /// expressed in the body frame.
+    pub rot_accel: DVec3,
 }
 
 /// Typed sibling of [`FrameDerivatives`].
@@ -154,7 +181,9 @@ pub struct FrameDerivatives {
 /// orientation is completely unrelated.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct FrameDerivativesTyped<F: Frame, V: Vehicle> {
+    /// Translational acceleration in the integration frame `F`.
     pub trans_accel: Acceleration<F>,
+    /// Angular acceleration about the body-frame origin of `V`.
     pub rot_accel: jeod_quantities::aliases::AngularAcceleration<BodyFrame<V>>,
     _v: PhantomData<V>,
 }
@@ -195,10 +224,20 @@ impl<F: Frame, V: Vehicle> FrameDerivativesTyped<F, V> {
     }
 }
 
+/// Per-body dynamics-mode toggles consumed by the integrator.
+///
+/// Mirrors JEOD's `DynBody.translational_dynamics` /
+/// `rotational_dynamics` / `three_dof` flags. `three_dof = true`
+/// suppresses creation of the rotational integrator; the validator
+/// panics on the inconsistent `three_dof = true && rotational = true`
+/// combination.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DynamicsConfig {
+    /// Integrate translational state.
     pub translational_dynamics: bool,
+    /// Integrate rotational state.
     pub rotational_dynamics: bool,
+    /// Run as a 3-DoF point mass (no rotational integrator created).
     pub three_dof: bool,
 }
 
@@ -233,6 +272,11 @@ impl DynamicsConfig {
     }
 }
 
+/// Compute translational acceleration from force and pre-computed
+/// inverse mass: `a = F · (1/m)`.
+///
+/// JEOD pre-computes `1/m` once per step on `MassPointState` so the
+/// inner loop is a multiply rather than a divide.
 // JEOD_INV: DB.18 — F=ma via precomputed inverse_mass (matches JEOD MassPointState.inverse_mass)
 pub fn compute_translational_acceleration(force: DVec3, inverse_mass: f64) -> DVec3 {
     force * inverse_mass

--- a/crates/jeod_dynamics/src/integration.rs
+++ b/crates/jeod_dynamics/src/integration.rs
@@ -1,3 +1,13 @@
+//! Integration-method dispatch and the per-method translational /
+//! rotational step kernels.
+//!
+//! Mirrors JEOD's
+//! [`models/utils/integration/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/integration/)
+//! integration manager (v5.4.0). RK4, RKF45, Adams-Bashforth-Moulton 4
+//! (ABM4), and Gauss-Jackson 8 are dispatched through the
+//! `IntegrationMethod` enum below; multi-stage methods run as an inner
+//! loop within a single `FixedUpdate` tick.
+
 use crate::mass::MassProperties;
 use crate::rotational::*;
 use crate::state::TranslationalState;

--- a/crates/jeod_dynamics/src/lib.rs
+++ b/crates/jeod_dynamics/src/lib.rs
@@ -29,6 +29,7 @@
 //! wiring lives in the `bevy_jeod` root crate.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub mod abm4;
 pub mod attach;

--- a/crates/jeod_dynamics/src/mass.rs
+++ b/crates/jeod_dynamics/src/mass.rs
@@ -1,3 +1,12 @@
+//! [`MassProperties`] and the typed sibling [`MassPropertiesTyped`] —
+//! mass, inertia tensor, and CoM offset for a rigid body.
+//!
+//! Ports
+//! [`models/dynamics/mass/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/dynamics/mass/)
+//! from JEOD v5.4.0. Inertia is stored about the body-frame axes
+//! through the centre of mass; composing child masses into a parent
+//! applies the parallel-axis (Steiner) theorem.
+
 use core::marker::PhantomData;
 
 use glam::{DMat3, DVec3};
@@ -13,13 +22,22 @@ use uom::si::mass::kilogram;
 /// spacecraft inertia tensors (principal moments ~1–10000 kg*m^2).
 pub const INERTIA_CONSISTENCY_TOL: f64 = 1e-6;
 
+/// Rigid-body mass / inertia / CoM-offset block.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MassProperties {
-    pub mass: f64,              // kg
-    pub inverse_mass: f64,      // 1/kg, precomputed (matches JEOD MassPointState.inverse_mass)
-    pub inertia: DMat3,         // kg*m^2, in body frame
-    pub inverse_inertia: DMat3, // precomputed I^-1
-    pub position: DVec3,        // m, in structural frame
+    /// Total mass in kg.
+    pub mass: f64,
+    /// Pre-computed inverse mass (`1/mass`, in `1/kg`). Mirrors JEOD's
+    /// `MassPointState::inverse_mass` so the inner loop is a multiply.
+    pub inverse_mass: f64,
+    /// Inertia tensor about the body-frame axes through the centre of
+    /// mass (kg·m²).
+    pub inertia: DMat3,
+    /// Pre-computed inverse inertia tensor.
+    pub inverse_inertia: DMat3,
+    /// Centre-of-mass position relative to the structural-frame
+    /// origin, in metres.
+    pub position: DVec3,
     /// Rotation matrix from the structural frame to the body frame,
     /// matching JEOD `MassPointState::T_parent_this` for the
     /// composite-body point. Defaults to `IDENTITY` (struct = body), which

--- a/crates/jeod_dynamics/src/rotational.rs
+++ b/crates/jeod_dynamics/src/rotational.rs
@@ -1,3 +1,12 @@
+//! Rotational state: attitude quaternion, angular velocity, and the
+//! integration kernels that propagate them under applied torque.
+//!
+//! Mirrors the rotational side of JEOD's
+//! [`models/dynamics/dyn_body/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/dynamics/dyn_body/)
+//! integrator (v5.4.0). Quaternions follow the JEOD scalar-first
+//! left-transformation convention; the typed siblings live in
+//! [`jeod_quantities::body_attitude`].
+
 use core::marker::PhantomData;
 
 use crate::state::TranslationalState;
@@ -34,7 +43,9 @@ impl Default for RotationalState {
 /// Combined translational + rotational state for 6-DOF integration.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct SixDofState {
+    /// Translational position + velocity.
     pub trans: TranslationalState,
+    /// Attitude quaternion + angular velocity.
     pub rot: RotationalState,
 }
 

--- a/crates/jeod_dynamics/src/state.rs
+++ b/crates/jeod_dynamics/src/state.rs
@@ -1,11 +1,26 @@
+//! [`TranslationalState`] — position and velocity in the integration
+//! frame.
+//!
+//! Mirrors the translational half of JEOD's
+//! [`models/dynamics/dyn_body/include/dyn_body.hh`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/dynamics/dyn_body/include/dyn_body.hh)
+//! state from JEOD v5.4.0. Stored in the integration frame (typically
+//! J2000 ECI); `position` is **absolute** (relative to the ECI origin),
+//! not the parent-frame-relative form used by `jeod_frames`'s
+//! `RefFrameState`.
+
 use glam::DVec3;
 use jeod_quantities::aliases::{Position, Velocity};
 use jeod_quantities::frame::{Frame, Inertial};
 
+/// Translational state in the integration frame.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct TranslationalState {
-    pub position: DVec3, // m, in integration frame
-    pub velocity: DVec3, // m/s, in integration frame
+    /// Position of the body's centre of mass, in metres, in the
+    /// integration frame.
+    pub position: DVec3,
+    /// Velocity of the body's centre of mass, in m/s, in the
+    /// integration frame.
+    pub velocity: DVec3,
 }
 
 impl TranslationalState {

--- a/crates/jeod_ephemeris/Cargo.toml
+++ b/crates/jeod_ephemeris/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_ephemeris"
 description = "DE4xx binary ephemeris reader and body positions for bevy_jeod"
+readme = "README.md"
 keywords = ["ephemeris", "de440", "spice", "orbital-mechanics", "aerospace"]
 categories = ["science", "aerospace"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }

--- a/crates/jeod_ephemeris/README.md
+++ b/crates/jeod_ephemeris/README.md
@@ -1,0 +1,49 @@
+# jeod_ephemeris
+
+Planetary ephemerides backed by JPL DE-series SPK files for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/environment/ephemerides/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/ephemerides/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod). Where JEOD links a
+hand-rolled binary loader to JPL DE405 / DE421 kernels, this crate delegates
+the file format and Chebyshev evaluation to the
+[`anise`](https://crates.io/crates/anise) crate (a pure-Rust SPICE/NAIF
+reimplementation) and exposes a thin, frame-tagged API on top.
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_ephemeris   ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_quantities  (Position<Inertial>, Velocity<Inertial>, frame tags)
+```
+
+`jeod_ephemeris` is part of the `jeod_*` physics layer — pure Rust with no
+Bevy dependency. The Bevy-side glue lives in `bevy_jeod::*`; the pipeline
+that drives it lives in `jeod_sim`. See the project
+[Strategy wiki page](https://github.com/simnaut/bevy_jeod/wiki/Strategy)
+for the layered architecture.
+
+## Public surface
+
+- `Ephemeris` — owns an `anise::Almanac` and answers position/velocity
+  queries from `.bsp` files (e.g., `de421.bsp`, `de440.bsp`).
+- `EphemerisBody` — body-identifier enum mapping JEOD's body IDs to
+  NAIF integer IDs.
+- `EphemerisError` — fail-loudly error type for missing files,
+  unsupported bodies, or out-of-range epochs.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `EP.*`
+  tags catalog the ephemeris invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture and
+  conventions.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_ephemeris/>

--- a/crates/jeod_ephemeris/README.md
+++ b/crates/jeod_ephemeris/README.md
@@ -40,10 +40,10 @@ for the layered architecture.
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `EP.*`
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `EP.*`
   tags catalog the ephemeris invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture and
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture and
   conventions.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_ephemeris/>

--- a/crates/jeod_ephemeris/src/bodies.rs
+++ b/crates/jeod_ephemeris/src/bodies.rs
@@ -1,3 +1,12 @@
+//! Solar-system body identifier enum used by [`crate::Ephemeris`] queries.
+//!
+//! Ports the body-ID conventions in [`models/environment/ephemerides/include/de4xx_ephem.hh`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/ephemerides/include/de4xx_ephem.hh)
+//! from JEOD v5.4.0. The numeric values come from the JPL/NAIF SPICE
+//! conventions used by the DE4xx kernels, exposed via the `anise` crate.
+//!
+//! Most planet variants name **system barycenters**, not body centers; see
+//! [`EphemerisBody`] for per-variant documentation.
+
 /// Solar system body identifiers for ephemeris queries.
 ///
 /// Follows the JEOD/JPL DE4xx convention where planet names (items 0-8)

--- a/crates/jeod_ephemeris/src/ephemeris.rs
+++ b/crates/jeod_ephemeris/src/ephemeris.rs
@@ -1,3 +1,15 @@
+//! [`Ephemeris`] reader and the [`EphemerisError`] failure type.
+//!
+//! Ports the kernel-loader / state-query surface of
+//! [`models/environment/ephemerides/de4xx_ephem/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/ephemerides/de4xx_ephem/)
+//! from JEOD v5.4.0. JEOD links a hand-rolled binary loader to JPL DE405 /
+//! DE421 kernels; this crate delegates the file format and Chebyshev
+//! evaluation to the `anise` crate (a Rust SPICE/NAIF reimplementation) and
+//! exposes a thin frame-tagged wrapper.
+//!
+//! Outputs are wrapped as [`Position<Inertial>`] / [`Velocity<Inertial>`]
+//! from [`jeod_quantities`] in the J2000 ICRF (meters and m/s).
+
 use std::path::Path;
 
 use anise::constants::celestial_objects::*;
@@ -198,8 +210,15 @@ fn body_to_frame(body: EphemerisBody) -> Frame {
 // failures (EP.14, EP.17 aggregated). JEOD uses distinct message codes; we aggregate.
 #[derive(Debug, thiserror::Error)]
 pub enum EphemerisError {
+    /// SPK / BPC kernel could not be loaded — bad path, wrong format,
+    /// or unreadable bytes. Aggregates JEOD's `EP.11`-`EP.13` load-time
+    /// failure codes.
     #[error("Failed to load ephemeris file: {0}")]
     LoadError(String),
+    /// Translation or rotation query failed — unsupported body, epoch
+    /// out of segment range, or missing orientation kernel.
+    /// Aggregates JEOD's `EP.14` (epoch range) and `EP.17`
+    /// (body availability) failure codes.
     #[error("Ephemeris query failed: {0}")]
     QueryError(String),
 }

--- a/crates/jeod_ephemeris/src/lib.rs
+++ b/crates/jeod_ephemeris/src/lib.rs
@@ -27,6 +27,7 @@
 //! Pure Rust, zero Bevy dependency.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub use jeod_quantities::prelude::*;
 

--- a/crates/jeod_frames/Cargo.toml
+++ b/crates/jeod_frames/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_frames"
 description = "Reference frame tree and Earth rotation (RNP, nutation, precession) for bevy_jeod"
+readme = "README.md"
 keywords = ["reference-frame", "earth-rotation", "orbital-mechanics", "aerospace", "geodesy"]
 categories = ["science", "aerospace"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_math = { path = "../jeod_math", version = "0.1.0" }

--- a/crates/jeod_frames/README.md
+++ b/crates/jeod_frames/README.md
@@ -1,0 +1,59 @@
+# jeod_frames
+
+Reference-frame tree and Earth/Mars/Moon rotation models for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/utils/ref_frames/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/ref_frames/)
+(the `RefFrame` tree that is the backbone of every coordinate system in
+JEOD) and
+[`models/environment/RNP/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/RNP/)
+(precession, nutation, polar motion) from
+[NASA JEOD v5.4.0](https://github.com/nasa/jeod).
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_frames      ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_quantities, jeod_math
+```
+
+`jeod_frames` is part of the `jeod_*` physics layer — pure Rust with no
+Bevy dependency.
+
+## Public surface
+
+- `FrameTree` / `FrameNode` / `FrameId` — arena-based hierarchy
+  mirroring JEOD's parent/child links. State is stored **relative to
+  parent**.
+- `RefFrameState` / `RefFrameTrans` / `RefFrameRot` — untyped storage
+  form of a frame's translational + rotational state (RF.06 + RF.07).
+- `RefFrameStateTyped<P, C>` — frame-tagged sibling for the public API
+  boundary.
+- `rotation_j2000`, `precession_j2000`, `nutation_j2000`,
+  `data_nutation_j2000` — Earth precession + IAU-1980 nutation series.
+- `rotation_mars`, `rotation_moon` — body-fixed rotation models for the
+  Mars and Moon target bodies used by the JEOD verification sims.
+
+## JEOD conventions
+
+- Quaternions are **scalar-first, left-transformation** — see
+  `jeod_math::JeodQuat`.
+- Translational state is in **parent-frame coordinates**, not absolute /
+  inertial.
+- `t_parent_this` is a derived cache of `q_parent_this`; the quaternion
+  is the canonical source of truth (RF.04).
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `RF.*`
+  invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_frames/>

--- a/crates/jeod_frames/README.md
+++ b/crates/jeod_frames/README.md
@@ -51,9 +51,9 @@ Bevy dependency.
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `RF.*`
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `RF.*`
   invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_frames/>

--- a/crates/jeod_frames/src/data_nutation_j2000.rs
+++ b/crates/jeod_frames/src/data_nutation_j2000.rs
@@ -1,25 +1,31 @@
-// IAU 1980 nutation coefficients for J2000.
-//
-// Extracted from JEOD 5.4:
-//   models/environment/RNP/RNPJ2000/data/src/data_nutation_j2000.cc
-//
-// Reference:
-//   Mulcihy, David D. and Bond, Victor R.,
-//   "The RNP Routine for the Standard Epoch J2000",
-//   NASA:JSC-24574, September 1990.
-//
-// 106 terms of the IAU 1980 Theory of Nutation.
-// Each array is indexed 0..105.
-//
-// The five fundamental argument multipliers (L, M, F, D, omega) are integer
-// coefficients that select which combination of Delaunay arguments drives
-// each nutation term.
-//
-// long_coeffs / long_t_coeffs:  longitude nutation (units: 0.0001 arcsec)
-// obliq_coeffs / obliq_t_coeffs: obliquity nutation (units: 0.0001 arcsec)
-//
-// The "t" arrays are the time-dependent (secular) parts, multiplied by T
-// (Julian centuries from J2000).
+//! IAU 1980 nutation coefficient tables for J2000.
+//!
+//! Extracted from
+//! [`models/environment/RNP/RNPJ2000/data/src/data_nutation_j2000.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/RNP/RNPJ2000/data/src/data_nutation_j2000.cc)
+//! in JEOD v5.4.0.
+//!
+//! Reference: Mulcihy, David D. and Bond, Victor R., *"The RNP Routine
+//! for the Standard Epoch J2000"*, NASA:JSC-24574, September 1990.
+//!
+//! 106 terms of the IAU 1980 Theory of Nutation. Each array is indexed
+//! `0..[NUM_NUTATION_COEFFS]`.
+//!
+//! The five fundamental-argument multiplier arrays
+//! ([`L_COEFFS`], [`M_COEFFS`], [`F_COEFFS`], [`D_COEFFS`],
+//! [`OMEGA_COEFFS`]) are integer coefficients that select which
+//! combination of Delaunay arguments drives each nutation term:
+//!
+//! - `L`: mean anomaly of the Moon
+//! - `M` (= `l'`): mean anomaly of the Sun
+//! - `F`: mean argument of latitude of the Moon
+//! - `D`: mean elongation of the Moon from the Sun
+//! - `Omega`: mean longitude of the ascending node of the Moon
+//!
+//! [`LONG_COEFFS`] / [`LONG_T_COEFFS`] hold the longitude-nutation
+//! amplitude and its time-dependent (secular) part.
+//! [`OBLIQ_COEFFS`] / [`OBLIQ_T_COEFFS`] hold the same for obliquity
+//! nutation. All amplitudes are in `0.0001 arcsec`; the `*_T_COEFFS`
+//! arrays multiply Julian centuries from J2000.
 
 /// Number of nutation coefficients.
 pub const NUM_NUTATION_COEFFS: usize = 106;

--- a/crates/jeod_frames/src/data_nutation_j2000.rs
+++ b/crates/jeod_frames/src/data_nutation_j2000.rs
@@ -7,8 +7,8 @@
 //! Reference: Mulcihy, David D. and Bond, Victor R., *"The RNP Routine
 //! for the Standard Epoch J2000"*, NASA:JSC-24574, September 1990.
 //!
-//! 106 terms of the IAU 1980 Theory of Nutation. Each array is indexed
-//! `0..[NUM_NUTATION_COEFFS]`.
+//! 106 terms of the IAU 1980 Theory of Nutation — each array has length
+//! [`NUM_NUTATION_COEFFS`] and is indexed `0..NUM_NUTATION_COEFFS`.
 //!
 //! The five fundamental-argument multiplier arrays
 //! ([`L_COEFFS`], [`M_COEFFS`], [`F_COEFFS`], [`D_COEFFS`],

--- a/crates/jeod_frames/src/data_nutation_j2000.rs
+++ b/crates/jeod_frames/src/data_nutation_j2000.rs
@@ -4,7 +4,7 @@
 //! [`models/environment/RNP/RNPJ2000/data/src/data_nutation_j2000.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/RNP/RNPJ2000/data/src/data_nutation_j2000.cc)
 //! in JEOD v5.4.0.
 //!
-//! Reference: Mulcihy, David D. and Bond, Victor R., *"The RNP Routine
+//! Reference: Mulcahy, David D. and Bond, Victor R., *"The RNP Routine
 //! for the Standard Epoch J2000"*, NASA:JSC-24574, September 1990.
 //!
 //! 106 terms of the IAU 1980 Theory of Nutation — each array has length

--- a/crates/jeod_frames/src/lib.rs
+++ b/crates/jeod_frames/src/lib.rs
@@ -32,6 +32,7 @@
 //! JEOD source: `models/utils/ref_frames/` and `models/environment/RNP/`.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub mod data_nutation_j2000;
 pub mod frame_tree;

--- a/crates/jeod_frames/src/nutation_j2000.rs
+++ b/crates/jeod_frames/src/nutation_j2000.rs
@@ -2,7 +2,7 @@
 //!
 //! Faithful port of JEOD's `nutation_j2000.cc` with IAU 1980 model (106 terms).
 //!
-//! Reference: Mulcihy & Bond, "The RNP Routine for the Standard Epoch J2000",
+//! Reference: Mulcahy & Bond, "The RNP Routine for the Standard Epoch J2000",
 //! NASA JSC-24574, September 1990.
 
 // Constants ported verbatim from JEOD — suppress excessive precision warnings.
@@ -33,7 +33,7 @@ pub fn nutation(time: f64) -> NutationResult {
     let time2 = time * time;
     let time3 = time2 * time;
 
-    // Fundamental arguments in degrees (Mulcihy & Bond, JSC-24574)
+    // Fundamental arguments in degrees (Mulcahy & Bond, JSC-24574)
     let l = 134.9629813888889
         + 477198.8673980555 * time
         + 0.008697222222222223 * time2

--- a/crates/jeod_frames/src/precession_j2000.rs
+++ b/crates/jeod_frames/src/precession_j2000.rs
@@ -2,7 +2,7 @@
 //!
 //! Faithful port of JEOD's `precession_j2000.cc` (IAU-76/FK5).
 //!
-//! Reference: Mulcihy & Bond, "The RNP Routine for the Standard Epoch J2000",
+//! Reference: Mulcahy & Bond, "The RNP Routine for the Standard Epoch J2000",
 //! NASA JSC-24574, September 1990.
 
 // Constants ported verbatim from JEOD — suppress excessive precision warnings.
@@ -29,7 +29,7 @@ pub fn precession_matrix(time: f64) -> DMat3 {
     let time2 = time * time;
     let time3 = time2 * time;
 
-    // Precession parameters in arcseconds (Mulcihy & Bond, JSC-24574),
+    // Precession parameters in arcseconds (Mulcahy & Bond, JSC-24574),
     // then converted to radians in place (matching JEOD convention).
     let mut zeta = 2306.2181 * time + 0.30188 * time2 + 0.017998 * time3;
     let mut theta = 2004.3109 * time - 0.42665 * time2 - 0.041833 * time3;

--- a/crates/jeod_frames/src/ref_frame_state.rs
+++ b/crates/jeod_frames/src/ref_frame_state.rs
@@ -1,3 +1,15 @@
+//! Per-node frame state — the untyped storage form used by the
+//! [`crate::FrameTree`] arena and the typed sibling
+//! [`RefFrameStateTyped<P, C>`] used at the public API boundary.
+//!
+//! Ports
+//! [`models/utils/ref_frames/src/ref_frame_state.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/ref_frames/src/ref_frame_state.cc)
+//! from JEOD v5.4.0. Position and velocity are stored **in parent
+//! coordinates** (RF.06); the rotation field uses the JEOD scalar-first
+//! left-transformation quaternion convention (RF.07) and treats the
+//! quaternion as the canonical source of truth with `t_parent_this` as a
+//! derived cache (RF.04).
+
 use core::marker::PhantomData;
 
 use glam::{DMat3, DVec3};
@@ -6,10 +18,17 @@ use jeod_quantities::aliases::{AngularVelocity, Position, Velocity};
 use jeod_quantities::frame::Frame;
 use jeod_quantities::quat::{LeftTransform, NormalizedQuat, ScalarFirst};
 
+/// Translational state of a frame relative to its parent.
+///
+/// Untyped storage form used by the [`crate::FrameTree`] arena. Position
+/// and velocity are expressed in **parent-frame coordinates**, matching
+/// JEOD's `RefFrameTrans`.
 // JEOD_INV: RF.06 — position/velocity in parent coordinates (structural convention)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RefFrameTrans {
+    /// Position of this frame's origin in the parent frame, in meters.
     pub position: DVec3, // m, in parent frame
+    /// Velocity of this frame's origin in the parent frame, in m/s.
     pub velocity: DVec3, // m/s, in parent frame
 }
 
@@ -22,12 +41,22 @@ impl Default for RefFrameTrans {
     }
 }
 
+/// Rotational state of a frame relative to its parent.
+///
+/// Untyped storage form. The quaternion `q_parent_this` is JEOD's
+/// scalar-first left-transformation form, and is the canonical source of
+/// truth — `t_parent_this` is a derived cache that callers must keep in
+/// sync (RF.04). Angular velocity is expressed in this-frame coordinates.
 // JEOD_INV: RF.07 — Q_parent_this is left-transformation quaternion (JEOD convention)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RefFrameRot {
-    pub q_parent_this: JeodQuat, // left transformation quaternion
-    pub t_parent_this: DMat3,    // transformation matrix
-    pub ang_vel_this: DVec3,     // rad/s, in this frame
+    /// Left-transformation quaternion (parent → this), scalar-first.
+    pub q_parent_this: JeodQuat,
+    /// 3×3 transformation matrix derived from `q_parent_this`.
+    pub t_parent_this: DMat3,
+    /// Angular velocity of this frame relative to parent, expressed in
+    /// this-frame coordinates, in rad/s.
+    pub ang_vel_this: DVec3,
 }
 
 impl Default for RefFrameRot {
@@ -40,22 +69,36 @@ impl Default for RefFrameRot {
     }
 }
 
+/// Combined translational + rotational state of a frame relative to its
+/// parent. The untyped storage form used by [`crate::FrameTree`].
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct RefFrameState {
+    /// Translational state in parent coordinates.
     pub trans: RefFrameTrans,
+    /// Rotational state (parent → this).
     pub rot: RefFrameRot,
 }
 
+/// Identifier metadata for a frame-tree node — name plus the
+/// [`RefFrameKind`] discriminator.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RefFrameInfo {
+    /// Human-readable frame name (e.g., `"earth.ecef"`, `"iss.body"`).
     pub name: String,
+    /// Discriminator marking which kind of frame this is.
     pub kind: RefFrameKind,
 }
 
+/// Discriminator for frame-tree nodes. Mirrors the runtime tags JEOD
+/// uses to distinguish inertial, planet-fixed, and body frames.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RefFrameKind {
+    /// Inertial (J2000 / ICRF) frame — typically the root of a tree.
     Inertial,
+    /// Planet-fixed (ECEF / IAU body-fixed) frame rotating with its
+    /// parent body.
     PlanetFixed,
+    /// Vehicle / body frame attached to a `DynBody` or composite.
     Body,
 }
 
@@ -291,7 +334,9 @@ impl<F: Frame> Default for RefFrameRotTyped<F, F> {
 /// state spanning the union.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RefFrameStateTyped<P: Frame, C: Frame> {
+    /// Typed translational state in parent coordinates.
     pub trans: RefFrameTransTyped<P>,
+    /// Typed rotational state (parent → child).
     pub rot: RefFrameRotTyped<P, C>,
 }
 

--- a/crates/jeod_frames/src/rotation_j2000.rs
+++ b/crates/jeod_frames/src/rotation_j2000.rs
@@ -3,7 +3,7 @@
 //! Faithful port of JEOD's `rotation_j2000.cc` (IAU-76/FK5).
 //! Computes the inertial-to-planet-fixed rotation matrix from time scales.
 //!
-//! Reference: Mulcihy & Bond, "The RNP Routine for the Standard Epoch J2000",
+//! Reference: Mulcahy & Bond, "The RNP Routine for the Standard Epoch J2000",
 //! NASA JSC-24574, September 1990.
 
 // Constants ported verbatim from JEOD — suppress excessive precision warnings.

--- a/crates/jeod_gravity/Cargo.toml
+++ b/crates/jeod_gravity/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_gravity"
 description = "Spherical-harmonics gravity (Gottlieb), tides, and third-body for bevy_jeod"
+readme = "README.md"
 keywords = ["gravity", "spherical-harmonics", "orbital-mechanics", "aerospace", "physics"]
 categories = ["science", "aerospace"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_math = { path = "../jeod_math", version = "0.1.0" }

--- a/crates/jeod_gravity/README.md
+++ b/crates/jeod_gravity/README.md
@@ -1,0 +1,57 @@
+# jeod_gravity
+
+Gravity computation for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace —
+point-mass, spherical harmonics (Gottlieb algorithm), tides, and
+post-Newtonian relativistic corrections.
+
+Ports
+[`models/environment/gravity/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod). The core spherical-
+harmonics kernel is a faithful port of
+[`spherical_harmonics_calc_nonspherical.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/spherical_harmonics_calc_nonspherical.cc),
+a numerically stable normalized Legendre recursion that scales to high
+degree and order without the underflow / overflow problems of the
+classical formulation.
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_gravity     ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_dynamics, jeod_math, jeod_quantities
+```
+
+`jeod_gravity` is part of the `jeod_*` physics layer — pure Rust with
+no Bevy dependency.
+
+## Public surface
+
+- `calc_spherical`, `gravitation`, `gravitation_with_scratch` — point-
+  mass and dispatched gravity computation.
+- `calc_nonspherical*`, `GottliebScratch` — the Gottlieb spherical-
+  harmonics kernel + reusable scratch buffers.
+- `GravitySource`, `GravityModel`, `SphericalHarmonicsData` — per-body
+  μ + coefficient payload.
+- `GravityControl`, `GravityControls` — per-source selectors (degree /
+  order, gradient, third-body / Battin / relativistic toggles).
+- `tides`, `relativistic` — small-correction terms.
+
+Coefficient files at JEOD source paths like
+[`earth_GGM05C.hh`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/data/include/earth_GGM05C.hh)
+are parsed by `jeod_test_data::jeod_cc` into the binary fixtures
+committed under `test_data/gravity/`; production gravity does not parse
+JEOD source.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `GV.*`
+  invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_gravity/>

--- a/crates/jeod_gravity/README.md
+++ b/crates/jeod_gravity/README.md
@@ -49,9 +49,9 @@ JEOD source.
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `GV.*`
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `GV.*`
   invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_gravity/>

--- a/crates/jeod_gravity/src/coefficients.rs
+++ b/crates/jeod_gravity/src/coefficients.rs
@@ -15,8 +15,11 @@ use crate::spherical_harmonics_gravity_source::SphericalHarmonicsData;
 /// Errors from loading a binary spherical-harmonics coefficient blob.
 #[derive(Debug, thiserror::Error)]
 pub enum CoeffLoadError {
+    /// Underlying I/O failure when reading the coefficient blob.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// Blob bytes did not match the expected layout (truncated header,
+    /// triangular-array length mismatch, etc.).
     #[error("invalid binary format: {0}")]
     InvalidFormat(String),
 }

--- a/crates/jeod_gravity/src/compute.rs
+++ b/crates/jeod_gravity/src/compute.rs
@@ -1,3 +1,14 @@
+//! Top-level gravity-acceleration computation.
+//!
+//! The point-mass kernel and the multi-source dispatcher that selects
+//! between [`calc_spherical`] and the spherical-harmonics path in
+//! [`crate::spherical_harmonics_calc_nonspherical`] depending on the
+//! [`crate::GravityModel`] variant.
+//!
+//! Ports
+//! [`models/environment/gravity/src/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/)
+//! from JEOD v5.4.0.
+
 use glam::{DMat3, DVec3};
 use jeod_dynamics::GravityAcceleration;
 use jeod_math::{

--- a/crates/jeod_gravity/src/gravity_controls.rs
+++ b/crates/jeod_gravity/src/gravity_controls.rs
@@ -1,3 +1,15 @@
+//! Per-source gravity-control configuration ([`GravityControl`] +
+//! typed sibling [`GravityControlTyped`]).
+//!
+//! Ports
+//! [`models/environment/gravity/src/gravity_controls.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/gravity_controls.cc)
+//! and
+//! [`spherical_harmonics_gravity_controls.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/spherical_harmonics_gravity_controls.cc)
+//! from JEOD v5.4.0. A `GravityControl` selects whether a single source
+//! contributes point-mass or spherical-harmonics gravity, picks the
+//! degree / order, gates the gradient computation, and flags
+//! third-body / Battin / relativistic corrections.
+
 use glam::DMat3;
 use glam::DVec3;
 use jeod_dynamics::GravityAcceleration;
@@ -6,9 +18,19 @@ use jeod_quantities::aliases::HarmonicDegree;
 use crate::gravity_source::{GravityModel, GravitySource};
 use log::warn;
 
+/// Per-source gravity selector — point-mass vs. spherical harmonics,
+/// degree / order, gradient flags, and third-body / Battin /
+/// relativistic toggles.
+///
+/// `SourceId` is a generic source identifier so adapters can carry the
+/// source as a `String`, a workspace-internal `usize` index, or a Bevy
+/// `Entity` handle. Use [`Self::retag_source`] to map between
+/// instantiations without enumerating the field list.
 #[derive(Debug, Clone)]
 pub struct GravityControl<SourceId = String> {
+    /// Source identifier.
     pub source_name: SourceId,
+    /// Compute the gravity-gradient tensor in addition to acceleration.
     pub gradient: bool,
     /// If true, use only point-mass (spherical) gravity for this source,
     /// ignoring any spherical harmonics data. Matches JEOD's `spherical` flag
@@ -495,16 +517,27 @@ impl<SourceId> GravityControl<SourceId> {
 /// ordinal is bounded by another's runtime value.
 #[derive(Debug, Clone)]
 pub struct GravityControlTyped<SourceId = String> {
+    /// Source identifier (see [`GravityControl::source_name`]).
     pub source_name: SourceId,
+    /// Compute the gravity-gradient tensor in addition to acceleration.
     pub gradient: bool,
+    /// Use only point-mass gravity for this source.
     pub spherical: bool,
+    /// Spherical-harmonics degree to use (must be ≤ source degree).
     pub degree: HarmonicDegree,
+    /// Spherical-harmonics order to use (must be ≤ source order, ≤ degree).
     pub order: HarmonicDegree,
+    /// Exclude `n=0,1` (point-mass) terms from the SH evaluation.
     pub perturbing_only: bool,
+    /// Degree for gradient computation (must be ≤ degree).
     pub gradient_degree: HarmonicDegree,
+    /// Order for gradient computation (must be ≤ order, ≤ gradient_degree).
     pub gradient_order: HarmonicDegree,
+    /// Treat this source as a third-body and use differential acceleration.
     pub differential: bool,
+    /// Use Battin's method for differential gravity (third-body only).
     pub battin_method: bool,
+    /// Apply post-Newtonian relativistic correction.
     pub relativistic: bool,
 }
 

--- a/crates/jeod_gravity/src/gravity_source.rs
+++ b/crates/jeod_gravity/src/gravity_source.rs
@@ -1,15 +1,34 @@
+//! [`GravitySource`] / [`GravityModel`] — the per-body μ + model
+//! payload that gravity-control evaluation runs against.
+//!
+//! Ports the runtime side of
+//! [`models/environment/gravity/src/gravity_source.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/gravity_source.cc)
+//! from JEOD v5.4.0. JEOD's separate `SphericalHarmonicsGravitySource`
+//! subclass is folded into the [`GravityModel::SphericalHarmonics`]
+//! enum variant.
+
 use crate::spherical_harmonics_gravity_source::SphericalHarmonicsData;
 use jeod_quantities::dims::GravParam;
 
+/// Per-body gravity payload: gravitational parameter `mu` plus the
+/// [`GravityModel`] that selects between point-mass and
+/// spherical-harmonics evaluation.
 #[derive(Debug, Clone)]
 pub struct GravitySource {
-    pub mu: f64, // gravitational parameter, m^3/s^2
+    /// Gravitational parameter, in `m³/s²`.
+    pub mu: f64,
+    /// Gravity model variant.
     pub model: GravityModel,
 }
 
+/// Gravity-model selector — point-mass (μ/r²) vs. spherical-harmonics
+/// (Gottlieb-recursion `Cnm`/`Snm` evaluation).
 #[derive(Debug, Clone)]
 pub enum GravityModel {
+    /// Newtonian point-mass gravity. Only `mu` matters.
     PointMass,
+    /// Spherical-harmonics expansion. The boxed payload carries
+    /// coefficients, reference radius, and Gottlieb scratch arrays.
     SphericalHarmonics(Box<SphericalHarmonicsData>),
 }
 

--- a/crates/jeod_gravity/src/lib.rs
+++ b/crates/jeod_gravity/src/lib.rs
@@ -36,6 +36,7 @@
 //! input. Pure Rust, zero Bevy dependency.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub mod coefficients;
 pub mod compute;

--- a/crates/jeod_gravity/src/spherical_harmonics_gravity_controls.rs
+++ b/crates/jeod_gravity/src/spherical_harmonics_gravity_controls.rs
@@ -1,6 +1,20 @@
+//! Multi-source [`GravityControls`] aggregator — the per-vehicle list
+//! of [`GravityControl`] entries the gravity pipeline iterates each
+//! step.
+//!
+//! Mirrors the `GravityControls` collection inside JEOD's
+//! [`spherical_harmonics_gravity_controls.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/spherical_harmonics_gravity_controls.cc)
+//! from JEOD v5.4.0.
+
 use crate::gravity_controls::GravityControl;
 
+/// Ordered list of [`GravityControl`] entries — one per gravity source
+/// active for the vehicle. The pipeline accumulates each source's
+/// contribution into the vehicle's net gravity acceleration in
+/// iteration order.
 #[derive(Debug, Clone, Default)]
 pub struct GravityControls<SourceId = String> {
+    /// Per-source controls. Order is significant for differential /
+    /// third-body sources whose contributions partially cancel.
     pub controls: Vec<GravityControl<SourceId>>,
 }

--- a/crates/jeod_gravity/src/spherical_harmonics_gravity_source.rs
+++ b/crates/jeod_gravity/src/spherical_harmonics_gravity_source.rs
@@ -1,3 +1,12 @@
+//! [`SphericalHarmonicsData`] — coefficient table and precomputed
+//! Gottlieb helper arrays for spherical-harmonics gravity.
+//!
+//! Ports
+//! [`models/environment/gravity/src/spherical_harmonics_gravity_source.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/spherical_harmonics_gravity_source.cc)
+//! from JEOD v5.4.0. Coefficients are normalized; the
+//! [`crate::spherical_harmonics_calc_nonspherical`] kernel expects the
+//! Gottlieb helper arrays to be filled by [`SphericalHarmonicsData::new`].
+
 use jeod_quantities::dims::GravParam;
 use uom::si::f64::Length;
 

--- a/crates/jeod_gravity/src/tides.rs
+++ b/crates/jeod_gravity/src/tides.rs
@@ -53,9 +53,13 @@ pub struct TidalBody {
 /// other dimensionless physical quantities.
 #[derive(Debug, Clone)]
 pub struct TidalConfigTyped {
+    /// Love number `k2` of the deformable body (dimensionless).
     pub k2: Ratio,
+    /// Gravitational parameter μ of the primary body.
     pub mu_primary: GravParam,
+    /// Reference radius of the primary body.
     pub radius_primary: Length,
+    /// Tidal-perturber bodies (Sun, Moon, …).
     pub tidal_bodies: Vec<TidalBodyTyped>,
 }
 
@@ -64,7 +68,9 @@ pub struct TidalConfigTyped {
 /// `position_inertial` carries the [`Position<Inertial>`] phantom tag.
 #[derive(Debug, Clone)]
 pub struct TidalBodyTyped {
+    /// Gravitational parameter μ of the perturber.
     pub mu: GravParam,
+    /// Position of the perturber in the inertial frame.
     pub position_inertial: Position<Inertial>,
 }
 

--- a/crates/jeod_interactions/Cargo.toml
+++ b/crates/jeod_interactions/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_interactions"
 description = "Aerodynamic drag, SRP, gravity-gradient torque, shadow, and contact for bevy_jeod"
+readme = "README.md"
 keywords = ["drag", "srp", "gravity-gradient", "orbital-mechanics", "aerospace"]
 categories = ["science", "aerospace"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 glam = { workspace = true }

--- a/crates/jeod_interactions/README.md
+++ b/crates/jeod_interactions/README.md
@@ -1,0 +1,51 @@
+# jeod_interactions
+
+Surface interactions — aerodynamic drag, solar radiation pressure,
+gravity-gradient torque, shadow geometry, contact, thermal — for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/interactions/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/interactions/)
+and the surface-model utilities under
+[`models/utils/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod).
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration; sums forces into TotalForce)
+   ↓
+jeod_interactions ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_atmosphere, jeod_quantities
+```
+
+Each module produces a force, torque, or environmental scalar at a
+vehicle position. The orchestration that sums them into a body's
+`jeod_dynamics::TotalForce` lives in `jeod_sim`.
+
+## Public surface
+
+- `aero_drag` (scalar-Cd) and `flat_plate_aero` (per-facet) —
+  aerodynamic drag.
+- `radiation_pressure` — solar flux against a surface model with
+  absorption / specular / diffuse coefficients.
+- `shadow` — umbra / penumbra geometry. `earth_lighting` extends with
+  Earth-albedo and IR contributions.
+- `gravity_torque` — cross product of inertia tensor and
+  gravity-gradient tensor through body attitude.
+- `surface_model` — `SurfaceFacet`, `ArticulatedFacet`, `SurfaceShape`
+  — per-facet geometry shared by aero / SRP / contact / thermal.
+- `contact` — collision / contact response.
+- `thermal_rider` — per-facet power balance.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `AE.*`,
+  `RP.*`, `GG.*`, `SH.*`, `CT.*`, `TH.*` invariants.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_interactions/>

--- a/crates/jeod_interactions/README.md
+++ b/crates/jeod_interactions/README.md
@@ -43,9 +43,9 @@ vehicle position. The orchestration that sums them into a body's
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `AE.*`,
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `AE.*`,
   `RP.*`, `GG.*`, `SH.*`, `CT.*`, `TH.*` invariants.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_interactions/>

--- a/crates/jeod_interactions/src/aero_drag.rs
+++ b/crates/jeod_interactions/src/aero_drag.rs
@@ -117,8 +117,13 @@ pub fn compute_ballistic_drag(
 /// [`MassDensity`] (kg/m³).
 #[derive(Debug, Clone, Copy)]
 pub struct DragConfigTyped {
+    /// Drag coefficient (dimensionless).
     pub cd: Ratio,
+    /// Reference area exposed to the flow.
     pub area: Area,
+    /// Optional override density. When `Some`, the drag kernel uses
+    /// this value instead of querying the atmosphere model — used for
+    /// constant-density unit tests.
     pub constant_density: Option<MassDensity>,
 }
 
@@ -154,7 +159,9 @@ impl DragConfigTyped {
 /// rotates inertial vectors *into*).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AerodynamicForceTyped<V: Vehicle> {
+    /// Aerodynamic force in the structural frame of vehicle `V`.
     pub force: Force<StructuralFrame<V>>,
+    /// Aerodynamic torque about the structural-frame origin of vehicle `V`.
     pub torque: jeod_quantities::aliases::Torque<StructuralFrame<V>>,
 }
 

--- a/crates/jeod_interactions/src/lib.rs
+++ b/crates/jeod_interactions/src/lib.rs
@@ -39,6 +39,7 @@
 //! zero Bevy dependency.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub mod aero_drag;
 pub mod contact;

--- a/crates/jeod_math/Cargo.toml
+++ b/crates/jeod_math/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_math"
 description = "Quaternion, Euler, geodetic, orbital-element, and LVLH math kernels for bevy_jeod"
+readme = "README.md"
 keywords = ["orbital-mechanics", "math", "quaternion", "geodetic", "aerospace"]
 categories = ["science", "aerospace", "mathematics"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }

--- a/crates/jeod_math/README.md
+++ b/crates/jeod_math/README.md
@@ -54,10 +54,10 @@ Bevy dependency. After Phase 2 (#104) of the type-system refactor,
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `OE.*`,
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `OE.*`,
   `QT.*`, `EU.*`, `GD.*` invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture and
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture and
   conventions.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_math/>

--- a/crates/jeod_math/README.md
+++ b/crates/jeod_math/README.md
@@ -1,0 +1,63 @@
+# jeod_math
+
+JEOD-faithful math kernels — quaternions, Euler angles, orbital
+elements, geodetic coordinates, the LVLH frame, the solar beta angle,
+and the small but load-bearing collection of vector / matrix helpers
+that mirror JEOD's `Vector3` / `Matrix3x3` inline functions.
+
+Ports
+[`models/utils/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod). Specifically:
+[`orbital_elements/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/orbital_elements/),
+[`orientation/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/orientation/),
+[`planet_fixed/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/planet_fixed/),
+[`lvlh_frame/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/lvlh_frame/),
+[`quaternion/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/quaternion/),
+and the inline helpers under
+[`math/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/math/include/).
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_math        ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_quantities  (typed quantities + JeodQuat re-export)
+```
+
+`jeod_math` is part of the `jeod_*` physics layer — pure Rust with no
+Bevy dependency. After Phase 2 (#104) of the type-system refactor,
+`JeodQuat` is a re-export of `jeod_quantities::JeodQuat`.
+
+## Public surface
+
+- `OrbitalElements` — Cartesian ↔ Keplerian conversion.
+- `EulerSequence`, `compute_*_typed` helpers — Euler-angle algebra.
+- `cartesian_to_geodetic_typed` / `geodetic_to_cartesian_typed`,
+  `GeodeticState`, `GeodeticStateTyped` — ellipsoidal coordinates.
+- `compute_lvlh_frame_typed`, `LvlhFrame` — local-vertical / local-
+  horizontal frame.
+- `solar_beta_angle_typed` — solar beta angle.
+- `quaternion` — JEOD-convention algebra on the unified `JeodQuat`.
+- `types::mat3_from_rows` — row-major constructor for `glam::DMat3`,
+  matching JEOD source layout.
+
+## JEOD conventions
+
+- Quaternions are **scalar-first, left-transformation** (`JeodQuat ==
+  Quat<ScalarFirst, LeftTransform>`).
+- Geodetic conversions follow Borkowski's iterative latitude solver.
+- All angles in radians, all lengths in meters.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `OE.*`,
+  `QT.*`, `EU.*`, `GD.*` invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture and
+  conventions.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_math/>

--- a/crates/jeod_math/src/error.rs
+++ b/crates/jeod_math/src/error.rs
@@ -1,9 +1,24 @@
+//! Error type for the orbital-element kernels in
+//! [`crate::orbital_elements`].
+//!
+//! Mirrors the failure cases JEOD's
+//! [`models/utils/orbital_elements/src/orbital_elements.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/orbital_elements/src/orbital_elements.cc)
+//! reports through `MessageHandler::fail()`.
+
+/// Errors emitted by the orbital-element conversions.
 #[derive(Debug, thiserror::Error)]
 pub enum OrbitalError {
+    /// Newton iteration on Kepler's equation failed to converge within
+    /// the configured iteration cap. The carried value is the iteration
+    /// count actually attempted.
     #[error("Kepler equation failed to converge after {0} iterations")]
     KeplerConvergence(usize),
+    /// Gravitational parameter `mu` was non-positive — JEOD requires
+    /// `mu > 0` for any orbital computation.
     #[error("Invalid gravitational parameter: {0}")]
     InvalidMu(f64),
+    /// Position or velocity vector had effectively zero magnitude, so
+    /// the orbital frame cannot be built.
     #[error("Degenerate orbit: zero position or velocity magnitude")]
     DegenerateOrbit,
 }

--- a/crates/jeod_math/src/euler_angles.rs
+++ b/crates/jeod_math/src/euler_angles.rs
@@ -31,19 +31,31 @@ use uom::si::f64::Angle;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(usize)]
 pub enum EulerSequence {
-    // Tait-Bryan (aerodynamic)
+    // ── Tait-Bryan (aerodynamic) ────────────────────────────────────
+    /// Tait-Bryan XYZ: roll → pitch → yaw about body X, Y, Z.
     XYZ = 0,
+    /// Tait-Bryan XZY.
     XZY = 1,
+    /// Tait-Bryan YZX.
     YZX = 2,
+    /// Tait-Bryan YXZ.
     YXZ = 3,
+    /// Tait-Bryan ZXY.
     ZXY = 4,
+    /// Tait-Bryan ZYX (yaw → pitch → roll).
     ZYX = 5,
-    // Proper Euler (astronomical)
+    // ── Proper Euler (astronomical) ─────────────────────────────────
+    /// Proper-Euler XYX (first and third rotations share the X axis).
     XYX = 6,
+    /// Proper-Euler XZX.
     XZX = 7,
+    /// Proper-Euler YZY.
     YZY = 8,
+    /// Proper-Euler YXY.
     YXY = 9,
+    /// Proper-Euler ZXZ — classical astronomical sequence.
     ZXZ = 10,
+    /// Proper-Euler ZYZ.
     ZYZ = 11,
 }
 

--- a/crates/jeod_math/src/geodetic.rs
+++ b/crates/jeod_math/src/geodetic.rs
@@ -31,9 +31,12 @@ const MAX_ITERATION_LIMIT: usize = 10;
 /// Geodetic coordinates on a reference ellipsoid.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct GeodeticState {
-    pub latitude: f64,  // rad, geodetic latitude
-    pub longitude: f64, // rad, geodetic longitude
-    pub altitude: f64,  // m, height above reference ellipsoid
+    /// Geodetic latitude in radians (positive north, range `±π/2`).
+    pub latitude: f64,
+    /// Geodetic longitude in radians (positive east).
+    pub longitude: f64,
+    /// Height above the reference ellipsoid, in meters.
+    pub altitude: f64,
 }
 
 impl GeodeticState {
@@ -96,9 +99,12 @@ impl GeodeticStateTyped {
 /// Spherical coordinates relative to a spherical planet.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SphericalState {
-    pub latitude: f64,  // rad, geocentric latitude
-    pub longitude: f64, // rad, longitude
-    pub altitude: f64,  // m, height above mean equatorial radius
+    /// Geocentric latitude in radians.
+    pub latitude: f64,
+    /// Longitude in radians (positive east).
+    pub longitude: f64,
+    /// Height above the mean equatorial radius, in meters.
+    pub altitude: f64,
 }
 
 /// Convert Cartesian PCPF coordinates to spherical coordinates.

--- a/crates/jeod_math/src/lib.rs
+++ b/crates/jeod_math/src/lib.rs
@@ -51,6 +51,7 @@
 //! Pure Rust, zero Bevy dependency.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub use jeod_quantities::prelude::*;
 

--- a/crates/jeod_math/src/orbital_elements.rs
+++ b/crates/jeod_math/src/orbital_elements.rs
@@ -1,3 +1,15 @@
+//! Classical orbital elements and Cartesian ↔ Keplerian conversion.
+//!
+//! Ports
+//! [`models/utils/orbital_elements/src/orbital_elements.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/orbital_elements/src/orbital_elements.cc)
+//! from JEOD v5.4.0. Holds semi-major axis, eccentricity, inclination,
+//! RAAN, argument of periapsis, the three anomalies (true, mean,
+//! orbital), and energy / angular-momentum diagnostics.
+//!
+//! Public callers should reach for the typed conversions on
+//! [`OrbitalElements`]; the bare-`f64` siblings are kept
+//! module-private after the Phase 10 typed-API purge.
+
 use std::f64::consts::{PI, TAU};
 
 use crate::error::OrbitalError;

--- a/crates/jeod_math/src/test_utils.rs
+++ b/crates/jeod_math/src/test_utils.rs
@@ -1,13 +1,25 @@
+//! Approximate-equality helpers for unit and Tier-2 tests.
+//!
+//! Gated behind the `test-utils` Cargo feature so downstream crates
+//! (e.g., [`jeod_dynamics`](https://docs.rs/jeod_dynamics)) can reuse
+//! the same tolerance helpers without the production build paying for
+//! them. Mirrors the comparison helpers used in JEOD's verification
+//! sims under `models/utils/math/verif/`.
+
 use crate::types::{DMat3, DVec3};
 
+/// Returns `true` if `|a - b| < tol`.
 pub fn approx_eq_f64(a: f64, b: f64, tol: f64) -> bool {
     (a - b).abs() < tol
 }
 
+/// Returns `true` if the L2 norm of `a - b` is less than `tol`.
 pub fn approx_eq_vec3(a: DVec3, b: DVec3, tol: f64) -> bool {
     (a - b).length() < tol
 }
 
+/// Returns `true` if every element of `a - b` is within `tol`
+/// (componentwise infinity norm).
 pub fn approx_eq_mat3(a: &DMat3, b: &DMat3, tol: f64) -> bool {
     for c in 0..3 {
         for r in 0..3 {

--- a/crates/jeod_math/src/types.rs
+++ b/crates/jeod_math/src/types.rs
@@ -1,3 +1,15 @@
+//! Vector / matrix helpers ported from
+//! [`models/utils/math/include/vector3_inline.hh`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/math/include/vector3_inline.hh)
+//! and
+//! [`models/utils/math/include/matrix3x3_inline.hh`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/math/include/matrix3x3_inline.hh)
+//! in JEOD v5.4.0.
+//!
+//! JEOD source is row-major while `glam` is column-major; the
+//! [`mat3_from_rows`] helper lets a port read top-to-bottom against the
+//! C++ source and still produce a correct `glam::DMat3`. The other
+//! helpers wrap the inline `Vector3::*` / `Matrix3x3::*` operators so
+//! kernel code can name them at the JEOD convention.
+
 pub use glam::{DMat3, DQuat, DVec3};
 
 /// Construct a `DMat3` from three row vectors.

--- a/crates/jeod_planet/Cargo.toml
+++ b/crates/jeod_planet/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_planet"
 description = "Planet definitions and presets (Earth, Moon, Sun, Mars) for bevy_jeod"
+readme = "README.md"
 keywords = ["planet", "ephemeris", "orbital-mechanics", "aerospace"]
 categories = ["science", "aerospace"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }

--- a/crates/jeod_planet/README.md
+++ b/crates/jeod_planet/README.md
@@ -41,9 +41,9 @@ than IERS 2010, to keep cross-validation faithful to JEOD source.
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `PL.*`
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `PL.*`
   invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_planet/>

--- a/crates/jeod_planet/README.md
+++ b/crates/jeod_planet/README.md
@@ -1,0 +1,49 @@
+# jeod_planet
+
+Reference-ellipsoid parameters and standard preset bodies for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/environment/planet/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/planet/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod) — the per-body
+shape parameters (gravitational parameter, equatorial and polar radii,
+flattening) consumed by gravity, geodetic, atmospheric, and
+frame-rotation code.
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_planet      ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_quantities  (typed length / GravParam quantities)
+```
+
+`jeod_planet` is part of the `jeod_*` physics layer — pure Rust with no
+Bevy dependency. See the project
+[Strategy wiki page](https://github.com/simnaut/bevy_jeod/wiki/Strategy)
+for the layered architecture.
+
+## Public surface
+
+- `PlanetShape` — reference-ellipsoid parameter block (`mu`, `r_eq`,
+  `r_pol`, `flat_coeff`) with derived helpers and typed accessors.
+- `presets::EARTH` / `MOON` / `SUN` / `MARS` — canonical constants
+  matching the JEOD `planet/data/src/<body>.cc` files plus the
+  corresponding gravity-model `mu` (Earth uses GGM05C, Moon GRAIL150,
+  Mars MRO110B2, Sun spherical).
+
+Earth's `mu` follows the GGM05C value `3.986004415e14 m³/s²` rather
+than IERS 2010, to keep cross-validation faithful to JEOD source.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `PL.*`
+  invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_planet/>

--- a/crates/jeod_planet/src/lib.rs
+++ b/crates/jeod_planet/src/lib.rs
@@ -28,6 +28,7 @@
 //! dependency.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub use jeod_quantities::prelude::*;
 

--- a/crates/jeod_planet/src/planet.rs
+++ b/crates/jeod_planet/src/planet.rs
@@ -1,3 +1,12 @@
+//! Reference-ellipsoid parameter block for a planetary body.
+//!
+//! Ports the `Planet` struct in
+//! [`models/environment/planet/include/planet.hh`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/planet/include/planet.hh)
+//! from JEOD v5.4.0. Stores `name`, `mu` (m³/s²), `r_eq` (m), `r_pol` (m),
+//! and `flat_coeff` along with derived helpers (`flat_inv`,
+//! `e_ellipsoid`, `e_ellip_sq`) plus typed accessors that wrap the raw
+//! `f64` fields as `jeod_quantities` quantities.
+
 /// Planetary shape parameters (reference ellipsoid).
 ///
 /// Mirrors JEOD's `Planet` struct from `planet.hh`. The `mu` field stores the

--- a/crates/jeod_planet/src/presets.rs
+++ b/crates/jeod_planet/src/presets.rs
@@ -1,3 +1,15 @@
+//! Canonical [`PlanetShape`] constants matching the
+//! per-body data files under
+//! [`models/environment/planet/data/src/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/planet/data/src/)
+//! in JEOD v5.4.0.
+//!
+//! Each preset combines the shape parameters from `<body>.cc` with the
+//! gravitational parameter from the corresponding `<body>_<model>.cc`
+//! gravity-coefficient file, so a downstream caller can pull a single
+//! `PlanetShape` constant rather than reconstructing the values
+//! field-by-field. Source-line citations live on the per-constant
+//! definitions below.
+
 use crate::planet::PlanetShape;
 
 /// Earth (WGS84 ellipsoid).

--- a/crates/jeod_quantities/Cargo.toml
+++ b/crates/jeod_quantities/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_quantities"
 description = "Phantom-tagged typed quantities (Position, Velocity, ...) for orbital dynamics"
+readme = "README.md"
 keywords = ["orbital-mechanics", "physics", "type-system", "aerospace"]
 categories = ["science", "aerospace", "data-structures"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 glam = { workspace = true }

--- a/crates/jeod_quantities/README.md
+++ b/crates/jeod_quantities/README.md
@@ -1,0 +1,59 @@
+# jeod_quantities
+
+Dimensional-analysis and phantom-tag foundation for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Sits at the bottom of the workspace dependency graph. Every other
+`jeod_*` crate, plus `jeod_sim`, `jeod_runner`, and the `bevy_jeod`
+Bevy glue, depends on `jeod_quantities` for typed quantities and the
+phantom frame / time-scale tags.
+
+## Three-layer facade
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Facade  (bevy_jeod::prelude, jeod_sim::recipes)          │
+│   F64Ext: 400.0.km(), 51.6.deg(), 420_000.0.kg()         │
+│   Concrete Component wrappers (no visible generics)      │
+│   Custom #[diagnostic::on_unimplemented] messages        │
+├──────────────────────────────────────────────────────────┤
+│ Typed jeod_* siblings                                     │
+│   Position<F: Frame>, SecondsSince<S: TimeScale>,        │
+│   Quat<L, T>, NormalizedQuat, FrameTransform<From, To>   │
+├──────────────────────────────────────────────────────────┤
+│ jeod_quantities  (you are here)                          │
+│   uom re-exports, Qty3<D, F>, phantom frames/scales,     │
+│   F64Ext / Vec3Ext / Array3Ext                           │
+└──────────────────────────────────────────────────────────┘
+```
+
+Mission-crate code consumes the facade layer and never sees
+`PhantomData` or `uom::si::*` paths. Internal physics kernels drop
+down to raw `glam::DVec3` / `f64` for arithmetic density via
+`.raw_si()` and re-wrap on exit.
+
+## Public surface
+
+- Reference-frame and time-scale phantom markers (`Inertial`, `Ecef`,
+  `PlanetFixed<P>`, `BodyFrame<V>`, `Lvlh<Chief>`, `TAI`, `TT`, …).
+- `uom`-backed componentwise 3-vectors `Qty3<D, F>` with aliases
+  `Position<F>`, `Velocity<F>`, `Acceleration<F>`, `Force<F>`,
+  `Torque<F>`, …
+- Quaternion convention tags (`ScalarFirst`/`ScalarLast`,
+  `LeftTransform`/`RightTransform`) plus the `NormalizedQuat`
+  constructor-gated witness.
+- Typed `FrameTransform<From, To>` composing only when inner frames
+  match.
+- The `F64Ext` facade (`400.0.km()`, `51.6.deg()`, `420_000.0.kg()`).
+- Compiler error messages in physics language via
+  `#[diagnostic::on_unimplemented]`.
+
+## See also
+
+- [Type-System wiki page](https://github.com/simnaut/bevy_jeod/wiki/Type-System)
+  — contributor primer (phantom-tag pattern, adding a new
+  frame/scale/quantity, escape hatches).
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_quantities/>

--- a/crates/jeod_quantities/README.md
+++ b/crates/jeod_quantities/README.md
@@ -53,7 +53,7 @@ down to raw `glam::DVec3` / `f64` for arithmetic density via
 - [Type-System wiki page](https://github.com/simnaut/bevy_jeod/wiki/Type-System)
   — contributor primer (phantom-tag pattern, adding a new
   frame/scale/quantity, escape hatches).
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_quantities/>

--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -56,7 +56,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 mod sealed;
 

--- a/crates/jeod_runner/Cargo.toml
+++ b/crates/jeod_runner/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
 name = "jeod_runner"
 description = "Standalone simulation runner and Tier 3 verification harness for bevy_jeod"
+readme = "README.md"
 keywords = ["orbital-mechanics", "simulation", "propagator", "aerospace", "verification"]
 categories = ["science", "aerospace", "simulation"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+no-default-features = true
+features = []
 
 [features]
 # Default-on: enables the `run_verification` module and its

--- a/crates/jeod_runner/README.md
+++ b/crates/jeod_runner/README.md
@@ -1,0 +1,42 @@
+# jeod_runner
+
+Standalone simulation runner and Tier 3 verification harness for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+`jeod_runner` is a parallel non-Bevy consumer of `jeod_sim`. It owns
+its own state and drives the same pipeline functions the Bevy adapter
+runs from system schedules. Used for:
+
+- **Tier 3 cross-validation tests** (`tests/tier3_*.rs`) — propagating
+  from JEOD initial conditions and comparing against Trick reference
+  CSVs without standing up a Bevy `App`.
+- **Batch propagation, scripting, and offline studies** that don't
+  need ECS scheduling, parallelism, or Bevy plugins.
+
+## Layered architecture
+
+```
+                  jeod_sim
+                  /       \
+        bevy_jeod          jeod_runner    ←  this crate
+        (Bevy adapter)     (plain Rust harness)
+```
+
+`jeod_runner` and `bevy_jeod` sit *next to* each other in the dep
+graph — both depend on `jeod_sim` and the wider `jeod_*` family;
+neither depends on the other. Mission code targeting the production
+Bevy runtime depends on `bevy_jeod`, never on `jeod_runner`.
+
+## Features
+
+- `verification` (default) — pulls in `jeod_test_data` and exposes the
+  `run_verification::*` Tier-3 case machinery. `--no-default-features`
+  drops the JEOD-source-backed fixtures and gives a smaller runner.
+
+## See also
+
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture, Tier
+  conventions, regen workflow.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_runner/>

--- a/crates/jeod_runner/README.md
+++ b/crates/jeod_runner/README.md
@@ -35,8 +35,8 @@ Bevy runtime depends on `bevy_jeod`, never on `jeod_runner`.
 
 ## See also
 
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture, Tier
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture, Tier
   conventions, regen workflow.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_runner/>

--- a/crates/jeod_runner/src/lib.rs
+++ b/crates/jeod_runner/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 pub mod branded;
 pub mod builder;

--- a/crates/jeod_sim/README.md
+++ b/crates/jeod_sim/README.md
@@ -1,0 +1,50 @@
+# jeod_sim
+
+Pipeline orchestration, the typestate `VehicleBuilder`, and the
+recipes module — the single API surface that any consumer (the Bevy
+adapter or a non-Bevy runner) depends on.
+
+`jeod_sim` composes the
+[`jeod_*`](https://github.com/simnaut/bevy_jeod/tree/main/crates) physics
+crates into pipeline stages and re-exports their types so a downstream
+crate only needs `jeod_sim` to access the entire physics surface.
+Pure Rust, zero Bevy dependency.
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter)
+   ↓
+jeod_sim         ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_dynamics, jeod_gravity, jeod_time, jeod_frames,
+jeod_atmosphere, jeod_interactions, jeod_ephemeris,
+jeod_planet, jeod_math, jeod_quantities
+```
+
+The titular simulation environment is `bevy_jeod` (the workspace root
+package). `jeod_sim` is also exercised directly by the standalone
+`jeod_runner` Tier 3 harness; both consumers share the same API
+surface. See the
+[Strategy wiki page](https://github.com/simnaut/bevy_jeod/wiki/Strategy)
+for the layered-architecture rules.
+
+## Public surface
+
+- `VehicleBuilder` — typestate builder that refuses `.build()` until
+  state, mass, and integrator are set.
+- `recipes::*` — `earth`, `orbital_elements`, `vehicle`, `scenarios`,
+  `verification` (the last gated behind the in-repo-only
+  `jeod-source` feature).
+- Per-stage pipeline functions (`accumulate_gravity`,
+  `validate_body`, …) that mirror the `JeodSet` schedule slot the
+  Bevy adapter exposes.
+
+## See also
+
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [`examples/typed_mission.rs`](../../examples/typed_mission.rs) —
+  canonical worked example.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_sim/>

--- a/crates/jeod_sim/README.md
+++ b/crates/jeod_sim/README.md
@@ -42,9 +42,9 @@ for the layered-architecture rules.
 
 ## See also
 
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
-- [`examples/typed_mission.rs`](../../examples/typed_mission.rs) —
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
+- [`examples/typed_mission.rs`](https://github.com/simnaut/bevy_jeod/blob/main/examples/typed_mission.rs) —
   canonical worked example.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_sim/>

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -35,7 +35,7 @@
 //! execution order that any adapter must respect.
 
 #![forbid(unsafe_code)]
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 pub mod atmosphere;
 pub mod derived;

--- a/crates/jeod_test_data/Cargo.toml
+++ b/crates/jeod_test_data/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_test_data"
 description = "JEOD reference-data parsers and Tier 3 baseline tooling for bevy_jeod"
+readme = "README.md"
 keywords = ["jeod", "test-data", "verification", "aerospace"]
 categories = ["science", "aerospace", "development-tools"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }

--- a/crates/jeod_test_data/README.md
+++ b/crates/jeod_test_data/README.md
@@ -1,0 +1,50 @@
+# jeod_test_data
+
+JEOD reference-data parsers, Tier 2 fixtures, and Tier 3 baseline
+tooling for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Parses JEOD's `Modified_data/*.py`, `S_define`, `Leap_Second.dat`, the
+gravity `data/include/*.cc` coefficient files, the `verif_out.txt`
+gravity-test vectors, and the Trick CSV reference logs. Sources are
+under
+[NASA JEOD v5.4.0](https://github.com/nasa/jeod/tree/jeod_v5.4.0).
+
+## Layered architecture
+
+```
+bevy_jeod / mission code     (production)
+   ↑    only for tests / dev / regen
+jeod_test_data               ←  this crate (dev / test only)
+   ↓
+jeod_quantities, jeod_gravity, jeod_math
+```
+
+`jeod_test_data` is **not** part of the production code path. Its
+parsers populate the binary fixtures committed under `test_data/`; the
+production `jeod_*` crates read those committed fixtures and never
+parse JEOD source themselves.
+
+## Public surface
+
+- `jeod_inputs` — committed mirror of JEOD `.py` / `.dat` source files.
+- `jeod_cc` — JEOD `.cc` gravity-coefficient parser; produces
+  `SphericalHarmonicsData`.
+- `gravity_fixtures` — load committed binary coefficient fixtures.
+- `gravity_verif` — `verif_out.txt` test-vector parser.
+- `body_init_fixtures`, `mass_data`, `orbital_init`, `reference_state`,
+  `time_config`, `s_define`, `leap_second`, `gravity_control` — JEOD
+  Trick `Modified_data/*.py` parsers.
+- `tier3_csv`, `dyncomp_csv`, `apollo_truth`, `apollo_mass_tree`,
+  `crossval` — Tier 3 reference-CSV loaders and the cross-validation
+  report.
+- `extract_*` binaries (under `src/bin/`) regenerate fixtures from a
+  fresh `$JEOD_HOME` checkout.
+
+## See also
+
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — Tier 1 / 2 / 3 conventions, fixture
+  layout, regen workflow.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_test_data/>

--- a/crates/jeod_test_data/README.md
+++ b/crates/jeod_test_data/README.md
@@ -43,8 +43,8 @@ parse JEOD source themselves.
 
 ## See also
 
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — Tier 1 / 2 / 3 conventions, fixture
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — Tier 1 / 2 / 3 conventions, fixture
   layout, regen workflow.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_test_data/>

--- a/crates/jeod_test_data/src/apollo_mass_tree.rs
+++ b/crates/jeod_test_data/src/apollo_mass_tree.rs
@@ -12,6 +12,7 @@ use glam::{DMat3, DVec3};
 /// One body's printed mass properties.
 #[derive(Debug, Clone)]
 pub struct PrintedBody {
+    /// Body identifier as printed in the JEOD mass-tree dump.
     pub name: String,
     /// Structural offset in parent's structural frame (m).
     pub structure_offset: DVec3,
@@ -34,6 +35,7 @@ pub struct PrintedBody {
 /// A complete mass tree printout (one or more bodies).
 #[derive(Debug, Clone)]
 pub struct PrintedTree {
+    /// Per-body entries in printed order.
     pub bodies: Vec<PrintedBody>,
 }
 

--- a/crates/jeod_test_data/src/body_init_fixtures.rs
+++ b/crates/jeod_test_data/src/body_init_fixtures.rs
@@ -57,6 +57,8 @@ use std::sync::OnceLock;
 /// committed JSON fixtures (runtime path).
 #[derive(Debug, thiserror::Error)]
 pub enum BodyInitFixtureError {
+    /// Source data violated the expected layout (missing fields,
+    /// non-numeric values, mismatched array lengths).
     #[error("malformed body-init data: {0}")]
     Malformed(String),
 }
@@ -70,7 +72,9 @@ impl BodyInitFixtureError {
 /// One reference-state record (ECI position / velocity).
 #[derive(Debug, Clone)]
 pub struct ReferenceStateRecord {
+    /// Position in metres, expressed in the inertial frame.
     pub position: [f64; 3],
+    /// Velocity in m/s, expressed in the inertial frame.
     pub velocity: [f64; 3],
 }
 
@@ -79,34 +83,53 @@ pub struct ReferenceStateRecord {
 /// `ReferenceState` types for compatibility with downstream tests).
 #[derive(Debug, Clone)]
 pub struct OrbitalInitRecord {
+    /// Vehicle name as recorded in the JEOD `Modified_data/*.py` source.
     pub name: String,
+    /// Semi-major axis in metres.
     pub semi_major_axis: f64,
+    /// Orbital eccentricity (dimensionless).
     pub eccentricity: f64,
+    /// Inclination in radians.
     pub inclination: f64,
+    /// Right Ascension of the Ascending Node, in radians.
     pub ascending_node: f64,
+    /// Argument of periapsis, in radians.
     pub arg_periapsis: f64,
+    /// Time-since-periapsis in seconds, when the JEOD source uses it.
     pub time_periapsis: Option<f64>,
+    /// Mean anomaly in radians, when the JEOD source uses it.
     pub mean_anomaly: Option<f64>,
+    /// True anomaly in radians, when the JEOD source uses it.
     pub true_anomaly: Option<f64>,
+    /// JEOD `planet_name` — Earth / Moon / Sun / Mars.
     pub planet_name: String,
+    /// JEOD `reference_frame` selector (e.g. `"earth.inertial"`).
     pub reference_frame: String,
 }
 
 /// One direct-Cartesian init record.
 #[derive(Debug, Clone)]
 pub struct TransStateRecord {
+    /// Vehicle name as recorded in the JEOD `Modified_data/*.py` source.
     pub name: String,
+    /// Initial position in metres.
     pub position: [f64; 3],
+    /// Initial velocity in m/s.
     pub velocity: [f64; 3],
+    /// JEOD `reference_frame` selector (e.g. `"earth.inertial"`).
     pub reference_frame: String,
 }
 
 /// Per-vehicle bundle as parsed from the JSON fixture.
 #[derive(Debug, Clone)]
 pub struct BodyInitBundle {
+    /// Vehicle name (e.g. `"iss"`, `"sts114"`).
     pub vehicle: String,
+    /// Reference inertial state, when the source provides one.
     pub reference_inertial: Option<ReferenceStateRecord>,
+    /// Orbital-element initialization records.
     pub orbital_inits: Vec<OrbitalInitRecord>,
+    /// Direct-Cartesian translational-state records.
     pub trans_states: Vec<TransStateRecord>,
 }
 

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -55,12 +55,19 @@ fn reference_timestep(reference: &[StateLog]) -> f64 {
 /// A single state snapshot at one timestep.
 #[derive(Clone, Default)]
 pub struct StateLog {
+    /// Sample time in seconds since the trajectory's t=0.
     pub time: f64,
+    /// Position in metres, when sampled.
     pub position: Option<DVec3>,
+    /// Velocity in m/s, when sampled.
     pub velocity: Option<DVec3>,
+    /// Acceleration in m/s², when sampled.
     pub acceleration: Option<DVec3>,
+    /// Attitude quaternion, when sampled.
     pub quaternion: Option<DQuat>,
+    /// Angular velocity in rad/s, when sampled.
     pub ang_vel: Option<DVec3>,
+    /// Angular acceleration in rad/s², when sampled.
     pub ang_accel: Option<DVec3>,
 }
 
@@ -71,13 +78,20 @@ pub struct StateLog {
 pub struct CrossvalReport {
     test_name: String,
 
-    // Computed by `compute()` — per-component max |ours - ref| across trajectory
+    /// Per-axis max `|ours − ref|` of position over the trajectory.
     pub position: Option<[f64; 3]>,
+    /// Per-axis max `|ours − ref|` of velocity over the trajectory.
     pub velocity: Option<[f64; 3]>,
+    /// Per-axis max `|ours − ref|` of acceleration over the trajectory.
     pub acceleration: Option<[f64; 3]>,
+    /// Per-component max `|ours − ref|` of the quaternion (`[x,y,z,w]`).
     pub quaternion: Option<[f64; 4]>,
+    /// Maximum attitude error angle (radians) inferred from the
+    /// quaternion delta.
     pub quat_angle: Option<f64>,
+    /// Per-axis max `|ours − ref|` of angular velocity.
     pub ang_vel: Option<[f64; 3]>,
+    /// Per-axis max `|ours − ref|` of angular acceleration.
     pub ang_accel: Option<[f64; 3]>,
 
     // Test-specific extras: (variable_name, value, unit)

--- a/crates/jeod_test_data/src/dyncomp_csv.rs
+++ b/crates/jeod_test_data/src/dyncomp_csv.rs
@@ -22,28 +22,42 @@ use std::path::Path;
 /// State of a single JEOD reference frame at one timestep.
 #[derive(Debug, Clone)]
 pub struct FrameState {
+    /// Position in metres, in the parent frame.
     pub position: DVec3,
+    /// Velocity in m/s, in the parent frame.
     pub velocity: DVec3,
+    /// Angular velocity in rad/s, in this frame's coordinates.
     pub ang_vel: DVec3,
+    /// `T_parent_this` rotation matrix (parent → this).
     pub t_parent_this: DMat3,
+    /// Attitude quaternion (parent → this), JEOD scalar-first
+    /// left-transformation convention.
     pub quaternion: DQuat,
 }
 
 /// Frame derivatives at one timestep.
 #[derive(Debug, Clone)]
 pub struct FrameDerivs {
+    /// Non-gravitational acceleration in m/s².
     pub non_grav_accel: DVec3,
+    /// Translational acceleration in m/s².
     pub trans_accel: DVec3,
+    /// Rotational (angular) acceleration in rad/s².
     pub rot_accel: DVec3,
 }
 
 /// One row from the 80-column SIM_dyncomp state CSV.
 #[derive(Debug, Clone)]
 pub struct DyncompRecord {
+    /// Sample time in seconds since simulation t=0.
     pub time: f64,
+    /// Composite-body frame state (CoM of the assembled vehicle).
     pub composite_body: FrameState,
+    /// Core-body frame state (CoM of the core body alone).
     pub core_body: FrameState,
+    /// Structural-frame state (geometric origin).
     pub structure: FrameState,
+    /// Frame-derivatives block, when present in the CSV.
     pub derivs: Option<FrameDerivs>,
 }
 

--- a/crates/jeod_test_data/src/gravity_control.rs
+++ b/crates/jeod_test_data/src/gravity_control.rs
@@ -1,3 +1,13 @@
+//! Parser for JEOD Trick `input.py` gravity-control assignments.
+//!
+//! Reads expressions like `earth_grav_control.spherical = False` /
+//! `earth_grav_control.degree = 4` from a JEOD verification sim's
+//! `SET_test/RUN_*/input.py` and produces a `GravityControlConfig` that
+//! the Tier 2 / Tier 3 test harness translates into a runtime
+//! `jeod_gravity::GravityControl`. See
+//! [`verif/SIM_dyncomp/SET_test/RUN_2/input.py`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/verif/SIM_dyncomp/SET_test/RUN_2/input.py)
+//! for an example of the format we parse.
+
 use regex::Regex;
 use std::path::Path;
 
@@ -10,9 +20,13 @@ use std::path::Path;
 /// - `earth_grav_control.gradient = False`
 #[derive(Debug, Clone)]
 pub struct GravityControlConfig {
+    /// Use point-mass-only gravity (`.spherical = True/False`).
     pub spherical: bool,
+    /// Spherical-harmonics degree (`.degree = N`).
     pub degree: usize,
+    /// Spherical-harmonics order (`.order = N`).
     pub order: usize,
+    /// Compute the gravity-gradient tensor (`.gradient = True/False`).
     pub gradient: bool,
 }
 

--- a/crates/jeod_test_data/src/gravity_verif.rs
+++ b/crates/jeod_test_data/src/gravity_verif.rs
@@ -1,3 +1,11 @@
+//! Parser for JEOD's static gravity-verification reference data.
+//!
+//! Reads
+//! [`models/environment/gravity/verif/unit_tests/grav_geospherical/data/verif_out.txt`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/verif/unit_tests/grav_geospherical/data/verif_out.txt)
+//! from JEOD v5.4.0 — the 40 case-by-case `(position →
+//! acceleration / gradient / potential)` test vectors used by Tier 2
+//! `tier2_grav_geospherical`.
+
 use glam::{DMat3, DVec3};
 
 /// A single test case from JEOD's grav_geospherical verification data.
@@ -10,15 +18,24 @@ use glam::{DMat3, DVec3};
 ///   `[0,0], [0,1], [0,2], [1,1], [1,2], [2,2]`.
 #[derive(Debug, Clone)]
 pub struct GravityTestCase {
+    /// 1-based case number from the JEOD verif file.
     pub case_num: usize,
+    /// Spherical-harmonics degree exercised by this case.
     pub degree: usize,
+    /// Spherical-harmonics order exercised by this case.
     pub order: usize,
+    /// Whether the case uses perturbing-only (no `n=0,1`) evaluation.
     pub perturb_only: bool,
+    /// Whether the case computes the gravity-gradient tensor.
     pub grad_active: bool,
+    /// Probe position in metres (planet-fixed frame).
     pub position: DVec3,
+    /// Expected gravitational potential (`m²/s²`).
     pub potential: f64,
+    /// Expected gravitational acceleration in m/s².
     pub acceleration: DVec3,
-    pub gradient: DMat3, // full symmetric matrix
+    /// Expected gravity-gradient tensor (full symmetric matrix).
+    pub gradient: DMat3,
 }
 
 /// Load all gravity test cases from the committed

--- a/crates/jeod_test_data/src/jeod_cc.rs
+++ b/crates/jeod_test_data/src/jeod_cc.rs
@@ -19,10 +19,18 @@ use jeod_gravity::SphericalHarmonicsData;
 /// Errors from parsing a JEOD C++ gravity data file.
 #[derive(Debug, thiserror::Error)]
 pub enum CoeffLoadError {
+    /// Underlying I/O failure when reading the `.cc` source file.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// Expected field (e.g. `mu`, `radius`, a `Cnm` row) was missing
+    /// from the parsed source file.
     #[error("missing field '{field}' in {path}")]
-    MissingField { field: &'static str, path: String },
+    MissingField {
+        /// Name of the expected field that was not found.
+        field: &'static str,
+        /// Source-file path that was being parsed.
+        path: String,
+    },
 }
 
 /// Load only the gravitational parameter (mu) from a JEOD C++ gravity data file.

--- a/crates/jeod_test_data/src/leap_second.rs
+++ b/crates/jeod_test_data/src/leap_second.rs
@@ -1,12 +1,22 @@
+//! Parser for JEOD's `Leap_Second.dat` table.
+//!
+//! Reads
+//! [`models/environment/time/data/Leap_Second.dat`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/data/Leap_Second.dat)
+//! from JEOD v5.4.0 (mirrored at `test_data/time/Leap_Second.dat`)
+//! into a `Vec<LeapSecondEntry>` consumed by `jeod_time::LeapSecondTable`.
+
 /// A single entry from JEOD's `Leap_Second.dat`.
 ///
 /// Each non-comment line: `MJD  day month year  TAI-UTC`
 #[derive(Debug, Clone)]
 pub struct LeapSecondEntry {
-    /// Modified Julian Date of the leap second boundary.
+    /// Modified Julian Date of the leap-second boundary.
     pub mjd: f64,
+    /// Calendar day of month (1–31).
     pub day: u32,
+    /// Calendar month (1–12).
     pub month: u32,
+    /// Calendar year (e.g. `2017`).
     pub year: u32,
     /// TAI minus UTC in seconds (cumulative offset).
     pub tai_utc: f64,

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -60,6 +60,7 @@
 //! [`gravity_fixtures`] for parsed gravity coefficients.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub use jeod_quantities::prelude::*;
 

--- a/crates/jeod_test_data/src/mass_data.rs
+++ b/crates/jeod_test_data/src/mass_data.rs
@@ -1,3 +1,13 @@
+//! Parser for JEOD Trick `Modified_data/mass/*.py` mass-initialization
+//! Python files (e.g.
+//! [`SIM_dyncomp/Modified_data/mass/iss_mass.py`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/verif/SIM_dyncomp/Modified_data/mass/iss_mass.py))
+//! into a [`MassInitData`] struct that the test-data pipeline turns
+//! into a runtime `jeod_dynamics::MassProperties`.
+//!
+//! Strips Trick's `trick.attach_units("kg", …)` / `trick.attach_units("kg*m2", …)`
+//! wrappers per the parsability tier 2 documented in the project
+//! [`CLAUDE.md`](../../CLAUDE.md).
+
 use regex::Regex;
 
 /// Mass initialization data from a JEOD Trick mass.py file.

--- a/crates/jeod_test_data/src/mass_data.rs
+++ b/crates/jeod_test_data/src/mass_data.rs
@@ -6,7 +6,7 @@
 //!
 //! Strips Trick's `trick.attach_units("kg", …)` / `trick.attach_units("kg*m2", …)`
 //! wrappers per the parsability tier 2 documented in the project
-//! [`CLAUDE.md`](../../CLAUDE.md).
+//! [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md#jeod-verification-data).
 
 use regex::Regex;
 

--- a/crates/jeod_test_data/src/orbital_init.rs
+++ b/crates/jeod_test_data/src/orbital_init.rs
@@ -38,15 +38,25 @@ use crate::body_init_fixtures::{
 /// - `"s"` -> seconds (no conversion)
 #[derive(Debug, Clone)]
 pub struct OrbitalInitData {
-    pub semi_major_axis: f64, // meters (converted from km)
+    /// Semi-major axis in metres (converted from km in the source).
+    pub semi_major_axis: f64,
+    /// Eccentricity (dimensionless).
     pub eccentricity: f64,
-    pub inclination: f64,            // radians (converted from degrees)
-    pub ascending_node: f64,         // radians
-    pub arg_periapsis: f64,          // radians
-    pub time_periapsis: Option<f64>, // seconds
-    pub mean_anomaly: Option<f64>,   // radians
-    pub true_anomaly: Option<f64>,   // radians
+    /// Inclination in radians (converted from degrees in the source).
+    pub inclination: f64,
+    /// Right Ascension of the Ascending Node in radians.
+    pub ascending_node: f64,
+    /// Argument of periapsis in radians.
+    pub arg_periapsis: f64,
+    /// Time-since-periapsis in seconds, when used.
+    pub time_periapsis: Option<f64>,
+    /// Mean anomaly in radians, when used.
+    pub mean_anomaly: Option<f64>,
+    /// True anomaly in radians, when used.
+    pub true_anomaly: Option<f64>,
+    /// JEOD `planet_name` (e.g. `"Earth"`, `"Mars"`).
     pub planet_name: String,
+    /// JEOD `reference_frame` selector (e.g. `"earth.inertial"`).
     pub reference_frame: String,
 }
 
@@ -228,8 +238,11 @@ fn convert_units(val: f64, unit: &str) -> Result<f64, BodyInitFixtureError> {
 /// `trick.attach_units("m/s", [...])` wrappers.
 #[derive(Debug, Clone)]
 pub struct TransStateData {
-    pub position: [f64; 3], // meters
-    pub velocity: [f64; 3], // m/s
+    /// Position in metres.
+    pub position: [f64; 3],
+    /// Velocity in m/s.
+    pub velocity: [f64; 3],
+    /// JEOD `reference_frame` selector.
     pub reference_frame: String,
 }
 

--- a/crates/jeod_test_data/src/planet_geodetic_verif.rs
+++ b/crates/jeod_test_data/src/planet_geodetic_verif.rs
@@ -31,21 +31,34 @@ use glam::DVec3;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PlanetFixedSeed {
     /// `update_from_cart`: Cartesian PCPF position (m).
-    Cartesian { read_time: f64, cart_m: DVec3 },
+    Cartesian {
+        /// `add_read` time tag from the JEOD `input.py`.
+        read_time: f64,
+        /// Seed Cartesian PCPF position in metres.
+        cart_m: DVec3,
+    },
     /// `update_from_spher`: Spherical altitude (m), latitude (rad),
     /// longitude (rad).
     Spherical {
+        /// `add_read` time tag from the JEOD `input.py`.
         read_time: f64,
+        /// Spherical altitude above the mean equatorial radius, in metres.
         altitude_m: f64,
+        /// Geocentric latitude in radians.
         latitude_rad: f64,
+        /// Longitude in radians.
         longitude_rad: f64,
     },
     /// `update_from_ellip`: Elliptical (geodetic) altitude (m),
     /// latitude (rad), longitude (rad).
     Elliptical {
+        /// `add_read` time tag from the JEOD `input.py`.
         read_time: f64,
+        /// Geodetic altitude above the reference ellipsoid, in metres.
         altitude_m: f64,
+        /// Geodetic latitude in radians.
         latitude_rad: f64,
+        /// Longitude in radians.
         longitude_rad: f64,
     },
 }

--- a/crates/jeod_test_data/src/reference_state.rs
+++ b/crates/jeod_test_data/src/reference_state.rs
@@ -31,7 +31,9 @@ use crate::body_init_fixtures::{load_vehicle_bundle, BodyInitFixtureError, Refer
 /// and [`ReferenceState::velocity_typed`] to obtain frame-tagged typed views.
 #[derive(Debug, Clone)]
 pub struct ReferenceState {
+    /// Position in metres, in the inertial (ICRF) frame.
     pub position: DVec3,
+    /// Velocity in m/s, in the inertial (ICRF) frame.
     pub velocity: DVec3,
 }
 

--- a/crates/jeod_test_data/src/s_define.rs
+++ b/crates/jeod_test_data/src/s_define.rs
@@ -1,3 +1,11 @@
+//! Parser for JEOD Trick `S_define` simulation-definition files.
+//!
+//! Extracts the `#define DYNAMICS <float>` integration step size from
+//! files like
+//! [`verif/SIM_dyncomp/S_define`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/verif/SIM_dyncomp/S_define)
+//! so the Tier 3 harness can configure the simulation step at the same
+//! cadence as the JEOD reference run.
+
 use regex::Regex;
 use std::path::Path;
 

--- a/crates/jeod_test_data/src/tier3_csv.rs
+++ b/crates/jeod_test_data/src/tier3_csv.rs
@@ -51,20 +51,32 @@ fn read_csv(path: &Path, sim_name: &str) -> String {
 
 // ── SIM_OrbElem CSV (21+ columns) ──────────────────────────────────────────
 
+/// One row from the SIM_OrbElem 21-column reference CSV.
 #[derive(Debug)]
 pub struct OrbElemRecord {
+    /// Sample time in seconds since simulation t=0.
     pub time: f64,
+    /// Semi-major axis in metres.
     pub semi_major_axis: f64,
+    /// Eccentricity magnitude.
     pub e_mag: f64,
+    /// Inclination in radians.
     pub inclination: f64,
+    /// Argument of periapsis in radians.
     pub arg_periapsis: f64,
+    /// Longitude of ascending node in radians.
     pub long_asc_node: f64,
+    /// True anomaly in radians.
     pub true_anom: f64,
+    /// Mean anomaly in radians.
     pub mean_anom: f64,
+    /// Cartesian position in metres.
     pub position: DVec3,
+    /// Cartesian velocity in m/s.
     pub velocity: DVec3,
 }
 
+/// Parse a SIM_OrbElem CSV at `path` into [`OrbElemRecord`] rows.
 pub fn load_orbelem_csv(path: &Path) -> Vec<OrbElemRecord> {
     let content = read_csv(path, "SIM_OrbElem");
     let mut records = Vec::new();
@@ -98,15 +110,22 @@ pub fn load_orbelem_csv(path: &Path) -> Vec<OrbElemRecord> {
 
 // ── SIM_LVLH CSV (17+ columns) ─────────────────────────────────────────────
 
+/// One row from a SIM_LVLH 17-column reference CSV.
 #[derive(Debug)]
 pub struct LvlhRecord {
+    /// Sample time in seconds since simulation t=0.
     pub time: f64,
+    /// LVLH parent-to-this rotation matrix.
     pub t_parent_this: DMat3,
+    /// Magnitude of the LVLH angular velocity in rad/s.
     pub ang_vel_mag: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
 }
 
+/// Parse a SIM_LVLH CSV at `path` into [`LvlhRecord`] rows.
 pub fn load_lvlh_csv(path: &Path) -> Vec<LvlhRecord> {
     let content = read_csv(path, "SIM_LVLH");
     let mut records = Vec::new();
@@ -140,19 +159,30 @@ pub fn load_lvlh_csv(path: &Path) -> Vec<LvlhRecord> {
 
 // ── SIM_NED CSV (16+ columns) ──────────────────────────────────────────────
 
+/// One row from a SIM_NED 16-column reference CSV.
 #[derive(Debug)]
 pub struct NedRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Geodetic altitude in metres.
     pub ellip_altitude: f64,
+    /// Geodetic latitude in radians.
     pub ellip_latitude: f64,
+    /// Geodetic longitude in radians.
     pub ellip_longitude: f64,
+    /// Spherical altitude in metres.
     pub sphere_altitude: f64,
+    /// Geocentric latitude in radians.
     pub sphere_latitude: f64,
+    /// Spherical longitude in radians.
     pub sphere_longitude: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
 }
 
+/// Parse a SIM_NED CSV at `path` into [`NedRecord`] rows.
 pub fn load_ned_csv(path: &Path) -> Vec<NedRecord> {
     let content = read_csv(path, "SIM_NED");
     let mut records = Vec::new();
@@ -185,13 +215,18 @@ pub fn load_ned_csv(path: &Path) -> Vec<NedRecord> {
 
 // ── SrpRecord (7 columns: time + pos[3] + vel[3]) ──────────────────────────
 
+/// One row from a SIM_3_ORBIT SRP-trajectory CSV (7 columns).
 #[derive(Debug)]
 pub struct SrpRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
 }
 
+/// Parse a SIM_3_ORBIT SRP-trajectory CSV at `path`.
 pub fn load_srp_trajectory(path: &Path) -> Vec<SrpRecord> {
     let content = read_csv(path, "SIM_3_ORBIT");
     let mut records = Vec::new();
@@ -218,15 +253,22 @@ pub fn load_srp_trajectory(path: &Path) -> Vec<SrpRecord> {
 
 // ── SIM_1_BASIC SRP CSV (9 columns) ────────────────────────────────────────
 
+/// One row from a SIM_1_BASIC SRP CSV (9 columns).
 #[derive(Debug)]
 pub struct SrpBasicRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// SRP force in newtons.
     pub force: DVec3,
+    /// SRP torque in N·m.
     pub torque: DVec3,
+    /// Solar-flux magnitude in W/m².
     pub flux_mag: f64,
+    /// Surface temperature in K.
     pub temperature: f64,
 }
 
+/// Parse a SIM_1_BASIC SRP CSV at `path`.
 pub fn load_srp_basic_csv(path: &Path) -> Vec<SrpBasicRecord> {
     let content = read_csv(path, "SIM_1_BASIC");
     let mut records = Vec::new();
@@ -255,15 +297,22 @@ pub fn load_srp_basic_csv(path: &Path) -> Vec<SrpBasicRecord> {
 
 // ── SIM_VER_DRAG CSV (11 columns) ──────────────────────────────────────────
 
+/// One row from a SIM_VER_DRAG CSV (11 columns).
 #[derive(Debug)]
 pub struct DragRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Aerodynamic force in newtons.
     pub aero_force: DVec3,
+    /// Aerodynamic torque in N·m.
     pub aero_torque: DVec3,
+    /// Inertial velocity in m/s.
     pub inertial_vel: DVec3,
+    /// Aerodynamic-acceleration magnitude in m/s².
     pub accel_mag: f64,
 }
 
+/// Parse a SIM_VER_DRAG CSV at `path`.
 pub fn load_drag_csv(path: &Path) -> Vec<DragRecord> {
     let content = read_csv(path, "SIM_VER_DRAG");
     let mut records = Vec::new();
@@ -292,17 +341,24 @@ pub fn load_drag_csv(path: &Path) -> Vec<DragRecord> {
 
 // ── SIM_Euler CSV (56 columns: time + 36 angles + 6 pos/vel + 9 T + 4 quat) ─
 
+/// One row from a SIM_Euler CSV (56 columns).
 #[derive(Debug)]
 pub struct EulerRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// 36 Euler-angle samples (12 sequences × 3 angles).
     pub angles: [f64; 36],
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
+    /// Parent-to-this rotation matrix.
     pub t_parent_this: DMat3,
     /// JEOD scalar-first: `[q0_scalar, q1, q2, q3]`.
     pub quaternion: [f64; 4],
 }
 
+/// Parse a SIM_Euler CSV at `path` into [`EulerRecord`] rows.
 pub fn load_euler_csv(path: &Path) -> Vec<EulerRecord> {
     let content = read_csv(path, "SIM_Euler");
     let mut records = Vec::new();
@@ -345,14 +401,20 @@ pub fn load_euler_csv(path: &Path) -> Vec<EulerRecord> {
 
 // ── SIM_SolarBeta CSV (8 columns) ──────────────────────────────────────────
 
+/// One row from a SIM_SolarBeta CSV (8 columns).
 #[derive(Debug)]
 pub struct SolarBetaRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Solar beta angle in radians.
     pub solar_beta: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
 }
 
+/// Parse a SIM_SolarBeta CSV at `path`.
 pub fn load_solar_beta_csv(path: &Path) -> Vec<SolarBetaRecord> {
     let content = read_csv(path, "SIM_SolarBeta");
     let mut records = Vec::new();
@@ -380,15 +442,22 @@ pub fn load_solar_beta_csv(path: &Path) -> Vec<SolarBetaRecord> {
 
 // ── SIM_2A_SHADOW_CALC CSV (11 columns) ────────────────────────────────────
 
+/// One row from a SIM_2A_SHADOW_CALC CSV (11 columns).
 #[derive(Debug)]
 pub struct ShadowCalcRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Solar-flux magnitude in W/m².
     pub flux_mag: f64,
+    /// SRP force in newtons.
     pub force: DVec3,
+    /// SRP torque in N·m.
     pub torque: DVec3,
 }
 
+/// Parse a SIM_2A_SHADOW_CALC CSV at `path`.
 pub fn load_shadow_calc_csv(path: &Path) -> Vec<ShadowCalcRecord> {
     let content = read_csv(path, "SIM_2A_SHADOW_CALC");
     let mut records = Vec::new();
@@ -417,18 +486,26 @@ pub fn load_shadow_calc_csv(path: &Path) -> Vec<ShadowCalcRecord> {
 
 // ── SIM_torque_compare_simple CSV (26 columns) ─────────────────────────────
 
+/// One row from a SIM_torque_compare_simple CSV (26 columns).
 #[derive(Debug)]
 pub struct TorqueSimpleRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
+    /// Body angular velocity in rad/s.
     pub ang_vel: DVec3,
+    /// Parent-to-this rotation matrix.
     pub t_parent_this: DMat3,
     /// JEOD scalar-first: `[q0_scalar, q1, q2, q3]`.
     pub quaternion: [f64; 4],
+    /// Gravity-gradient torque in N·m.
     pub gravity_torque: DVec3,
 }
 
+/// Parse a SIM_torque_compare_simple CSV at `path`.
 pub fn load_torque_simple_csv(path: &Path) -> Vec<TorqueSimpleRecord> {
     let content = read_csv(path, "SIM_torque_compare_simple");
     let mut records = Vec::new();
@@ -465,15 +542,22 @@ pub fn load_torque_simple_csv(path: &Path) -> Vec<TorqueSimpleRecord> {
 
 // ── SIM_dyncomp atmosphere trajectory (9 columns) ──────────────────────────
 
+/// One row from a SIM_dyncomp atmosphere-trajectory CSV (9 columns).
 #[derive(Debug)]
 pub struct AtmosTrajRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
+    /// Atmospheric density in kg/m³.
     pub density: f64,
+    /// Atmospheric temperature in K.
     pub temperature: f64,
 }
 
+/// Parse a SIM_dyncomp atmosphere-trajectory CSV at `path`.
 pub fn load_atmos_traj_csv(path: &Path) -> Vec<AtmosTrajRecord> {
     let content = read_csv(path, "SIM_dyncomp (atmos_traj)");
     let mut records = Vec::new();
@@ -502,16 +586,24 @@ pub fn load_atmos_traj_csv(path: &Path) -> Vec<AtmosTrajRecord> {
 
 // ── SIM_dyncomp aero trajectory (14 columns) ───────────────────────────────
 
+/// One row from a SIM_dyncomp aero-trajectory CSV (14 columns).
 #[derive(Debug)]
 pub struct AeroTrajRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
+    /// Aerodynamic force in newtons.
     pub aero_force: DVec3,
+    /// Aerodynamic torque in N·m.
     pub aero_torque: DVec3,
+    /// Atmospheric density in kg/m³.
     pub density: f64,
 }
 
+/// Parse a SIM_dyncomp aero-trajectory CSV at `path`.
 pub fn load_aero_traj_csv(path: &Path) -> Vec<AeroTrajRecord> {
     let content = read_csv(path, "SIM_dyncomp (aero_traj)");
     let mut records = Vec::new();
@@ -541,13 +633,18 @@ pub fn load_aero_traj_csv(path: &Path) -> Vec<AeroTrajRecord> {
 
 // ── SIM_orbinit CSV (7 columns: time + pos[3] + vel[3]) ───────────────────
 
+/// One row from a SIM_orbinit CSV (7 columns: time + pos + vel).
 #[derive(Debug)]
 pub struct OrbInitRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
 }
 
+/// Parse a SIM_orbinit CSV at `path`.
 pub fn load_orbinit_csv(path: &Path) -> Vec<OrbInitRecord> {
     let content = read_csv(path, "SIM_orbinit");
     let mut records = Vec::new();
@@ -599,15 +696,20 @@ pub fn load_gj_csv(path: &Path) -> Vec<OrbInitRecord> {
 
 // ── SIM_tide_verif CSV (8 columns: time + pos[3] + vel[3] + dC20) ──────────
 
+/// One row from a SIM_tide_verif CSV (8 columns).
 #[derive(Debug)]
 pub struct TideRecord {
+    /// Sample time in seconds.
     pub time: f64,
+    /// Body position in metres.
     pub position: DVec3,
+    /// Body velocity in m/s.
     pub velocity: DVec3,
     /// Tidal ΔC20 correction logged by JEOD's SIM_tide_verif.
     pub delta_c20: f64,
 }
 
+/// Parse a SIM_tide_verif CSV at `path`.
 pub fn load_tide_csv(path: &Path) -> Vec<TideRecord> {
     let content = read_csv(path, "SIM_tide_verif");
     let mut records = Vec::new();

--- a/crates/jeod_test_data/src/time_config.rs
+++ b/crates/jeod_test_data/src/time_config.rs
@@ -40,7 +40,9 @@ pub struct TimeConfig {
     pub utc_hour: u32,
     /// Minute of hour (0–59).
     pub utc_minute: u32,
-    /// Seconds of minute (`0.0..60.0`, or `< 61.0` during a leap second).
+    /// Seconds of minute, in `[0.0, 61.0)`. The standard range is
+    /// `[0.0, 60.0)`; values in `[60.0, 61.0)` are reserved for the
+    /// smeared second during a positive UTC leap second.
     pub utc_second: f64,
     /// Override `TAI − UTC` in seconds, when JEOD's input forces a value.
     pub tai_utc_override: Option<f64>,

--- a/crates/jeod_test_data/src/time_config.rs
+++ b/crates/jeod_test_data/src/time_config.rs
@@ -1,3 +1,11 @@
+//! Parser for JEOD Trick time-initializer input files.
+//!
+//! Reads `Modified_data/time.py` / `Modified_data/date_and_time.py`
+//! files like
+//! [`verif/SIM_dyncomp/Modified_data/date_n_time/date_and_time.py`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/verif/SIM_dyncomp/Modified_data/date_n_time/date_and_time.py)
+//! and produces the `(scale, calendar-date)` pair the Tier 3 harness
+//! feeds into `jeod_time::SimulationTime` at sim startup.
+
 use regex::Regex;
 use std::path::Path;
 
@@ -22,13 +30,21 @@ pub enum TimeInitializer {
 pub struct TimeConfig {
     /// Which time scale the parsed date refers to.
     pub initializer: TimeInitializer,
+    /// Calendar year.
     pub utc_year: i32,
+    /// Calendar month (1–12).
     pub utc_month: u32,
+    /// Calendar day of month (1–31).
     pub utc_day: u32,
+    /// Hour of day (0–23).
     pub utc_hour: u32,
+    /// Minute of hour (0–59).
     pub utc_minute: u32,
+    /// Seconds of minute (`0.0..60.0`, or `< 61.0` during a leap second).
     pub utc_second: f64,
+    /// Override `TAI − UTC` in seconds, when JEOD's input forces a value.
     pub tai_utc_override: Option<f64>,
+    /// Override `UT1 − TAI` in seconds, when JEOD's input forces a value.
     pub tai_to_ut1_override: Option<f64>,
 }
 

--- a/crates/jeod_test_data/src/time_config.rs
+++ b/crates/jeod_test_data/src/time_config.rs
@@ -42,7 +42,8 @@ pub struct TimeConfig {
     pub utc_minute: u32,
     /// Seconds of minute, in `[0.0, 61.0)`. The standard range is
     /// `[0.0, 60.0)`; values in `[60.0, 61.0)` are reserved for the
-    /// smeared second during a positive UTC leap second.
+    /// positive UTC leap second (`23:59:60` and any fractional second
+    /// within it).
     pub utc_second: f64,
     /// Override `TAI − UTC` in seconds, when JEOD's input forces a value.
     pub tai_utc_override: Option<f64>,

--- a/crates/jeod_time/Cargo.toml
+++ b/crates/jeod_time/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "jeod_time"
 description = "Time scales (TAI/UTC/UT1/TDB/TT/GMST) and converters for bevy_jeod"
+readme = "README.md"
 keywords = ["time", "timescale", "tai", "utc", "aerospace"]
 categories = ["science", "aerospace", "date-and-time"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 jeod_quantities = { path = "../jeod_quantities", version = "0.1.0" }

--- a/crates/jeod_time/README.md
+++ b/crates/jeod_time/README.md
@@ -1,0 +1,48 @@
+# jeod_time
+
+Time scales, leap seconds, calendar dates, and the time manager for the
+[`bevy_jeod`](https://github.com/simnaut/bevy_jeod) workspace.
+
+Ports
+[`models/environment/time/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/)
+from [NASA JEOD v5.4.0](https://github.com/nasa/jeod), including the
+[`Leap_Second.dat`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/data/Leap_Second.dat)
+table.
+
+## Layered architecture
+
+```
+bevy_jeod        (Bevy ECS adapter, mission code)
+   ↓
+jeod_sim         (orchestration, recipes, single API surface)
+   ↓
+jeod_time        ←  this crate (pure Rust, zero Bevy)
+   ↓
+jeod_quantities  (typed time scales, SecondsSince<S>)
+```
+
+`jeod_time` is part of the `jeod_*` physics layer — pure Rust with no
+Bevy dependency.
+
+## Public surface
+
+- `TimeManager`, `TimeScaleId` — orchestrator for registered scales.
+- `SimulationTime` — per-step time-state resource (gravity, ephemeris,
+  atmosphere read from this).
+- `DynamicTime` — dynamics-frame time passed through the integrator.
+- `LeapSecondTable` — JEOD `Leap_Second.dat` parser / lookup.
+- `CalendarDate`, `UTC_EPOCH_TAI_TJT` — Gregorian calendar.
+- `UserDefinedEpoch`, `MissionElapsedTime` — sim-defined epoch + MET.
+- `GpsTimeComponents`, `TAI_GPS_OFFSET` — GPS week / time-of-week.
+- Per-pair converters: `time_converter_tai_tdb`,
+  `time_converter_tai_tt`, `time_converter_ut1_gmst`. GMST drives
+  Earth body-fixed rotation in `jeod_frames`.
+
+## See also
+
+- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `TM.*`,
+  `LS.*` invariants this crate enforces.
+- [Project README](../../README.md) and
+  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- Rendered rustdoc:
+  <https://simnaut.github.io/bevy_jeod/jeod_time/>

--- a/crates/jeod_time/README.md
+++ b/crates/jeod_time/README.md
@@ -40,9 +40,9 @@ Bevy dependency.
 
 ## See also
 
-- [`docs/JEOD_invariants.md`](../../docs/JEOD_invariants.md) — `TM.*`,
+- [`docs/JEOD_invariants.md`](https://github.com/simnaut/bevy_jeod/blob/main/docs/JEOD_invariants.md) — `TM.*`,
   `LS.*` invariants this crate enforces.
-- [Project README](../../README.md) and
-  [`CLAUDE.md`](../../CLAUDE.md) — workspace-level architecture.
+- [Project README](https://github.com/simnaut/bevy_jeod/blob/main/README.md) and
+  [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
   <https://simnaut.github.io/bevy_jeod/jeod_time/>

--- a/crates/jeod_time/src/epoch.rs
+++ b/crates/jeod_time/src/epoch.rs
@@ -1,3 +1,11 @@
+//! Standard astronomical epochs and JD ↔ MJD ↔ TJT conversions.
+//!
+//! Matches JEOD's epoch definitions in
+//! [`models/environment/time/include/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/include/)
+//! (v5.4.0). The Truncated Julian Time (`TJT = MJD - 40000`) is JEOD's
+//! preferred internal time variable because it loses the leading
+//! `4.0e4` decimal digits that hurt `f64` precision in long sims.
+
 /// J2000.0 epoch as Julian Date: 2000-01-01 12:00:00 TT.
 pub const J2000_TT_JD: f64 = 2_451_545.0;
 

--- a/crates/jeod_time/src/leap_second.rs
+++ b/crates/jeod_time/src/leap_second.rs
@@ -1,3 +1,12 @@
+//! [`LeapSecondTable`] — TAI ↔ UTC leap-second lookup.
+//!
+//! Ports
+//! [`models/environment/time/src/tai_to_utc.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/src/tai_to_utc.cc)
+//! and the
+//! [`Leap_Second.dat`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/data/Leap_Second.dat)
+//! parser from JEOD v5.4.0. Required for any simulation that hits a
+//! UTC ↔ TAI conversion.
+
 use crate::epoch::{mjd_to_tjt, SECONDS_PER_DAY};
 use log::warn;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/jeod_time/src/lib.rs
+++ b/crates/jeod_time/src/lib.rs
@@ -33,6 +33,7 @@
 //! Rust, zero Bevy dependency.
 
 #![forbid(unsafe_code)]
+#![deny(missing_docs)]
 
 pub use jeod_quantities::prelude::*;
 

--- a/crates/jeod_time/src/simulation_time.rs
+++ b/crates/jeod_time/src/simulation_time.rs
@@ -1,3 +1,13 @@
+//! [`SimulationTime`] — the per-step time-state resource that the
+//! integration loop advances each step and that downstream consumers
+//! (gravity, ephemeris, atmosphere) read from.
+//!
+//! Mirrors JEOD's
+//! [`TimeManager::time`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/src/time_manager.cc)
+//! aggregate from JEOD v5.4.0. All time scales are stored in a single
+//! struct so updates are atomic and downstream readers never see a
+//! mid-step partial update.
+
 use crate::epoch::{J2000_NOON_TJT, J2000_TAI_TJT, SECONDS_PER_DAY, TAI_TT_OFFSET};
 use crate::leap_second::LeapSecondTable;
 use crate::time_converter_tai_tdb;

--- a/crates/jeod_time/src/simulation_time.rs
+++ b/crates/jeod_time/src/simulation_time.rs
@@ -4,9 +4,11 @@
 //!
 //! Mirrors JEOD's
 //! [`TimeManager::time`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/src/time_manager.cc)
-//! aggregate from JEOD v5.4.0. All time scales are stored in a single
-//! struct so updates are atomic and downstream readers never see a
-//! mid-step partial update.
+//! aggregate from JEOD v5.4.0. All time scales live in a single struct
+//! mutated through `&mut self`, so any reader holding a shared borrow
+//! observes a consistent snapshot — the exclusive borrow on the update
+//! path (which calls `recompute_derived` before returning) prevents
+//! mid-step partial reads.
 
 use crate::epoch::{J2000_NOON_TJT, J2000_TAI_TJT, SECONDS_PER_DAY, TAI_TT_OFFSET};
 use crate::leap_second::LeapSecondTable;

--- a/crates/jeod_time/src/time_converter_tai_tdb.rs
+++ b/crates/jeod_time/src/time_converter_tai_tdb.rs
@@ -1,3 +1,11 @@
+//! TAI ↔ TDB time-scale conversion.
+//!
+//! Ports
+//! [`models/environment/time/src/time_converter_tai_tdb.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/src/time_converter_tai_tdb.cc)
+//! from JEOD v5.4.0. Uses the simplified Astronomical-Almanac formula
+//! for the TDB − TT offset (accurate to ±0.1 µs), then chains through
+//! TT ↔ TAI in [`crate::time_converter_tai_tt`].
+
 use crate::epoch::{J2000_TAI_TJT, TAI_TT_OFFSET};
 use crate::time_converter_tai_tt::tai_to_tt;
 use crate::{SecondsSince, TAI, TDB};

--- a/crates/jeod_time/src/time_converter_tai_tt.rs
+++ b/crates/jeod_time/src/time_converter_tai_tt.rs
@@ -1,3 +1,10 @@
+//! TAI ↔ TT time-scale conversion (constant `32.184` s offset).
+//!
+//! Ports
+//! [`models/environment/time/src/time_converter_tai_tt.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/src/time_converter_tai_tt.cc)
+//! from JEOD v5.4.0. The TT − TAI offset is exact by definition:
+//! [`crate::epoch::TAI_TT_OFFSET`].
+
 use crate::epoch::TAI_TT_OFFSET;
 use crate::{SecondsSince, TAI, TT};
 

--- a/crates/jeod_time/src/time_converter_ut1_gmst.rs
+++ b/crates/jeod_time/src/time_converter_ut1_gmst.rs
@@ -1,3 +1,10 @@
+//! UT1 → GMST conversion (Greenwich Mean Sidereal Time).
+//!
+//! Ports
+//! [`models/environment/time/src/time_converter_ut1_gmst.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/src/time_converter_ut1_gmst.cc)
+//! from JEOD v5.4.0. GMST drives Earth's body-fixed rotation in
+//! [`jeod_frames`](https://docs.rs/jeod_frames).
+
 use crate::{SecondsSince, GMST};
 use std::f64::consts::PI;
 use uom::si::angle::radian;

--- a/crates/jeod_time/src/time_utc.rs
+++ b/crates/jeod_time/src/time_utc.rs
@@ -17,11 +17,18 @@ pub const UTC_EPOCH_TAI_TJT: f64 = 11_544.499_257_129_63;
 /// Matches JEOD's `TimeStandard` calendar fields.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CalendarDate {
+    /// Gregorian year (e.g., `2025`).
     pub year: i32,
+    /// Calendar month, 1–12.
     pub month: i32,
+    /// Day of month, 1–31.
     pub day: i32,
+    /// Hour of day, 0–23.
     pub hour: i32,
+    /// Minute of hour, 0–59.
     pub minute: i32,
+    /// Second of minute, `0.0..60.0` (or `< 61.0` during a positive
+    /// leap second).
     pub second: f64,
 }
 

--- a/crates/jeod_time/src/time_utc.rs
+++ b/crates/jeod_time/src/time_utc.rs
@@ -27,8 +27,9 @@ pub struct CalendarDate {
     pub hour: i32,
     /// Minute of hour, 0–59.
     pub minute: i32,
-    /// Second of minute, `0.0..60.0` (or `< 61.0` during a positive
-    /// leap second).
+    /// Second of minute, in `[0.0, 61.0)`. The standard range is
+    /// `[0.0, 60.0)`; the half-open extension up to `61.0` is reserved
+    /// for the smeared second during a positive UTC leap second.
     pub second: f64,
 }
 

--- a/crates/jeod_time/src/time_utc.rs
+++ b/crates/jeod_time/src/time_utc.rs
@@ -28,8 +28,9 @@ pub struct CalendarDate {
     /// Minute of hour, 0–59.
     pub minute: i32,
     /// Second of minute, in `[0.0, 61.0)`. The standard range is
-    /// `[0.0, 60.0)`; the half-open extension up to `61.0` is reserved
-    /// for the smeared second during a positive UTC leap second.
+    /// `[0.0, 60.0)`; values in `[60.0, 61.0)` are reserved for the
+    /// positive UTC leap second (`23:59:60` and any fractional second
+    /// within it).
     pub second: f64,
 }
 


### PR DESCRIPTION
Closes #100.

Brings every `jeod_*` workspace crate to `#![deny(missing_docs)]`, adds module- and item-level rustdoc to clear the lint, drops a per-crate `README.md`, and wires `readme` + `[package.metadata.docs.rs]` into each `Cargo.toml`.

## Crates covered

**Newly gated `#![deny(missing_docs)]`** (10 crates — added the lint, then closed coverage gaps until it goes green):

- `jeod_atmosphere`, `jeod_dynamics`, `jeod_ephemeris`, `jeod_frames`, `jeod_gravity`, `jeod_interactions`, `jeod_math`, `jeod_planet`, `jeod_test_data`, `jeod_time`.

**Promoted from `#![warn(missing_docs)]` to `#![deny(missing_docs)]`** (3 crates that already had `warn` from the type-system / Phase 11 work):

- `jeod_quantities`, `jeod_runner`, `jeod_sim`.

## What landed per crate

- Module-level `//!` on every `pub mod` that lacked one (~28 modules).
- Item-level `///` on every `pub fn` / `pub struct` / `pub enum` / field / variant the lint flagged. Inline `// kg`-style comments on field declarations were converted to `///` blocks.
- A `README.md` in each crate (13 total) summarising role, layered position, public surface, and link to the rendered rustdoc on GitHub Pages.
- `readme = "README.md"` and `[package.metadata.docs.rs]` in every `Cargo.toml`. Crates that gate JEOD-source parsers behind a feature (`jeod_runner`, `jeod_sim`) use `no-default-features = true` for docs.rs so the published page surfaces only the production-facing API.

## JEOD source citation convention

All new doc comments cite JEOD by **GitHub permalink to the pinned `jeod_v5.4.0` tag**, file-level (and line-anchored where helpful), e.g.:

```
[`spherical_harmonics_calc_nonspherical.cc`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/gravity/src/spherical_harmonics_calc_nonspherical.cc)
```

A `jeod_v5.4.0` tagged URL is immutable, so the file-vs-directory tradeoff in the issue's "Execution hints" (which assumed linking to `main`) doesn't apply.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean.
- `cargo test --doc --workspace` — pass.
- `cargo fmt --check` — clean.
- `cargo clippy --workspace --tests -- -D warnings` — clean.
- `cargo test --workspace -- --skip tier3_` — pass.

The existing `docs-enforce` CI job (already running `RUSTDOCFLAGS="-D warnings"`) is the regression gate going forward.

## Test plan

- [x] Workspace docs build clean under `-D warnings`.
- [x] Workspace doctests pass.
- [x] Workspace fmt + clippy clean.
- [x] Unit + Tier 2 tests pass.
- [ ] Tier 3 tests run on CI (no production-code changes — pure rustdoc / metadata, expected to pass).

https://claude.ai/code/session_01Si5uad3uiiNn97HU3dvmJU