### PR TITLE
[study #268] Prototype: ECS-native frame tree

### DIFF
--- a/crates/jeod_frames/src/frame_storage.rs
+++ b/crates/jeod_frames/src/frame_storage.rs
@@ -1,0 +1,223 @@
+//! Storage-agnostic frame-tree algorithms (issue #268 prototype experiment).
+//!
+//! This module factors the load-bearing tree-walking algorithms
+//! (`compose_to_ancestor`, `common_ancestor`, `compute_relative_state`)
+//! over a small [`FrameStorage`] trait so the same algorithm serves
+//! both backends:
+//!
+//! - the runner's arena-based [`crate::FrameTree`] (via the `impl
+//!   FrameStorage for FrameTree` here), and
+//! - the Bevy adapter's ECS-hierarchy view (`bevy_jeod`'s
+//!   `RelativeFrameState` `SystemParam`, which `impl`s `FrameStorage`
+//!   for itself).
+//!
+//! The trait is **internal scaffolding**, not a mission-code surface.
+//! Mission code uses `bevy_jeod::frame_param::RelativeFrameState`
+//! (`SystemParam`); the trait is the implementation detail that lets
+//! the runner and Bevy share one copy of the algorithms.
+//!
+//! ## What the trait abstracts
+//!
+//! Pure read-only graph traversal:
+//! - `parent(id) -> Option<id>` — walk one link upward.
+//! - `state(id) -> RefFrameState` — read the state stored at a node
+//!   (relative to its parent).
+//!
+//! Mutation (e.g. `reparent`) is **not** in the trait: it lives in
+//! each backend's native API because mutating Bevy hierarchy goes
+//! through `Commands` (deferred), while mutating the arena is direct.
+//! Trying to abstract over those two mutation models would force one
+//! into the other's idiom — exactly what this design declined to do
+//! at the mission-code surface (per CLAUDE.md feedback memory).
+
+use crate::frame_tree::{FrameId, FrameTree};
+use crate::ref_frame_state::RefFrameState;
+
+/// Read-only access to a frame tree, abstracting over the underlying
+/// storage. Implementors: [`FrameTree`] (arena), and Bevy adapters
+/// such as `bevy_jeod`'s `RelativeFrameState` `SystemParam`.
+pub trait FrameStorage {
+    /// Identifier type for a frame in this storage. Arena uses
+    /// [`FrameId`] (== `usize`); ECS adapter uses `bevy::ecs::entity::Entity`.
+    type Id: Copy + Eq + std::fmt::Debug;
+
+    /// Parent of `id`, or `None` for a root.
+    fn parent(&self, id: Self::Id) -> Option<Self::Id>;
+
+    /// State stored at `id`, expressed relative to its parent.
+    /// Roots return [`RefFrameState::default`] semantically, but the
+    /// trait does not require this — `compose_to_ancestor` early-exits
+    /// before the state of a root is read in practice.
+    fn state(&self, id: Self::Id) -> RefFrameState;
+}
+
+/// Compose states from `id` up to `ancestor`, returning the state of
+/// `id` relative to `ancestor`. Generic counterpart to
+/// [`FrameTree::compose_to_ancestor`] (which is private).
+///
+/// # Panics
+/// Panics if `id` is not a descendant of `ancestor` (the caller is
+/// expected to call [`common_ancestor`] first).
+pub fn compose_to_ancestor<S: FrameStorage>(
+    storage: &S,
+    id: S::Id,
+    ancestor: S::Id,
+) -> RefFrameState {
+    if id == ancestor {
+        return RefFrameState::default();
+    }
+    let mut composed = storage.state(id);
+    let mut current = id;
+    while let Some(parent) = storage.parent(current) {
+        if parent == ancestor {
+            return composed;
+        }
+        composed.incr_left(&storage.state(parent));
+        current = parent;
+    }
+    panic!(
+        "compose_to_ancestor: frame {id:?} is not a descendant of \
+         ancestor {ancestor:?}; common_ancestor walk should have caught this"
+    );
+}
+
+/// Find the lowest common ancestor of two frames, or `None` if they
+/// are in disconnected subtrees. Walks both up to equal depth, then
+/// in lockstep until they meet.
+pub fn common_ancestor<S: FrameStorage>(storage: &S, a: S::Id, b: S::Id) -> Option<S::Id> {
+    let mut da = depth(storage, a);
+    let mut db = depth(storage, b);
+    let mut ca = a;
+    let mut cb = b;
+    while da > db {
+        ca = storage.parent(ca)?;
+        da -= 1;
+    }
+    while db > da {
+        cb = storage.parent(cb)?;
+        db -= 1;
+    }
+    while ca != cb {
+        ca = storage.parent(ca)?;
+        cb = storage.parent(cb)?;
+    }
+    Some(ca)
+}
+
+/// Depth of `id` in the tree (root = 0).
+fn depth<S: FrameStorage>(storage: &S, id: S::Id) -> usize {
+    let mut d = 0usize;
+    let mut current = id;
+    while let Some(parent) = storage.parent(current) {
+        d += 1;
+        current = parent;
+    }
+    d
+}
+
+/// Compute the state of `to` relative to `from`. Generic counterpart
+/// to [`FrameTree::compute_relative_state`].
+///
+/// # Panics
+/// Panics if `from` and `to` do not share a common ancestor.
+pub fn compute_relative_state<S: FrameStorage>(
+    storage: &S,
+    from: S::Id,
+    to: S::Id,
+) -> RefFrameState {
+    if from == to {
+        return RefFrameState::default();
+    }
+    let ancestor = common_ancestor(storage, from, to).unwrap_or_else(|| {
+        panic!(
+            "compute_relative_state: frames {from:?} and {to:?} do not \
+             share a common ancestor"
+        )
+    });
+    let state_from = compose_to_ancestor(storage, from, ancestor);
+    let state_to = compose_to_ancestor(storage, to, ancestor);
+    let from_negated = RefFrameState::negate(&state_from);
+    from_negated.incr_right(&state_to)
+}
+
+// ── Arena impl ────────────────────────────────────────────────────────
+
+impl FrameStorage for FrameTree {
+    type Id = FrameId;
+
+    fn parent(&self, id: FrameId) -> Option<FrameId> {
+        // Delegates to the inherent `parent` method on FrameTree.
+        FrameTree::parent(self, id)
+    }
+
+    fn state(&self, id: FrameId) -> RefFrameState {
+        self.get(id).state
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ref_frame_state::{RefFrameKind, RefFrameRot, RefFrameTrans};
+    use glam::DVec3;
+
+    fn build_tree() -> (FrameTree, FrameId, FrameId, FrameId) {
+        let mut tree = FrameTree::new();
+        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+        let a = tree.add_child(
+            root,
+            "A".into(),
+            RefFrameKind::Body,
+            RefFrameState {
+                trans: RefFrameTrans {
+                    position: DVec3::new(1.0e6, 2.0e6, 3.0e6),
+                    velocity: DVec3::new(10.0, 20.0, 30.0),
+                },
+                rot: RefFrameRot::default(),
+            },
+        );
+        let b = tree.add_child(
+            a,
+            "B".into(),
+            RefFrameKind::Body,
+            RefFrameState {
+                trans: RefFrameTrans {
+                    position: DVec3::new(100.0, 200.0, 300.0),
+                    velocity: DVec3::new(1.0, 2.0, 3.0),
+                },
+                rot: RefFrameRot::default(),
+            },
+        );
+        (tree, root, a, b)
+    }
+
+    #[test]
+    fn shared_compute_relative_state_matches_inherent() {
+        let (tree, root, _a, b) = build_tree();
+        // Inherent (FrameTree's own implementation).
+        let inherent = tree.compute_relative_state(root, b);
+        // Shared (this module's generic implementation, dispatched via
+        // FrameStorage on FrameTree).
+        let shared = compute_relative_state(&tree, root, b);
+        assert_eq!(inherent.trans.position, shared.trans.position);
+        assert_eq!(inherent.trans.velocity, shared.trans.velocity);
+        assert_eq!(inherent.rot.t_parent_this, shared.rot.t_parent_this);
+        assert_eq!(inherent.rot.ang_vel_this, shared.rot.ang_vel_this);
+    }
+
+    #[test]
+    fn shared_common_ancestor_matches_inherent() {
+        let (tree, root, a, b) = build_tree();
+        // Sibling-of-A under root, to make common_ancestor non-trivial.
+        let mut tree = tree;
+        let _c = tree.add_child(
+            root,
+            "C".into(),
+            RefFrameKind::Body,
+            RefFrameState::default(),
+        );
+        assert_eq!(common_ancestor(&tree, b, a), Some(a));
+        assert_eq!(common_ancestor(&tree, b, root), Some(root));
+        assert_eq!(common_ancestor(&tree, a, b), Some(a));
+    }
+}

--- a/crates/jeod_frames/src/lib.rs
+++ b/crates/jeod_frames/src/lib.rs
@@ -35,6 +35,7 @@
 #![deny(missing_docs)]
 
 pub mod data_nutation_j2000;
+pub mod frame_storage;
 pub mod frame_tree;
 pub mod nutation_j2000;
 pub mod precession_j2000;
@@ -43,5 +44,8 @@ pub mod rotation_j2000;
 pub mod rotation_mars;
 pub mod rotation_moon;
 
+pub use frame_storage::{
+    common_ancestor, compose_to_ancestor, compute_relative_state, FrameStorage,
+};
 pub use frame_tree::{FrameId, FrameNode, FrameTree};
 pub use ref_frame_state::*;

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -163,7 +163,9 @@ pub use jeod_interactions::{
 // need when constructing or reading frame nodes; `RefFrameStateTyped` is
 // the typed sibling for Phase C of issue #71.
 pub use jeod_frames::{
-    FrameId, FrameNode, FrameTree, RefFrameKind, RefFrameRot, RefFrameState, RefFrameStateTyped,
+    common_ancestor as frame_common_ancestor, compose_to_ancestor as frame_compose_to_ancestor,
+    compute_relative_state as frame_compute_relative_state_via_storage, FrameId, FrameNode,
+    FrameStorage, FrameTree, RefFrameKind, RefFrameRot, RefFrameState, RefFrameStateTyped,
     RefFrameTrans,
 };
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -467,6 +467,122 @@ pub struct IntegSourceC(pub Option<Entity>);
 #[reflect(opaque, Component)]
 pub struct FrameSwitchesC(pub Vec<jeod_sim::FrameSwitchConfig<Entity>>);
 
+// ── Issue #268 prototype: frames-as-entities components ──
+//
+// Prototype components for the long-term ECS-native frame-tree shape
+// described in issue #268. These live on **frame entities** (not body
+// or source entities) and mirror the per-node state of the arena's
+// `FrameTree`. During the prototype, both the arena and these
+// components are populated (dual-write) so existing `FrameTreeR`
+// consumers stay green while new SystemParam-based consumers can read
+// from the ECS hierarchy directly via `ChildOf`/`Children`.
+//
+// Component split rationale: the three pieces of `RefFrameState` are
+// independently mutated in practice. `FrameTransC` is rewritten by
+// integration / source-position updates; `FrameRotC` is rewritten by
+// planet-fixed rotation updates; `FrameAngVelC` is rewritten alongside
+// `FrameRotC` for pfix frames but stays at zero for inertial / body
+// frames. Splitting lets change-detection fire on the right writers
+// only.
+
+/// Translational state (position + velocity) of a frame entity
+/// relative to its parent frame entity. Mirrors
+/// [`jeod_sim::RefFrameTrans`]. Stored raw (`DVec3`) at the prototype
+/// stage; the future shape may carry typed `Position<P>` / `Velocity<P>`
+/// keyed off the parent frame entity's marker. Issue #268.
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+#[reflect(opaque, Component)]
+pub struct FrameTransC {
+    /// Position relative to parent frame, in parent-frame coordinates (m).
+    pub position: DVec3,
+    /// Velocity relative to parent frame, in parent-frame coordinates (m/s).
+    pub velocity: DVec3,
+}
+
+/// Rotational state of a frame entity relative to its parent: the
+/// left-transformation quaternion and the cached transformation matrix
+/// `t_parent_this`. Mirrors the rotation portion of
+/// [`jeod_sim::RefFrameRot`] minus `ang_vel_this`, which lives in
+/// [`FrameAngVelC`] for change-detection granularity. Issue #268.
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(opaque, Component)]
+pub struct FrameRotC {
+    /// Left-transformation quaternion (parent → this).
+    pub q_parent_this: jeod_sim::JeodQuat,
+    /// Transformation matrix `t_parent_this` derived from the quaternion (cache).
+    pub t_parent_this: glam::DMat3,
+}
+
+impl Default for FrameRotC {
+    fn default() -> Self {
+        Self {
+            q_parent_this: jeod_sim::JeodQuat::identity(),
+            t_parent_this: glam::DMat3::IDENTITY,
+        }
+    }
+}
+
+/// Angular velocity of a frame entity relative to its parent, expressed
+/// in this-frame coordinates (rad/s). Mirrors
+/// [`jeod_sim::RefFrameRot::ang_vel_this`]. Split from [`FrameRotC`] so
+/// pfix-rotation systems that only rewrite angular velocity (or body
+/// integration that only rewrites attitude) get fine-grained
+/// change-detection. Issue #268.
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut, Reflect)]
+#[reflect(opaque, Component)]
+pub struct FrameAngVelC(pub DVec3);
+
+// Marker components — mark the kind of frame an entity represents.
+// Bevy idiom: query keying via `With<…>`. Replaces the runtime
+// `RefFrameKind` enum on the arena side. Suffix `Marker` avoids
+// colliding with `jeod_sim`'s phantom-frame types (`BodyFrame`,
+// `PlanetFixed`, `IntegrationFrame`, `RootInertial`).
+
+/// Marker: this entity is a root or planet inertial frame. Issue #268.
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
+pub struct InertialFrameMarker;
+
+/// Marker: this entity is a planet-fixed (pfix) frame, child of an
+/// inertial frame, rotating with the planet. Issue #268.
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
+pub struct PlanetFixedFrameMarker;
+
+/// Marker: this entity is a body's body-frame (composite_body in JEOD).
+/// Issue #268.
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
+pub struct BodyFrameMarker;
+
+/// Marker: this entity is currently serving as the integration frame
+/// for at least one body. Set by `register_body_frames_system` /
+/// `frame_switch_system`. A frame entity may carry both
+/// `InertialFrameMarker` and `IntegrationFrameMarker` simultaneously —
+/// they describe orthogonal properties of the frame. Issue #268.
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component)]
+pub struct IntegrationFrameMarker;
+
+/// Bidirectional handle linking a body / source / planet entity to its
+/// frame entity in the ECS hierarchy. Inserted by
+/// `register_*_frames_system` alongside the existing `*FrameIdC`
+/// components during the prototype dual-write phase. Once
+/// `RelativeFrameState` SystemParam consumers replace all `FrameTreeR`
+/// readers, this becomes the only frame-tree handle the body / source
+/// entity needs. Issue #268.
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque, Component)]
+pub struct FrameEntityC(pub Entity);
+
+/// Frame entity for a source's planet-fixed (pfix) child frame.
+/// Mirrors [`SourcePfixFrameIdC`] in the entity-as-frame world.
+/// Inserted alongside `SourcePfixFrameIdC` during the prototype.
+/// Issue #268.
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque, Component)]
+pub struct PfixFrameEntityC(pub Entity);
+
 /// Angular velocity of the planet-fixed frame relative to its inertial
 /// parent, expressed in pfix coordinates. Computed each step by
 /// `planet_fixed_rotation_system` as `[0, 0, omega]` matching JEOD's

