### PR TITLE
[#278] Frame-tree PR 2: mission-facing read paths via FrameOrigin + RelativeFrameState

### DIFF
--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -159,7 +159,7 @@ impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
 /// - [`FrameOrigin::origin_in_root`] —
 ///   `(Position<RootInertial>, Velocity<RootInertial>)`. The typed
 ///   surface that lifts the result into the root-inertial phantom
-///   without an `from_raw_si` boundary at the call site.
+///   without a `from_raw_si` boundary at the call site.
 ///   Equivalent to
 ///   `frame_origin_typed::<RootInertial>(tree, root, frame)` /
 ///   `(rel.position_velocity(root, frame))`-then-wrap.

--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -218,8 +218,8 @@ impl<'w, 's> FrameOrigin<'w, 's> {
     ) -> (Position<RootInertial>, Velocity<RootInertial>) {
         let (pos_raw, vel_raw) = self.origin_in(root, frame);
         (
-            Position::<RootInertial>::from_raw_si(pos_raw),
-            Velocity::<RootInertial>::from_raw_si(vel_raw),
+            Position::<RootInertial>::from_raw_si(pos_raw), // allowed: SystemParam typed boundary — relative-frame walk returns raw DVec3 (storage-agnostic algorithm shared with the runner's arena); the caller asserts the ancestor is the root by passing the root frame entity, so RootInertial is the correct phantom by construction.
+            Velocity::<RootInertial>::from_raw_si(vel_raw), // allowed: same SystemParam typed boundary as `pos_raw` above.
         )
     }
 
@@ -236,8 +236,8 @@ impl<'w, 's> FrameOrigin<'w, 's> {
     ) -> (Position<F>, Velocity<F>) {
         let (pos_raw, vel_raw) = self.origin_in(ancestor, frame);
         (
-            Position::<F>::from_raw_si(pos_raw),
-            Velocity::<F>::from_raw_si(vel_raw),
+            Position::<F>::from_raw_si(pos_raw), // allowed: SystemParam typed boundary — caller asserts that `ancestor`'s frame marker is `F` (no runtime check, mirroring `jeod_sim::frame_origin_typed`); the relative-frame walk returns raw DVec3 in `ancestor`-frame coordinates by construction.
+            Velocity::<F>::from_raw_si(vel_raw), // allowed: same SystemParam typed boundary as `pos_raw` above.
         )
     }
 }

--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -154,7 +154,7 @@ impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
 /// frequently "in the root frame," which is the form gravity,
 /// integration, and `IntegOrigin`-shift sites need.
 ///
-/// The two-method shape mirrors the design doc's catalog:
+/// The three-method shape mirrors the design doc's catalog:
 ///
 /// - [`FrameOrigin::origin_in_root`] —
 ///   `(Position<RootInertial>, Velocity<RootInertial>)`. The typed
@@ -168,6 +168,12 @@ impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
 ///   child of root, not root itself). Caller chooses the
 ///   ancestor entity, mirroring the arena helper's `(root, frame)`
 ///   parameter shape.
+/// - [`FrameOrigin::origin_in_typed`] — generic-typed sibling of
+///   `origin_in_root` for callers whose ancestor frame's marker is
+///   some other `F: Frame` (e.g. a `PlanetInertial<P>` integration
+///   frame). Caller asserts that `ancestor`'s marker is `F`; the
+///   phantom-tag attachment is unchecked at runtime, mirroring
+///   `jeod_sim::frame_origin_typed`.
 ///
 /// # Example
 /// ```ignore

--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -1,5 +1,5 @@
-//! Bevy-native `SystemParam` for cross-frame state computation
-//! ([Frame-Tree-ECS-Native § 13][1] — additive infrastructure, PR 1).
+//! Bevy-native `SystemParam`s for cross-frame state computation
+//! ([Frame-Tree-ECS-Native § 13][1]).
 //!
 //! Replaces `FrameTreeR`-backed arena lookups (`compute_relative_state`,
 //! `frame_origin`) with ECS hierarchy walks over Bevy's `ChildOf` /
@@ -13,20 +13,42 @@
 //! `FrameStorage` trait abstraction described in [§ 7][2]); this
 //! `SystemParam` only supplies the storage adapter.
 //!
-//! At PR 1 (this module) the dual-write path keeps the new components
-//! exactly in sync with the arena, so this `SystemParam` and
-//! `FrameTreeR.compute_relative_state` return bit-identical numerics
-//! (see `tests/frame_storage_relative_frame_state.rs`). Mission code may
-//! adopt the new surface incrementally; the arena is removed in
+//! Two SystemParams are exposed (mirroring [§ 6][3]'s mission-code
+//! catalog):
+//!
+//! - [`RelativeFrameState`] — general "state of `to` relative to
+//!   `from`" query. Returns raw `DVec3` (and the full
+//!   [`RefFrameState`] when the rotation/angular-velocity portion is
+//!   needed). The drop-in replacement for
+//!   `FrameTreeR.compute_relative_state(from, to)`.
+//! - [`FrameOrigin`] — specialized "origin of a frame in an ancestor
+//!   frame" query. Returns
+//!   `(Position<RootInertial>, Velocity<RootInertial>)` typed at the
+//!   root-inertial phantom when called against the root frame entity.
+//!   Sugar over `RelativeFrameState::position_velocity(root, frame)`
+//!   that makes the resulting frame phantom explicit in the
+//!   signature. The drop-in replacement for
+//!   `frame_origin(tree, root, frame_id)` /
+//!   `frame_origin_typed::<RootInertial>(tree, root, frame_id)`.
+//!
+//! During the dual-write phase (PR 1–3) the underlying components are
+//! kept in lockstep with [`crate::FrameTreeR`], so these `SystemParam`s
+//! and the arena helpers return bit-identical numerics
+//! (see `tests/frame_storage_relative_frame_state.rs`). Mission code
+//! may adopt the new surface incrementally; the arena is removed in
 //! Section 13 PR 4.
 //!
 //! [1]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing
 //! [2]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#7-internal-algorithm-sharing-q1
+//! [3]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#6-mission-code-surface--systemparam-catalog-q7
 
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use glam::DVec3;
-use jeod_sim::{FrameStorage, RefFrameRot, RefFrameState, RefFrameTrans};
+use jeod_sim::{
+    Frame, FrameStorage, Position, RefFrameRot, RefFrameState, RefFrameTrans, RootInertial,
+    Velocity,
+};
 
 use crate::components::{FrameAngVelC, FrameRotC, FrameTransC};
 
@@ -116,5 +138,106 @@ impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
                 ang_vel_this: ang_vel.0,
             },
         }
+    }
+}
+
+/// Compute the origin (position + velocity) of a frame entity expressed
+/// in a chosen ancestor frame's coordinates. ECS-native replacement for
+/// `jeod_sim::frame_origin` / `jeod_sim::frame_origin_typed::<F>`.
+/// Issue #278 (Frame-Tree-ECS-Native § 6, PR 2).
+///
+/// Internally backed by the same `Query<&ChildOf>` +
+/// `Query<(&FrameTransC, &FrameRotC, &FrameAngVelC)>` walks as
+/// [`RelativeFrameState`]; in fact `FrameOrigin` wraps a
+/// [`RelativeFrameState`]. `FrameOrigin` is a specialized variant for
+/// the common "origin of frame F in an ancestor frame" query — most
+/// frequently "in the root frame," which is the form gravity,
+/// integration, and `IntegOrigin`-shift sites need.
+///
+/// The two-method shape mirrors the design doc's catalog:
+///
+/// - [`FrameOrigin::origin_in_root`] —
+///   `(Position<RootInertial>, Velocity<RootInertial>)`. The typed
+///   surface that lifts the result into the root-inertial phantom
+///   without an `from_raw_si` boundary at the call site.
+///   Equivalent to
+///   `frame_origin_typed::<RootInertial>(tree, root, frame)` /
+///   `(rel.position_velocity(root, frame))`-then-wrap.
+/// - [`FrameOrigin::origin_in`] — raw `DVec3` form for callers whose
+///   ancestor isn't the root (e.g. an integration frame that's a
+///   child of root, not root itself). Caller chooses the
+///   ancestor entity, mirroring the arena helper's `(root, frame)`
+///   parameter shape.
+///
+/// # Example
+/// ```ignore
+/// use bevy::prelude::*;
+/// use bevy_jeod::prelude::*;
+///
+/// fn read_origin_in_root(
+///     origin: FrameOrigin,
+///     root: Res<RootFrameEntityR>,
+///     bodies: Query<&FrameEntityC, With<MyBody>>,
+/// ) -> Position<RootInertial> {
+///     let body_e = bodies.single().unwrap().0;
+///     let (pos, _vel) = origin.origin_in_root(root.0, body_e);
+///     pos
+/// }
+/// ```
+#[derive(SystemParam)]
+pub struct FrameOrigin<'w, 's> {
+    rel: RelativeFrameState<'w, 's>,
+}
+
+impl<'w, 's> FrameOrigin<'w, 's> {
+    /// `(position, velocity)` of `frame`'s origin expressed in
+    /// `ancestor`-frame coordinates. Raw `DVec3` form for callers
+    /// whose ancestor isn't the root (e.g. an `IntegrationFrame` that
+    /// is a child of root, not root itself).
+    ///
+    /// When `frame == ancestor`, returns `(DVec3::ZERO, DVec3::ZERO)` —
+    /// the same identity short-circuit as
+    /// `jeod_sim::frame_origin(tree, root, root)`.
+    pub fn origin_in(&self, ancestor: Entity, frame: Entity) -> (DVec3, DVec3) {
+        self.rel.position_velocity(ancestor, frame)
+    }
+
+    /// Typed `(Position<RootInertial>, Velocity<RootInertial>)` for the
+    /// common "origin in the root inertial frame" query. Caller passes
+    /// the root frame [`Entity`] (typically `Res<RootFrameEntityR>.0`)
+    /// — the typed phantom is `RootInertial` by convention, asserted
+    /// at the call site by passing the root frame entity.
+    ///
+    /// Equivalent to
+    /// `jeod_sim::frame_origin_typed::<RootInertial>(tree, root, frame)`
+    /// without the per-call `from_raw_si` lift at the consumer's site.
+    pub fn origin_in_root(
+        &self,
+        root: Entity,
+        frame: Entity,
+    ) -> (Position<RootInertial>, Velocity<RootInertial>) {
+        let (pos_raw, vel_raw) = self.origin_in(root, frame);
+        (
+            Position::<RootInertial>::from_raw_si(pos_raw),
+            Velocity::<RootInertial>::from_raw_si(vel_raw),
+        )
+    }
+
+    /// Generic-typed sibling of [`origin_in_root`](Self::origin_in_root)
+    /// for callers whose ancestor frame's marker is some other
+    /// `F: Frame` (e.g. a `PlanetInertial<P>` integration frame). The
+    /// caller asserts that `ancestor`'s marker is `F`; no runtime
+    /// check is performed (mirroring `jeod_sim::frame_origin_typed`,
+    /// which is also a phantom-tag attachment).
+    pub fn origin_in_typed<F: Frame>(
+        &self,
+        ancestor: Entity,
+        frame: Entity,
+    ) -> (Position<F>, Velocity<F>) {
+        let (pos_raw, vel_raw) = self.origin_in(ancestor, frame);
+        (
+            Position::<F>::from_raw_si(pos_raw),
+            Velocity::<F>::from_raw_si(vel_raw),
+        )
     }
 }

--- a/src/frame_param.rs
+++ b/src/frame_param.rs
@@ -31,12 +31,12 @@
 //!   `frame_origin(tree, root, frame_id)` /
 //!   `frame_origin_typed::<RootInertial>(tree, root, frame_id)`.
 //!
-//! During the dual-write phase (PR 1–3) the underlying components are
-//! kept in lockstep with [`crate::FrameTreeR`], so these `SystemParam`s
-//! and the arena helpers return bit-identical numerics
-//! (see `tests/frame_storage_relative_frame_state.rs`). Mission code
-//! may adopt the new surface incrementally; the arena is removed in
-//! Section 13 PR 4.
+//! While the underlying components are kept in lockstep with
+//! [`crate::FrameTreeR`] via dual-write, these `SystemParam`s and the
+//! arena helpers return bit-identical numerics (see
+//! `tests/frame_storage_relative_frame_state.rs`). Mission code may
+//! adopt the new surface incrementally; the arena will be removed once
+//! all internal consumers have migrated.
 //!
 //! [1]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing
 //! [2]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#7-internal-algorithm-sharing-q1
@@ -60,12 +60,12 @@ use crate::components::{FrameAngVelC, FrameRotC, FrameTransC};
 ///
 /// ECS-native replacement for
 /// `FrameTreeR.compute_relative_state(from_id, to_id)` and
-/// `frame_origin(tree, root, frame_id)`. Issue #277.
+/// `frame_origin(tree, root, frame_id)`.
 ///
