### PR TITLE
PR #260 round-3 review closeouts (#264, #265, #210)

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -658,6 +658,24 @@ pub struct SunMarker;
 #[reflect(opaque, Component)]
 pub struct MoonMarker;
 
+/// Marks an entity as the simulation's designated central body.
+///
+/// [`crate::SourceMutator::set_source_position`] and
+/// [`crate::SourceMutator::set_source_state`] panic if the target entity
+/// carries this marker. Mission code attaches it to the gravity-source
+/// entity it treats as the pinned origin (e.g. Earth in an Earth-centered
+/// scenario), opting that entity into the same protection that
+/// `jeod_runner::Simulation::set_source_*` enforces against the
+/// root-mapped source via `assert_ne!(fid, root_frame_id, …)`.
+///
+/// At most one entity should carry this marker per simulation; multiple
+/// markers are not currently rejected, but `SourceMutator` panics on
+/// every call that targets a marked entity, so a well-behaved app
+/// attaches it once.
+#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(opaque, Component)]
+pub struct CentralSourceMarker;
+
 // ── Planet ──
 
 /// Bevy component wrapping `PlanetShape`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,14 @@ impl Default for FrameTreeR {
 pub struct RootFrameIdR(pub jeod_sim::FrameId);
 
 /// Unified JEOD plugin — registers all pipeline systems and schedule sets.