--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -1,0 +1,272 @@
+//! Issue #268 prototype: Bevy-native `SystemParam`s for cross-frame
+//! state computation.
+//!
+//! Replaces `FrameTreeR`-backed arena lookups (`compute_relative_state`,
+//! `frame_origin`) with ECS hierarchy walks over Bevy 0.18's
+//! `ChildOf` / `Children` relationship and the new
+//! [`FrameTransC`](crate::components::FrameTransC) /
+//! [`FrameRotC`](crate::components::FrameRotC) /
+//! [`FrameAngVelC`](crate::components::FrameAngVelC) components.
+//!
+//! Mission code asks for cross-frame state by passing entity handles,
+//! never `FrameId`s — the surface looks like any other Bevy
+//! SystemParam.
+
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use glam::DVec3;
+use jeod_sim::{RefFrameRot, RefFrameState, RefFrameTrans};
+
+use crate::components::{FrameAngVelC, FrameRotC, FrameTransC};
+
+/// Compute relative state between two frame entities by walking
+/// Bevy's hierarchy and composing per-node states with the pure-state
+/// math from `jeod_frames` (`incr_left`, `incr_right`, `negate`).
+///
+/// ECS-native replacement for
+/// `FrameTreeR.compute_relative_state(from_id, to_id)` /
+/// `frame_origin(tree, root, frame_id)`. Issue #268.
+#[derive(SystemParam)]
+pub struct RelativeFrameState<'w, 's> {
+    parents: Query<'w, 's, &'static ChildOf>,
+    states: Query<
+        'w,
+        's,
+        (
+            &'static FrameTransC,
+            &'static FrameRotC,
+            &'static FrameAngVelC,
+        ),
+    >,
+}
+
+impl<'w, 's> RelativeFrameState<'w, 's> {
+    /// `(position, velocity)` of `to` relative to `from`, both in
+    /// `from`-frame coordinates.
+    pub fn position_velocity(&self, from: Entity, to: Entity) -> (DVec3, DVec3) {
+        let rel = self.relative_state(from, to);
+        (rel.trans.position, rel.trans.velocity)
+    }
+
+    /// Position of `to` relative to `from`, in `from`-frame
+    /// coordinates.
+    pub fn position(&self, from: Entity, to: Entity) -> DVec3 {
+        self.relative_state(from, to).trans.position
+    }
+
+    /// Full [`RefFrameState`] of `to` relative to `from`.
+    /// Mirrors `FrameTree::compute_relative_state(from, to)`.
+    pub fn relative_state(&self, from: Entity, to: Entity) -> RefFrameState {
+        if from == to {
+            return RefFrameState::default();
+        }
+        let ancestor = self.common_ancestor(from, to).unwrap_or_else(|| {
+            panic!(
+                "RelativeFrameState::relative_state: frames {from:?} and {to:?} \
+                 do not share a common ancestor in the ECS hierarchy. Spawn both \
+                 under the same root frame entity."
+            )
+        });
+        let state_from = self.compose_to_ancestor(from, ancestor);
+        let state_to = self.compose_to_ancestor(to, ancestor);
+        let from_negated = RefFrameState::negate(&state_from);
+        from_negated.incr_right(&state_to)
+    }
+
+    fn common_ancestor(&self, a: Entity, b: Entity) -> Option<Entity> {
+        let mut da = self.depth(a);
+        let mut db = self.depth(b);
+        let mut ca = a;
+        let mut cb = b;
+        while da > db {
+            ca = self.parent_of(ca)?;
+            da -= 1;
+        }
+        while db > da {
+            cb = self.parent_of(cb)?;
+            db -= 1;
+        }
+        while ca != cb {
+            ca = self.parent_of(ca)?;
+            cb = self.parent_of(cb)?;
+        }
+        Some(ca)
+    }
+
+    fn depth(&self, entity: Entity) -> usize {
+        let mut d = 0;
+        let mut current = entity;
+        while let Some(parent) = self.parent_of(current) {
+            d += 1;
+            current = parent;
+        }
+        d
+    }
+
+    fn parent_of(&self, entity: Entity) -> Option<Entity> {
+        self.parents
+            .get(entity)
+            .ok()
+            .map(|child_of| child_of.parent())
+    }
+
+    /// Compose states from `id` up to `ancestor`, returning the state
+    /// of `id` relative to `ancestor`. Mirrors
+    /// `FrameTree::compose_to_ancestor`.
+    fn compose_to_ancestor(&self, id: Entity, ancestor: Entity) -> RefFrameState {
+        if id == ancestor {
+            return RefFrameState::default();
+        }
+        let mut composed = self.state_of(id);
+        let mut current = id;
+        while let Some(parent_entity) = self.parent_of(current) {
+            if parent_entity == ancestor {
+                return composed;
+            }
+            composed.incr_left(&self.state_of(parent_entity));
+            current = parent_entity;
+        }
+        panic!(
+            "RelativeFrameState::compose_to_ancestor: frame {id:?} is not a \
+             descendant of ancestor {ancestor:?} in the ECS hierarchy. \
+             Common-ancestor walk should have caught this."
+        );
+    }
+
+    fn state_of(&self, entity: Entity) -> RefFrameState {
+        let (trans, rot, ang_vel) = self.states.get(entity).unwrap_or_else(|err| {
+            panic!(
+                "RelativeFrameState::state_of: frame entity {entity:?} is missing \
+                 FrameTransC / FrameRotC / FrameAngVelC components ({err:?}). \
+                 Frame entities must be spawned with all three (or use the \
+                 register_*_frames_system path that inserts them)."
+            )
+        });
+        RefFrameState {
+            trans: RefFrameTrans {
+                position: trans.position,
+                velocity: trans.velocity,
+            },
+            rot: RefFrameRot {
+                q_parent_this: rot.q_parent_this,
+                t_parent_this: rot.t_parent_this,
+                ang_vel_this: ang_vel.0,
+            },
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Issue #268 design-doc evidence: Sketch 2 — frame switch handler
+// rewritten in ECS-native shape using `ChildOf` + `RelativeFrameState`.
+//
+// Compiles but is not wired into any schedule. Exists to demonstrate
+// the "After" snippet from the plan reads cleanly and that the
+// `RelativeFrameState` SystemParam composes with `Commands` and
+// hierarchy mutation for the canonical frame-switch use case. The
+// production `frame_switch_system` (`crate::systems::frame_switch_system`)
+// stays on the lifted `jeod_sim::evaluate_and_apply_frame_switch`
+// helper for now — this sketch is the design-doc reference for what
+// the eventual replacement looks like.
+// ──────────────────────────────────────────────────────────────────────
+
+use crate::components::{BodyFrameMarker, FrameEntityC, FrameSwitchesC};
+use jeod_sim::{Position, RootInertial, SwitchSense, Velocity};
+
+/// Sketch: Bevy-native frame-switch handler. Walks each body's
+/// `FrameSwitchesC`, evaluates switch distance via the
+/// [`RelativeFrameState`] SystemParam, and on trigger reparents the
+/// body's frame entity via `commands.entity(child).insert(ChildOf(p))`
+/// — the canonical ECS-native pattern.
+///
+/// **Not wired into the schedule.** The production frame-switch system
+/// uses the lifted arena helper `jeod_sim::evaluate_and_apply_frame_switch`.
+/// This sketch is design-doc evidence per issue #268: it demonstrates
+/// that the "After" snippet in the plan compiles in real Rust.
+#[allow(dead_code)]
+pub fn frame_switch_system_ecs_native_sketch(
+    mut commands: Commands,
+    rel: RelativeFrameState,
+    sources: Query<&FrameEntityC, Without<BodyFrameMarker>>,
+    mut bodies: Query<
+        (
+            Entity,
+            &mut crate::components::TranslationalStateC,
+            &FrameEntityC,
+            &mut FrameSwitchesC,
+            &mut crate::components::GravityControlsC,
+        ),
+        With<crate::components::DynamicsConfigC>,
+    >,
+    parents: Query<&ChildOf>,
+) {
+    for (body_entity, mut trans, body_frame, mut switches, mut gravity_controls) in &mut bodies {
+        if switches.0.is_empty() {
+            continue;
+        }
+
+        // Current integ frame is the body frame's parent in the ECS
+        // hierarchy — no `IntegFrameIdC` lookup needed.
+        let current_integ_frame = match parents.get(body_frame.0) {
+            Ok(child_of) => child_of.parent(),
+            Err(_) => continue,
+        };
+
+        // Evaluate each active switch using `RelativeFrameState`.
+        let mut triggered: Option<(usize, Entity)> = None;
+        for (idx, sw) in switches.0.iter().enumerate() {
+            if !sw.active {
+                continue;
+            }
+            let target_frame = match sources.get(sw.target_source).ok() {
+                Some(fe) => fe.0,
+                None => continue,
+            };
+            // Body position expressed in the target frame: if it's
+            // within the switch distance, fire the switch.
+            let body_in_target = rel.position(target_frame, body_frame.0).length_squared();
+            let body_in_current = rel
+                .position(current_integ_frame, body_frame.0)
+                .length_squared();
+            let threshold_sq = sw.switch_distance * sw.switch_distance;
+            let fire = match sw.switch_sense {
+                SwitchSense::OnApproach => body_in_target < threshold_sq,
+                SwitchSense::OnDeparture => body_in_current > threshold_sq,
+            };
+            if fire {
+                triggered = Some((idx, target_frame));
+                break;
+            }
+        }
+
+        let Some((idx, new_parent_frame)) = triggered else {
+            continue;
+        };
+
+        // Reproject body's translational state into the new integ
+        // frame. `rel.position`/`relative_state` operate over the
+        // current ECS hierarchy — exactly what we need to compute the
+        // body's position vs. the new parent before reparenting.
+        let new_state = rel.relative_state(new_parent_frame, body_frame.0);
+        trans.0.position = Position::<RootInertial>::from_raw_si(new_state.trans.position);
+        trans.0.velocity = Velocity::<RootInertial>::from_raw_si(new_state.trans.velocity);
+
+        // Reparent the body's frame entity. This is the load-bearing
+        // ECS-native operation: replaces `FrameTree::reparent` and
+        // sidesteps the entire arena `FrameId` machinery. Bevy's
+        // hierarchy plugin updates `Children` on both old and new
+        // parents automatically.
+        commands
+            .entity(body_frame.0)
+            .insert(ChildOf(new_parent_frame));
+
+        // Flip gravity controls: target source becomes central; all
+        // others differential.
+        let target_source = switches.0[idx].target_source;
+        switches.0[idx].active = false;
+        for ctrl in &mut gravity_controls.0.controls {
+            ctrl.differential = ctrl.source_name != target_source;
+        }
+        let _ = body_entity; // kept for symmetry with production system's diagnostic strings
+    }
+}

--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -15,7 +15,7 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use glam::DVec3;
-use jeod_sim::{RefFrameRot, RefFrameState, RefFrameTrans};
+use jeod_sim::{FrameStorage, RefFrameRot, RefFrameState, RefFrameTrans};
 
 use crate::components::{FrameAngVelC, FrameRotC, FrameTransC};
 
@@ -54,89 +54,31 @@ impl<'w, 's> RelativeFrameState<'w, 's> {
         self.relative_state(from, to).trans.position
     }
 
-    /// Full [`RefFrameState`] of `to` relative to `from`.
-    /// Mirrors `FrameTree::compute_relative_state(from, to)`.
+    /// Full [`RefFrameState`] of `to` relative to `from`. Delegates
+    /// to the storage-agnostic
+    /// [`jeod_sim::frame_compute_relative_state_via_storage`]
+    /// algorithm via this `SystemParam`'s [`FrameStorage`] impl —
+    /// the same code path the runner's arena uses, so the algorithm
+    /// is single-sourced.
     pub fn relative_state(&self, from: Entity, to: Entity) -> RefFrameState {
-        if from == to {
-            return RefFrameState::default();
-        }
-        let ancestor = self.common_ancestor(from, to).unwrap_or_else(|| {
+        jeod_sim::frame_compute_relative_state_via_storage(self, from, to)
+    }
+}
+
+// `FrameStorage` impl: lets the storage-agnostic algorithms in
+// `jeod_frames::frame_storage` operate over the ECS hierarchy + the
+// new frame-state components. Issue #268 trait-experiment.
+impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
+    type Id = Entity;
+
+    fn parent(&self, id: Entity) -> Option<Entity> {
+        self.parents.get(id).ok().map(|child_of| child_of.parent())
+    }
+
+    fn state(&self, id: Entity) -> RefFrameState {
+        let (trans, rot, ang_vel) = self.states.get(id).unwrap_or_else(|err| {
             panic!(
-                "RelativeFrameState::relative_state: frames {from:?} and {to:?} \
-                 do not share a common ancestor in the ECS hierarchy. Spawn both \
-                 under the same root frame entity."
-            )
-        });
-        let state_from = self.compose_to_ancestor(from, ancestor);
-        let state_to = self.compose_to_ancestor(to, ancestor);
-        let from_negated = RefFrameState::negate(&state_from);
-        from_negated.incr_right(&state_to)
-    }
-
-    fn common_ancestor(&self, a: Entity, b: Entity) -> Option<Entity> {
-        let mut da = self.depth(a);
-        let mut db = self.depth(b);
-        let mut ca = a;
-        let mut cb = b;
-        while da > db {
-            ca = self.parent_of(ca)?;
-            da -= 1;
-        }
-        while db > da {
-            cb = self.parent_of(cb)?;
-            db -= 1;
-        }
-        while ca != cb {
-            ca = self.parent_of(ca)?;
-            cb = self.parent_of(cb)?;
-        }
-        Some(ca)
-    }
-
-    fn depth(&self, entity: Entity) -> usize {
-        let mut d = 0;
-        let mut current = entity;
-        while let Some(parent) = self.parent_of(current) {
-            d += 1;
-            current = parent;
-        }
-        d
-    }
-
-    fn parent_of(&self, entity: Entity) -> Option<Entity> {
-        self.parents
-            .get(entity)
-            .ok()
-            .map(|child_of| child_of.parent())
-    }
-
-    /// Compose states from `id` up to `ancestor`, returning the state
-    /// of `id` relative to `ancestor`. Mirrors
-    /// `FrameTree::compose_to_ancestor`.
-    fn compose_to_ancestor(&self, id: Entity, ancestor: Entity) -> RefFrameState {
-        if id == ancestor {
-            return RefFrameState::default();
-        }
-        let mut composed = self.state_of(id);
-        let mut current = id;
-        while let Some(parent_entity) = self.parent_of(current) {
-            if parent_entity == ancestor {
-                return composed;
-            }
-            composed.incr_left(&self.state_of(parent_entity));
-            current = parent_entity;
-        }
-        panic!(
-            "RelativeFrameState::compose_to_ancestor: frame {id:?} is not a \
-             descendant of ancestor {ancestor:?} in the ECS hierarchy. \
-             Common-ancestor walk should have caught this."
-        );
-    }
-
-    fn state_of(&self, entity: Entity) -> RefFrameState {
-        let (trans, rot, ang_vel) = self.states.get(entity).unwrap_or_else(|err| {
-            panic!(
-                "RelativeFrameState::state_of: frame entity {entity:?} is missing \
+                "RelativeFrameState::state: frame entity {id:?} is missing \
                  FrameTransC / FrameRotC / FrameAngVelC components ({err:?}). \
                  Frame entities must be spawned with all three (or use the \
                  register_*_frames_system path that inserts them)."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod bundles;
 pub mod components;
+pub mod frame_param;
 pub mod prelude;
 pub mod recipes;
 pub mod sets;
@@ -126,6 +127,16 @@ impl Default for FrameTreeR {
 #[derive(Resource, Debug, Clone, Copy, Deref, DerefMut)]
 pub struct RootFrameIdR(pub jeod_sim::FrameId);
 
+/// Bevy resource holding the [`Entity`] of the root frame entity in
+/// the ECS-native frame hierarchy. Mirrors [`RootFrameIdR`] in the
+/// entity-as-frame world: the same logical root frame, expressed
+/// once as an arena `FrameId` and once as a Bevy Entity. Spawned by
+/// [`JeodPlugin::build`] before any source/body registration so the
+/// registration systems can `ChildOf`-link their frame entities to
+/// it. Issue #268 prototype.
+#[derive(Resource, Debug, Clone, Copy, Deref, DerefMut)]
+pub struct RootFrameEntityR(pub Entity);
+
 /// Unified JEOD plugin — registers all pipeline systems and schedule sets.
 pub struct JeodPlugin;
 
@@ -237,6 +248,23 @@ impl Plugin for JeodPlugin {
                  or insert neither and let the plugin create them.",
             ),
         }
+
+        // ── Issue #268 prototype: ECS-native root frame entity ──
+        // Spawn the root frame entity that mirrors the arena's root
+        // frame node. Source / body registration `ChildOf`-links its
+        // frame entities under this one, so the ECS hierarchy and the
+        // arena describe the same logical frame tree in parallel.
+        let root_frame_entity = app
+            .world_mut()
+            .spawn((
+                Name::new("root.frame"),
+                components::InertialFrameMarker,
+                components::FrameTransC::default(),
+                components::FrameRotC::default(),
+                components::FrameAngVelC::default(),
+            ))
+            .id();
+        app.insert_resource(RootFrameEntityR(root_frame_entity));
 
         // ── Typed-Component reflection (#154) ──
         // Centralized in `register_jeod_component_types` so the smoke
@@ -458,6 +486,16 @@ pub fn register_jeod_component_types(app: &mut App) {
     app.register_type::<components::FrameSwitchesC>();
     app.register_type::<components::BodyFrameIdC>();
     app.register_type::<components::IntegFrameIdC>();
+    // Issue #268 prototype: frames-as-entities components.
+    app.register_type::<components::FrameTransC>();
+    app.register_type::<components::FrameRotC>();
+    app.register_type::<components::FrameAngVelC>();
+    app.register_type::<components::InertialFrameMarker>();
+    app.register_type::<components::PlanetFixedFrameMarker>();
+    app.register_type::<components::BodyFrameMarker>();
+    app.register_type::<components::IntegrationFrameMarker>();
+    app.register_type::<components::FrameEntityC>();
+    app.register_type::<components::PfixFrameEntityC>();
     // Tidal
     app.register_type::<components::TidalConfigC>();
     app.register_type::<components::TidalDeltaC20C>();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -50,6 +50,8 @@ pub fn register_source_frames_system(
     mut commands: Commands,
     mut frame_tree: ResMut<FrameTreeR>,
     root: Res<crate::RootFrameIdR>,
+    // Issue #268 prototype: also spawn ECS frame entities under this root.
+    root_frame_entity: Res<crate::RootFrameEntityR>,
     sources: Query<
         (
             Entity,
@@ -86,8 +88,28 @@ pub fn register_source_frames_system(
                 rot: jeod_sim::RefFrameRot::default(),
             },
         );
-        let mut entity_cmds = commands.entity(entity);
-        entity_cmds.insert(SourceFrameIdC(inertial_id));
+
+        // Issue #268 prototype: spawn the source's ECS frame entity
+        // parented under the root frame entity. Both arena `FrameId`
+        // and ECS `Entity` describe the same logical inertial frame
+        // until consumers migrate off the arena.
+        let source_frame_entity = commands
+            .spawn((
+                Name::new(format!("{label}.frame.inertial")),
+                InertialFrameMarker,
+                FrameTransC {
+                    position: init_pos,
+                    velocity: init_vel,
+                },
+                FrameRotC::default(),
+                FrameAngVelC::default(),
+                ChildOf(root_frame_entity.0),
+            ))
+            .id();
+        commands.entity(entity).insert((
+            SourceFrameIdC(inertial_id),
+            FrameEntityC(source_frame_entity),
+        ));
 
         // Create a pfix child frame only if this source actually rotates.
         // The presence of `PlanetFixedRotationC` is the indicator —
@@ -110,7 +132,20 @@ pub fn register_source_frames_system(
                     jeod_sim::RefFrameKind::PlanetFixed,
                     jeod_sim::RefFrameState::default(),
                 );
-                entity_cmds.insert(SourcePfixFrameIdC(pfix_id));
+                let pfix_frame_entity = commands
+                    .spawn((
+                        Name::new(format!("{label}.frame.pfix")),
+                        PlanetFixedFrameMarker,
+                        FrameTransC::default(),
+                        FrameRotC::default(),
+                        FrameAngVelC::default(),
+                        ChildOf(source_frame_entity),
+                    ))
+                    .id();
+                commands.entity(entity).insert((
+                    SourcePfixFrameIdC(pfix_id),
+                    PfixFrameEntityC(pfix_frame_entity),
+                ));
             }
         }
     }
@@ -148,6 +183,9 @@ pub fn register_pfix_frames_system(
             Entity,
             Option<&Name>,
             &SourceFrameIdC,
+            // Issue #268 prototype: read the source's frame entity so
+            // the spawned pfix frame entity can ChildOf-link under it.
+            Option<&FrameEntityC>,
             Option<&RotationModelC>,
             Option<&RetiredPfixFrameIdC>,
         ),
@@ -158,7 +196,7 @@ pub fn register_pfix_frames_system(
         ),
     >,
 ) {
-    for (entity, name, source_fid, rotation_model, retired) in &sources {
+    for (entity, name, source_fid, source_frame_entity, rotation_model, retired) in &sources {
         let default_model = jeod_sim::RotationModel::EarthRNP;
         let model_value = rotation_model.map_or(default_model, |m| m.0);
         if matches!(model_value, jeod_sim::RotationModel::None) {
@@ -187,7 +225,30 @@ pub fn register_pfix_frames_system(
                 jeod_sim::RefFrameState::default(),
             )
         };
-        commands.entity(entity).insert(SourcePfixFrameIdC(pfix_id));
+
+        // Issue #268 prototype: spawn pfix frame entity under the
+        // source's frame entity (when present). Skip the late-pfix
+        // ECS spawn if FrameEntityC is missing — that's a source that
+        // was registered before the prototype components landed; the
+        // arena pfix is still updated above for backward compat.
+        if let Some(parent_frame) = source_frame_entity {
+            let pfix_frame_entity = commands
+                .spawn((
+                    Name::new(format!("{label}.frame.pfix")),
+                    PlanetFixedFrameMarker,
+                    FrameTransC::default(),
+                    FrameRotC::default(),
+                    FrameAngVelC::default(),
+                    ChildOf(parent_frame.0),
+                ))
+                .id();
+            commands.entity(entity).insert((
+                SourcePfixFrameIdC(pfix_id),
+                PfixFrameEntityC(pfix_frame_entity),
+            ));
+        } else {
+            commands.entity(entity).insert(SourcePfixFrameIdC(pfix_id));
+        }
     }
 }
 
@@ -225,16 +286,34 @@ pub fn sync_source_to_frame_system(
         &SourceInertialPositionC,
         Option<&SourceInertialVelocityC>,
         Option<&TranslationalStateC>,
+        // Issue #268 prototype: dual-write target.
+        Option<&FrameEntityC>,
     )>,
+    mut frame_states: Query<&mut FrameTransC>,
 ) {
-    for (fid, pos, vel, trans) in &sources {
-        let node = frame_tree.0.get_mut(fid.0);
-        node.state.trans.position = pos.0.raw_si();
+    for (fid, pos, vel, trans, frame_entity) in &sources {
+        let position = pos.0.raw_si();
         let velocity = vel
             .map(|v| v.0.raw_si())
             .or_else(|| trans.map(|t| t.0.velocity.raw_si()));
+
+        // Arena write (existing path).
+        let node = frame_tree.0.get_mut(fid.0);
+        node.state.trans.position = position;
         if let Some(v) = velocity {
             node.state.trans.velocity = v;
+        }
+
+        // Issue #268 prototype: ECS dual-write to the source's frame
+        // entity. Skip silently if the source was registered before
+        // the prototype components landed (no FrameEntityC).
+        if let Some(fe) = frame_entity {
+            if let Ok(mut frame_trans) = frame_states.get_mut(fe.0) {
+                frame_trans.position = position;
+                if let Some(v) = velocity {
+                    frame_trans.velocity = v;
+                }
+            }
         }
     }
 }
@@ -261,7 +340,10 @@ pub fn register_body_frames_system(
     mut commands: Commands,
     mut frame_tree: ResMut<FrameTreeR>,
     root: Res<crate::RootFrameIdR>,
-    sources: Query<&SourceFrameIdC>,
+    // Issue #268 prototype: the ECS-side root frame entity, used as
+    // the body's frame parent when no IntegSourceC is supplied.
+    root_frame_entity: Res<crate::RootFrameEntityR>,
+    sources: Query<(&SourceFrameIdC, Option<&FrameEntityC>)>,
     bodies: Query<
         (
             Entity,
@@ -282,10 +364,11 @@ pub fn register_body_frames_system(
             .unwrap_or_else(|| format!("body{:?}", entity));
 
         // Resolve the integration frame ID. Default: root inertial.
-        let integ_frame_id = match integ_source.and_then(|c| c.0) {
+        // Issue #268 prototype: also resolve the integ frame ECS entity.
+        let (integ_frame_id, integ_frame_entity) = match integ_source.and_then(|c| c.0) {
             Some(source_entity) => sources
                 .get(source_entity)
-                .map(|c| c.0)
+                .map(|(fid, fent)| (fid.0, fent.map(|f| f.0)))
                 .unwrap_or_else(|err| {
                     panic!(
                         "register_body_frames_system: body {entity:?} has \
@@ -296,7 +379,7 @@ pub fn register_body_frames_system(
                          Underlying error: {err:?}"
                     )
                 }),
-            None => root.0,
+            None => (root.0, Some(root_frame_entity.0)),
         };
 
         // Body frame node carries the body's current state relative to its
@@ -305,10 +388,12 @@ pub fn register_body_frames_system(
         // bodies the body's TranslationalStateC is interpreted as
         // already in integ-frame coordinates (mission code is
         // responsible for supplying state in the integ-frame).
+        let init_pos = trans.0.position.raw_si();
+        let init_vel = trans.0.velocity.raw_si();
         let body_state = jeod_sim::RefFrameState {
             trans: jeod_sim::RefFrameTrans {
-                position: trans.0.position.raw_si(),
-                velocity: trans.0.velocity.raw_si(),
+                position: init_pos,
+                velocity: init_vel,
             },
             rot: jeod_sim::RefFrameRot::default(),
         };
@@ -318,9 +403,41 @@ pub fn register_body_frames_system(
             jeod_sim::RefFrameKind::Body,
             body_state,
         );
-        commands
-            .entity(entity)
-            .insert((BodyFrameIdC(body_fid), IntegFrameIdC(integ_frame_id)));
+
+        // Issue #268 prototype: spawn body frame entity parented under
+        // its integ frame's ECS entity. Tag the integ frame entity
+        // with `IntegrationFrameMarker` if not already (idempotent
+        // insert via Commands). Skip the ECS spawn if we couldn't
+        // resolve an integ frame entity (e.g. a source registered
+        // before the prototype components landed); the arena body
+        // node is still added above for backward compat.
+        if let Some(parent_frame_entity) = integ_frame_entity {
+            commands
+                .entity(parent_frame_entity)
+                .insert(IntegrationFrameMarker);
+            let body_frame_entity = commands
+                .spawn((
+                    Name::new(format!("{label}.frame.body")),
+                    BodyFrameMarker,
+                    FrameTransC {
+                        position: init_pos,
+                        velocity: init_vel,
+                    },
+                    FrameRotC::default(),
+                    FrameAngVelC::default(),
+                    ChildOf(parent_frame_entity),
+                ))
+                .id();
+            commands.entity(entity).insert((
+                BodyFrameIdC(body_fid),
+                IntegFrameIdC(integ_frame_id),
+                FrameEntityC(body_frame_entity),
+            ));
+        } else {
+            commands
+                .entity(entity)
+                .insert((BodyFrameIdC(body_fid), IntegFrameIdC(integ_frame_id)));
+        }
     }
 }
 
@@ -427,12 +544,32 @@ pub fn on_body_frame_despawn(
 /// before `frame_switch_system`. Issue #71 item 2.
 pub fn sync_body_to_frame_system(
     mut frame_tree: ResMut<FrameTreeR>,
-    bodies: Query<(&TranslationalStateC, &BodyFrameIdC)>,
+    bodies: Query<(
+        &TranslationalStateC,
+        &BodyFrameIdC,
+        // Issue #268 prototype: dual-write target.
+        Option<&FrameEntityC>,
+    )>,
+    mut frame_states: Query<&mut FrameTransC>,
 ) {
-    for (trans, body_fid) in &bodies {
+    for (trans, body_fid, frame_entity) in &bodies {
+        let position = trans.0.position.raw_si();
+        let velocity = trans.0.velocity.raw_si();
+
+        // Arena write (existing path).
         let node = frame_tree.0.get_mut(body_fid.0);
-        node.state.trans.position = trans.0.position.raw_si();
-        node.state.trans.velocity = trans.0.velocity.raw_si();
+        node.state.trans.position = position;
+        node.state.trans.velocity = velocity;
+
+        // Issue #268 prototype: ECS dual-write to the body's frame
+        // entity. Skip silently if the body was registered before
+        // the prototype components landed (no FrameEntityC).
+        if let Some(fe) = frame_entity {
+            if let Ok(mut frame_trans) = frame_states.get_mut(fe.0) {
+                frame_trans.position = position;
+                frame_trans.velocity = velocity;
+            }
+        }
     }
 }
 
@@ -562,7 +699,7 @@ pub fn time_advance_system(mut sim_time: ResMut<SimulationTimeR>, time: Res<Time
 ///
 /// Earth RNP is lazy-computed once per step and reused across all `EarthRNP`
 /// entities.
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn planet_fixed_rotation_system(
     mut commands: Commands,
     sim_time: Res<SimulationTimeR>,
@@ -576,7 +713,11 @@ pub fn planet_fixed_rotation_system(
         Option<&PlanetOmegaC>,
         Option<&mut PlanetAngularVelocityC>,
         Option<&SourcePfixFrameIdC>,
+        // Issue #268 prototype: dual-write target for pfix frame entity.
+        Option<&PfixFrameEntityC>,
     )>,
+    mut frame_rots: Query<&mut FrameRotC>,
+    mut frame_ang_vels: Query<&mut FrameAngVelC>,
 ) {
     let polar_params = polar.map(|p| (p.xp, p.yp));
     // Lazy-compute Earth RNP only if needed (most common case). Cache the
@@ -588,7 +729,7 @@ pub fn planet_fixed_rotation_system(
         jeod_sim::FrameTransform<jeod_sim::RootInertial, jeod_sim::PlanetFixed<SelfPlanet>>;
     let mut earth_rotation: Option<EarthRot> = Option::None;
     let mut earth_rotation_raw: Option<glam::DMat3> = Option::None;
-    for (entity, mut rot, model, omega, ang_vel, pfix_fid) in &mut query {
+    for (entity, mut rot, model, omega, ang_vel, pfix_fid, pfix_frame_entity) in &mut query {
         let default_model = jeod_sim::RotationModel::EarthRNP;
         let rotation_model = model.map_or(&default_model, |m| &m.0);
         // Track whether we wrote a rotation this tick — controls
@@ -699,6 +840,18 @@ pub fn planet_fixed_rotation_system(
             // pfix) saw stale identity rotation and zero angular velocity.
             if let (Some(matrix), Some(pfix_fid)) = (raw_matrix, pfix_fid) {
                 jeod_sim::sync_pfix_rotation(&mut frame_tree.0, pfix_fid.0, matrix, omega_value);
+                // Issue #268 prototype: ECS dual-write to the pfix
+                // frame entity. Same data, different storage.
+                if let Some(pfix_fe) = pfix_frame_entity {
+                    if let Ok(mut frame_rot) = frame_rots.get_mut(pfix_fe.0) {
+                        frame_rot.q_parent_this =
+                            jeod_sim::JeodQuat::left_quat_from_transformation(&matrix);
+                        frame_rot.t_parent_this = matrix;
+                    }
+                    if let Ok(mut frame_av) = frame_ang_vels.get_mut(pfix_fe.0) {
+                        frame_av.0 = glam::DVec3::new(0.0, 0.0, omega_value);
+                    }
+                }
             }
         } else {
             // `RotationModel::None`: actively clear the rotation matrix,
@@ -730,6 +883,17 @@ pub fn planet_fixed_rotation_system(
                     glam::DMat3::IDENTITY,
                     0.0,
                 );
+                // Issue #268 prototype: ECS dual-write — clear the
+                // pfix frame entity's state to identity so any new
+                // SystemParam reader sees the same identity-clear.
+                if let Some(pfix_fe) = pfix_frame_entity {
+                    if let Ok(mut frame_rot) = frame_rots.get_mut(pfix_fe.0) {
+                        *frame_rot = FrameRotC::default();
+                    }
+                    if let Ok(mut frame_av) = frame_ang_vels.get_mut(pfix_fe.0) {
+                        frame_av.0 = glam::DVec3::ZERO;
+                    }
+                }
                 // Clearing the pfix node's matrix/omega isn't enough
                 // on its own — consumers that branch on the *presence*
                 // of `SourcePfixFrameIdC` would keep treating the

--- a/tests/prototype_relative_frame_state.rs
+++ b/tests/prototype_relative_frame_state.rs
@@ -1,0 +1,277 @@
+//! Issue #268 prototype validation: bit-identity between
+//! `FrameTreeR.compute_relative_state` (the arena read path) and the
+//! new `RelativeFrameState` `SystemParam` (the ECS-native read path).
+//!
+//! This test exists on the `study/268-frame-tree-ecs-native` branch
+//! to demonstrate that the dual-write infrastructure (issue #268 Phase
+//! B) keeps the two storage backends numerically equivalent — and to
+//! document the **mission-code ergonomic improvement** by showing
+//! both API surfaces side by side.
+//!
+//! ## Before / After diff (the load-bearing design-doc evidence)
+//!
+//! **Before** (arena read through `FrameTreeR` + `FrameId` components):
+//! ```ignore
+//! fn read_via_arena(
+//!     frame_tree: Res<FrameTreeR>,
+//!     bodies: Query<&BodyFrameIdC, With<MyBody>>,
+//!     planets: Query<&SourcePfixFrameIdC, With<MyPlanet>>,
+//! ) -> DVec3 {
+//!     let body_fid = bodies.single().unwrap().0;
+//!     let pfix_fid = planets.single().unwrap().0;
+//!     frame_tree.0.compute_relative_state(pfix_fid, body_fid).trans.position
+//! }
+//! ```
+//!
+//! **After** (`RelativeFrameState` SystemParam wrapping ECS queries):
+//! ```ignore
+//! fn read_via_systemparam(
+//!     rel: RelativeFrameState,
+//!     bodies: Query<&FrameEntityC, With<MyBody>>,
+//!     planets: Query<&PfixFrameEntityC, With<MyPlanet>>,
+//! ) -> DVec3 {
+//!     let body_e = bodies.single().unwrap().0;
+//!     let pfix_e = planets.single().unwrap().0;
+//!     rel.position(pfix_e, body_e)
+//! }
+//! ```
+//!
+//! The "After" surface never names a `FrameId`, never holds a
+//! `Res<FrameTreeR>`, and reads like any other Bevy `SystemParam`.
+//! This is the ergonomic delta the design doc commits to.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_jeod::frame_param::RelativeFrameState;
+use bevy_jeod::{
+    BodyFrameIdC, DynamicsConfigC, FrameEntityC, FrameTreeR, GravityControlsC, JeodPlugin,
+    MassPropertiesC, PfixFrameEntityC, PlanetBundle, RotationalStateC, SourcePfixFrameIdC,
+    TranslationalStateC,
+};
+use glam::DVec3;
+use jeod_sim::{
+    DynamicsConfig, GravityControls, JeodQuat, MassProperties, PlanetConfig, RotationalState,
+    TranslationalState, EARTH,
+};
+
+const DT: f64 = 60.0;
+
+fn step_once(app: &mut App) {
+    app.world_mut()
+        .resource_mut::<Time<Fixed>>()
+        .advance_by(Duration::from_secs_f64(DT));
+    app.world_mut().run_schedule(FixedUpdate);
+}
+
+fn build_app(planet_name: &str, planet: &PlanetConfig) -> (App, Entity, Entity) {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+
+    let planet_e = app
+        .world_mut()
+        .spawn(PlanetBundle::point_mass(planet_name, planet))
+        .id();
+
+    // A simple rotational + translational body in low Earth orbit.
+    let trans = TranslationalState {
+        position: DVec3::new(6_778_137.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7668.56, 0.0),
+    };
+    let rot = RotationalState {
+        quaternion: JeodQuat::identity(),
+        ang_vel_body: DVec3::new(0.001, -0.0005, 0.001),
+    };
+    let body_e = app
+        .world_mut()
+        .spawn((
+            Name::new("body"),
+            TranslationalStateC::from(trans),
+            RotationalStateC::from(rot),
+            MassPropertiesC::from(MassProperties::new(1.0)),
+            DynamicsConfigC(DynamicsConfig {
+                translational_dynamics: true,
+                rotational_dynamics: true,
+                three_dof: false,
+            }),
+            GravityControlsC(GravityControls::<Entity> { controls: vec![] }),
+        ))
+        .id();
+
+    (app, planet_e, body_e)
+}
+
+fn assert_bits_eq(label: &str, a: f64, b: f64) {
+    assert!(
+        a.to_bits() == b.to_bits(),
+        "{label} not bit-identical:\n  arena: {a} (bits={:#018x})\n  ecs:   {b} (bits={:#018x})",
+        a.to_bits(),
+        b.to_bits(),
+    );
+}
+
+fn assert_dvec3_bits_eq(label: &str, arena: DVec3, ecs: DVec3) {
+    for i in 0..3 {
+        assert_bits_eq(&format!("{label}[{i}]"), arena[i], ecs[i]);
+    }
+}
+
+/// Validate that the dual-write (T6) keeps `FrameTransC` exactly in
+/// sync with the arena's `state.trans` for the body frame.
+#[test]
+fn body_trans_arena_matches_ecs_after_step() {
+    let (mut app, _planet_e, body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    let world = app.world();
+
+    // Arena read.
+    let body_fid = world.get::<BodyFrameIdC>(body_e).unwrap().0;
+    let frame_tree = world.resource::<FrameTreeR>();
+    let arena_trans = frame_tree.0.get(body_fid).state.trans;
+
+    // ECS read via the dual-written FrameTransC component.
+    let body_frame_e = world.get::<FrameEntityC>(body_e).unwrap().0;
+    let ecs_trans = *world
+        .get::<bevy_jeod::FrameTransC>(body_frame_e)
+        .expect("body frame entity should carry FrameTransC after dual-write");
+
+    assert_dvec3_bits_eq(
+        "body trans.position",
+        arena_trans.position,
+        ecs_trans.position,
+    );
+    assert_dvec3_bits_eq(
+        "body trans.velocity",
+        arena_trans.velocity,
+        ecs_trans.velocity,
+    );
+}
+
+/// Validate that the dual-write (T6) keeps the pfix frame entity's
+/// `FrameRotC` + `FrameAngVelC` exactly in sync with the arena's
+/// `state.rot` after `planet_fixed_rotation_system` runs.
+#[test]
+fn pfix_rot_arena_matches_ecs_after_step() {
+    let (mut app, planet_e, _body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    let world = app.world();
+
+    // Arena read.
+    let pfix_fid = world.get::<SourcePfixFrameIdC>(planet_e).unwrap().0;
+    let frame_tree = world.resource::<FrameTreeR>();
+    let arena_rot = frame_tree.0.get(pfix_fid).state.rot;
+
+    // ECS read.
+    let pfix_frame_e = world.get::<PfixFrameEntityC>(planet_e).unwrap().0;
+    let ecs_rot = world
+        .get::<bevy_jeod::FrameRotC>(pfix_frame_e)
+        .expect("pfix frame entity should carry FrameRotC");
+    let ecs_ang_vel = world
+        .get::<bevy_jeod::FrameAngVelC>(pfix_frame_e)
+        .expect("pfix frame entity should carry FrameAngVelC");
+
+    // Quaternion components.
+    for i in 0..4 {
+        assert_bits_eq(
+            &format!("pfix q_parent_this[{i}]"),
+            arena_rot.q_parent_this.data[i],
+            ecs_rot.q_parent_this.data[i],
+        );
+    }
+    // Rotation matrix.
+    for col in 0..3 {
+        for row in 0..3 {
+            assert_bits_eq(
+                &format!("pfix t_parent_this[{col}][{row}]"),
+                arena_rot.t_parent_this.col(col)[row],
+                ecs_rot.t_parent_this.col(col)[row],
+            );
+        }
+    }
+    assert_dvec3_bits_eq("pfix ang_vel_this", arena_rot.ang_vel_this, ecs_ang_vel.0);
+}
+
+/// Validate that `RelativeFrameState::position(planet_inertial, body)`
+/// returns the same value as `FrameTreeR.compute_relative_state(planet_inertial_id, body_id).trans.position`.
+///
+/// This is the **load-bearing** prototype validation: it proves the
+/// new SystemParam read path produces bit-identical numerics to the
+/// arena read path. The design doc cites this test as the "After"
+/// surface's correctness evidence.
+#[test]
+fn relative_frame_state_matches_arena() {
+    let (mut app, planet_e, body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    // Arena answer: compute relative state (planet inertial → body)
+    // via the existing FrameTreeR.compute_relative_state.
+    let arena_pos = {
+        let world = app.world();
+        let body_fid = world.get::<BodyFrameIdC>(body_e).unwrap().0;
+        let planet_inertial_fid = world.get::<bevy_jeod::SourceFrameIdC>(planet_e).unwrap().0;
+        let frame_tree = world.resource::<FrameTreeR>();
+        frame_tree
+            .0
+            .compute_relative_state(planet_inertial_fid, body_fid)
+            .trans
+            .position
+    };
+
+    // ECS answer: same query through RelativeFrameState SystemParam.
+    let body_frame_e = app.world().get::<FrameEntityC>(body_e).unwrap().0;
+    let planet_frame_e = app.world().get::<FrameEntityC>(planet_e).unwrap().0;
+    let ecs_pos = app.world_mut().run_system_cached_with(
+        |In((from, to)): In<(Entity, Entity)>, rel: RelativeFrameState| -> DVec3 {
+            rel.position(from, to)
+        },
+        (planet_frame_e, body_frame_e),
+    );
+    let ecs_pos = ecs_pos.expect("run_system_cached_with should succeed");
+
+    assert_dvec3_bits_eq("planet→body relative position", arena_pos, ecs_pos);
+    println!("RelativeFrameState SystemParam vs FrameTreeR arena: bit-identical");
+}
+
+/// Same as above but for a deeper hierarchy: planet → pfix child →
+/// (no body underneath, but exercises the compose-up path through
+/// pfix). Body is parented under planet inertial as before.
+///
+/// Computes (pfix → body) which traverses pfix up to planet inertial
+/// (1 step) then down to body (1 step) — a 2-segment compose with
+/// rotation involved.
+#[test]
+fn relative_frame_state_matches_arena_through_pfix() {
+    let (mut app, planet_e, body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    // Arena: pfix → body relative state through compute_relative_state.
+    let arena_pos = {
+        let world = app.world();
+        let body_fid = world.get::<BodyFrameIdC>(body_e).unwrap().0;
+        let pfix_fid = world.get::<SourcePfixFrameIdC>(planet_e).unwrap().0;
+        let frame_tree = world.resource::<FrameTreeR>();
+        frame_tree
+            .0
+            .compute_relative_state(pfix_fid, body_fid)
+            .trans
+            .position
+    };
+
+    // ECS: same via SystemParam.
+    let body_frame_e = app.world().get::<FrameEntityC>(body_e).unwrap().0;
+    let pfix_frame_e = app.world().get::<PfixFrameEntityC>(planet_e).unwrap().0;
+    let ecs_pos = app.world_mut().run_system_cached_with(
+        |In((from, to)): In<(Entity, Entity)>, rel: RelativeFrameState| -> DVec3 {
+            rel.position(from, to)
+        },
+        (pfix_frame_e, body_frame_e),
+    );
+    let ecs_pos = ecs_pos.expect("run_system_cached_with should succeed");
+
+    assert_dvec3_bits_eq("pfix→body relative position", arena_pos, ecs_pos);
+    println!("RelativeFrameState through pfix SystemParam vs FrameTreeR arena: bit-identical");
+}


### PR DESCRIPTION
**Study branch — not for merge.** Posted as a draft PR so reviewers can comment on the prototype code; the architectural decision lives on the [design doc](https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native) (linked from issue #268).

## Summary

- New components on **frame entities** (`FrameTransC`, `FrameRotC`, `FrameAngVelC`, marker components, `FrameEntityC`, `PfixFrameEntityC`).
- `RelativeFrameState<'w, 's>` SystemParam — ECS-native replacement for `FrameTreeR.compute_relative_state` / `frame_origin`. Walks Bevy 0.18's `ChildOf` plus the new state components.
- Dual-write extensions to existing registration / sync / pfix-rotation systems so the new ECS components stay in lockstep with `FrameTreeR`.
- Compile-only `frame_switch_system_ecs_native_sketch` demonstrating the design's "After" form for the frame-switch handler.

## Validation

- 4 new prototype tests in `tests/prototype_relative_frame_state.rs` assert bit-identity between arena and ECS reads (body `trans`, pfix `rot`+`ang_vel`, and `RelativeFrameState::position` vs `compute_relative_state` both directly and through pfix).
- All 115 existing `bevy_parity_*` tests stay green.
- Full `bevy_jeod` test suite (150 tests) green.

## Scope cuts

- No production system rewritten (gravity, integration, frame-switch all unchanged).
- No `FrameTreeR` removal.
- No #263 typed-state work (sequenced as PR 5 in the design doc).

Closes nothing — closes once the migration in the design doc lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)