-/// During the dual-write phase (PR 1) the underlying components are
-/// kept in lockstep with the arena; this `SystemParam` is therefore a
-/// drop-in alternative with identical numerics. Mission code that
-/// migrates first sees an `Entity`-keyed surface (no `FrameId`s, no
+/// While the dual-write infrastructure keeps the underlying components
+/// in lockstep with the arena, this `SystemParam` is a drop-in
+/// alternative with identical numerics. Mission code that migrates
+/// first sees an `Entity`-keyed surface (no `FrameId`s, no
 /// `Res<FrameTreeR>`).
 #[derive(SystemParam)]
 pub struct RelativeFrameState<'w, 's> {
@@ -110,7 +110,7 @@ impl<'w, 's> RelativeFrameState<'w, 's> {
 
 /// `FrameStorage` impl: lets the storage-agnostic algorithms in
 /// `jeod_frames::frame_storage` operate over the ECS hierarchy + the
-/// new frame-state components. Issue #277.
+/// frame-state components.
 impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
     type Id = Entity;
 
@@ -143,8 +143,10 @@ impl<'w, 's> FrameStorage for RelativeFrameState<'w, 's> {
 
 /// Compute the origin (position + velocity) of a frame entity expressed
 /// in a chosen ancestor frame's coordinates. ECS-native replacement for
-/// `jeod_sim::frame_origin` / `jeod_sim::frame_origin_typed::<F>`.
-/// Issue #278 (Frame-Tree-ECS-Native § 6, PR 2).
+/// `jeod_sim::frame_origin` / `jeod_sim::frame_origin_typed::<F>`
+/// ([Frame-Tree-ECS-Native § 6][1]).
+///
+/// [1]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#6-mission-code-surface--systemparam-catalog-q7
 ///
 /// Internally backed by the same `Query<&ChildOf>` +
 /// `Query<(&FrameTransC, &FrameRotC, &FrameAngVelC)>` walks as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,20 +87,84 @@ pub struct EphemerisR(pub jeod_sim::Ephemeris);
 #[derive(Resource, Deref, DerefMut)]
 pub struct MassTreeR(pub jeod_sim::MassTree);
 
-/// Bevy resource wrapping the simulation's [`jeod_sim::FrameTree`].
-///
-/// Mirrors `jeod_runner::Simulation::frame_tree`. Inserted at startup by
-/// [`JeodPlugin`] with a single root inertial frame node; mission code or
-/// recipes can register additional frame nodes (source inertials, pfix
-/// frames, body frames) during entity spawning.
-///
-/// Issue #71: this resource is the data structure that the lifted
-/// `jeod_sim::{frame_orchestration, source_state}` helpers operate on,
-/// so the Bevy adapter can consume the same orchestration code as
-/// `jeod_runner` instead of re-implementing it.
-#[derive(Resource, Deref, DerefMut)]
-pub struct FrameTreeR(pub jeod_sim::FrameTree);
+// Issue #278: hosting the deprecated tuple struct inside a tiny
+// private submodule (`frame_tree_r_internal`) lets us blanket-suppress
+// the in-expansion warnings the derive macros (`Resource`, `Deref`,
+// `DerefMut`) emit at the type definition itself, while the
+// `#[deprecated]` attribute still fires at every external use site —
+// the deprecation surface PR 2 (#278) targets. PR 4 (#280) removes
+// the resource entirely; this submodule disappears with it.
+mod frame_tree_r_internal {
+    #![allow(deprecated)]
+    use bevy::prelude::*;
 
+    /// Bevy resource wrapping the simulation's [`jeod_sim::FrameTree`].
+    ///
+    /// Mirrors `jeod_runner::Simulation::frame_tree`. Inserted at startup by
+    /// [`crate::JeodPlugin`] with a single root inertial frame node; mission
+    /// code or recipes can register additional frame nodes (source inertials,
+    /// pfix frames, body frames) during entity spawning.
+    ///
+    /// Issue #71: this resource is the data structure that the lifted
+    /// `jeod_sim::{frame_orchestration, source_state}` helpers operate on,
+    /// so the Bevy adapter can consume the same orchestration code as
+    /// `jeod_runner` instead of re-implementing it.
+    ///
+    /// # Deprecated for mission-code use (issue #278 / [Frame-Tree-ECS-Native § 13][1])
+    ///
+    /// `FrameTreeR` is the *internal* arena backing the dual-write phase of
+    /// the ECS-native frame-tree migration. **Mission code must not read
+    /// `Res<FrameTreeR>` directly.** The supported mission-facing surface
+    /// is the pair of `SystemParam`s in [`crate::frame_param`]:
+    ///
+    /// - [`crate::frame_param::RelativeFrameState`] for "state of `to`
+    ///   relative to `from`" — replaces
+    ///   `FrameTreeR.compute_relative_state(from_id, to_id)`.
+    /// - [`crate::frame_param::FrameOrigin`] for "origin of frame `F` in
+    ///   an ancestor frame" — replaces
+    ///   `jeod_sim::frame_origin(tree, root, frame_id)` /
+    ///   `jeod_sim::frame_origin_typed::<RootInertial>(tree, root, frame_id)`.
+    ///
+    /// Both walk the ECS hierarchy (`Query<&ChildOf>`) over the
+    /// dual-written [`crate::FrameTransC`] / [`crate::FrameRotC`] /
+    /// [`crate::FrameAngVelC`] components, return numerics bit-identical to
+    /// the arena (see `tests/frame_storage_relative_frame_state.rs`), and
+    /// never expose a `FrameId`.
+    ///
+    /// Internal physics systems (gravity, integration, frame-switch,
+    /// derived-state) still read this resource during the PR 2 → PR 3
+    /// transition; those call sites are kept inside files annotated with
+    /// `#![allow(deprecated)]` and a refactor comment noting they're
+    /// rewritten to the SystemParams in PR 3 (#279). The `Resource` itself
+    /// is removed in PR 4 (#280) once internal systems also migrate.
+    ///
+    /// [1]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing
+    #[deprecated(
+        since = "0.1.0",
+        note = "mission code must not read FrameTreeR directly. \
+                Use `bevy_jeod::frame_param::RelativeFrameState` for cross-frame state queries \
+                (replaces `FrameTreeR.compute_relative_state(from, to)`) \
+                and `bevy_jeod::frame_param::FrameOrigin` for frame-origin queries \
+                (replaces `frame_origin(tree, root, frame_id)`). \
+                Internal physics systems still read FrameTreeR until PR 3 (#279); \
+                the Resource itself is removed in PR 4 (#280). \
+                See https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing"
+    )]
+    #[derive(Resource, Deref, DerefMut)]
+    pub struct FrameTreeR(pub jeod_sim::FrameTree);
+}
+
+#[allow(deprecated)]
+pub use frame_tree_r_internal::FrameTreeR;
+
+// Issue #278: the `FrameTreeR` definition is `#[deprecated]` for
+// mission-code use; the inherent `impl` block and the `Default` impl
+// below are the resource's own internal API and read/write the inner
+// `pub jeod_sim::FrameTree` field. Per the "deprecated for mission-
+// code use only" carveout in PR 2 (issue #278), suppress the
+// resulting warnings at the `impl` header. Removed in PR 4 (#280)
+// when the resource itself is removed.
+#[allow(deprecated)]
 impl FrameTreeR {
     /// Create a new frame tree pre-populated with a permanent
     /// `root.inertial` root frame. Unlike `jeod_runner::Simulation::new`
@@ -116,6 +180,7 @@ impl FrameTreeR {
     }
 }
 
+#[allow(deprecated)] // Issue #278: see comment on inherent impl above.
 impl Default for FrameTreeR {
     fn default() -> Self {
         Self::new().0
@@ -183,6 +248,13 @@ impl Plugin for JeodPlugin {
         // `RootFrameIdR` *before* adding `JeodPlugin`; the plugin then
         // preserves them. Inserting either alone is rejected — they
         // describe the same tree and must stay consistent.
+        //
+        // Issue #278: `FrameTreeR` is `#[deprecated]` for mission code;
+        // the `JeodPlugin::build` plumbing here owns the resource's
+        // lifecycle and is rewritten in PR 4 (#280) when the resource
+        // is removed. The whole match is `#[allow(deprecated)]` because
+        // this is the *infrastructure* installing the resource.
+        #[allow(deprecated)]
         match (
             app.world().contains_resource::<FrameTreeR>(),
             app.world().contains_resource::<RootFrameIdR>(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,13 +87,13 @@ pub struct EphemerisR(pub jeod_sim::Ephemeris);
 #[derive(Resource, Deref, DerefMut)]
 pub struct MassTreeR(pub jeod_sim::MassTree);
 
-// Issue #278: hosting the deprecated tuple struct inside a tiny
-// private submodule (`frame_tree_r_internal`) lets us blanket-suppress
-// the in-expansion warnings the derive macros (`Resource`, `Deref`,
-// `DerefMut`) emit at the type definition itself, while the
-// `#[deprecated]` attribute still fires at every external use site —
-// the deprecation surface PR 2 (#278) targets. PR 4 (#280) removes
-// the resource entirely; this submodule disappears with it.
+// Hosting the deprecated tuple struct inside a tiny private submodule
+// (`frame_tree_r_internal`) lets us blanket-suppress the in-expansion
+// warnings the derive macros (`Resource`, `Deref`, `DerefMut`) emit at
+// the type definition itself, while the `#[deprecated]` attribute
+// still fires at every external use site — the surface mission code
+// is meant to migrate off of. The submodule disappears together with
+// the resource once internal physics consumers also migrate.
 mod frame_tree_r_internal {
     #![allow(deprecated)]
     use bevy::prelude::*;
@@ -105,12 +105,12 @@ mod frame_tree_r_internal {
     /// code or recipes can register additional frame nodes (source inertials,
     /// pfix frames, body frames) during entity spawning.
     ///
-    /// Issue #71: this resource is the data structure that the lifted
+    /// This resource is the data structure that the lifted
     /// `jeod_sim::{frame_orchestration, source_state}` helpers operate on,
     /// so the Bevy adapter can consume the same orchestration code as
     /// `jeod_runner` instead of re-implementing it.
     ///
-    /// # Deprecated for mission-code use (issue #278 / [Frame-Tree-ECS-Native § 13][1])
+    /// # Deprecated for mission-code use ([Frame-Tree-ECS-Native § 13][1])
     ///
     /// `FrameTreeR` is the *internal* arena backing the dual-write phase of
     /// the ECS-native frame-tree migration. **Mission code must not read
@@ -132,11 +132,11 @@ mod frame_tree_r_internal {
     /// never expose a `FrameId`.
     ///
     /// Internal physics systems (gravity, integration, frame-switch,
-    /// derived-state) still read this resource during the PR 2 → PR 3
-    /// transition; those call sites are kept inside files annotated with
-    /// `#![allow(deprecated)]` and a refactor comment noting they're
-    /// rewritten to the SystemParams in PR 3 (#279). The `Resource` itself
-    /// is removed in PR 4 (#280) once internal systems also migrate.
+    /// derived-state) still read this resource; those call sites are kept
+    /// inside files annotated with `#![allow(deprecated)]` and a comment
+    /// noting they are scheduled to migrate to the SystemParams. The
+    /// `Resource` itself will be removed once internal systems have
+    /// migrated.
     ///
     /// [1]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing
     #[deprecated(
@@ -146,8 +146,8 @@ mod frame_tree_r_internal {
                 (replaces `FrameTreeR.compute_relative_state(from, to)`) \
                 and `bevy_jeod::frame_param::FrameOrigin` for frame-origin queries \
                 (replaces `frame_origin(tree, root, frame_id)`). \
-                Internal physics systems still read FrameTreeR until PR 3 (#279); \
-                the Resource itself is removed in PR 4 (#280). \
+                Internal physics systems still read FrameTreeR; the Resource \
+                itself will be removed once those internal consumers have migrated. \
                 See https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing"
     )]
     #[derive(Resource, Deref, DerefMut)]
@@ -157,13 +157,12 @@ mod frame_tree_r_internal {
 #[allow(deprecated)]
 pub use frame_tree_r_internal::FrameTreeR;
 
-// Issue #278: the `FrameTreeR` definition is `#[deprecated]` for
-// mission-code use; the inherent `impl` block and the `Default` impl
-// below are the resource's own internal API and read/write the inner
+// The `FrameTreeR` definition is `#[deprecated]` for mission-code use;
+// the inherent `impl` block and the `Default` impl below are the
+// resource's own internal API and read/write the inner
 // `pub jeod_sim::FrameTree` field. Per the "deprecated for mission-
-// code use only" carveout in PR 2 (issue #278), suppress the
-// resulting warnings at the `impl` header. Removed in PR 4 (#280)
-// when the resource itself is removed.
+// code use only" carveout, suppress the resulting warnings at the
+// `impl` header. These impls disappear together with the resource.
 #[allow(deprecated)]
 impl FrameTreeR {
     /// Create a new frame tree pre-populated with a permanent
@@ -180,7 +179,7 @@ impl FrameTreeR {
     }
 }
 
-#[allow(deprecated)] // Issue #278: see comment on inherent impl above.
+#[allow(deprecated)] // See comment on inherent impl above.
 impl Default for FrameTreeR {
     fn default() -> Self {
         Self::new().0
@@ -200,8 +199,8 @@ pub struct RootFrameIdR(pub jeod_sim::FrameId);
 /// once as an arena `FrameId` and once as a Bevy `Entity`. Spawned
 /// by [`JeodPlugin::build`] before any source/body registration so
 /// the registration systems can `ChildOf`-link their frame entities
-/// to it. Issue #277 — additive infrastructure for the
-/// [Frame-Tree-ECS-Native][1] migration (Section 13 PR 1).
+/// to it. Part of the additive infrastructure for the
+/// [Frame-Tree-ECS-Native][1] migration.
 ///
 /// [1]: https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native
 #[derive(Resource, Debug, Clone, Copy, Deref, DerefMut)]
@@ -249,11 +248,10 @@ impl Plugin for JeodPlugin {
         // preserves them. Inserting either alone is rejected — they
         // describe the same tree and must stay consistent.
         //
-        // Issue #278: `FrameTreeR` is `#[deprecated]` for mission code;
-        // the `JeodPlugin::build` plumbing here owns the resource's
-        // lifecycle and is rewritten in PR 4 (#280) when the resource
-        // is removed. The whole match is `#[allow(deprecated)]` because
-        // this is the *infrastructure* installing the resource.
+        // `FrameTreeR` is `#[deprecated]` for mission code; the
+        // `JeodPlugin::build` plumbing here owns the resource's
+        // lifecycle and is the *infrastructure* installing it, so the
+        // whole match is `#[allow(deprecated)]`.
         #[allow(deprecated)]
         match (
             app.world().contains_resource::<FrameTreeR>(),
@@ -267,17 +265,16 @@ impl Plugin for JeodPlugin {
             (true, true) => {
                 // Caller pre-installed both; verify that the supplied
                 // `RootFrameIdR` actually points at a root of the
-                // supplied `FrameTreeR`. PR #260 round-10 review
-                // fixup: the docs encourage pre-seeding custom trees,
-                // but a mismatched pair (e.g. a stale `FrameId` from a
-                // different tree, or an interior frame mistakenly
-                // labelled as the root) would silently attach
-                // sources/bodies under the wrong node, panic later in
-                // unrelated systems, or silently corrupt
-                // frame-relative state. Catch it here per the
-                // "Fail Loudly" rule — the diagnostic names the
-                // broken assumption and tells the caller how to fix
-                // it.
+                // supplied `FrameTreeR`. The docs encourage pre-seeding
+                // custom trees, but a mismatched pair (e.g. a stale
+                // `FrameId` from a different tree, or an interior
+                // frame mistakenly labelled as the root) would
+                // silently attach sources/bodies under the wrong
+                // node, panic later in unrelated systems, or
+                // silently corrupt frame-relative state. Catch it
+                // here per the "Fail Loudly" rule — the diagnostic
+                // names the broken assumption and tells the caller
+                // how to fix it.
                 let frame_tree = app.world().resource::<FrameTreeR>();
                 let root_id = app.world().resource::<RootFrameIdR>().0;
                 assert!(
@@ -310,7 +307,7 @@ impl Plugin for JeodPlugin {
                 // pre-installed `RootFrameIdR` that points to a
                 // `PlanetFixed` / `Body` node would let all that math run
                 // against a non-inertial root and silently produce wrong
-                // physics. PR #260 reviewer-flagged gap.
+                // physics — fail loud here.
                 let root_kind = frame_tree.0.get(root_id).kind;
                 assert!(
                     matches!(root_kind, jeod_sim::RefFrameKind::Inertial),
@@ -338,28 +335,26 @@ impl Plugin for JeodPlugin {
             ),
         }
 
-        // ── Issue #277: ECS-native root frame entity ──
+        // ── ECS-native root frame entity ──
         // Spawn the root frame entity that mirrors the arena's root
         // frame node. Source / body registration `ChildOf`-links its
         // frame entities under this one, so the ECS hierarchy and the
-        // arena describe the same logical frame tree in parallel
-        // during the dual-write phase (Section 13 PR 1).
+        // arena describe the same logical frame tree in parallel.
         //
-        // Issue #277 PR 1 round-5 review fixup: only spawn when the caller
-        // hasn't pre-installed `RootFrameEntityR`. Mirrors the
-        // `FrameTreeR` / `RootFrameIdR` pattern above so a mission
-        // (or a second `JeodPlugin::build` call — `Plugin::build` is
-        // not idempotent on its own) cannot silently leak the
-        // previously-spawned root entity and re-parent future frame
-        // entities under a different root than the existing ones.
-        // When pre-installed we validate that the referenced entity
-        // still exists and carries the required frame components /
-        // `InertialFrameMarker` so source / body registration's
-        // `ChildOf`-links and the typed `<RootInertial>` assumptions
-        // hold. Per the "Fail Loudly" rule a stale or
-        // wrong-kind pre-installed entity panics with a diagnostic
-        // that names the broken assumption and tells the caller how
-        // to fix it.
+        // Only spawn when the caller hasn't pre-installed
+        // `RootFrameEntityR`. Mirrors the `FrameTreeR` / `RootFrameIdR`
+        // pattern above so a mission (or a second `JeodPlugin::build`
+        // call — `Plugin::build` is not idempotent on its own) cannot
+        // silently leak the previously-spawned root entity and
+        // re-parent future frame entities under a different root than
+        // the existing ones. When pre-installed we validate that the
+        // referenced entity still exists and carries the required
+        // frame components / `InertialFrameMarker` so source / body
+        // registration's `ChildOf`-links and the typed
+        // `<RootInertial>` assumptions hold. Per the "Fail Loudly"
+        // rule a stale or wrong-kind pre-installed entity panics with
+        // a diagnostic that names the broken assumption and tells the
+        // caller how to fix it.
         if !app.world().contains_resource::<RootFrameEntityR>() {
             let root_frame_entity = app
                 .world_mut()
@@ -417,7 +412,7 @@ impl Plugin for JeodPlugin {
             );
         }
 
-        // ── Typed-Component reflection (#154) ──
+        // ── Typed-Component reflection ──
         // Centralized in `register_jeod_component_types` so the smoke
         // test and any other consumer registers exactly the same set.
         register_jeod_component_types(app);
@@ -434,10 +429,10 @@ impl Plugin for JeodPlugin {
         // sources are skipped — registering is one-time per source.
         // Body-frame registration follows so bodies can resolve
         // `IntegSourceC(Some(source_entity))` against an already-registered
-        // source. Issue #71 items 2, 4, 5.
+        // source.
         //
         // Registration is wired into three schedules so it catches every
-        // spawn surface (PR #260 round-3 R3 fixup):
+        // spawn surface:
         //   - Startup: initial spawns before any tick.
         //   - PreUpdate: catches entities spawned during the previous
         //     frame's `Update` / `PostUpdate`. They are registered before
@@ -453,9 +448,9 @@ impl Plugin for JeodPlugin {
         // Each pass is a no-op for already-registered entities (the
         // `Without<SourceFrameIdC>` / `Without<BodyFrameIdC>` filters
         // make repeated runs cost a single query iteration).
-        // `register_pfix_frames_system` covers a rare but real case
-        // (round-9 fixup): a source spawned without `PlanetFixedRotationC`
-        // that gains it after the initial registration. The main
+        // `register_pfix_frames_system` covers a rare but real case:
+        // a source spawned without `PlanetFixedRotationC` that gains
+        // it after the initial registration. The main
         // `register_source_frames_system` filters by
         // `Without<SourceFrameIdC>` so it can't observe that mutation;
         // the dedicated pfix pass uses `Without<SourcePfixFrameIdC>` +
@@ -468,8 +463,7 @@ impl Plugin for JeodPlugin {
                 systems::register_body_frames_system.after(systems::register_pfix_frames_system),
                 // Maintain `MassPointRef` ↔ `MassPropertiesC` invariant
                 // for bodies that gain or lose mass after the one-time
-                // body-frame registration pass. PR #283 review thread
-                // `PRRT_kwDORtae6c5_K7qF`.
+                // body-frame registration pass.
                 systems::sync_body_mass_point_ref_system
                     .after(systems::register_body_frames_system),
             ),
@@ -487,17 +481,16 @@ impl Plugin for JeodPlugin {
         // Frame-tree despawn cleanup: rename + reset orphan nodes so
         // `find_by_name` lookups don't shadow a future re-spawn of the
         // same name and stale state can't leak through frame-tree
-        // queries. PR #260 reviewer-flagged gap; see the module-level
-        // comment in `src/systems.rs` ("Frame-tree despawn cleanup")
-        // for the why.
+        // queries. See the module-level comment in `src/systems.rs`
+        // ("Frame-tree despawn cleanup") for the why.
         app.add_observer(systems::on_source_frame_despawn);
         app.add_observer(systems::on_source_pfix_frame_despawn);
         app.add_observer(systems::on_retired_pfix_frame_despawn);
         app.add_observer(systems::on_retired_pfix_frame_entity_despawn);
         app.add_observer(systems::on_body_frame_despawn);
-        // Issue #277 PR 1 round-2 review: dual-write ECS frame
-        // entities also need cleanup on owner despawn so the
-        // dual-write sites in `register_source_frames_system` /
+        // Dual-write ECS frame entities also need cleanup on owner
+        // despawn so the dual-write sites in
+        // `register_source_frames_system` /
         // `register_body_frames_system` (and the pfix branch of the
         // former / `register_pfix_frames_system`) don't leak frame
         // entities after the source / body entity is gone.
@@ -513,7 +506,7 @@ impl Plugin for JeodPlugin {
                 // `planet_fixed_rotation_system` / `ephemeris_update_system`.
                 systems::register_source_frames_system.before(JeodSet::EphemerisUpdate),
                 // Late-attached `PlanetFixedRotationC` → pfix child node
-                // (round-9 fixup; see `register_pfix_frames_system` doc).
+                // (see `register_pfix_frames_system` doc).
                 systems::register_pfix_frames_system
                     .after(systems::register_source_frames_system)
                     .before(JeodSet::EphemerisUpdate),
@@ -525,7 +518,6 @@ impl Plugin for JeodPlugin {
                 // Late-acquired / late-lost `MassPropertiesC` →
                 // insert / remove `MassPointRef` for bodies that have
                 // already passed through `register_body_frames_system`.
-                // PR #283 review thread `PRRT_kwDORtae6c5_K7qF`.
                 systems::sync_body_mass_point_ref_system
                     .after(systems::register_body_frames_system)
                     .before(JeodSet::EphemerisUpdate),
@@ -550,7 +542,7 @@ impl Plugin for JeodPlugin {
                 // After ephemeris_update_system writes new source position /
                 // velocity, mirror the values into FrameTreeR so frame-tree
                 // consumers (compute_relative_state, frame_origin) see the
-                // latest state. PR #260 review fixup.
+                // latest state.
                 systems::sync_source_to_frame_system
                     .in_set(JeodSet::EphemerisUpdate)
                     .after(systems::ephemeris_update_system)
@@ -571,8 +563,8 @@ impl Plugin for JeodPlugin {
                 // `MassChildOf` edges bottom-up via the
                 // `jeod_sim::MassStorage` trait and writes composite
                 // mass / inertia / CoM back into `MassPropertiesC`.
-                // Issue #271. Runs after `mass_update_system` so the
-                // per-entity inverse caches are fresh, and before
+                // Runs after `mass_update_system` so the per-entity
+                // inverse caches are fresh, and before
                 // `JeodSet::EphemerisUpdate` so downstream gravity /
                 // interaction / integration systems see the
                 // composite. Fast-paths to a no-op when no entity
@@ -604,12 +596,12 @@ impl Plugin for JeodPlugin {
                 systems::integration_system.in_set(JeodSet::Integration),
                 // After integration, sync the body's typed state into its
                 // FrameTreeR node so frame-switch evaluation sees current
-                // distances. Issue #71 item 2.
+                // distances.
                 systems::sync_body_to_frame_system
                     .in_set(JeodSet::Integration)
                     .after(systems::integration_system),
                 // Evaluate distance-based frame switches and reparent the
-                // body in the frame tree on trigger. Issue #71 item 3.
+                // body in the frame tree on trigger.
                 systems::frame_switch_system
                     .in_set(JeodSet::Integration)
                     .after(systems::sync_body_to_frame_system),
@@ -674,7 +666,7 @@ pub fn register_jeod_component_types(app: &mut App) {
     app.register_type::<components::FrameSwitchesC>();
     app.register_type::<components::BodyFrameIdC>();
     app.register_type::<components::IntegFrameIdC>();
-    // Issue #277: frames-as-entities components.
+    // Frames-as-entities components.
     app.register_type::<components::FrameTransC>();
     app.register_type::<components::FrameRotC>();
     app.register_type::<components::FrameAngVelC>();
@@ -764,7 +756,7 @@ pub trait VehicleConfigBevyExt {
     /// torque component. `source_entities` resolves each `usize` index in
     /// `gravity_controls` to the corresponding ECS [`Entity`].
     ///
-    /// Wired in PR #260: `integ_source` (translated to
+    /// Also wires `integ_source` (translated to
     /// [`components::IntegSourceC`] when `Some`) and `frame_switches`
     /// (translated to [`components::FrameSwitchesC`] when non-empty),
     /// retagging each `usize` source index to the matching ECS
@@ -857,14 +849,14 @@ impl VehicleConfigBevyExt for jeod_sim::VehicleConfig {
             // so this is a one-time insertion-time lift — not a per-step
             // bypass. Migrating `VehicleConfig` itself to typed external
             // fields is a deeper refactor inside `jeod_sim`; out of
-            // scope for the Bevy-adapter boundary that #172 H1 targets.
-            let f = jeod_sim::Force::<jeod_sim::RootInertial>::from_raw_si(self.external_force); // allowed: #172 H1 insertion-time boundary (VehicleConfig still untyped)
+            // scope for this Bevy-adapter boundary.
+            let f = jeod_sim::Force::<jeod_sim::RootInertial>::from_raw_si(self.external_force); // allowed: insertion-time boundary — VehicleConfig still exposes external_force as untyped DVec3, lifted once into Force<RootInertial> at spawn time (not a per-step bypass).
             entity.insert(components::ExternalForceC(f));
         }
         if self.external_torque != glam::DVec3::ZERO {
             let t = jeod_sim::Torque::<jeod_sim::BodyFrame<jeod_sim::SelfRef>>::from_raw_si(
                 self.external_torque,
-            ); // allowed: #172 H1 insertion-time boundary (VehicleConfig still untyped)
+            ); // allowed: same insertion-time boundary as `external_force` above — VehicleConfig still untyped.
             entity.insert(components::ExternalTorqueC(t));
         }
         if self.compute_gravity_gradient {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -34,15 +34,16 @@ pub use crate::{
     SourceInertialVelocityC, StructuralTransformC, TotalForceC, TranslationalStateC,
     VehicleConfigBevyExt,
 };
-// Issue #277 / #278 — ECS-native frame-tree mission-code surface.
-// `RelativeFrameState` (issue #277) is the mission-facing replacement
-// for `FrameTreeR.compute_relative_state`. `FrameOrigin` (issue #278)
-// is the specialized "origin of frame F in an ancestor frame"
-// SystemParam — typed `(Position<RootInertial>, Velocity<RootInertial>)`
-// for the common root-inertial form, matching `frame_origin_typed::<RootInertial>`.
-// Both live in the dedicated `frame_param` module so their
-// `SystemParam` imports are explicit at the use site, but the prelude
-// re-exports them for the "use bevy_jeod::prelude::*" path.
+// ECS-native frame-tree mission-code surface.
+// `RelativeFrameState` is the mission-facing replacement for
+// `FrameTreeR.compute_relative_state`. `FrameOrigin` is the
+// specialized "origin of frame F in an ancestor frame" SystemParam —
+// typed `(Position<RootInertial>, Velocity<RootInertial>)` for the
+// common root-inertial form, matching
+// `frame_origin_typed::<RootInertial>`. Both live in the dedicated
+// `frame_param` module so their `SystemParam` imports are explicit at
+// the use site, but the prelude re-exports them for the
+// "use bevy_jeod::prelude::*" path.
 pub use crate::frame_param::{FrameOrigin, RelativeFrameState};
 
 // All `jeod_quantities` re-exports come through `jeod_sim` so the

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -34,13 +34,16 @@ pub use crate::{
     SourceInertialVelocityC, StructuralTransformC, TotalForceC, TranslationalStateC,
     VehicleConfigBevyExt,
 };
-// Issue #277 — additive infrastructure for the ECS-native frame tree.
-// `RelativeFrameState` is the mission-facing replacement for
-// `FrameTreeR.compute_relative_state` / `frame_origin`; it lives in
-// the dedicated `frame_param` module so its `SystemParam` import is
-// explicit at the use site, but the prelude re-exports it for the
-// "use bevy_jeod::prelude::*" path.
-pub use crate::frame_param::RelativeFrameState;
+// Issue #277 / #278 — ECS-native frame-tree mission-code surface.
+// `RelativeFrameState` (issue #277) is the mission-facing replacement
+// for `FrameTreeR.compute_relative_state`. `FrameOrigin` (issue #278)
+// is the specialized "origin of frame F in an ancestor frame"
+// SystemParam — typed `(Position<RootInertial>, Velocity<RootInertial>)`
+// for the common root-inertial form, matching `frame_origin_typed::<RootInertial>`.
+// Both live in the dedicated `frame_param` module so their
+// `SystemParam` imports are explicit at the use site, but the prelude
+// re-exports them for the "use bevy_jeod::prelude::*" path.
+pub use crate::frame_param::{FrameOrigin, RelativeFrameState};
 
 // All `jeod_quantities` re-exports come through `jeod_sim` so the
 // `bevy_jeod` root package keeps its single dependency on `jeod_sim`

--- a/src/source_mutator.rs
+++ b/src/source_mutator.rs
@@ -30,6 +30,16 @@
 //! The mutator runs against [`crate::FrameTreeR`] + entities carrying a
 //! [`crate::SourceFrameIdC`] (auto-inserted on every gravity source
 //! entity by `register_source_frames_system`).
+//!
+//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2): [`crate::FrameTreeR`]
+//! is `#[deprecated]` for mission-code use. `SourceMutator` is
+//! mission-facing but mutates the arena directly during the dual-write
+//! phase — that's the *internal* coupling PR 4 (#280) replaces by
+//! mutating the ECS frame entities and removing the resource. The
+//! mission-facing surface (mutator method shapes) is stable; only the
+//! storage backing changes. The file-level `#![allow(deprecated)]`
+//! keeps the dual-write internals quiet until PR 4.
+#![allow(deprecated)] // Issue #278: internal FrameTreeR mutation; rewritten in PR 4 (#280)
 
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;

--- a/src/source_mutator.rs
+++ b/src/source_mutator.rs
@@ -1,4 +1,4 @@
-//! Source-state mutation API for Bevy missions (issue #71 item 5).
+//! Source-state mutation API for Bevy missions.
 //!
 //! `jeod_runner::Simulation` exposes `set_source_position`,
 //! `set_source_state`, and `set_source_ephemeris` for runtime gravity-source
@@ -31,15 +31,14 @@
 //! [`crate::SourceFrameIdC`] (auto-inserted on every gravity source
 //! entity by `register_source_frames_system`).
 //!
-//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2): [`crate::FrameTreeR`]
-//! is `#[deprecated]` for mission-code use. `SourceMutator` is
-//! mission-facing but mutates the arena directly during the dual-write
-//! phase — that's the *internal* coupling PR 4 (#280) replaces by
-//! mutating the ECS frame entities and removing the resource. The
-//! mission-facing surface (mutator method shapes) is stable; only the
-//! storage backing changes. The file-level `#![allow(deprecated)]`
-//! keeps the dual-write internals quiet until PR 4.
-#![allow(deprecated)] // Issue #278: internal FrameTreeR mutation; rewritten in PR 4 (#280)
+//! [`crate::FrameTreeR`] is `#[deprecated]` for mission-code use.
+//! `SourceMutator` is mission-facing but mutates the arena directly
+//! during the dual-write phase — that's the *internal* coupling that
+//! will be replaced by mutating the ECS frame entities and removing
+//! the resource. The mission-facing surface (mutator method shapes)
+//! is stable; only the storage backing changes. The file-level
+//! `#![allow(deprecated)]` keeps the dual-write internals quiet.
+#![allow(deprecated)] // Internal FrameTreeR mutation during the dual-write phase.
 
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
@@ -63,10 +62,10 @@ use crate::{FrameTreeR, RootFrameIdR};
 /// [`SourceInertialVelocityC`] when [`Self::set_source_state`] is called
 /// with a non-zero velocity, the component is auto-inserted so the
 /// gravity / PPN code that reads it sees the new value on the next
-/// step. (Closes a footgun raised in PR #260 review:
-/// `PlanetBundle::point_mass` doesn't include
-/// [`SourceInertialVelocityC`] by default; without auto-insert,
-/// `set_source_state` would silently no-op on the velocity write.)
+/// step. (Without this auto-insert, `set_source_state` would silently
+/// no-op on the velocity write for sources spawned via
+/// `PlanetBundle::point_mass`, which doesn't include
+/// [`SourceInertialVelocityC`] by default.)
 ///
 /// **Central-body protection**: `jeod_runner::Simulation` rejects
 /// mutations of the *root* source (the central body, since the root
@@ -122,7 +121,7 @@ impl SourceMutator<'_, '_> {
         // the more fundamental misconfiguration to surface (a non-source
         // entity carrying CentralSourceMarker hits the SourceFrameIdC
         // panic before the marker panic, which is the diagnostic ordering
-        // a debugging user actually wants — PR #267 review).
+        // a debugging user actually wants).
         let fid = self.fetch_frame_id(source, "set_source_position");
         self.assert_not_central(source, "set_source_position");
         let source_frames = [SourceFrameIds {
@@ -183,8 +182,8 @@ impl SourceMutator<'_, '_> {
         }
         // Auto-insert SourceInertialVelocityC if the source doesn't carry
         // one — `PlanetBundle::point_mass` doesn't include it by default,
-        // and without auto-insert the velocity write would silently no-op
-        // (footgun raised in PR #260 review).
+        // and without auto-insert the velocity write would silently
+        // no-op.
         match self.velocities.get_mut(source) {
             Ok(mut vc) => vc.0 = typed_vel,
             Err(_) => {
@@ -214,7 +213,7 @@ impl SourceMutator<'_, '_> {
     /// Format a user-facing label for `entity` — `"Earth (Entity {…})"` if a
     /// `Name` component is present, falling back to the raw `Entity` debug
     /// form. Used by the panic-formatting helpers so diagnostics name the
-    /// gravity source the way mission code spelled it (PR #267 review).
+    /// gravity source the way mission code spelled it.
     fn entity_label(&self, entity: Entity) -> String {
         match self.names.get(entity) {
             Ok(name) => format!("{name} ({entity:?})"),

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -2,6 +2,20 @@
 //! orchestration functions. Each system queries the relevant components,
 //! calls into `jeod_sim`, and writes the result back. No physics
 //! algorithms live here.
+//!
+//! ## Deprecation suppression
+//!
+//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2) marks
+//! [`crate::FrameTreeR`] `#[deprecated]` for mission-code use. The
+//! systems in this module are *internal physics* and continue to read
+//! the arena during the dual-write phase (PR 1–3). PR 3 (#279)
+//! rewrites these systems to use the
+//! [`crate::frame_param::RelativeFrameState`] /
+//! [`crate::frame_param::FrameOrigin`] SystemParams; PR 4 (#280)
+//! removes the `FrameTreeR` resource entirely. Until then, the
+//! file-level `#![allow(deprecated)]` keeps the internal call sites
+//! quiet without weakening the deprecation signal mission code sees.
+#![allow(deprecated)] // Issue #278: internal FrameTreeR consumers; rewritten in PR 3 (#279)
 
 use bevy::prelude::*;
 use glam::DVec3;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -5,17 +5,15 @@
 //!
 //! ## Deprecation suppression
 //!
-//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2) marks
-//! [`crate::FrameTreeR`] `#[deprecated]` for mission-code use. The
+//! [`crate::FrameTreeR`] is `#[deprecated]` for mission-code use. The
 //! systems in this module are *internal physics* and continue to read
-//! the arena during the dual-write phase (PR 1–3). PR 3 (#279)
-//! rewrites these systems to use the
-//! [`crate::frame_param::RelativeFrameState`] /
-//! [`crate::frame_param::FrameOrigin`] SystemParams; PR 4 (#280)
-//! removes the `FrameTreeR` resource entirely. Until then, the
+//! the arena during the dual-write phase. They will eventually be
+//! rewritten to use the [`crate::frame_param::RelativeFrameState`] /
+//! [`crate::frame_param::FrameOrigin`] SystemParams, after which the
+//! `FrameTreeR` resource will be removed entirely. Until then, the
 //! file-level `#![allow(deprecated)]` keeps the internal call sites
 //! quiet without weakening the deprecation signal mission code sees.
-#![allow(deprecated)] // Issue #278: internal FrameTreeR consumers; rewritten in PR 3 (#279)
+#![allow(deprecated)] // Internal FrameTreeR consumers during the dual-write phase.
 
 use bevy::prelude::*;
 use glam::DVec3;
@@ -48,8 +46,8 @@ use crate::SimulationTimeR;
 /// `planet_fixed_rotation_system`.
 ///
 /// This is the Bevy analog of `jeod_runner::Simulation::add_source` —
-/// it makes the lifted source-mutation helpers (issue #71 item 5)
-/// usable directly via [`crate::SourceMutator`].
+/// it makes the lifted source-mutation helpers usable directly via
+/// [`crate::SourceMutator`].
 ///
 /// **Divergence from jeod_runner**: every source becomes a child of
 /// the root frame, including the central body. `jeod_runner` renames
@@ -57,14 +55,14 @@ use crate::SimulationTimeR;
 /// adapter keeps a generic root and treats all sources uniformly so
 /// the registration order doesn't matter and so adding a body in a
 /// non-Earth-central simulation doesn't require special-casing
-/// "central" sources. Frame-switch parity (issue #71 items 2-4) lives
-/// at the orchestration layer, where this divergence is invisible.
+/// "central" sources. Frame-switch parity lives at the orchestration
+/// layer, where this divergence is invisible.
 #[allow(clippy::type_complexity)]
 pub fn register_source_frames_system(
     mut commands: Commands,
     mut frame_tree: ResMut<FrameTreeR>,
     root: Res<crate::RootFrameIdR>,
-    // Issue #277: also spawn ECS frame entities under this root.
+    // Also spawn ECS frame entities under this root.
     root_frame_entity: Res<crate::RootFrameEntityR>,
     sources: Query<
         (
@@ -87,7 +85,7 @@ pub fn register_source_frames_system(
         // lets sources that already carry a non-zero
         // `SourceInertialVelocityC` start with the right velocity in the
         // tree; sources without the velocity component get zero, matching
-        // their ECS state. (Phase B PR #260 review fixup.)
+        // their ECS state.
         let init_pos = pos.0.raw_si();
         let init_vel = vel.map_or(glam::DVec3::ZERO, |v| v.0.raw_si());
         let inertial_id = frame_tree.0.add_child(
@@ -103,10 +101,10 @@ pub fn register_source_frames_system(
             },
         );
 
-        // Issue #277: spawn the source's ECS frame entity parented
-        // under the root frame entity. Both the arena `FrameId` and
-        // the ECS `Entity` describe the same logical inertial frame
-        // until consumers migrate off the arena (Section 13 PRs 2–4).
+        // Spawn the source's ECS frame entity parented under the
+        // root frame entity. Both the arena `FrameId` and the ECS
+        // `Entity` describe the same logical inertial frame until
+        // consumers migrate off the arena.
         let source_frame_entity = commands
             .spawn((
                 Name::new(format!("{label}.frame.inertial")),
@@ -132,8 +130,8 @@ pub fn register_source_frames_system(
         // a permanent identity that `source_pfix_rotation()` would
         // mis-report as `Some(identity)` instead of `None`. Plain
         // point-mass sources spawned without `PlanetFixedRotationC` get no
-        // pfix node, matching `jeod_runner` for the same case (PR #260
-        // round-2 review fixup). When rotation IS present and
+        // pfix node, matching `jeod_runner` for the same case. When
+        // rotation IS present and
         // `RotationModelC` is omitted, the EarthRNP default applies —
         // same default as `planet_fixed_rotation_system`.
         if pfix_rot.is_some() {
@@ -146,8 +144,8 @@ pub fn register_source_frames_system(
                     jeod_sim::RefFrameKind::PlanetFixed,
                     jeod_sim::RefFrameState::default(),
                 );
-                // Issue #277: dual-write — spawn the pfix frame entity
-                // parented under the source's ECS frame entity.
+                // Dual-write — spawn the pfix frame entity parented
+                // under the source's ECS frame entity.
                 let pfix_frame_entity = commands
                     .spawn((
                         Name::new(format!("{label}.frame.pfix")),
@@ -204,13 +202,13 @@ pub fn register_pfix_frames_system(
             Entity,
             Option<&Name>,
             &SourceFrameIdC,
-            // Issue #277: read the source's frame entity so the
-            // spawned pfix frame entity can ChildOf-link under it.
+            // Read the source's frame entity so the spawned pfix
+            // frame entity can ChildOf-link under it.
             Option<&FrameEntityC>,
             Option<&RotationModelC>,
             Option<&RetiredPfixFrameIdC>,
-            // Round-1 review fixup: parallel ECS-entity retirement
-            // marker so we reuse instead of leak on toggle cycles.
+            // Parallel ECS-entity retirement marker so we reuse
+            // instead of leak on toggle cycles.
             Option<&RetiredPfixFrameEntityC>,
         ),
         (
@@ -262,13 +260,13 @@ pub fn register_pfix_frames_system(
             )
         };
 
-        // Issue #277: dual-write — restore or spawn the pfix frame
-        // entity. Round-1 review fixup: prefer reusing a retired
-        // entity (parallel to the arena reuse above) so toggle cycles
-        // don't leak ECS entities. Skip the ECS dual-write entirely
-        // if FrameEntityC is missing — that's a source registered
-        // before the issue #277 components landed; the arena pfix is
-        // still updated above for backward compat.
+        // Dual-write — restore or spawn the pfix frame entity.
+        // Prefer reusing a retired entity (parallel to the arena
+        // reuse above) so toggle cycles don't leak ECS entities. Skip
+        // the ECS dual-write entirely if FrameEntityC is missing —
+        // that's a source registered before the frames-as-entities
+        // components landed; the arena pfix is still updated above
+        // for backward compat.
         if let Some(parent_frame) = source_frame_entity {
             let pfix_frame_entity = if let Some(retired_e) = retired_entity {
                 // Reuse: restore canonical name (via Commands so we
@@ -282,9 +280,9 @@ pub fn register_pfix_frames_system(
                 commands
                     .entity(retired_e.0)
                     .insert(Name::new(format!("{label}.frame.pfix")));
-                // Issue #277 round-6 review fixup: fail loud if the
-                // retired pfix frame entity has lost any of its
-                // FrameTransC / FrameRotC / FrameAngVelC components
+                // Fail loud if the retired pfix frame entity has lost
+                // any of its FrameTransC / FrameRotC / FrameAngVelC
+                // components
                 // (or has been despawned out from under us). Silently
                 // skipping these resets would let stale rotation,
                 // angular velocity, or translation state leak into the
@@ -374,7 +372,7 @@ pub fn register_pfix_frames_system(
 /// per-stage source interpolation in [`integration_system`]) see the
 /// current source state rather than the registration-time snapshot.
 ///
-/// Velocity source-of-truth precedence (PR #260 round-3 review fixup):
+/// Velocity source-of-truth precedence:
 ///
 /// 1. [`SourceInertialVelocityC`] when present — the explicit
 ///    per-source velocity component.
@@ -384,9 +382,6 @@ pub fn register_pfix_frames_system(
 ///    (Sun / Moon entities used by SRP / earth-lighting are typically
 ///    spawned this way via `SunBundle` / `MoonBundle`).
 /// 3. Otherwise leave the frame-tree node's velocity unchanged.
-///
-/// Round 2 only consulted `SourceInertialVelocityC`, which left
-/// ephemeris-only sources stuck at zero velocity in the frame tree.
 ///
 /// Runs in `JeodSet::EphemerisUpdate` after `ephemeris_update_system`
 /// (which writes the ECS components from DE4xx) so the FrameTreeR sync
@@ -399,7 +394,7 @@ pub fn sync_source_to_frame_system(
         &SourceInertialPositionC,
         Option<&SourceInertialVelocityC>,
         Option<&TranslationalStateC>,
-        // Issue #277: dual-write target.
+        // Dual-write target.
         Option<&FrameEntityC>,
     )>,
     mut frame_states: Query<&mut FrameTransC>,
@@ -417,17 +412,17 @@ pub fn sync_source_to_frame_system(
             node.state.trans.velocity = v;
         }
 
-        // Issue #277: ECS dual-write to the source's frame entity.
-        // Skip silently if the source was registered before the
-        // issue #277 components landed (no FrameEntityC). When the
-        // component *is* present, the referenced frame entity must
-        // exist and carry FrameTransC — the registration sites
-        // (`PlanetBundle::spawn` / `register_pfix_frames_system`)
-        // spawn it with `FrameTransC::default()` and the despawn
-        // observers tear it down in lockstep with the source. Round-6
-        // review fixup: fail loud if `FrameEntityC` points at a stale
-        // / missing entity instead of silently leaving the ECS half
-        // of the dual-write out of sync with the arena.
+        // ECS dual-write to the source's frame entity. Skip silently
+        // if the source was registered before the frames-as-entities
+        // components landed (no FrameEntityC). When the component *is*
+        // present, the referenced frame entity must exist and carry
+        // FrameTransC — the registration sites (`PlanetBundle::spawn`
+        // / `register_pfix_frames_system`) spawn it with
+        // `FrameTransC::default()` and the despawn observers tear it
+        // down in lockstep with the source. Fail loud if
+        // `FrameEntityC` points at a stale / missing entity instead
+        // of silently leaving the ECS half of the dual-write out of
+        // sync with the arena.
         if let Some(fe) = frame_entity {
             let mut frame_trans = frame_states.get_mut(fe.0).unwrap_or_else(|err| {
                 panic!(
@@ -466,14 +461,13 @@ pub fn sync_source_to_frame_system(
 /// Runs at `Startup` and again before `JeodSet::EphemerisUpdate` to
 /// catch dynamically-spawned bodies. Filters by
 /// `Without<BodyFrameIdC>` so the registration is one-time per body.
-/// Issue #71 items 2 and 4.
 #[allow(clippy::type_complexity)]
 pub fn register_body_frames_system(
     mut commands: Commands,
     mut frame_tree: ResMut<FrameTreeR>,
     root: Res<crate::RootFrameIdR>,
-    // Issue #277: the ECS-side root frame entity, used as the body's
-    // frame parent when no IntegSourceC is supplied.
+    // The ECS-side root frame entity, used as the body's frame
+    // parent when no IntegSourceC is supplied.
     root_frame_entity: Res<crate::RootFrameEntityR>,
     sources: Query<(&SourceFrameIdC, Option<&FrameEntityC>)>,
     bodies: Query<
@@ -482,14 +476,13 @@ pub fn register_body_frames_system(
             Option<&Name>,
             &TranslationalStateC,
             Option<&IntegSourceC>,
-            // PR #283 review thread PRRT_kwDORtae6c5_KiLK — wire the
-            // frame-side `MassPointRef` back-pointer at body-frame
-            // registration time for any entity that also carries
-            // `MassPropertiesC` (i.e. participates in the mass tree).
-            // In the current Bevy adapter the body / mass / frame
-            // ECS entity is one and the same, so the back-pointer
-            // resolves to `MassPointRef(self)`. The component is
-            // skipped for kinematic-only bodies (no
+            // Wire the frame-side `MassPointRef` back-pointer at
+            // body-frame registration time for any entity that also
+            // carries `MassPropertiesC` (i.e. participates in the
+            // mass tree). In the current Bevy adapter the body /
+            // mass / frame ECS entity is one and the same, so the
+            // back-pointer resolves to `MassPointRef(self)`. The
+            // component is skipped for kinematic-only bodies (no
             // `MassPropertiesC`), matching the "absent for
             // kinematic-only attaches" contract on the type.
             Has<MassPropertiesC>,
@@ -507,7 +500,7 @@ pub fn register_body_frames_system(
             .unwrap_or_else(|| format!("body{:?}", entity));
 
         // Resolve the integration frame ID. Default: root inertial.
-        // Issue #277: also resolve the integ frame ECS entity.
+        // Also resolve the integ frame ECS entity.
         let (integ_frame_id, integ_frame_entity) = match integ_source.and_then(|c| c.0) {
             Some(source_entity) => sources
                 .get(source_entity)
@@ -547,22 +540,21 @@ pub fn register_body_frames_system(
             body_state,
         );
 
-        // Issue #277: spawn body frame entity parented under its
-        // integ frame's ECS entity. Tag the integ frame entity with
+        // Spawn the body frame entity parented under its integ
+        // frame's ECS entity. Tag the integ frame entity with
         // `IntegrationFrameMarker` (idempotent insert via Commands).
         // Skip the ECS spawn if we couldn't resolve an integ frame
-        // entity (e.g. a source registered before the issue #277
-        // components landed); the arena body node is still added
-        // above for backward compat.
+        // entity (e.g. a source registered before the
+        // frames-as-entities components landed); the arena body node
+        // is still added above for backward compat.
         //
-        // PR #283 review thread PRRT_kwDORtae6c5_KiLK — also wire the
-        // frame-side `MassPointRef` back-pointer at body-frame
-        // registration time for any entity that also carries
-        // `MassPropertiesC` (i.e. participates in the mass tree). In
-        // the current Bevy adapter the body / mass / frame ECS entity
-        // is one and the same, so the back-pointer resolves to
-        // `MassPointRef(self)`. The component is skipped for
-        // kinematic-only bodies (no `MassPropertiesC`).
+        // Also wire the frame-side `MassPointRef` back-pointer at
+        // body-frame registration time for any entity that also
+        // carries `MassPropertiesC` (i.e. participates in the mass
+        // tree). In the current Bevy adapter the body / mass / frame
+        // ECS entity is one and the same, so the back-pointer
+        // resolves to `MassPointRef(self)`. The component is skipped
+        // for kinematic-only bodies (no `MassPropertiesC`).
         if let Some(parent_frame_entity) = integ_frame_entity {
             commands
                 .entity(parent_frame_entity)
@@ -608,8 +600,7 @@ pub fn register_body_frames_system(
 /// at the body's first sight — a body that starts kinematic-only and
 /// later acquires `MassPropertiesC` would never receive the
 /// back-pointer, and a body that loses `MassPropertiesC` after first
-/// registration would keep a stale one. PR #283 review thread
-/// `PRRT_kwDORtae6c5_K7qF` flagged both directions.
+/// registration would keep a stale one.
 ///
 /// This system handles the post-registration transitions:
 ///
@@ -675,7 +666,7 @@ pub fn sync_body_mass_point_ref_system(
 // in the arena indefinitely with the original name, eventually
 // shadowing a future re-spawn of the same name via
 // [`jeod_sim::FrameTree::find_by_name`] and growing memory
-// monotonically. PR #260 reviewer-flagged gap.
+// monotonically.
 //
 // The observers below adopt the same "logical retirement" pattern
 // `planet_fixed_rotation_system` already uses for the rotation-toggle
@@ -693,11 +684,11 @@ pub fn sync_body_mass_point_ref_system(
 // Each observer cleans up only its own node; ordering across the
 // per-component `Despawn` triggers is therefore irrelevant.
 //
-// Out of scope (tracked in #268): a body whose
-// [`IntegSourceC`]'s source entity is despawned remains alive but
-// integrates against a now-retired frame. The Bevy-native
-// ECS-hierarchy redesign will close this naturally; until then,
-// mission code is responsible for despawning dependent bodies.
+// Out of scope: a body whose [`IntegSourceC`]'s source entity is
+// despawned remains alive but integrates against a now-retired frame.
+// The Bevy-native ECS-hierarchy redesign will close this naturally;
+// until then, mission code is responsible for despawning dependent
+// bodies.
 fn retire_frame_node(tree: &mut jeod_sim::FrameTree, fid: jeod_sim::FrameId) {
     let node = tree.get_mut(fid);
     if !node.name.ends_with(".despawned") {
@@ -784,13 +775,12 @@ pub fn on_retired_pfix_frame_entity_despawn(
 }
 
 /// On entity despawn, despawn the *frame entity* the source / body
-/// entity carries in [`FrameEntityC`]. Issue #277 PR 1 round-2
-/// review fixup (Copilot, comments 3177683390 + 3177683392):
-/// without this observer, despawning a source or body would leave
-/// its dual-write frame entity (and the pfix child it parents,
-/// when present) alive indefinitely under the root frame entity,
-/// growing the entity count over time and potentially shadowing
-/// future re-spawns of the same `Name`.
+/// entity carries in [`FrameEntityC`]. Without this observer,
+/// despawning a source or body would leave its dual-write frame
+/// entity (and the pfix child it parents, when present) alive
+/// indefinitely under the root frame entity, growing the entity
+/// count over time and potentially shadowing future re-spawns of
+/// the same `Name`.
 ///
 /// Fires for *any* entity that carries [`FrameEntityC`], i.e. both
 /// source entities (registered by [`register_source_frames_system`])
@@ -798,11 +788,9 @@ pub fn on_retired_pfix_frame_entity_despawn(
 /// The cleanup logic is identical for the two cases — the despawning
 /// entity hands us its frame-entity handle and we tear down the
 /// referenced frame entity — so the observer is named for the
-/// component it watches, not for either of the owner kinds. (Issue
-/// #277 PR 1 round-8 review fixup, threadId
-/// `PRRT_kwDORtae6c5_LE-U`: the previous name
-/// `on_source_frame_entity_despawn` misled future readers into
-/// thinking the observer only handled sources.)
+/// component it watches, not for either of the owner kinds (a
+/// previous name `on_source_frame_entity_despawn` misled readers
+/// into thinking the observer only handled sources).
 ///
 /// `try_despawn` (not `despawn`) because Bevy's `ChildOf` /
 /// `Children` relationship already triggers recursive despawn on the
@@ -815,10 +803,10 @@ pub fn on_retired_pfix_frame_entity_despawn(
 /// retirement helpers in this module.
 ///
 /// Mirrors [`on_source_frame_despawn`] / [`on_body_frame_despawn`]
-/// on the ECS-entity track, closing the issue #277 PR 1 round-2
-/// gap: the dual-write spawn sites in
+/// on the ECS-entity track, providing a parallel cleanup for the
+/// dual-write spawn sites in
 /// [`register_source_frames_system`] and
-/// [`register_body_frames_system`] had no parallel cleanup.
+/// [`register_body_frames_system`].
 pub fn on_frame_entity_despawn(
     trigger: On<Despawn, FrameEntityC>,
     owners: Query<&FrameEntityC>,
@@ -858,13 +846,13 @@ pub fn on_source_pfix_frame_entity_despawn(
 /// sees current body state when evaluating switch distances.
 ///
 /// Runs in `JeodSet::Integration` after `integration_system` and
-/// before `frame_switch_system`. Issue #71 item 2.
+/// before `frame_switch_system`.
 pub fn sync_body_to_frame_system(
     mut frame_tree: ResMut<FrameTreeR>,
     bodies: Query<(
         &TranslationalStateC,
         &BodyFrameIdC,
-        // Issue #277: dual-write target.
+        // Dual-write target.
         Option<&FrameEntityC>,
     )>,
     mut frame_states: Query<&mut FrameTransC>,
@@ -878,17 +866,16 @@ pub fn sync_body_to_frame_system(
         node.state.trans.position = position;
         node.state.trans.velocity = velocity;
 
-        // Issue #277: ECS dual-write to the body's frame entity.
-        // Skip silently if the body was registered before the
-        // issue #277 components landed (no FrameEntityC). When the
-        // component *is* present, the referenced body frame entity
-        // must exist and carry FrameTransC — `register_body_frames_system`
+        // ECS dual-write to the body's frame entity. Skip silently
+        // if the body was registered before the frames-as-entities
+        // components landed (no FrameEntityC). When the component
+        // *is* present, the referenced body frame entity must exist
+        // and carry FrameTransC — `register_body_frames_system`
         // spawns it with `FrameTransC` populated from the body's
         // initial state, and the despawn observers tear it down in
-        // lockstep with the body. Round-6 review fixup: fail loud if
-        // `FrameEntityC` points at a stale / missing entity instead
-        // of silently leaving the ECS half of the dual-write out of
-        // sync with the arena.
+        // lockstep with the body. Fail loud if `FrameEntityC` points
+        // at a stale / missing entity instead of silently leaving
+        // the ECS half of the dual-write out of sync with the arena.
         if let Some(fe) = frame_entity {
             let mut frame_trans = frame_states.get_mut(fe.0).unwrap_or_else(|err| {
                 panic!(
@@ -918,15 +905,15 @@ pub fn sync_body_to_frame_system(
 /// source becomes non-differential.
 ///
 /// Runs in `JeodSet::Integration` after [`sync_body_to_frame_system`].
-/// Bodies without [`FrameSwitchesC`] are skipped. Issue #71 item 3.
+/// Bodies without [`FrameSwitchesC`] are skipped.
 ///
 /// JEOD reference: `dyn_body_frame_switch.cc:173-182`. The Bevy adapter
 /// borrows the same logic via the lifted helper, so behavior is
 /// bit-identical to `jeod_runner::Simulation` for the same scenario.
 ///
-/// Phase C4: `FrameSwitchConfig<Entity>` and `GravityControls<Entity>`
-/// flow into the generic helper directly via a closure-based source
-/// lookup; there is no longer a `usize`-keyed bridge.
+/// `FrameSwitchConfig<Entity>` and `GravityControls<Entity>` flow into
+/// the generic helper directly via a closure-based source lookup;
+/// there is no `usize`-keyed bridge.
 #[allow(clippy::type_complexity)]
 pub fn frame_switch_system(
     mut frame_tree: ResMut<FrameTreeR>,
@@ -1049,7 +1036,7 @@ pub fn planet_fixed_rotation_system(
         Option<&PlanetOmegaC>,
         Option<&mut PlanetAngularVelocityC>,
         Option<&SourcePfixFrameIdC>,
-        // Issue #277: dual-write target for the pfix frame entity.
+        // Dual-write target for the pfix frame entity.
         Option<&PfixFrameEntityC>,
     )>,
     mut frame_rots: Query<&mut FrameRotC>,
@@ -1138,19 +1125,17 @@ pub fn planet_fixed_rotation_system(
         // on the pfix frame node. Mirror that on (a) the `PlanetAngularVelocityC`
         // ECS component and (b) the FrameTreeR pfix node so velocity
         // composition both via the typed component and via the lifted
-        // `compute_relative_state` reads the correct rate. Issue #71 item 1
-        // + Copilot review (PR #260): the pfix-node sync via
-        // `jeod_sim::sync_pfix_rotation` is what closes the frame-tree
-        // half of the gap.
+        // `compute_relative_state` reads the correct rate. The
+        // pfix-node sync via `jeod_sim::sync_pfix_rotation` is what
+        // closes the frame-tree half of the gap.
         if rotated {
             // Falling back to `0.0` for a rotating planet (`RotationModelC`
             // present but `PlanetOmegaC` absent) silently misreports the
-            // pfix angular velocity as zero, which leaves issue #71 item 1
-            // broken for manual-spawn call sites that include
-            // `PlanetFixedRotationC` + `RotationModelC` but not
-            // `PlanetOmegaC`. Map the rotation model to the canonical
-            // `PlanetConfig::omega` when the explicit override is absent
-            // (PR #260 round-2 review fixup).
+            // pfix angular velocity as zero for manual-spawn call sites
+            // that include `PlanetFixedRotationC` + `RotationModelC` but
+            // not `PlanetOmegaC`. Map the rotation model to the
+            // canonical `PlanetConfig::omega` when the explicit
+            // override is absent.
             let default_omega = match rotation_model {
                 jeod_sim::RotationModel::None => 0.0,
                 jeod_sim::RotationModel::EarthRNP => jeod_sim::EARTH.omega,
@@ -1177,17 +1162,17 @@ pub fn planet_fixed_rotation_system(
             if let (Some(matrix), Some(pfix_fid)) = (raw_matrix, pfix_fid) {
                 jeod_sim::sync_pfix_rotation(&mut frame_tree.0, pfix_fid.0, matrix, omega_value);
             }
-            // Issue #277: ECS dual-write to the pfix frame entity.
-            // Same data, different storage — keeps `RelativeFrameState`
+            // ECS dual-write to the pfix frame entity. Same data,
+            // different storage — keeps `RelativeFrameState`
             // bit-identical with the arena via `compute_relative_state`.
-            // Round-6 review fixup: when `PfixFrameEntityC` is present
-            // the referenced entity must be alive with FrameRotC /
-            // FrameAngVelC intact (spawned by `register_pfix_frames_system`,
-            // torn down in lockstep with the marker by the despawn
-            // observers and the rotation-toggle retirement path). A
-            // stale handle here would silently leave the ECS pfix
-            // rotation/omega out of sync with the arena, breaking the
-            // dual-write invariant.
+            // When `PfixFrameEntityC` is present the referenced entity
+            // must be alive with FrameRotC / FrameAngVelC intact
+            // (spawned by `register_pfix_frames_system`, torn down in
+            // lockstep with the marker by the despawn observers and
+            // the rotation-toggle retirement path). A stale handle
+            // here would silently leave the ECS pfix rotation/omega
+            // out of sync with the arena, breaking the dual-write
+            // invariant.
             if let (Some(matrix), Some(pfix_fe)) = (raw_matrix, pfix_frame_entity) {
                 let mut frame_rot = frame_rots.get_mut(pfix_fe.0).unwrap_or_else(|err| {
                     panic!(
@@ -1231,7 +1216,7 @@ pub fn planet_fixed_rotation_system(
             // last-tick `(matrix, omega)` on the FrameTreeR pfix node —
             // so frame-tree queries would still report a rotating
             // planet-fixed frame even though the source is configured
-            // as non-rotating. PR #260 round-9 review fixup.
+            // as non-rotating.
             // allowed: explicit identity clear when rotation model toggles to None;
             // the RootInertial → PlanetFixed<SelfPlanet> phantoms are correct by
             // construction (same shape as the rotating-branch from_matrix sites).
@@ -1252,10 +1237,9 @@ pub fn planet_fixed_rotation_system(
                     glam::DMat3::IDENTITY,
                     0.0,
                 );
-                // Issue #277: ECS dual-write — clear the pfix frame
-                // entity's state to identity so any
-                // `RelativeFrameState` reader sees the same identity
-                // clear as the arena. Round-6 review fixup: when
+                // ECS dual-write — clear the pfix frame entity's state
+                // to identity so any `RelativeFrameState` reader sees
+                // the same identity clear as the arena. When
                 // `PfixFrameEntityC` is present, the referenced entity
                 // must be alive with FrameRotC / FrameAngVelC intact;
                 // silently skipping the clear would leave the ECS
@@ -1323,15 +1307,16 @@ pub fn planet_fixed_rotation_system(
                     .remove::<SourcePfixFrameIdC>()
                     .insert(RetiredPfixFrameIdC(pfix_fid.0));
 
-                // Round-1 review fixup: mirror the arena retirement on
-                // the ECS-entity side. Without this, the source kept a
-                // stale `PfixFrameEntityC` handle pointing at an
+                // Mirror the arena retirement on the ECS-entity side.
+                // Without this, the source would keep a stale
+                // `PfixFrameEntityC` handle pointing at an
                 // identity-cleared but otherwise live entity *and*
                 // `register_pfix_frames_system` (which filters by
-                // `Without<SourcePfixFrameIdC>`) spawned a fresh pfix
-                // frame entity on every retoggle — leaking one orphan
-                // ECS entity per `None → rotating → None …` cycle in
-                // addition to the (already-bounded) arena leak.
+                // `Without<SourcePfixFrameIdC>`) would spawn a fresh
+                // pfix frame entity on every retoggle — leaking one
+                // orphan ECS entity per `None → rotating → None …`
+                // cycle in addition to the (already-bounded) arena
+                // leak.
                 //
                 // Retirement semantics for the entity parallel the
                 // arena: the orphan entity stays alive (its
@@ -1439,8 +1424,7 @@ pub fn ephemeris_update_system(
 /// Placed before `JeodSet::EphemerisUpdate` so gravity and force collection
 /// see current mass properties.
 ///
-/// **Change-detection contract** (PR #283 review thread
-/// `PRRT_kwDORtae6c5_K0dm`): the dirty-flag check below is read through
+/// **Change-detection contract**: the dirty-flag check below is read through
 /// `Mut::deref` (immutable access), and `recompute_derived()` is only
 /// invoked — triggering `DerefMut` and marking the component as
 /// `Changed` — when the entity actually needs updating. Without this
@@ -1531,8 +1515,9 @@ pub fn force_collection_system(
         // RotationalStateC and MassPropertiesC now wrap typed siblings;
         // convert to untyped at the kernel boundary. (The kernel
         // signature still takes the untyped form. Migrating the kernel
-        // signature itself is out of scope for #172 H1; the win here
-        // is at the ECS surface where mission code interacts.)
+        // signature itself is out of scope for the ECS-surface typing;
+        // the win here is at the ECS surface where mission code
+        // interacts.)
         let rot_untyped = rot_state.map(|r| r.0.to_untyped());
         let mass_untyped = mass.map(|m| m.0.to_untyped());
 
@@ -1642,7 +1627,7 @@ pub fn integration_system(
             Option<&TidalConfigC>,
             // Fallback velocity source for ephemeris-driven sources (Sun /
             // Moon via SunBundle / MoonBundle) that don't carry
-            // SourceInertialVelocityC. PR #260 round-3 review.
+            // SourceInertialVelocityC.
             Option<&TranslationalStateC>,
         ),
         // Static disjointness vs. the `bodies` query's `&mut
@@ -1678,7 +1663,7 @@ pub fn integration_system(
     // similarly interpolated when the integ frame moves, so the Newtonian
     // gravity field stays consistent across stages. PPN (relativistic)
     // corrections use step-start source state — runner does the same
-    // (`step/integrate.rs:199-202`). Issue #71 item 4 + PR #260 review.
+    // (`step/integrate.rs:199-202`).
     let eval_gravity = |entity: Entity,
                         controls: &GravityControlsC,
                         pos: DVec3,
@@ -1703,18 +1688,18 @@ pub fn integration_system(
         // for the thermal-SRP path) accept a `gravity_fn` closure
         // that receives raw `DVec3` per-stage state. These lifts are
         // inside `jeod_sim` boundary territory, not at the Bevy ECS
-        // surface that #172 H1 was specifically about.
+        // surface where the typed quantities live.
         let typed_abs_pos = Position::<RootInertial>::from_raw_si(pos + stage_origin_pos); // allowed: integrator-kernel boundary
         let typed_abs_vel = Velocity::<RootInertial>::from_raw_si(vel + integ_origin_vel); // allowed: integrator-kernel boundary
         let typed_origin = Position::<RootInertial>::from_raw_si(stage_origin_pos); // allowed: integrator-kernel boundary
 
         // Helper: resolve a source's effective velocity, falling back to
         // `TranslationalStateC.velocity` when the explicit
-        // `SourceInertialVelocityC` component is absent. PR #260 round-3
-        // fix — without the fallback, ephemeris-driven Sun/Moon sources
-        // (spawned via SunBundle/MoonBundle, which include
-        // `TranslationalStateC` but not `SourceInertialVelocityC`) get
-        // treated as stationary at every RK sub-stage.
+        // `SourceInertialVelocityC` component is absent. Without the
+        // fallback, ephemeris-driven Sun/Moon sources (spawned via
+        // SunBundle/MoonBundle, which include `TranslationalStateC`
+        // but not `SourceInertialVelocityC`) get treated as stationary
+        // at every RK sub-stage.
         let source_vel =
             |v: Option<&SourceInertialVelocityC>, ts: Option<&TranslationalStateC>| -> DVec3 {
                 v.map(|v| v.0.raw_si())
@@ -1757,8 +1742,6 @@ pub fn integration_system(
         // and velocities — `jeod_runner::run_integration` snapshots both
         // outside the per-stage closure (`step/integrate.rs:199-202`),
         // so per-stage interpolation here would drift from runner.
-        // (Round-2 PR #260 introduced the per-stage interpolation; round
-        // 3 review R1 caught the divergence.)
         let rel = jeod_sim::accumulate_relativistic_corrections_typed(
             typed_abs_pos,
             typed_abs_vel,
@@ -1805,7 +1788,7 @@ pub fn integration_system(
         // Per-body integration-frame origin (relative to root). Computed
         // once per step — the integ frame doesn't move during a single
         // integration step, so the multi-stage RK4 sub-evaluations
-        // reuse the same value. Issue #71 item 4.
+        // reuse the same value.
         let (integ_origin_pos, integ_origin_vel) = match integ_frame {
             Some(c) if c.0 != root.0 => jeod_sim::frame_origin(&frame_tree.0, root.0, c.0),
             _ => (DVec3::ZERO, DVec3::ZERO),
@@ -1890,7 +1873,7 @@ pub fn integration_system(
                     // intermediate `DVec3` in the body's *integration*
                     // frame, which equals root inertial only when
                     // `IntegFrameIdC == root`. For `IntegFrameIdC != root`
-                    // (issue #71 item 4) we shift via the per-stage origin
+                    // we shift via the per-stage origin
                     // before differencing against `srp_inputs.sun_position`
                     // (which is typed `Position<RootInertial>`). Mirrors
                     // `jeod_runner::run_integration`'s coupled SRP path
@@ -2069,8 +2052,8 @@ pub fn integration_system(
 /// gravity field; the same origin is passed to
 /// [`jeod_sim::accumulate_gravity_typed`] so the differential gravity
 /// correction subtracts the integ frame's own acceleration toward each
-/// source. Issue #71 item 4. Bodies without [`IntegFrameIdC`] continue
-/// to use the root inertial frame as before.
+/// source. Bodies without [`IntegFrameIdC`] continue to use the root
+/// inertial frame as before.
 #[allow(clippy::type_complexity)]
 pub fn gravity_computation_system(
     frame_tree: Res<FrameTreeR>,
@@ -2090,24 +2073,22 @@ pub fn gravity_computation_system(
         Option<&TidalDeltaC20C>,
         Option<&TidalConfigC>,
         // Fallback velocity source for ephemeris-driven sources that
-        // don't carry SourceInertialVelocityC. PR #260 round-3.
+        // don't carry SourceInertialVelocityC.
         Option<&TranslationalStateC>,
     )>,
 ) {
     for (entity, state, controls, mut accel, integ_frame) in &mut bodies {
         // TranslationalStateC stores typed `Position<IntegrationFrame>` /
-        // `Velocity<IntegrationFrame>` (issue #71 item 4 + #255). For
-        // root-integrated bodies the integ frame numerically equals
-        // root inertial, so the raw values match what gravity wants.
-        // For non-root bodies we shift to absolute root-inertial
-        // coordinates below via `IntegFrameIdC` + `frame_origin_typed`.
-        // (Pre-#172-H1 the system extracted raw DVec3 here and called
-        // `from_raw_si` to mint typed values; that bypass is gone.)
+        // `Velocity<IntegrationFrame>`. For root-integrated bodies the
+        // integ frame numerically equals root inertial, so the raw
+        // values match what gravity wants. For non-root bodies we
+        // shift to absolute root-inertial coordinates below via
+        // `IntegFrameIdC` + `frame_origin_typed`.
         let body_pos = state.position;
         let body_vel = state.velocity;
 
         // Integration-frame origin (relative to root). Zero for
-        // root-integrated bodies. Issue #71 item 4 + Phase C5: typed
+        // root-integrated bodies. Typed
         // `frame_origin_typed::<RootInertial>` returns `Position<RootInertial>`
         // directly, so no `from_raw_si` lift is needed at the boundary.
         let (integ_origin, integ_origin_vel) = match integ_frame {
@@ -2168,7 +2149,7 @@ pub fn gravity_computation_system(
                     .map(|(s, _, p, v, _, _, ts)| {
                         // Fall back to TranslationalStateC.velocity when
                         // SourceInertialVelocityC is absent — same precedence
-                        // as `sync_source_to_frame_system`. PR #260 round-3.
+                        // as `sync_source_to_frame_system`.
                         let velocity = v
                             .map(|v| v.0.raw_si())
                             .or_else(|| ts.map(|t| t.0.velocity.raw_si()))
@@ -2265,8 +2246,8 @@ pub fn aero_drag_system(
         // the system reads them directly. The result carries
         // `StructuralFrame<SelfRef>` phantoms, which the structural-frame
         // `AerodynamicForceC` unwraps via `.raw_si()` for storage (the
-        // structural-frame Component still uses raw DVec3; that's the
-        // remaining boundary inside the H1 migration).
+        // structural-frame Component still uses raw DVec3; that's a
+        // remaining typed-storage boundary).
         let rot_untyped = rot.0.to_untyped();
         // Bevy adapter stores body velocity as `Velocity<RootInertial>`
         // (current sims have root=Earth.inertial). Drag's typed sibling
@@ -2274,7 +2255,7 @@ pub fn aero_drag_system(
         // bit-identical and asserts the Earth-orbit assumption.
         use jeod_sim::{Earth, PlanetInertial, Velocity};
         // allowed: RootInertial → PlanetInertial<Earth> relabel for the
-        // typed sibling; bit-identical (no arithmetic). Documented at #255.
+        // typed sibling; bit-identical (no arithmetic).
         let drag_velocity = Velocity::<PlanetInertial<Earth>>::from_raw_si(state.velocity.raw_si());
         let result = jeod_sim::compute_drag_typed::<Earth, SelfRef>(
             &drag_config.0,
@@ -2360,7 +2341,7 @@ pub fn orbital_elements_system(
         use jeod_sim::{Earth, PlanetInertial, Position, Velocity};
         let mu_typed = jeod_sim::F64Ext::m3_per_s2(source.mu);
         // allowed: RootInertial → PlanetInertial<Earth> relabel for the
-        // typed sibling; bit-identical (no arithmetic). Documented at #255.
+        // typed sibling; bit-identical (no arithmetic).
         let pos = Position::<PlanetInertial<Earth>>::from_raw_si(state.position.raw_si());
         // allowed: same relabel as `pos` above.
         let vel = Velocity::<PlanetInertial<Earth>>::from_raw_si(state.velocity.raw_si());
@@ -2408,7 +2389,7 @@ pub fn lvlh_system(mut query: Query<(&TranslationalStateC, &mut LvlhFrameC)>) {
         // assumption that root coincides with Earth.inertial here.
         use jeod_sim::{Earth, PlanetInertial};
         // allowed: RootInertial → PlanetInertial<Earth> relabel for the
-        // typed sibling; bit-identical (no arithmetic). Documented at #255.
+        // typed sibling; bit-identical (no arithmetic).
         let pos = jeod_sim::Position::<PlanetInertial<Earth>>::from_raw_si(state.position.raw_si());
         // allowed: same relabel as `pos` above.
         let vel = jeod_sim::Velocity::<PlanetInertial<Earth>>::from_raw_si(state.velocity.raw_si());
@@ -2434,7 +2415,7 @@ pub fn geodetic_system(
         use jeod_sim::F64Ext;
         use jeod_sim::{Earth, PlanetInertial};
         // allowed: RootInertial → PlanetInertial<Earth> relabel for the
-        // typed sibling; bit-identical (no arithmetic). Documented at #255.
+        // typed sibling; bit-identical (no arithmetic).
         let pos = jeod_sim::Position::<PlanetInertial<Earth>>::from_raw_si(state.position.raw_si());
         geodetic.0 = jeod_sim::compute_body_geodetic_typed::<Earth>(
             pos,
@@ -2850,8 +2831,7 @@ pub fn staging_system(
 
     // Sync composite mass properties for all affected nodes.
     //
-    // PR #283 review thread PRRT_kwDORtae6c5_KHnH: these writes go
-    // through `bypass_change_detection` because the value being
+    // These writes go through `bypass_change_detection` because the value being
     // written is the *composite* (post-Steiner) mass, not a core-mass
     // edit by mission code. The `composite_mass_system` ECS path uses
     // `Changed<MassPropertiesC>` to detect mid-sim core edits (fuel

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -10,14 +10,14 @@
 //! matches JEOD's `DynManager` which only invariants bodies that participate
 //! in integration.
 //!
-//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2): the `is_root_equivalent`
-//! function reads [`crate::FrameTreeR`] (now `#[deprecated]` for
-//! mission-code use) to compare a body's integration frame against the
-//! root. This is *internal* validation infrastructure and is rewritten
-//! in PR 3 (#279) to use [`crate::frame_param::RelativeFrameState`] /
+//! The `is_root_equivalent` function reads [`crate::FrameTreeR`] (now
+//! `#[deprecated]` for mission-code use) to compare a body's
+//! integration frame against the root. This is *internal* validation
+//! infrastructure and is scheduled to migrate to
+//! [`crate::frame_param::RelativeFrameState`] /
 //! [`crate::frame_param::FrameOrigin`]. The file-level
 //! `#![allow(deprecated)]` keeps the call sites quiet until then.
-#![allow(deprecated)] // Issue #278: internal FrameTreeR consumer; rewritten in PR 3 (#279)
+#![allow(deprecated)] // Internal FrameTreeR consumer during the dual-write phase.
 
 use bevy::prelude::*;
 
@@ -130,10 +130,10 @@ pub fn validate_jeod_invariants(
         Option<&MoonMarker>,
         Option<&TranslationalStateC>,
     )>,
-    // Frame-tree state for non-root validation. PR #260 round-8 fixup:
-    // mirrors `Simulation::validate()`'s frame-switch + non-root checks
+    // Frame-tree state for non-root validation. Mirrors
+    // `Simulation::validate()`'s frame-switch + non-root checks
     // (`crates/jeod_runner/src/simulation/validate.rs:129-184`) so the
-    // typed `VehicleBuilder` API (which now plumbs `integ_source` and
+    // typed `VehicleBuilder` API (which plumbs `integ_source` and
     // `frame_switches` through `spawn_bevy`) doesn't silently land
     // bodies in misconfigured non-root setups.
     body_frame_state: Query<(Option<&IntegFrameIdC>, Option<&FrameSwitchesC>)>,
@@ -286,8 +286,8 @@ pub fn validate_jeod_invariants(
 
         // ── Frame-switch + non-root frame validation ──
         // Mirrors `Simulation::validate()` checks at
-        // `crates/jeod_runner/src/simulation/validate.rs:129-184` (PR #260
-        // round-8 fixup): every active `FrameSwitchConfig.target_source`
+        // `crates/jeod_runner/src/simulation/validate.rs:129-184`: every
+        // active `FrameSwitchConfig.target_source`
         // must (a) be a registered gravity source and (b) appear in the
         // body's `gravity_controls` so the post-switch differential flip
         // leaves a non-differential central body. Bodies whose

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -11,7 +11,7 @@
 //! in integration.
 //!
 //! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2): the `is_root_equivalent`
-//! folder reads [`crate::FrameTreeR`] (now `#[deprecated]` for
+//! function reads [`crate::FrameTreeR`] (now `#[deprecated]` for
 //! mission-code use) to compare a body's integration frame against the
 //! root. This is *internal* validation infrastructure and is rewritten
 //! in PR 3 (#279) to use [`crate::frame_param::RelativeFrameState`] /

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -9,6 +9,15 @@
 //! growth). Bodies added without `GravityControlsC` are not validated; this
 //! matches JEOD's `DynManager` which only invariants bodies that participate
 //! in integration.
+//!
+//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2): the `is_root_equivalent`
+//! folder reads [`crate::FrameTreeR`] (now `#[deprecated]` for
+//! mission-code use) to compare a body's integration frame against the
+//! root. This is *internal* validation infrastructure and is rewritten
+//! in PR 3 (#279) to use [`crate::frame_param::RelativeFrameState`] /
+//! [`crate::frame_param::FrameOrigin`]. The file-level
+//! `#![allow(deprecated)]` keeps the call sites quiet until then.
+#![allow(deprecated)] // Issue #278: internal FrameTreeR consumer; rewritten in PR 3 (#279)
 
 use bevy::prelude::*;
 

--- a/tests/bevy_frame_tree_despawn_cleanup.rs
+++ b/tests/bevy_frame_tree_despawn_cleanup.rs
@@ -1,4 +1,4 @@
-//! `FrameTreeR` despawn cleanup (PR #260 reviewer-flagged gap).
+//! `FrameTreeR` despawn cleanup.
 //!
 //! The frame tree is append-only — `jeod_frames::FrameTree` exposes no
 //! removal API because arena indices are stable handles other state may
@@ -12,13 +12,13 @@
 //! longer findable and any stale `frame_origin` query returns identity.
 //! See `src/systems.rs` "Frame-tree despawn cleanup" for the design.
 
-// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
-// `#[deprecated]` for mission-code use. These despawn-observer tests
-// validate the arena's per-node cleanup, which is the *internal*
-// dual-write infrastructure PR 4 (#280) replaces wholesale (the
-// resource itself is removed; ECS frame-entity despawn observers
-// stay). File-level `#![allow(deprecated)]` to keep the cleanup
-// validation operating against the still-live arena until PR 4.
+// `FrameTreeR` is `#[deprecated]` for mission-code use. These
+// despawn-observer tests validate the arena's per-node cleanup, which
+// is the *internal* dual-write infrastructure that will be replaced
+// wholesale once the resource is removed (the ECS frame-entity
+// despawn observers stay). File-level `#![allow(deprecated)]` to keep
+// the cleanup validation operating against the still-live arena until
+// then.
 #![allow(deprecated)]
 
 use std::time::Duration;
@@ -226,7 +226,7 @@ fn retired_pfix_node_despawn_retires_orphan() {
     );
 }
 
-// ── Issue #277 PR 1 round-2 review: ECS frame-entity cleanup ──
+// ── ECS frame-entity cleanup ──
 //
 // `register_source_frames_system` and `register_body_frames_system`
 // dual-write a frame *entity* alongside the arena `FrameId`. Without

--- a/tests/bevy_frame_tree_despawn_cleanup.rs
+++ b/tests/bevy_frame_tree_despawn_cleanup.rs
@@ -12,6 +12,15 @@
 //! longer findable and any stale `frame_origin` query returns identity.
 //! See `src/systems.rs` "Frame-tree despawn cleanup" for the design.
 
+// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
+// `#[deprecated]` for mission-code use. These despawn-observer tests
+// validate the arena's per-node cleanup, which is the *internal*
+// dual-write infrastructure PR 4 (#280) replaces wholesale (the
+// resource itself is removed; ECS frame-entity despawn observers
+// stay). File-level `#![allow(deprecated)]` to keep the cleanup
+// validation operating against the still-live arena until PR 4.
+#![allow(deprecated)]
+
 use std::time::Duration;
 
 use bevy::prelude::*;

--- a/tests/bevy_parity_frame_switch.rs
+++ b/tests/bevy_parity_frame_switch.rs
@@ -1,4 +1,4 @@
-//! Tier 3: Bevy frame-switch parity (issue #71 item 3).
+//! Tier 3: Bevy frame-switch parity.
 //!
 //! Verifies that distance-based integration-frame switching is
 //! bit-identical between Bevy `FrameSwitchesC` + `frame_switch_system`
@@ -13,11 +13,10 @@
 //! and its gravity controls flip so Moon becomes central
 //! (`differential = false`) and Earth becomes the third body.
 
-// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
-// `#[deprecated]` for mission-code use. This Tier 3 parity test
-// deliberately reads the arena to assert bit-identity of the
-// frame-switch reparent path against `jeod_runner`. PR 4 (#280)
-// removes the resource; the arena read here will be rewritten to use
+// `FrameTreeR` is `#[deprecated]` for mission-code use. This Tier 3
+// parity test deliberately reads the arena to assert bit-identity of
+// the frame-switch reparent path against `jeod_runner`. Once the
+// resource is removed, the arena read here will be rewritten to use
 // `RelativeFrameState`.
 #![allow(deprecated)]
 
@@ -96,7 +95,7 @@ fn tier3_bevy_frame_switch_earth_to_moon_matches_simulation() {
         .insert(SourceInertialVelocityC::default())
         .id();
 
-    // Phase C4: `FrameSwitchConfig<Entity>` — the Bevy adapter references
+    // `FrameSwitchConfig<Entity>` — the Bevy adapter references
     // gravity sources by their ECS entity, no usize bridge.
     let switches: Vec<FrameSwitchConfig<Entity>> = vec![FrameSwitchConfig {
         target_source: moon,
@@ -264,8 +263,8 @@ fn tier3_bevy_frame_switch_earth_to_moon_matches_simulation() {
 
 #[test]
 fn tier3_bevy_frame_switch_on_departure_matches_simulation() {
-    // PR #260 round-3 T5 fixup: cover the `OnDeparture` predicate in the
-    // shared generic helper. The `OnApproach` test above triggers a
+    // Cover the `OnDeparture` predicate in the shared generic helper.
+    // The `OnApproach` test above triggers a
     // switch when the body comes within `SWITCH_RADIUS` of the Moon;
     // this test triggers when the body departs beyond a threshold from
     // its *current* integration frame's origin (the body's

--- a/tests/bevy_parity_frame_switch.rs
+++ b/tests/bevy_parity_frame_switch.rs
@@ -13,6 +13,14 @@
 //! and its gravity controls flip so Moon becomes central
 //! (`differential = false`) and Earth becomes the third body.
 
+// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
+// `#[deprecated]` for mission-code use. This Tier 3 parity test
+// deliberately reads the arena to assert bit-identity of the
+// frame-switch reparent path against `jeod_runner`. PR 4 (#280)
+// removes the resource; the arena read here will be rewritten to use
+// `RelativeFrameState`.
+#![allow(deprecated)]
+
 use std::time::Duration;
 
 use bevy::prelude::*;

--- a/tests/bevy_parity_planet_ang_vel.rs
+++ b/tests/bevy_parity_planet_ang_vel.rs
@@ -1,10 +1,9 @@
 //! Tier 3: Bevy App vs jeod_runner::Simulation parity for the
-//! planet-fixed frame's angular velocity (issue #71 item 1).
+//! planet-fixed frame's angular velocity.
 //!
-//! Issue #71 catalogued that `jeod_runner::Simulation` writes
-//! `ang_vel_this = [0, 0, planet_omega]` onto every pfix node each step
-//! (matching JEOD's `planet_rnp.cc`), while the Bevy adapter only wrote
-//! the rotation matrix. This test exercises the new
+//! `jeod_runner::Simulation` writes `ang_vel_this = [0, 0, planet_omega]`
+//! onto every pfix node each step (matching JEOD's `planet_rnp.cc`),
+//! and the Bevy adapter must do the same. This test exercises the
 //! `PlanetAngularVelocityC` component populated by
 //! `planet_fixed_rotation_system` and asserts:
 //!
@@ -12,16 +11,11 @@
 //!    `[0, 0, omega_planet]` for each rotation model.
 //! 2. The Bevy value is bit-identical to the corresponding pfix node's
 //!    `state.rot.ang_vel_this` in `jeod_runner::Simulation::frame_tree()`.
-//!
-//! Phase B step B11 of the issue #71 plan; closes the parity-test gap
-//! flagged in the plan (no existing parity test exercises pfix angular
-//! velocity).
 
-// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
-// `#[deprecated]` for mission-code use. This Tier 3 parity test reads
-// the arena to assert bit-identity of the pfix-rotation node sync
-// path. PR 4 (#280) removes the resource; the arena reads here will
-// be rewritten to use `RelativeFrameState`.
+// `FrameTreeR` is `#[deprecated]` for mission-code use. This Tier 3
+// parity test reads the arena to assert bit-identity of the
+// pfix-rotation node sync path. Once the resource is removed, the
+// arena reads here will be rewritten to use `RelativeFrameState`.
 #![allow(deprecated)]
 
 use std::time::Duration;
@@ -103,7 +97,7 @@ fn sim_pfix_ang_vel(sim: &Simulation, name: &str) -> DVec3 {
 
 /// Read the FrameTreeR pfix node's `ang_vel_this` for a Bevy planet
 /// entity. Asserts the pfix-node-of-truth is in sync with the ECS
-/// `PlanetAngularVelocityC` component (PR #260 review fixup).
+/// `PlanetAngularVelocityC` component.
 fn bevy_pfix_node_ang_vel(app: &App, planet: Entity) -> DVec3 {
     let pfix_fid = app
         .world()
@@ -135,7 +129,7 @@ fn tier3_bevy_planet_ang_vel_earth_rnp() {
     assert_dvec3_bits_eq("Bevy vs Sim Earth pfix ang_vel", bevy_ang_vel, sim_ang_vel);
 
     // FrameTreeR pfix node must match too — frame-tree consumers rely
-    // on this (compute_relative_state through pfix). PR #260 review.
+    // on this (compute_relative_state through pfix).
     let bevy_node_ang_vel = bevy_pfix_node_ang_vel(&app, planet);
     assert_dvec3_bits_eq(
         "Bevy FrameTreeR Earth pfix-node ang_vel vs Sim",
@@ -283,7 +277,7 @@ fn tier3_bevy_rotation_none_toggle_removes_pfix_component() {
         app.world().get::<SourcePfixFrameIdC>(planet).is_none(),
         "toggling RotationModel to None must remove SourcePfixFrameIdC; \
          leaving it in place reintroduces the Some(identity) vs None \
-         ambiguity that round-9 registration fixed"
+         ambiguity that the registration path is meant to avoid"
     );
     // The orphan node must be renamed off `Earth.pfix` so a
     // `find_by_name` lookup of the canonical name returns nothing
@@ -367,9 +361,9 @@ fn tier3_bevy_rotation_none_toggle_removes_pfix_component() {
     );
 }
 
-/// Issue #277 PR 1 round-1 review fixup: the same retirement / reuse
-/// semantics the test above asserts on the *arena* side must also hold
-/// on the ECS-entity side. Without the parallel
+/// The same retirement / reuse semantics the test above asserts on
+/// the *arena* side must also hold on the ECS-entity side. Without
+/// the parallel
 /// `RetiredPfixFrameEntityC` retirement, the source kept a stale
 /// `PfixFrameEntityC` handle on toggle to `None` *and*
 /// `register_pfix_frames_system` (which filters
@@ -459,8 +453,8 @@ fn tier3_bevy_rotation_none_toggle_does_not_leak_pfix_frame_entity() {
 #[test]
 fn tier3_bevy_planet_ang_vel_moon_de421() {
     // MoonDE421 is the only RotationModel branch whose Bevy ↔ runner
-    // end-to-end path was previously uncovered (issue #265). Mirror the
-    // MoonIAU test, additionally inserting `EphemerisR` with the BPC
+    // end-to-end path was previously uncovered. Mirror the MoonIAU
+    // test, additionally inserting `EphemerisR` with the BPC
     // kernel that `planet_fixed_rotation_system`'s MoonDE421 branch
     // requires. The kernel `moon_pa_de421_1900-2050.bpc` is already
     // committed to `test_data/` (used by `tier3_simulation_earth_moon_clem`),

--- a/tests/bevy_parity_planet_ang_vel.rs
+++ b/tests/bevy_parity_planet_ang_vel.rs
@@ -17,6 +17,13 @@
 //! flagged in the plan (no existing parity test exercises pfix angular
 //! velocity).
 
+// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
+// `#[deprecated]` for mission-code use. This Tier 3 parity test reads
+// the arena to assert bit-identity of the pfix-rotation node sync
+// path. PR 4 (#280) removes the resource; the arena reads here will
+// be rewritten to use `RelativeFrameState`.
+#![allow(deprecated)]
+
 use std::time::Duration;
 
 use bevy::prelude::*;

--- a/tests/bevy_parity_source_mutation.rs
+++ b/tests/bevy_parity_source_mutation.rs
@@ -23,6 +23,15 @@
 //! flagged in the plan (no existing parity test exercised source
 //! mutation).
 
+// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
+// `#[deprecated]` for mission-code use. This is a Tier 3 parity test
+// between the Bevy adapter and `jeod_runner` — it deliberately reads
+// the arena to assert bit-identity of the source-mutation path. PR 4
+// (#280) removes the resource entirely; the parity assertion that
+// currently reads the arena will be rewritten to use
+// `RelativeFrameState` then.
+#![allow(deprecated)]
+
 use bevy::prelude::*;
 use bevy_jeod::{
     CentralSourceMarker, FrameTreeR, JeodPlugin, PlanetBundle, RootFrameIdR, SourceFrameIdC,

--- a/tests/bevy_parity_source_mutation.rs
+++ b/tests/bevy_parity_source_mutation.rs
@@ -1,11 +1,11 @@
 //! Tier 3: Bevy `SourceMutator` vs `jeod_runner::Simulation::set_source_*`
-//! parity (issue #71 item 5).
+//! parity.
 //!
-//! Issue #71 catalogued that `jeod_runner::Simulation` exposed
-//! `set_source_position`, `set_source_state`, and `set_source_ephemeris`
-//! for runtime gravity-source retargeting; the Bevy adapter had no
-//! equivalent. This test exercises the new
-//! [`bevy_jeod::SourceMutator`] system parameter and asserts that:
+//! `jeod_runner::Simulation` exposes `set_source_position`,
+//! `set_source_state`, and `set_source_ephemeris` for runtime
+//! gravity-source retargeting. The Bevy adapter mirrors the
+//! frame-tree-touching mutators via [`bevy_jeod::SourceMutator`]. This
+//! test asserts:
 //!
 //! 1. After mutation, the Bevy planet entity's `SourceInertialPositionC`,
 //!    `SourceInertialVelocityC`, and `TranslationalStateC` carry the
@@ -18,18 +18,13 @@
 //!    asserts central-body mutations are forbidden; Bevy currently
 //!    doesn't map any source to root, so this codepath only fires in
 //!    jeod_runner).
-//!
-//! Phase B step B11 of the issue #71 plan; closes the parity-test gap
-//! flagged in the plan (no existing parity test exercised source
-//! mutation).
 
-// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
-// `#[deprecated]` for mission-code use. This is a Tier 3 parity test
-// between the Bevy adapter and `jeod_runner` — it deliberately reads
-// the arena to assert bit-identity of the source-mutation path. PR 4
-// (#280) removes the resource entirely; the parity assertion that
-// currently reads the arena will be rewritten to use
-// `RelativeFrameState` then.
+// `FrameTreeR` is `#[deprecated]` for mission-code use. This is a
+// Tier 3 parity test between the Bevy adapter and `jeod_runner` — it
+// deliberately reads the arena to assert bit-identity of the
+// source-mutation path. Once the resource is removed, the parity
+// assertion that currently reads the arena will be rewritten to use
+// `RelativeFrameState`.
 #![allow(deprecated)]
 
 use bevy::prelude::*;
@@ -85,11 +80,11 @@ fn tier3_bevy_source_mutator_set_state_matches_runner() {
     app.world_mut()
         .spawn(PlanetBundle::point_mass("Earth", &EARTH));
     // Spawn the Moon WITHOUT `SourceInertialVelocityC` so the test
-    // exercises `SourceMutator::set_source_state`'s auto-insert path
-    // (PR #260 round-3 fixup): `PlanetBundle::point_mass` doesn't
-    // include the velocity component, and the auto-insert is the
-    // contract that prevents the silent-no-op footgun. Asserting the
-    // post-mutation velocity below confirms the component was inserted.
+    // exercises `SourceMutator::set_source_state`'s auto-insert path:
+    // `PlanetBundle::point_mass` doesn't include the velocity
+    // component, and the auto-insert is the contract that prevents
+    // the silent-no-op footgun. Asserting the post-mutation velocity
+    // below confirms the component was inserted.
     let moon_entity = app
         .world_mut()
         .spawn(PlanetBundle::point_mass("Moon", &MOON))
@@ -212,7 +207,7 @@ fn tier3_bevy_source_mutator_central_marker_panics_on_set_position() {
     // entity it treats as the pinned origin. `SourceMutator::set_source_position`
     // must panic on that entity, mirroring `jeod_runner::Simulation`'s
     // `assert_ne!(fid, root_frame_id, …)` rejection of root-source
-    // mutation. Issue #264 closeout.
+    // mutation.
     let mut app = build_app();
     let earth = app
         .world_mut()

--- a/tests/frame_origin_systemparam.rs
+++ b/tests/frame_origin_systemparam.rs
@@ -1,7 +1,7 @@
-//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2) bit-identity validation
-//! for the new [`FrameOrigin`] `SystemParam`. Mirrors the load-bearing
-//! correctness check that PR 1 added for [`RelativeFrameState`]
-//! (`tests/frame_storage_relative_frame_state.rs`): the new
+//! Bit-identity validation for the [`FrameOrigin`] `SystemParam`.
+//! Mirrors the load-bearing correctness check for
+//! [`RelativeFrameState`]
+//! (`tests/frame_storage_relative_frame_state.rs`): the
 //! mission-facing surface produces numerics bit-identical to the
 //! arena helpers (`jeod_sim::frame_origin` /
 //! `jeod_sim::frame_origin_typed`) the dual-write keeps in sync.
@@ -126,9 +126,9 @@ fn assert_dvec3_bits_eq(label: &str, arena: DVec3, ecs: DVec3) {
 /// `FrameOrigin::origin_in_root(root, body)` returns the same
 /// `(position, velocity)` as
 /// `jeod_sim::frame_origin(&frame_tree.0, root_fid, body_fid)`.
-/// This is the load-bearing correctness check for PR 2 — proving
-/// that the new mission-facing SystemParam reads bit-identical
-/// numerics to the arena helper consumers used to call.
+/// This is the load-bearing correctness check — proving that the
+/// mission-facing SystemParam reads bit-identical numerics to the
+/// arena helper consumers used to call.
 #[test]
 fn frame_origin_in_root_matches_arena() {
     let (mut app, _planet_e, body_e) = build_app("Earth", &EARTH);

--- a/tests/frame_origin_systemparam.rs
+++ b/tests/frame_origin_systemparam.rs
@@ -1,0 +1,276 @@
+//! Issue #278 (Frame-Tree-ECS-Native § 13 PR 2) bit-identity validation
+//! for the new [`FrameOrigin`] `SystemParam`. Mirrors the load-bearing
+//! correctness check that PR 1 added for [`RelativeFrameState`]
+//! (`tests/frame_storage_relative_frame_state.rs`): the new
+//! mission-facing surface produces numerics bit-identical to the
+//! arena helpers (`jeod_sim::frame_origin` /
+//! `jeod_sim::frame_origin_typed`) the dual-write keeps in sync.
+//!
+//! ## Before / After diff (the design-doc evidence)
+//!
+//! **Before** (arena read through `FrameTreeR` + `FrameId`
+//! components, held in a `Res<FrameTreeR>`):
+//! ```ignore
+//! fn read_via_arena(
+//!     frame_tree: Res<FrameTreeR>,
+//!     root: Res<RootFrameIdR>,
+//!     bodies: Query<&BodyFrameIdC, With<MyBody>>,
+//! ) -> DVec3 {
+//!     let body_fid = bodies.single().unwrap().0;
+//!     jeod_sim::frame_origin(&frame_tree.0, root.0, body_fid).0
+//! }
+//! ```
+//!
+//! **After** (`FrameOrigin` SystemParam, ECS-native, typed return):
+//! ```ignore
+//! fn read_via_systemparam(
+//!     origin: FrameOrigin,
+//!     root: Res<RootFrameEntityR>,
+//!     bodies: Query<&FrameEntityC, With<MyBody>>,
+//! ) -> Position<RootInertial> {
+//!     let body_e = bodies.single().unwrap().0;
+//!     let (pos, _vel) = origin.origin_in_root(root.0, body_e);
+//!     pos
+//! }
+//! ```
+//!
+//! The "After" surface never names a `FrameId`, never holds a
+//! `Res<FrameTreeR>`, and reads like any other Bevy `SystemParam`.
+//! It also returns `Position<RootInertial>` directly, lifting the
+//! arena's raw `DVec3` into the typed sibling without a per-call
+//! `from_raw_si` boundary at the consumer's site.
+
+// `FrameTreeR` is `#[deprecated]` for mission-code use; this test
+// reads the arena to assert the new SystemParam returns
+// bit-identical numerics. This is dual-write infrastructure
+// validation, not mission-shaped reads.
+#![allow(deprecated)]
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+use bevy_jeod::frame_param::{FrameOrigin, RelativeFrameState};
+use bevy_jeod::{
+    BodyFrameIdC, DynamicsConfigC, FrameEntityC, FrameTreeR, GravityControlsC, JeodPlugin,
+    MassPropertiesC, PfixFrameEntityC, PlanetBundle, RootFrameEntityR, RootFrameIdR,
+    RotationalStateC, SourcePfixFrameIdC, TranslationalStateC,
+};
+use glam::DVec3;
+use jeod_sim::{
+    DynamicsConfig, GravityControls, JeodQuat, MassProperties, PlanetConfig, Position,
+    RootInertial, RotationalState, TranslationalState, Velocity, EARTH,
+};
+
+const DT: f64 = 60.0;
+
+fn step_once(app: &mut App) {
+    app.world_mut()
+        .resource_mut::<Time<Fixed>>()
+        .advance_by(Duration::from_secs_f64(DT));
+    app.world_mut().run_schedule(FixedUpdate);
+}
+
+fn build_app(planet_name: &str, planet: &PlanetConfig) -> (App, Entity, Entity) {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+
+    let planet_e = app
+        .world_mut()
+        .spawn(PlanetBundle::point_mass(planet_name, planet))
+        .id();
+
+    let trans = TranslationalState {
+        position: DVec3::new(6_778_137.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7668.56, 0.0),
+    };
+    let rot = RotationalState {
+        quaternion: JeodQuat::identity(),
+        ang_vel_body: DVec3::new(0.001, -0.0005, 0.001),
+    };
+    let body_e = app
+        .world_mut()
+        .spawn((
+            Name::new("body"),
+            TranslationalStateC::from(trans),
+            RotationalStateC::from(rot),
+            MassPropertiesC::from(MassProperties::new(1.0)),
+            DynamicsConfigC(DynamicsConfig {
+                translational_dynamics: true,
+                rotational_dynamics: true,
+                three_dof: false,
+            }),
+            GravityControlsC(GravityControls::<Entity> { controls: vec![] }),
+        ))
+        .id();
+
+    (app, planet_e, body_e)
+}
+
+fn assert_bits_eq(label: &str, a: f64, b: f64) {
+    assert!(
+        a.to_bits() == b.to_bits(),
+        "{label} not bit-identical:\n  arena: {a} (bits={:#018x})\n  ecs:   {b} (bits={:#018x})",
+        a.to_bits(),
+        b.to_bits(),
+    );
+}
+
+fn assert_dvec3_bits_eq(label: &str, arena: DVec3, ecs: DVec3) {
+    for i in 0..3 {
+        assert_bits_eq(&format!("{label}[{i}]"), arena[i], ecs[i]);
+    }
+}
+
+/// `FrameOrigin::origin_in_root(root, body)` returns the same
+/// `(position, velocity)` as
+/// `jeod_sim::frame_origin(&frame_tree.0, root_fid, body_fid)`.
+/// This is the load-bearing correctness check for PR 2 — proving
+/// that the new mission-facing SystemParam reads bit-identical
+/// numerics to the arena helper consumers used to call.
+#[test]
+fn frame_origin_in_root_matches_arena() {
+    let (mut app, _planet_e, body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    // Arena answer (same path internal physics still uses).
+    let (arena_pos, arena_vel) = {
+        let world = app.world();
+        let body_fid = world.get::<BodyFrameIdC>(body_e).unwrap().0;
+        let root_fid = world.resource::<RootFrameIdR>().0;
+        let frame_tree = world.resource::<FrameTreeR>();
+        jeod_sim::frame_origin(&frame_tree.0, root_fid, body_fid)
+    };
+
+    // ECS answer via the typed FrameOrigin SystemParam.
+    let body_frame_e = app.world().get::<FrameEntityC>(body_e).unwrap().0;
+    let root_frame_e = app.world().resource::<RootFrameEntityR>().0;
+    let (ecs_pos, ecs_vel) = app
+        .world_mut()
+        .run_system_cached_with(
+            |In((root, body)): In<(Entity, Entity)>,
+             origin: FrameOrigin|
+             -> (Position<RootInertial>, Velocity<RootInertial>) {
+                origin.origin_in_root(root, body)
+            },
+            (root_frame_e, body_frame_e),
+        )
+        .expect("run_system_cached_with should succeed");
+
+    assert_dvec3_bits_eq("origin_in_root.pos", arena_pos, ecs_pos.raw_si());
+    assert_dvec3_bits_eq("origin_in_root.vel", arena_vel, ecs_vel.raw_si());
+}
+
+/// `FrameOrigin::origin_in_root(root, root)` returns
+/// `(DVec3::ZERO, DVec3::ZERO)` — the same identity short-circuit
+/// `jeod_sim::frame_origin(tree, root, root)` carries. The typed
+/// return wraps the zeros at the `Position<RootInertial>` /
+/// `Velocity<RootInertial>` phantom.
+#[test]
+fn frame_origin_in_root_of_root_is_zero() {
+    let (mut app, _planet_e, _body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    let root_frame_e = app.world().resource::<RootFrameEntityR>().0;
+    let (pos, vel) = app
+        .world_mut()
+        .run_system_cached_with(
+            |In(root): In<Entity>,
+             origin: FrameOrigin|
+             -> (Position<RootInertial>, Velocity<RootInertial>) {
+                origin.origin_in_root(root, root)
+            },
+            root_frame_e,
+        )
+        .expect("run_system_cached_with should succeed");
+    assert_eq!(pos.raw_si(), DVec3::ZERO);
+    assert_eq!(vel.raw_si(), DVec3::ZERO);
+}
+
+/// `FrameOrigin::origin_in(ancestor, frame)` for a non-root ancestor:
+/// query the body's origin in the planet's pfix-frame coordinates.
+/// The arena equivalent is
+/// `compute_relative_state(pfix_fid, body_fid).trans.{position,velocity}`,
+/// which is what `RelativeFrameState::position_velocity(pfix, body)`
+/// returns under the hood.
+#[test]
+fn frame_origin_in_pfix_matches_relative_frame_state() {
+    let (mut app, planet_e, body_e) = build_app("Earth", &EARTH);
+    step_once(&mut app);
+
+    let body_frame_e = app.world().get::<FrameEntityC>(body_e).unwrap().0;
+    let pfix_frame_e = app.world().get::<PfixFrameEntityC>(planet_e).unwrap().0;
+
+    // Arena answer.
+    let (arena_pos, arena_vel) = {
+        let world = app.world();
+        let body_fid = world.get::<BodyFrameIdC>(body_e).unwrap().0;
+        let pfix_fid = world.get::<SourcePfixFrameIdC>(planet_e).unwrap().0;
+        let frame_tree = world.resource::<FrameTreeR>();
+        let state = frame_tree.0.compute_relative_state(pfix_fid, body_fid);
+        (state.trans.position, state.trans.velocity)
+    };
+
+    // ECS answer via the FrameOrigin SystemParam (raw ancestor form).
+    let (origin_pos, origin_vel) = app
+        .world_mut()
+        .run_system_cached_with(
+            |In((ancestor, frame)): In<(Entity, Entity)>, origin: FrameOrigin| -> (DVec3, DVec3) {
+                origin.origin_in(ancestor, frame)
+            },
+            (pfix_frame_e, body_frame_e),
+        )
+        .expect("run_system_cached_with should succeed");
+
+    // ECS answer via RelativeFrameState (the FrameOrigin sibling).
+    // FrameOrigin::origin_in is sugar over
+    // RelativeFrameState::position_velocity, so they must agree.
+    let (rel_pos, rel_vel) = app
+        .world_mut()
+        .run_system_cached_with(
+            |In((ancestor, frame)): In<(Entity, Entity)>,
+             rel: RelativeFrameState|
+             -> (DVec3, DVec3) { rel.position_velocity(ancestor, frame) },
+            (pfix_frame_e, body_frame_e),
+        )
+        .expect("run_system_cached_with should succeed");
+
+    assert_dvec3_bits_eq("FrameOrigin.pos vs arena", arena_pos, origin_pos);
+    assert_dvec3_bits_eq("FrameOrigin.vel vs arena", arena_vel, origin_vel);
+    assert_dvec3_bits_eq("FrameOrigin.pos vs RelativeFrameState", origin_pos, rel_pos);
+    assert_dvec3_bits_eq("FrameOrigin.vel vs RelativeFrameState", origin_vel, rel_vel);
+}
+
+/// Compile-time assertion that the design-doc "After" mission-code
+/// shape compiles cleanly: a system that uses `FrameOrigin` to read a
+/// body's origin in the root inertial frame, holds no
+/// `Res<FrameTreeR>`, never names a `FrameId`, and returns a typed
+/// `Position<RootInertial>`. The system is registered (not run) — the
+/// purpose is to exercise the SystemParam wiring against the
+/// resources / queries `JeodPlugin` installs.
+#[test]
+fn after_diff_mission_code_shape_compiles() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.world_mut()
+        .spawn(PlanetBundle::point_mass("Earth", &EARTH));
+
+    fn read_body_origin_in_root(
+        origin: FrameOrigin,
+        root: Res<RootFrameEntityR>,
+        bodies: Query<&FrameEntityC, With<TranslationalStateC>>,
+    ) {
+        for body_e in &bodies {
+            let (_pos, _vel): (Position<RootInertial>, Velocity<RootInertial>) =
+                origin.origin_in_root(root.0, body_e.0);
+        }
+    }
+
+    // Registering the system is enough to type-check the SystemParam
+    // shape; we don't need to actually run it for this compile-time
+    // gate.
+    let _id = app.world_mut().register_system(read_body_origin_in_root);
+}

--- a/tests/frame_origin_systemparam.rs
+++ b/tests/frame_origin_systemparam.rs
@@ -245,10 +245,12 @@ fn frame_origin_in_pfix_matches_relative_frame_state() {
 /// Compile-time assertion that the design-doc "After" mission-code
 /// shape compiles cleanly: a system that uses `FrameOrigin` to read a
 /// body's origin in the root inertial frame, holds no
-/// `Res<FrameTreeR>`, never names a `FrameId`, and returns a typed
-/// `Position<RootInertial>`. The system is registered (not run) — the
-/// purpose is to exercise the SystemParam wiring against the
-/// resources / queries `JeodPlugin` installs.
+/// `Res<FrameTreeR>`, never names a `FrameId`, and binds typed
+/// `Position<RootInertial>` / `Velocity<RootInertial>` values directly
+/// (no `.from_raw_si` / phantom-stamping at the call site). The system
+/// is registered (not run) — the purpose is to exercise the
+/// SystemParam wiring against the resources / queries `JeodPlugin`
+/// installs.
 #[test]
 fn after_diff_mission_code_shape_compiles() {
     let mut app = App::new();

--- a/tests/frame_storage_relative_frame_state.rs
+++ b/tests/frame_storage_relative_frame_state.rs
@@ -44,6 +44,15 @@
 //!
 //! [1]: https://github.com/simnaut/bevy_jeod/tree/study/268-frame-tree-ecs-native
 
+// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
+// `#[deprecated]` for *mission-code* use. This test is bit-identity
+// dual-write infrastructure validation — it deliberately compares the
+// new SystemParam read path against the deprecated arena read path —
+// so the file-level `#![allow(deprecated)]` is appropriate. PR 4
+// (#280) removes the resource entirely; this test goes away with it
+// (it has no remaining purpose once the arena disappears).
+#![allow(deprecated)]
+
 use std::time::Duration;
 
 use bevy::prelude::*;

--- a/tests/frame_storage_relative_frame_state.rs
+++ b/tests/frame_storage_relative_frame_state.rs
@@ -1,9 +1,9 @@
-//! Issue #277 (PR 1) bit-identity validation: the ECS-native frame
-//! components (`FrameTransC` / `FrameRotC` / `FrameAngVelC`) and the
+//! Bit-identity validation: the ECS-native frame components
+//! (`FrameTransC` / `FrameRotC` / `FrameAngVelC`) and the
 //! [`RelativeFrameState`] `SystemParam` produce numerically identical
 //! results to [`FrameTreeR`]'s `compute_relative_state` after each
-//! step — the dual-write infrastructure (issue #277) keeps the two
-//! storage backends in lockstep.
+//! step — the dual-write infrastructure keeps the two storage
+//! backends in lockstep.
 //!
 //! Tests are carried over from the prototype branch
 //! [`study/268-frame-tree-ecs-native`][1] and document the
@@ -44,12 +44,12 @@
 //!
 //! [1]: https://github.com/simnaut/bevy_jeod/tree/study/268-frame-tree-ecs-native
 
-// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
-// `#[deprecated]` for *mission-code* use. This test is bit-identity
-// dual-write infrastructure validation — it deliberately compares the
-// new SystemParam read path against the deprecated arena read path —
-// so the file-level `#![allow(deprecated)]` is appropriate. PR 4
-// (#280) removes the resource entirely; this test goes away with it
+// `FrameTreeR` is `#[deprecated]` for *mission-code* use. This test
+// is bit-identity dual-write infrastructure validation — it
+// deliberately compares the new SystemParam read path against the
+// deprecated arena read path — so the file-level
+// `#![allow(deprecated)]` is appropriate. The test will be retired
+// together with the arena resource once the dual-write window closes
 // (it has no remaining purpose once the arena disappears).
 #![allow(deprecated)]
 

--- a/tests/jeod_plugin_frame_tree_validation.rs
+++ b/tests/jeod_plugin_frame_tree_validation.rs
@@ -22,12 +22,11 @@
 //! 6. Neither pre-installed: plugin seeds both itself.
 //! 7. Both pre-installed and consistent: plugin preserves them.
 
-// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
-// `#[deprecated]` for mission-code use. This test pre-installs the
-// resource explicitly to exercise `JeodPlugin`'s pre-installation
-// validation path — the test *is* exercising the deprecated surface
-// to check it fails-loud on misuse. PR 4 (#280) removes the
-// pre-install path along with the resource.
+// `FrameTreeR` is `#[deprecated]` for mission-code use. This test
+// pre-installs the resource explicitly to exercise `JeodPlugin`'s
+// pre-installation validation path — the test *is* exercising the
+// deprecated surface to check it fails-loud on misuse. The
+// pre-install path will be retired alongside the resource itself.
 #![allow(deprecated)]
 
 use bevy::prelude::*;

--- a/tests/jeod_plugin_frame_tree_validation.rs
+++ b/tests/jeod_plugin_frame_tree_validation.rs
@@ -22,6 +22,14 @@
 //! 6. Neither pre-installed: plugin seeds both itself.
 //! 7. Both pre-installed and consistent: plugin preserves them.
 
+// Issue #278 (Frame-Tree-ECS-Native PR 2): `FrameTreeR` is
+// `#[deprecated]` for mission-code use. This test pre-installs the
+// resource explicitly to exercise `JeodPlugin`'s pre-installation
+// validation path — the test *is* exercising the deprecated surface
+// to check it fails-loud on misuse. PR 4 (#280) removes the
+// pre-install path along with the resource.
+#![allow(deprecated)]
+
 use bevy::prelude::*;
 use bevy_jeod::{FrameTreeR, JeodPlugin, RootFrameIdR};
 


### PR DESCRIPTION
## Summary

PR 2 of the 5-PR Section-13 migration ([Frame-Tree-ECS-Native § 13](https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing)). Closes the mission-facing read-path half of issue #278: adds the `FrameOrigin` SystemParam and marks `FrameTreeR` `#[deprecated]` for mission-code use. Internal physics systems still read `FrameTreeR` and are rewritten in PR 3 (#279); the resource is removed in PR 4 (#280).

Refs: #278, design-doc [§ 13 (Migration Sequencing)](https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#13-migration-sequencing) and [§ 6 (Mission Code Surface — SystemParam Catalog)](https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#6-mission-code-surface--systemparam-catalog-q7) including the [Before / After diff](https://github.com/simnaut/bevy_jeod/wiki/Frame-Tree-ECS-Native#before--after-diff-prototype-branch-evidence). Builds on PR 1 (#277, merged in `aeb3686`).

### What's in scope

- **`FrameOrigin<'w, 's>` SystemParam** (`src/frame_param.rs`) — backed by `Query<&ChildOf>` + `Query<(&FrameTransC, &FrameRotC, &FrameAngVelC)>` walks (the same machinery `RelativeFrameState` uses; `FrameOrigin` wraps a `RelativeFrameState`). Three methods:
  - `origin_in(ancestor, frame) -> (DVec3, DVec3)` — raw form for callers whose ancestor isn't root (e.g. an integration-frame child of root).
  - `origin_in_root(root, frame) -> (Position<RootInertial>, Velocity<RootInertial>)` — typed sugar matching `frame_origin_typed::<RootInertial>(tree, root, frame)`.
  - `origin_in_typed::<F>(ancestor, frame) -> (Position<F>, Velocity<F>)` — generic-typed for non-root ancestors with another `F: Frame` marker.
- **`FrameTreeR` deprecation** (`src/lib.rs`) — `#[deprecated]` with a `note` pointing at `RelativeFrameState` and `FrameOrigin`. The struct is hosted inside a tiny private submodule (`frame_tree_r_internal`) with `#![allow(deprecated)]` so the derive-macro expansion (`Resource`, `Deref`, `DerefMut`) doesn't trip on its own deprecation; **the deprecation still fires at every external use site** (mission code, tests, downstream crates).
- **Prelude re-export** (`src/prelude.rs`) — `FrameOrigin` joins `RelativeFrameState` for `use bevy_jeod::prelude::*;`.
- **Internal call-site suppression** — file-level `#![allow(deprecated)]` (with a refactor comment noting "removed in PR 3 (#279)") on `src/systems.rs`, `src/validation.rs`, `src/source_mutator.rs`. The same scoping is applied to the existing dual-write / parity tests (`tests/{bevy_frame_tree_despawn_cleanup,bevy_parity_frame_switch,bevy_parity_planet_ang_vel,bevy_parity_source_mutation,frame_storage_relative_frame_state,jeod_plugin_frame_tree_validation}.rs`) since those tests are arena-bit-identity validation, not mission-shaped reads.
- **New test** (`tests/frame_origin_systemparam.rs`) — bit-identity check between `FrameOrigin::origin_in_root(root, body)` and `jeod_sim::frame_origin(&frame_tree.0, root_fid, body_fid)`, plus the design-doc "Before / After" mission-code shape as a compile-time gate.

### What's out of scope

- Internal physics systems (gravity / integration / frame-switch / derived-state) still read `FrameTreeR`. That's PR 3 (#279).
- The `FrameTreeR` resource itself stays in place. Removal is PR 4 (#280) along with the `frame_tree_r_internal` submodule.
- No changes to the runner or the `jeod_*` physics crates (per CLAUDE.md three-layer rule, this PR only touches `bevy_jeod`'s adapter surface).

### Deprecation scope (clarification)

The `#[deprecated]` is mission-facing only:

- Mission code that holds `Res<FrameTreeR>` → warning fires.
- Internal physics in `src/systems.rs` / `src/validation.rs` / `src/source_mutator.rs` → suppressed with file-level `#![allow(deprecated)]` and a refactor comment naming PR 3 / PR 4.
- The struct definition itself (derive-macro expansion) → suppressed inside the private submodule. PR 4 removes both.

This matches the issue #278 contract: "Mark `FrameTreeR` as `#[deprecated]` for mission-code use only ... Internal systems still read it during PR 3, so the attribute must not break the internal call sites."

## Test plan

- [x] `cargo fmt --check` (clean).
- [x] `cargo clippy --workspace --tests -- -D warnings` (clean).
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 940 passed, 332 skipped (4 new tests in `frame_origin_systemparam.rs`).
- [x] `cargo doc -p bevy_jeod --no-deps` with `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links"` (clean — the type's docstring lives on the inner module's struct definition; intra-doc links to `crate::frame_param::*` resolve correctly).
- [x] Existing parity / dual-write tests (`bevy_parity_planet_ang_vel`, `bevy_parity_source_mutation`, etc.) still pass against the deprecated `FrameTreeR` reads.
- [ ] CI: full Tier 3 suite (best-effort locally; CI runs the full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)