### PR TITLE
Document compile-time guards in jeod_quantities crate rustdoc

### DIFF
--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -58,10 +58,13 @@
 //!   `#[diagnostic::on_unimplemented]` message pointing at
 //!   `FrameTransform`. Wired via the
 //!   [`diagnostics::CompatibleFrames`]`<Fl, Fr>` bound in [`ops`].
-//! - **Time-scale separation** — `SecondsSince<S>` has no `Add`/`Sub` impl
-//!   across distinct scales; the only way to combine scales is via
-//!   `TimeConverter::apply`. Cross-scale arithmetic is structurally
-//!   impossible.
+//! - **Time-scale separation** — `SecondsSince<S>` has no `Add`/`Sub`
+//!   impl across distinct scales, so direct arithmetic between (e.g.)
+//!   `SecondsSince<TAI>` and `SecondsSince<TT>` is rejected. The intended
+//!   way to combine scales is via `TimeConverter::apply`. The raw
+//!   `SecondsSince::from_seconds` / `as_seconds` boundaries can still
+//!   relabel an `f64` across scales without applying the offset — see
+//!   "Where the guards stop" below.
 //! - **Quaternion convention separation** — layout (`ScalarFirst` vs
 //!   `ScalarLast`), transform convention (`LeftTransform` vs
 //!   `RightTransform`), and normalization status are distinct phantom
@@ -101,13 +104,30 @@
 //!
 //! ### Where the guards stop
 //!
-//! [`Qty3::raw_si`] and [`Qty3::from_raw_si`] are the documented escape
-//! hatches into raw `glam::DVec3`. Inside the `_inner` / `_impl` kernels
-//! of `jeod_*` crates that operate on `f64` / `DVec3`, the dimensional
-//! and frame guards are absent by design — that's where arithmetic
-//! density lives. Unit slips *inside* a kernel (m vs ft) are caught only
-//! at the `F64Ext` ingestion boundary; once you've called `.raw_si()` the
-//! caller is responsible for keeping things in SI base units.
+//! The crate has several public raw-value boundaries where the
+//! type-system guards end and the caller takes responsibility for
+//! correctness:
+//!
+//! - [`Qty3::raw_si`] / [`Qty3::from_raw_si`] — into and out of raw
+//!   `glam::DVec3` (frame tag and dimension are erased on `raw_si`,
+//!   reattached without check on `from_raw_si`).
+//! - `SecondsSince::from_seconds` / `as_seconds` — into and out of raw
+//!   `f64` seconds (time-scale tag is erased on `as_seconds`, reattached
+//!   without check on `from_seconds`, which is how a `TAI` reading can
+//!   be relabeled as `TT` without applying the 32.184 s offset).
+//! - `JeodQuat::from_array` — accepts a raw `[f64; 4]` without
+//!   normalization or convention checks. Use `NormalizedQuat::new(q)?`
+//!   to recover the unit-norm witness.
+//! - `FrameTransform::from_matrix` — accepts a raw `DMat3` without
+//!   checking orthogonality. The validating sibling is
+//!   `FrameTransform::from_matrix_validated`.
+//!
+//! These boundaries are deliberate: inside the `_inner` / `_impl`
+//! kernels of `jeod_*` crates the math runs on `f64` / `DVec3` /
+//! `DMat3` for arithmetic density. Unit, frame, time-scale, and
+//! quaternion-convention slips inside a kernel are caught only at the
+//! `F64Ext` and typed-API ingestion boundary — once you've crossed into
+//! a raw representation the caller is responsible.
 //!
 //! See the [Type-System wiki page] for the contributor primer (phantom-tag
 //! pattern, adding a new frame/scale/quantity, reading compiler errors,

--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -45,6 +45,77 @@
 //! - Compiler error messages in physics language via
 //!   `#[diagnostic::on_unimplemented]`
 //!