+///
+/// All systems are registered on Bevy's `FixedUpdate` schedule, which
+/// acts as a single JEOD-style integration group: every body matched by
+/// the integrating systems advances together at the schedule's shared
+/// `dt`. Multi-stage integrators (RK4, etc.) loop internally inside
+/// [`JeodSet::Integration`] — they do *not* trigger multiple schedule
+/// passes. See the [`sets`] module docs for the full mapping and the
+/// recipe for scenarios that need separate integration groups.
 pub struct JeodPlugin;
 
 impl Plugin for JeodPlugin {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,7 @@ pub fn register_jeod_component_types(app: &mut App) {
     app.register_type::<components::EphemerisBodyC>();
     app.register_type::<components::SunMarker>();
     app.register_type::<components::MoonMarker>();
+    app.register_type::<components::CentralSourceMarker>();
     // Derived-state config
     app.register_type::<components::OrbitalElementsConfigC>();
     app.register_type::<components::EulerAnglesConfigC>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,13 +128,17 @@ pub struct RootFrameIdR(pub jeod_sim::FrameId);
 
 /// Unified JEOD plugin — registers all pipeline systems and schedule sets.
 ///
-/// All systems are registered on Bevy's `FixedUpdate` schedule, which
-/// acts as a single JEOD-style integration group: every body matched by
-/// the integrating systems advances together at the schedule's shared
-/// `dt`. Multi-stage integrators (RK4, etc.) loop internally inside
-/// [`JeodSet::Integration`] — they do *not* trigger multiple schedule
-/// passes. See the [`sets`] module docs for the full mapping and the
-/// recipe for scenarios that need separate integration groups.
+/// The seven [`JeodSet`] pipeline stages run in Bevy's `FixedUpdate`
+/// schedule, which acts as a single JEOD-style integration group: every
+/// body matched by the integrating systems advances together at the
+/// schedule's shared `dt`. (Auxiliary registration systems —
+/// `register_source_frames_system` / `register_body_frames_system` — also
+/// run in `Startup` and `PreUpdate` to catch late-spawned entities; they
+/// no-op for already-registered ones.) Multi-stage integrators (RK4, etc.)
+/// loop internally inside [`JeodSet::Integration`] — they do *not*
+/// trigger multiple schedule passes. See the [`sets`] module docs for
+/// the full mapping and the recipe for scenarios that need separate
+/// integration groups.
 pub struct JeodPlugin;
 
 impl Plugin for JeodPlugin {

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -1,11 +1,45 @@
 //! [`JeodSet`] — the Bevy `SystemSet` partition that mirrors JEOD's
 //! per-step pipeline.
+//!
+//! # Schedule as integration group
+//!
+//! JEOD's `JeodIntegrationGroup` collects a set of bodies that advance
+//! together under a single shared time step, with one integrator stage
+//! that consumes the group's force/torque accumulators and produces the
+//! next state for every member. In `bevy_jeod`, the Bevy `FixedUpdate`
+//! schedule **is** that integration group:
+//!
+//! - One `FixedUpdate` tick = one group advance at the schedule's fixed
+//!   `dt`. Every entity matched by the integrating system's query
+//!   shares that `dt` by construction — no per-body bookkeeping.
+//! - The seven [`JeodSet`] stages below run once per tick, in the order
+//!   declared, mirroring JEOD's init/update pipeline (force collection
+//!   feeds integration feeds derived state).
+//! - **Multi-stage integrators (RK4, etc.) are an inner loop inside
+//!   [`JeodSet::Integration`], not multiple schedule passes.** A four-
+//!   stage RK4 evaluates four sub-steps within the integration system
+//!   for the same outer `FixedUpdate` tick.
+//! - Multi-body sims (Apollo, Earth–Moon) need no extra wiring: every
+//!   body registered in the schedule is automatically a member of the
+//!   "group" in JEOD's sense.
+//!
+//! # Multiple integration groups
+//!
+//! When a scenario genuinely needs *separate* groups — different bodies
+//! integrating at different cadences — register a second Bevy schedule
+//! and run it on its own tick rate. This is plain Bevy mechanics, not
+//! a JEOD-specific construct, and no current scenario in this workspace
+//! uses it; the single-`FixedUpdate` model covers every shipped sim.
 
 use bevy::prelude::*;
 
 /// Bevy system-set partition mirroring JEOD's per-step pipeline. Stages
 /// run in declaration order; `JeodPlugin::build` configures the ordering
 /// when the plugin is added to the app.
+///
+/// All seven stages execute together inside one `FixedUpdate` tick at
+/// the schedule's shared `dt`, defining a single JEOD-style integration
+/// group; see the module-level docs for the full mapping.
 // JEOD_INV: DM.04 — system set ordering mirrors JEOD init/update pipeline
 // JEOD_INV: DM.13 — EphemerisUpdate before Environment ensures ephemeris is current for gravity
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -13,8 +13,8 @@
 //!   `dt`. Every entity matched by the integrating system's query
 //!   shares that `dt` by construction — no per-body bookkeeping.
 //! - The seven [`JeodSet`] stages below run once per tick, in the order
-//!   declared, mirroring JEOD's init/update pipeline (force collection
-//!   feeds integration feeds derived state).
+//!   declared, mirroring JEOD's init/update pipeline (force collection →
+//!   integration → derived state).
 //! - **Multi-stage integrators (RK4, etc.) are an inner loop inside
 //!   [`JeodSet::Integration`], not multiple schedule passes.** A four-
 //!   stage RK4 evaluates four sub-steps within the integration system

--- a/src/source_mutator.rs
+++ b/src/source_mutator.rs
@@ -86,6 +86,7 @@ pub struct SourceMutator<'w, 's> {
     velocities: Query<'w, 's, &'static mut SourceInertialVelocityC>,
     translational: Query<'w, 's, &'static mut TranslationalStateC>,
     central: Query<'w, 's, (), With<CentralSourceMarker>>,
+    names: Query<'w, 's, &'static Name>,
 }
 
 impl SourceMutator<'_, '_> {
@@ -107,8 +108,13 @@ impl SourceMutator<'_, '_> {
     ///   if `SourceFrameIdC(root_id)` is attached manually — Bevy's
     ///   `register_source_frames_system` never maps a source to root.)
     pub fn set_source_position(&mut self, source: Entity, position: DVec3) {
-        self.assert_not_central(source, "set_source_position");
+        // Verify the entity is a registered gravity source first; that's
+        // the more fundamental misconfiguration to surface (a non-source
+        // entity carrying CentralSourceMarker hits the SourceFrameIdC
+        // panic before the marker panic, which is the diagnostic ordering
+        // a debugging user actually wants — PR #267 review).
         let fid = self.fetch_frame_id(source, "set_source_position");
+        self.assert_not_central(source, "set_source_position");
         let source_frames = [SourceFrameIds {
             inertial: fid,
             pfix: None,
@@ -142,8 +148,8 @@ impl SourceMutator<'_, '_> {
     /// - `source` carries [`CentralSourceMarker`].
     /// - `source` maps to the root frame.
     pub fn set_source_state(&mut self, source: Entity, position: DVec3, velocity: DVec3) {
-        self.assert_not_central(source, "set_source_state");
         let fid = self.fetch_frame_id(source, "set_source_state");
+        self.assert_not_central(source, "set_source_state");
         let source_frames = [SourceFrameIds {
             inertial: fid,
             pfix: None,
@@ -186,12 +192,23 @@ impl SourceMutator<'_, '_> {
     fn assert_not_central(&self, source: Entity, method: &str) {
         if self.central.get(source).is_ok() {
             panic!(
-                "SourceMutator::{method}: entity {source:?} carries \
-                 CentralSourceMarker — the central body's state is \
-                 pinned by convention. Remove the marker (or target a \
-                 different gravity source) if retargeting the central \
-                 body is really intended."
+                "SourceMutator::{method}: {label} carries CentralSourceMarker \
+                 — the central body's state is pinned by convention. Remove \
+                 the marker (or target a different gravity source) if \
+                 retargeting the central body is really intended.",
+                label = self.entity_label(source),
             );
+        }
+    }
+
+    /// Format a user-facing label for `entity` — `"Earth (Entity {…})"` if a
+    /// `Name` component is present, falling back to the raw `Entity` debug
+    /// form. Used by the panic-formatting helpers so diagnostics name the
+    /// gravity source the way mission code spelled it (PR #267 review).
+    fn entity_label(&self, entity: Entity) -> String {
+        match self.names.get(entity) {
+            Ok(name) => format!("{name} ({entity:?})"),
+            Err(_) => format!("{entity:?}"),
         }
     }
 
@@ -201,11 +218,12 @@ impl SourceMutator<'_, '_> {
             .map(|c| c.0)
             .unwrap_or_else(|err| {
                 panic!(
-                    "SourceMutator::{method}: entity {source:?} is not a registered \
+                    "SourceMutator::{method}: {label} is not a registered \
                  gravity source (missing SourceFrameIdC). Spawn it via PlanetBundle \
                  (or insert GravitySourceC + SourceInertialPositionC) and let \
                  `register_source_frames_system` register the frame node before \
-                 mutating it. Underlying error: {err:?}"
+                 mutating it. Underlying error: {err:?}",
+                    label = self.entity_label(source),
                 )
             })
     }

--- a/src/source_mutator.rs
+++ b/src/source_mutator.rs
@@ -37,7 +37,8 @@ use glam::DVec3;
 use jeod_sim::{set_source_position, set_source_state, FrameId, SourceFrameIds};
 
 use crate::components::{
-    SourceFrameIdC, SourceInertialPositionC, SourceInertialVelocityC, TranslationalStateC,
+    CentralSourceMarker, SourceFrameIdC, SourceInertialPositionC, SourceInertialVelocityC,
+    TranslationalStateC,
 };
 use crate::{FrameTreeR, RootFrameIdR};
 
@@ -57,17 +58,19 @@ use crate::{FrameTreeR, RootFrameIdR};
 /// [`SourceInertialVelocityC`] by default; without auto-insert,
 /// `set_source_state` would silently no-op on the velocity write.)
 ///
-/// **Divergence from `jeod_runner`**: the runner's
-/// `set_source_position` / `set_source_state` reject mutations of the
-/// *root* source (the central body, since the root frame must stay
-/// identity). The Bevy adapter never maps any source to the root
+/// **Central-body protection**: `jeod_runner::Simulation` rejects
+/// mutations of the *root* source (the central body, since the root
+/// frame must stay identity) via `assert_ne!(fid, root_frame_id, …)`.
+/// The Bevy adapter never maps any source to the root
 /// (`register_source_frames_system` always adds sources as children),
-/// so the runtime "cannot retarget the root" panic only fires for
-/// entities that manually attach `SourceFrameIdC(root_id)` (which the
-/// `bevy_parity_source_mutation` panic test exercises). In a normal
-/// Bevy app, every gravity source — including whichever you treat as
-/// the central body — is freely mutable. Mission code that needs a
-/// pinned origin should not call this mutator on that entity.
+/// so that structural-root assertion only fires for entities that
+/// manually attach `SourceFrameIdC(root_id)`. To restore the
+/// user-facing protection in a normal Bevy app, attach
+/// [`CentralSourceMarker`] to the gravity-source entity that mission
+/// code treats as the pinned origin (e.g. Earth in an Earth-centered
+/// scenario). The mutator panics if the target entity carries the
+/// marker — same outcome as `jeod_runner`'s root-source rejection,
+/// just opt-in.
 #[derive(SystemParam)]
 pub struct SourceMutator<'w, 's> {
     /// The simulation frame tree resource.
@@ -82,6 +85,7 @@ pub struct SourceMutator<'w, 's> {
     positions: Query<'w, 's, &'static mut SourceInertialPositionC>,
     velocities: Query<'w, 's, &'static mut SourceInertialVelocityC>,
     translational: Query<'w, 's, &'static mut TranslationalStateC>,
+    central: Query<'w, 's, (), With<CentralSourceMarker>>,
 }
 
 impl SourceMutator<'_, '_> {
@@ -94,9 +98,16 @@ impl SourceMutator<'_, '_> {
     /// - `source` does not carry a [`SourceFrameIdC`] (i.e. it isn't a
     ///   registered gravity source — spawn it via [`crate::PlanetBundle`]
     ///   so `register_source_frames_system` registers it).
-    /// - `source` maps to the root frame (central body): the root frame
-    ///   must remain identity, so its position cannot be retargeted.
+    /// - `source` carries [`CentralSourceMarker`]: mission code has opted
+    ///   that entity into central-body protection (mirrors
+    ///   `jeod_runner::Simulation::set_source_position`'s root-source
+    ///   rejection).
+    /// - `source` maps to the root frame: the root frame must remain
+    ///   identity, so its position cannot be retargeted. (Only reachable
+    ///   if `SourceFrameIdC(root_id)` is attached manually — Bevy's
+    ///   `register_source_frames_system` never maps a source to root.)
     pub fn set_source_position(&mut self, source: Entity, position: DVec3) {
+        self.assert_not_central(source, "set_source_position");
         let fid = self.fetch_frame_id(source, "set_source_position");
         let source_frames = [SourceFrameIds {
             inertial: fid,
@@ -128,8 +139,10 @@ impl SourceMutator<'_, '_> {
     /// # Panics
     ///
     /// - `source` does not carry a [`SourceFrameIdC`].
+    /// - `source` carries [`CentralSourceMarker`].
     /// - `source` maps to the root frame.
     pub fn set_source_state(&mut self, source: Entity, position: DVec3, velocity: DVec3) {
+        self.assert_not_central(source, "set_source_state");
         let fid = self.fetch_frame_id(source, "set_source_state");
         let source_frames = [SourceFrameIds {
             inertial: fid,
@@ -167,6 +180,18 @@ impl SourceMutator<'_, '_> {
         if let Ok(mut ts) = self.translational.get_mut(source) {
             ts.0.position = typed_pos;
             ts.0.velocity = typed_vel;
+        }
+    }
+
+    fn assert_not_central(&self, source: Entity, method: &str) {
+        if self.central.get(source).is_ok() {
+            panic!(
+                "SourceMutator::{method}: entity {source:?} carries \
+                 CentralSourceMarker — the central body's state is \
+                 pinned by convention. Remove the marker (or target a \
+                 different gravity source) if retargeting the central \
+                 body is really intended."
+            );
         }
     }
 

--- a/tests/bevy_parity_planet_ang_vel.rs
+++ b/tests/bevy_parity_planet_ang_vel.rs
@@ -21,13 +21,16 @@ use std::time::Duration;
 
 use bevy::prelude::*;
 use bevy_jeod::{
-    FrameTreeR, GravitySourceC, JeodPlugin, PlanetAngularVelocityC, PlanetBundle,
+    EphemerisR, FrameTreeR, GravitySourceC, JeodPlugin, PlanetAngularVelocityC, PlanetBundle,
     PlanetFixedRotationC, PlanetOmegaC, RotationModelC, SourceInertialPositionC,
     SourcePfixFrameIdC,
 };
 use glam::DVec3;
 use jeod_runner::{RotationModel, Simulation};
-use jeod_sim::{GravityModel, GravitySource, GravitySourceEntry, PlanetConfig, EARTH, MARS, MOON};
+use jeod_sim::{
+    Ephemeris, GravityModel, GravitySource, GravitySourceEntry, PlanetConfig, EARTH, MARS, MOON,
+};
+use jeod_test_data::tier3_csv::test_data_path;
 
 const DT: f64 = 60.0;
 
@@ -354,5 +357,79 @@ fn tier3_bevy_rotation_none_toggle_removes_pfix_component() {
         app.world().get::<SourcePfixFrameIdC>(planet).unwrap().0,
         original_pfix_id,
         "the same pfix FrameId must be reused across every toggle cycle"
+    );
+}
+
+#[test]
+fn tier3_bevy_planet_ang_vel_moon_de421() {
+    // MoonDE421 is the only RotationModel branch whose Bevy ↔ runner
+    // end-to-end path was previously uncovered (issue #265). Mirror the
+    // MoonIAU test, additionally inserting `EphemerisR` with the BPC
+    // kernel that `planet_fixed_rotation_system`'s MoonDE421 branch
+    // requires. The kernel `moon_pa_de421_1900-2050.bpc` is already
+    // committed to `test_data/` (used by `tier3_simulation_earth_moon_clem`),
+    // so no new fixture commit is needed.
+    let bsp = test_data_path("de421.bsp");
+    let bpc = test_data_path("moon_pa_de421_1900-2050.bpc");
+
+    // ── Bevy ──
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    let mut eph = Ephemeris::from_bsp(&bsp).expect("DE421 BSP load");
+    eph.load_bpc(&bpc).expect("Moon DE421 BPC load");
+    app.insert_resource(EphemerisR(eph));
+    let planet = app
+        .world_mut()
+        .spawn(PlanetBundle::point_mass("Moon", &MOON))
+        .id();
+    // Override the bundle's default `RotationModelC(MoonIAU)` (copied
+    // from `MOON.rotation_model`) with `MoonDE421`. Inserting after
+    // spawn replaces the bundle's component cleanly.
+    app.world_mut()
+        .entity_mut(planet)
+        .insert(RotationModelC(RotationModel::MoonDE421));
+    step_bevy_once(&mut app);
+
+    let bevy_ang_vel = app
+        .world()
+        .get::<PlanetAngularVelocityC>(planet)
+        .unwrap()
+        .0
+        .raw_si();
+    let expected = DVec3::new(0.0, 0.0, MOON.omega);
+    assert_dvec3_bits_eq(
+        "Bevy Moon DE421 ang_vel vs PlanetConfig",
+        bevy_ang_vel,
+        expected,
+    );
+
+    // ── jeod_runner ──
+    // `central_body(&MOON)` copies `MOON.rotation_model` (= MoonIAU);
+    // override after construction to switch the branch to MoonDE421.
+    let time = jeod_sim::SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
+    let mut sim = Simulation::new(time, DT);
+    let mut entry = GravitySourceEntry::central_body(&MOON);
+    entry.rotation_model = RotationModel::MoonDE421;
+    sim.add_source("Moon", entry);
+    let mut sim_eph = Ephemeris::from_bsp(&bsp).expect("DE421 BSP load (sim)");
+    sim_eph.load_bpc(&bpc).expect("Moon DE421 BPC load (sim)");
+    sim.ephemeris = Some(sim_eph);
+    sim.validate().unwrap();
+    sim.step().expect("step failed");
+
+    let sim_ang_vel = sim_pfix_ang_vel(&sim, "Moon");
+    assert_dvec3_bits_eq(
+        "Bevy vs Sim Moon DE421 pfix ang_vel",
+        bevy_ang_vel,
+        sim_ang_vel,
+    );
+
+    let bevy_node_ang_vel = bevy_pfix_node_ang_vel(&app, planet);
+    assert_dvec3_bits_eq(
+        "Bevy FrameTreeR Moon DE421 pfix-node ang_vel vs Sim",
+        bevy_node_ang_vel,
+        sim_ang_vel,
     );
 }

--- a/tests/bevy_parity_source_mutation.rs
+++ b/tests/bevy_parity_source_mutation.rs
@@ -25,8 +25,8 @@
 
 use bevy::prelude::*;
 use bevy_jeod::{
-    FrameTreeR, JeodPlugin, PlanetBundle, RootFrameIdR, SourceFrameIdC, SourceInertialPositionC,
-    SourceInertialVelocityC, SourceMutator, TranslationalStateC,
+    CentralSourceMarker, FrameTreeR, JeodPlugin, PlanetBundle, RootFrameIdR, SourceFrameIdC,
+    SourceInertialPositionC, SourceInertialVelocityC, SourceMutator, TranslationalStateC,
 };
 use glam::DVec3;
 use jeod_runner::Simulation;
@@ -192,6 +192,59 @@ fn tier3_bevy_source_mutator_root_mutation_panics() {
         .world_mut()
         .register_system(move |mut mutator: SourceMutator| {
             mutator.set_source_position(source, DVec3::new(1.0, 2.0, 3.0));
+        });
+    let _ = app.world_mut().run_system(id);
+}
+
+#[test]
+#[should_panic(expected = "carries CentralSourceMarker")]
+fn tier3_bevy_source_mutator_central_marker_panics_on_set_position() {
+    // Mission code attaches `CentralSourceMarker` to the gravity-source
+    // entity it treats as the pinned origin. `SourceMutator::set_source_position`
+    // must panic on that entity, mirroring `jeod_runner::Simulation`'s
+    // `assert_ne!(fid, root_frame_id, …)` rejection of root-source
+    // mutation. Issue #264 closeout.
+    let mut app = build_app();
+    let earth = app
+        .world_mut()
+        .spawn((
+            PlanetBundle::point_mass("Earth", &EARTH),
+            CentralSourceMarker,
+        ))
+        .id();
+    // Run Startup so register_source_frames_system attaches `SourceFrameIdC`.
+    // The marker guard fires *before* the frame-id lookup, so this isn't
+    // strictly required for the panic, but it keeps the test exercising
+    // the same shape as a real mission setup.
+    app.world_mut().run_schedule(Startup);
+
+    let id = app
+        .world_mut()
+        .register_system(move |mut mutator: SourceMutator| {
+            mutator.set_source_position(earth, DVec3::new(1.0, 2.0, 3.0));
+        });
+    let _ = app.world_mut().run_system(id);
+}
+
+#[test]
+#[should_panic(expected = "carries CentralSourceMarker")]
+fn tier3_bevy_source_mutator_central_marker_panics_on_set_state() {
+    // Same as the position case above, but for `set_source_state`.
+    // Both setters must reject central-body mutation.
+    let mut app = build_app();
+    let earth = app
+        .world_mut()
+        .spawn((
+            PlanetBundle::point_mass("Earth", &EARTH),
+            CentralSourceMarker,
+        ))
+        .id();
+    app.world_mut().run_schedule(Startup);
+
+    let id = app
+        .world_mut()
+        .register_system(move |mut mutator: SourceMutator| {
+            mutator.set_source_state(earth, DVec3::new(1.0, 2.0, 3.0), DVec3::ZERO);
         });
     let _ = app.world_mut().run_system(id);
 }


### PR DESCRIPTION
Bundles the three follow-ups identified in PR #260's round-3 review.

## Closeouts

### #264 — `SourceMutator` central-body protection

Adds `CentralSourceMarker` (zero-sized, opt-in). Mission code attaches
it to the gravity-source entity it treats as the pinned origin;
`SourceMutator::set_source_position` and `set_source_state` panic when
targeting an entity carrying the marker, with a diagnostic naming the
entity and the opt-out. The structural `assert_ne!(fid, root_frame_id, …)`
in the lifted `jeod_sim::source_state` helpers stays in place — the
existing `tier3_bevy_source_mutator_root_mutation_panics` test continues
to exercise that root-identity invariant as a separate case.

Two new parity tests:
- `tier3_bevy_source_mutator_central_marker_panics_on_set_position`
- `tier3_bevy_source_mutator_central_marker_panics_on_set_state`

`SourceMutator` rustdoc updated: replaces the "every gravity source —
including whichever you treat as the central body — is freely mutable"
caveat with the marker opt-in.

### #265 — Tier 3 parity test for the MoonDE421 rotation branch

Adds `tier3_bevy_planet_ang_vel_moon_de421` to
`tests/bevy_parity_planet_ang_vel.rs`, mirroring the existing MoonIAU
test plus an `EphemerisR` insertion that loads the BPC kernel
`planet_fixed_rotation_system`'s MoonDE421 branch requires.

**Zero new fixture cost:** `test_data/moon_pa_de421_1900-2050.bpc` (1.7
MB) is already committed and used by `tier3_simulation_earth_moon_clem`.

All four `RotationModel` branches (EarthRNP, MarsIAU, MoonIAU, MoonDE421)
now have end-to-end Bevy ↔ runner parity coverage.

### #210 — Schedule-as-integration-group documentation

Module-level rustdoc additions on `src/sets.rs` (`# Schedule as
integration group` and `# Multiple integration groups` sections) plus
a pointer from `JeodPlugin`'s rustdoc in `src/lib.rs`. The companion
[Integration-Groups](https://github.com/simnaut/bevy_jeod/wiki/Integration-Groups)
wiki page (committed separately) is the strategic explainer that
cross-links to the rustdoc.

A follow-up commit narrows the `JeodPlugin` doc claim from "all systems
are registered on `FixedUpdate`" to scope it to the seven `JeodSet`
pipeline stages, parenthetically noting the auxiliary `Startup` /
`PreUpdate` registration systems that #260 wired in (Copilot review on
#267 caught the overstatement).

## Commits

| # | Commit | Closes |
|---|---|---|
| 1 | `[#210] Document schedule-as-integration-group in JeodSet rustdoc` | #210 |
| 2 | `[#264] Bevy SourceMutator: protect the central body via CentralSourceMarker` | #264 |
| 3 | `[#265] Tier 3 Bevy parity test for the MoonDE421 rotation branch` | #265 |
| 4 | `[#210] Don't overstate "all systems on FixedUpdate" in JeodPlugin doc` | #210 (review fix) |

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 833 unit
      + Tier 2 + bevy_parity tests pass
- [x] `cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'` — 322 Tier 3 tests pass (earth_moon excluded per CLAUDE.md; main-push CI covers it)
- [x] Targeted: `tier3_bevy_source_mutator_*` (4 tests) and
      `tier3_bevy_planet_ang_vel_*` (5 tests) all pass
- [x] Rebased onto `main` after #260 merged; `tier3_bevy_rotation_none_toggle_removes_pfix_component` (added by #260) and `tier3_bevy_planet_ang_vel_moon_de421` (added here) coexist cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)