### PR TITLE
Trim debug info to line tables only in dev/test profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,10 @@ typenum = "1.20"
 # opt-level=2 gives ~20× speedup with minimal compile-time increase.
 [profile.dev]
 opt-level = 2
+debug = "line-tables-only"
 [profile.test]
 opt-level = 2
+debug = "line-tables-only"
 
 [[example]]
 name = "kepler_orbit"


### PR DESCRIPTION
## Summary

- Adds `debug = "line-tables-only"` to `[profile.dev]` and `[profile.test]` in the workspace `Cargo.toml`.
- Drops type/variable DWARF; keeps file/line info so panic backtraces remain readable.

## Measured impact

Fresh `cargo build --workspace --all-targets` on this branch vs `main` (with `incremental = false` set globally for both — sccache config, not part of this PR):

| | Before | After |
|---|---|---|
| `target/` total | ~25G | **6.6G** |
| `target/debug/deps/` | 23G | 6.1G |
| Per integration test binary | ~250 MB | ~80 MB |

`opt-level = 2` is unchanged — physics performance untouched.

## Tradeoff

Step-debugging in `gdb`/`lldb` loses variable inspection (still works at the function level). Panic backtraces and `RUST_BACKTRACE=1` still show source locations. For this codebase's debugging workflow (panic-driven diagnostics + tracing), this is the right tradeoff.

## Test plan

- [x] `cargo build --workspace --all-targets` succeeds
- [ ] CI green (fmt + clippy + tier 2 + tier 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)