+//! ## Compile-time guards
+//!
+//! Beyond `uom`'s built-in dimensional analysis, this crate adds layered
+//! type-system guards specific to orbital-mechanics conventions. The
+//! actively-wired set:
+//!
+//! - **Dimensional mismatch** (uom-native): `Position + Mass` is rejected
+//!   because `Qty3`'s `Add` impl requires identical dimension `D`.
+//! - **Frame mismatch on `+`/`-`/`+=`/`-=`** — `Position<Ecef> +
+//!   Position<RootInertial>` fails with a tailored
+//!   `#[diagnostic::on_unimplemented]` message pointing at
+//!   `FrameTransform`. Wired via the
+//!   [`diagnostics::CompatibleFrames`]`<Fl, Fr>` bound in [`ops`].
+//! - **Time-scale separation** — `SecondsSince<S>` has no `Add`/`Sub` impl
+//!   across distinct scales; the only way to combine scales is via
+//!   `TimeConverter::apply`. Cross-scale arithmetic is structurally
+//!   impossible.
+//! - **Quaternion convention separation** — layout (`ScalarFirst` vs
+//!   `ScalarLast`), transform convention (`LeftTransform` vs
+//!   `RightTransform`), and normalization status are distinct phantom
+//!   tags. `NormalizedQuat<L, T>` is a separate type from `Quat<L, T>`,
+//!   so a raw `Quat` cannot stand in where a unit quaternion is required.
+//! - **`FrameTransform<From, To>` composition** only typechecks when the
+//!   two inner frames align (`A→B ∘ B→C`); the identity is only defined
+//!   for `From = To`.
+//! - **Cross-dimension multiply / divide on `Qty3`** uses `typenum`
+//!   exponent arithmetic, so `Velocity × Time → Position` and
+//!   `Acceleration × Time → Velocity` are type-safe by construction; a
+//!   bad combination produces a dimension that won't unify with the
+//!   target type.
+//! - **Inertial-flavor distinctions** (issue #255 / `RF.10`):
+//!   `RootInertial`, `PlanetInertial<P>`, and `IntegrationFrame` are
+//!   kind-distinct phantoms. Body integration-frame state cannot silently
+//!   flow into root-inertial-only consumers (gravity, SRP, relativistic);
+//!   the only safe transition is via [`IntegOrigin`].
+//!
+//! ### Scaffolded but not currently wired
+//!
+//! [`diagnostics::IntoLength`], [`diagnostics::IntoAngle`],
+//! [`diagnostics::IntoGravParam`], [`diagnostics::CompatibleTimeScales`],
+//! [`diagnostics::CompatibleQuatLayouts`],
+//! [`diagnostics::CompatibleQuatTransforms`],
+//! [`diagnostics::RequiresNormalizedQuat`],
+//! [`diagnostics::InertialOnly`], and [`diagnostics::NoVectorVectorMul`]
+//! carry tailored diagnostic messages but are not currently used as
+//! `where` bounds by any impl in the workspace. Today, for example,
+//! passing `400_000.0` where a `Length` is expected produces uom's stock
+//! "mismatched types" error rather than the `IntoLength` hint, and
+//! `Qty3 * Qty3` produces a default "no `Mul` impl" rather than the
+//! `NoVectorVectorMul` hint. `F64Ext` discoverability today comes from
+//! the prelude and worked examples. These scaffolds let a future
+//! contributor flip on an active guard without touching call sites — the
+//! diagnostic message is already in place.
+//!
+//! ### Where the guards stop
+//!
+//! [`Qty3::raw_si`] and [`Qty3::from_raw_si`] are the documented escape
+//! hatches into raw `glam::DVec3`. Inside the `_inner` / `_impl` kernels
+//! of `jeod_*` crates that operate on `f64` / `DVec3`, the dimensional
+//! and frame guards are absent by design — that's where arithmetic
+//! density lives. Unit slips *inside* a kernel (m vs ft) are caught only
+//! at the `F64Ext` ingestion boundary; once you've called `.raw_si()` the
+//! caller is responsible for keeping things in SI base units.
+//!
+//! See the [Type-System wiki page] for the contributor primer (phantom-tag
+//! pattern, adding a new frame/scale/quantity, reading compiler errors,
+//! escape hatches) and `examples/typed_mission.rs` for the canonical
+//! worked example.
+//!
+//! [Type-System wiki page]: https://github.com/simnaut/bevy_jeod/wiki/Type-System
+//!
 //! ## Quick start
 //!
 //! ```

--- a/scripts/check_no_escape_hatches.sh
+++ b/scripts/check_no_escape_hatches.sh
@@ -10,12 +10,28 @@
 #    Banned across `crates/` and `src/` except where annotated with
 #    `// allowed: <reason>`.
 #
