### PR TITLE
Per-package opt-levels in dev/test profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,15 +66,49 @@ thiserror = "2"
 uom = { version = "0.38", default-features = false, features = ["f64", "si", "std"] }
 typenum = "1.20"
 
-# Optimize all code in dev/test builds — spherical harmonics evaluation
-# is ~20× slower at opt-level=0, making 7-day lunar orbit tests impractical.
-# opt-level=2 gives ~20× speedup with minimal compile-time increase.
+# Per-package opt-levels: hot numerical crates need optimization (spherical
+# harmonics is ~20× slower at opt-level=0), but orchestration crates can
+# compile faster at opt-level=1. Dependencies compile once at opt-level=3
+# and are cached by sccache, so we pay that cost once.
 [profile.dev]
-opt-level = 2
+opt-level = 1
 debug = "line-tables-only"
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.dev.package.jeod_math]
+opt-level = 3
+[profile.dev.package.jeod_gravity]
+opt-level = 3
+[profile.dev.package.jeod_dynamics]
+opt-level = 3
+[profile.dev.package.jeod_ephemeris]
+opt-level = 3
+[profile.dev.package.jeod_atmosphere]
+opt-level = 3
+[profile.dev.package.jeod_interactions]
+opt-level = 3
+
 [profile.test]
-opt-level = 2
+opt-level = 1
 debug = "line-tables-only"
+
+[profile.test.package."*"]
+opt-level = 3
+
+[profile.test.package.jeod_math]
+opt-level = 3
+[profile.test.package.jeod_gravity]
+opt-level = 3
+[profile.test.package.jeod_dynamics]
+opt-level = 3
+[profile.test.package.jeod_ephemeris]
+opt-level = 3
+[profile.test.package.jeod_atmosphere]
+opt-level = 3
+[profile.test.package.jeod_interactions]
+opt-level = 3
 
 [[example]]
 name = "kepler_orbit"


### PR DESCRIPTION
## Summary

Splits the global `opt-level = 2` into per-package overrides:

- **Orchestration workspace crates** (`jeod_sim`, `jeod_runner`, `bevy_jeod` root, etc.) → `opt-level = 1` for faster edit-rebuild.
- **All transitive dependencies** → `opt-level = 3`. Compiled once, cached by sccache, so the higher cost amortizes.
- **Hot workspace crates** (`jeod_math`, `jeod_gravity`, `jeod_dynamics`, `jeod_ephemeris`, `jeod_atmosphere`, `jeod_interactions`) → `opt-level = 3` to preserve spherical-harmonics / integration / drag throughput that motivated the original optimization.

## Tradeoff

Cold-cold full builds run ~14s slower (~1m 24s vs ~1m 10s) — the higher dep opt-level dominates. The wins land on:

1. Subsequent builds within a checkout — deps already cached at opt=3.
2. Edit-rebuild loops touching only orchestration code (most physics dev hits the orchestration layer between dispatch and called math).

## Risk

If a hot loop lives in a workspace crate I haven't marked (e.g., the typed-quantities kernels in `jeod_quantities`), runtime regresses. Tier 3 timing on CI will surface this — happy to revert or add overrides if so.

## Test plan

- [x] `cargo build --workspace --all-targets` succeeds at the new profile
- [ ] Tier 3 wall-clock unchanged or improved
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)