-# 2. **Typed-quantity bypass constructors** (`from_untyped_unchecked`,
-#    `from_dmat3_unchecked`, `from_raw_si`):
-#    The Phase-8 typed-quantity facade promises that frame mismatches
-#    are compile errors. These constructors mint a typed value from raw
-#    storage without any check that the caller's frame phantom matches
-#    reality.
+# 2. **Typed-quantity bypass constructors** — raw constructors that mint
+#    a typed value from primitive storage without checking the caller's
+#    phantom tags / conventions / normalization invariants:
+#
+#      - `from_untyped_unchecked` — typed sibling boundary
+#      - `from_dmat3_unchecked`   — `InertiaTensor` (skips symmetry check)
+#      - `from_raw_si`            — `Qty3` (raw `DVec3` → typed)
+#      - `from_seconds`           — `SecondsSince` (raw `f64` → tagged time)
+#      - `from_array`             — `Quat`/`JeodQuat` (raw `[f64;4]` →
+#                                   tagged quaternion, skips normalization
+#                                   and convention checks)
+#      - `from_matrix(`           — `FrameTransform` (raw `DMat3` → typed
+#                                   transform, skips orthonormality check
+#                                   in release builds; the validating
+#                                   sibling is `from_matrix_validated`)
+#
+#    The Phase-8 typed-quantity facade promises that frame, time-scale,
+#    quaternion-convention, and dimensional mismatches are compile
+#    errors. These constructors mint a typed value from raw storage
+#    without any check that the caller's phantom matches reality, so
+#    per-step uses in the Bevy adapter are exactly the regression class
+#    audit finding H1 documented.
 #
 #    They are legitimately part of the typed-sibling boundary inside
 #    `crates/jeod_*/src/` — every typed sibling (`TranslationalStateTyped`,
@@ -81,7 +97,7 @@ bypass_matches=$(echo "$src_files_to_scan" | xargs awk '
     /^[[:space:]]*\/\// { next }
     # Blank: keep prev_allowed as-is.
     /^[[:space:]]*$/ { next }
-    /from_untyped_unchecked|from_dmat3_unchecked|from_raw_si/ {
+    /from_untyped_unchecked|from_dmat3_unchecked|from_raw_si|from_seconds|(JeodQuat|Quat)::from_array|FrameTransform::from_matrix\(/ {
         if (prev_allowed) { prev_allowed = 0; next }
         if ($0 ~ /\/\/ allowed:/) { prev_allowed = 0; next }
         printf "%s:%d: %s\n", FILENAME, FNR, $0
@@ -104,10 +120,13 @@ if [ -n "$bypass_matches" ]; then
     echo "FAIL: typed-quantity bypass constructors in the Bevy adapter" >&2
     echo "  (scanned: src/**, except the canonical boundary modules" >&2
     echo "   src/components.rs and src/lib.rs)" >&2
-    echo "  Banned: from_untyped_unchecked / from_dmat3_unchecked / from_raw_si" >&2
+    echo "  Banned: from_untyped_unchecked / from_dmat3_unchecked / from_raw_si /" >&2
+    echo "          from_seconds / (JeodQuat|Quat)::from_array / FrameTransform::from_matrix(" >&2
     echo "  These constructors mint a typed value from raw storage without" >&2
-    echo "  checking the caller's frame phantom. The Bevy adapter must use" >&2
-    echo "  the typed APIs (Position<Inertial>, etc.) directly via the" >&2
+    echo "  checking the caller's frame / time-scale / quaternion-convention /" >&2
+    echo "  normalization phantoms. The Bevy adapter must use the typed APIs" >&2
+    echo "  (Position<RootInertial>, SecondsSince<TAI>, NormalizedQuat<...>," >&2
+    echo "  FrameTransform::from_matrix_validated, etc.) directly via the" >&2
     echo "  components, not lift raw storage per step." >&2
     echo "  See issue #172 (audit finding H1) for context." >&2
     echo "  If you have a documented boundary case, annotate the line with" >&2

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -53,6 +53,7 @@ impl PlanetBundle {
             source: GravitySourceC(source),
             position: SourceInertialPositionC::default(),
             trans: TranslationalStateC::default(),
+            // allowed: IDENTITY placeholder; planet_fixed_rotation_system overwrites on tick 1
             rotation: PlanetFixedRotationC(FrameTransform::from_matrix(glam::DMat3::IDENTITY)),
             rotation_model: RotationModelC(config.rotation_model),
             shape: PlanetC(config.shape),

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -64,6 +64,9 @@ pub fn planet_fixed_rotation_system(
             jeod_sim::RotationModel::None => {}
             jeod_sim::RotationModel::EarthRNP => {
                 let rotation = *earth_rotation.get_or_insert_with(|| {
+                    // allowed: matrix is JEOD's RNP-derived rotation; the
+                    // RootInertial → PlanetFixed<SelfPlanet> phantoms match the kernel
+                    // by construction
                     jeod_sim::FrameTransform::from_matrix(
                         jeod_sim::compute_t_parent_this_from_tjt_with_polar(
                             sim_time.gmst_seconds,
@@ -77,6 +80,7 @@ pub fn planet_fixed_rotation_system(
             jeod_sim::RotationModel::MarsIAU => {
                 let tt_s_since_j2000 =
                     (sim_time.tt_tjt() - jeod_sim::J2000_TT_TJT) * jeod_sim::SECONDS_PER_DAY;
+                // allowed: matrix from JEOD-ported IAU Mars rotation formula
                 rot.0 = jeod_sim::FrameTransform::from_matrix(
                     jeod_sim::rotation_mars::compute_mars_rotation(tt_s_since_j2000),
                 );
@@ -85,6 +89,7 @@ pub fn planet_fixed_rotation_system(
                 let tdb_jd = sim_time.tdb_julian_date();
                 let tdb_s_since_j2000 =
                     (tdb_jd - jeod_sim::J2000_TT_JD) * jeod_sim::SECONDS_PER_DAY;
+                // allowed: matrix from JEOD-ported IAU Moon rotation formula
                 rot.0 = jeod_sim::FrameTransform::from_matrix(
                     jeod_sim::rotation_moon::compute_moon_rotation(tdb_s_since_j2000),
                 );
@@ -105,6 +110,7 @@ pub fn planet_fixed_rotation_system(
                              whose coverage includes the simulation epoch."
                         )
                     });
+                // allowed: matrix from NASA SPICE BPC kernel (DE421 / Moon-PA)
                 rot.0 = jeod_sim::FrameTransform::from_matrix(matrix);
             }
         }


### PR DESCRIPTION
## Summary

### Documentation

- Adds a "Compile-time guards" section to the `jeod_quantities` crate-level rustdoc enumerating the eight actively-wired type-system guards layered on top of `uom` (dimensional, frame, time-scale, quaternion convention, `FrameTransform` composition, cross-dimension `*`/`/`, inertial-flavor distinctions).
- Documents the nine diagnostic traits in `diagnostics.rs` that are scaffolded but not yet referenced as `where` bounds (`IntoLength`, `IntoAngle`, `IntoGravParam`, `CompatibleTimeScales`, `CompatibleQuatLayouts`, `CompatibleQuatTransforms`, `RequiresNormalizedQuat`, `InertialOnly`, `NoVectorVectorMul`) — so future contributors know which messages are aspirational vs active.
- Enumerates the public raw-value boundaries where the guards stop: `Qty3::raw_si`/`from_raw_si`, `SecondsSince::from_seconds`/`as_seconds`, `JeodQuat::from_array`, `FrameTransform::from_matrix` (vs the validating `from_matrix_validated`).
- Links to the Type-System wiki page for the contributor primer.

### CI guard expansion

- Broadens `scripts/check_no_escape_hatches.sh` to police the newly-documented raw boundaries in the Bevy adapter: `from_seconds`, `(JeodQuat|Quat)::from_array`, and `FrameTransform::from_matrix(` (the trailing `(` keeps `from_matrix_validated` exempt).
- Annotates the 5 existing `FrameTransform::from_matrix` call sites in `src/{systems.rs, bundles.rs}` with `// allowed:` reasons naming the validated source kernel for each (RNP, IAU Mars/Moon, NASA SPICE BPC, IDENTITY placeholder).
- `from_seconds` and `(JeodQuat|Quat)::from_array` had zero current `src/` uses; the addition is purely defensive against future per-step regressions.

### Companion wiki update

The Type-System wiki page was updated in a parallel push: §5 now opens with a cheat-sheet table and includes accurate examples for the structurally-enforced guards (time-scale separation, normalization witness, inertial-flavor distinction, `FrameTransform` composition). Stale `Inertial` references were corrected to `RootInertial`.

## Test plan

- [x] `cargo doc -p jeod_quantities --no-deps` — no warnings, intra-doc links resolve
- [x] `cargo test -p jeod_quantities --doc` — 30 doctests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `bash scripts/check_no_escape_hatches.sh` — passes with new patterns and annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)