### PR TITLE
[#308] Mass-tree dual-write coordination: capture composite state before MassChildOf removal

### DIFF
--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -437,6 +437,7 @@ MA.10–MA.21 gap fill. Source: `../jeod/models/dynamics/mass/src/`.
 | Tag | Invariant | Enforcement | Category | Our Status |
 |-----|-----------|-------------|----------|------------|
 | MA.22 | Detach-on-drop is safe: destroying a still-attached body must not leave dangling parent pointers (`mass_body.cc:94-108` pattern — `mass_children.remove()` is resilient) | structural | structural | n/a (Rust's ownership model: references don't outlive owners; `MassBodyStore` is an arena of values, so a freed `MassBodyId` cannot produce a dangling pointer) |
+| MA.23 | Composite-property reads at detach see the live (pre-detach) composite, not a downstream cache (JEOD reads `parent->mass.composite_properties` straight from `MassBody` in `mass_attach.cc::detach_update_properties`; the value member is the canonical store, no cache layer can shadow it). | structural | consistency | enforced (`bevy_jeod::staging_system` reads `parent_pre_composite_props` from the `MassTreeR` arena via `tree.get(tree_root_id).composite_properties` — the same arena `Simulation::detach_subtree` reads — instead of from the entity's `MassPropertiesC`, which the ECS-tree fast path in `composite_mass_system` may have just reverted to its `CoreMassPropertiesC` cache during the same tick. The arena tree is mutated in lock-step with the detach handler so its composite is the live pre-detach value at read time. Both adapters thus key the parent-side CoM-shift formula off the same pre-detach composite, keeping post-detach parent state bit-identical.) |
 
 ## Section DM: DynManager (gap fill)
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3189,6 +3189,30 @@ pub fn staging_system(
         // Keeping these as raw f64 fields (not borrowing the query)
         // avoids holding a borrow across the `bodies.iter()` /
         // `bodies.get_mut` calls below.
+        //
+        // `parent_pre_composite_props` is read from the legacy
+        // `MassTreeR` arena rather than the entity's
+        // `MassPropertiesC` because the ECS-tree fast path in
+        // `composite_mass_system` reverts `MassPropertiesC` to its
+        // `CoreMassPropertiesC` cache for any entity that has no
+        // `MassChildOf` edge, and the arena attach/detach path
+        // exercised here never adds those edges. Without this
+        // arena-read, by the time the detach handler runs (in the
+        // same tick, after `composite_mass_system`),
+        // `parent_mass_c.0.to_untyped()` would yield the just-reverted
+        // *core* mass instead of the live post-attach composite — and
+        // the CoM-shift formula below would key off
+        // `composite_properties.position == core.position` (typically
+        // zero), corrupting the parent's post-detach inertial position.
+        // The arena tree is the same source of truth the runner reads
+        // in `Simulation::detach_subtree`, so this also keeps the two
+        // adapters bit-identical for the parent-side post-detach
+        // CoM-shift. Mirrors `jeod_runner::Simulation::detach_subtree`'s
+        // `tree.get(tree_root_id).composite_properties` access.
+        //
+        // JEOD_INV: MA.23 — composite-property reads at detach must
+        // see the live (pre-detach) composite, not a downstream
+        // cache; the `MassTree` arena is the canonical store.
         let (
             parent_pre_position,
             parent_pre_velocity,
@@ -3196,7 +3220,7 @@ pub fn staging_system(
             parent_pre_ang_vel_body,
             parent_pre_composite_props,
         ) = {
-            let (_, _, parent_mass_c, parent_trans, parent_rot) = bodies
+            let (_, _, _, parent_trans, parent_rot) = bodies
                 .get(tree_root_entity)
                 .expect("id_to_entity points at a valid mass body");
             let position = parent_trans
@@ -3214,7 +3238,8 @@ pub fn staging_system(
                     (u.quaternion, u.ang_vel_body)
                 })
                 .unwrap_or((jeod_sim::JeodQuat::identity(), glam::DVec3::ZERO));
-            (position, velocity, q, w, parent_mass_c.0.to_untyped())
+            let composite = tree.get(tree_root_id).composite_properties;
+            (position, velocity, q, w, composite)
         };
 
         // Walk root → subtree applying `propagate_forward` at each

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3198,10 +3198,10 @@ pub fn staging_system(
         // `MassChildOf` edge, and the arena attach/detach path
         // exercised here never adds those edges. Without this
         // arena-read, by the time the detach handler runs (in the
-        // same tick, after `composite_mass_system`),
-        // `parent_mass_c.0.to_untyped()` would yield the just-reverted
-        // *core* mass instead of the live post-attach composite — and
-        // the CoM-shift formula below would key off
+        // same tick, after `composite_mass_system`), reading the
+        // entity's `MassPropertiesC` component would yield the
+        // just-reverted *core* mass instead of the live post-attach
+        // composite — and the CoM-shift formula below would key off
         // `composite_properties.position == core.position` (typically
         // zero), corrupting the parent's post-detach inertial position.
         // The arena tree is the same source of truth the runner reads

--- a/tests/bevy_parity_attach_detach_momentum.rs
+++ b/tests/bevy_parity_attach_detach_momentum.rs
@@ -1056,6 +1056,142 @@ fn bevy_detached_body_skips_force_pipeline() {
     );
 }
 
+/// Regression: the detach handler must read the parent's
+/// pre-detach composite-CoM from the live `MassTreeR` arena, not
+/// from `MassPropertiesC`. The ECS-tree fast path in
+/// `composite_mass_system` runs **before** `staging_system` in the
+/// same FixedUpdate tick (and on every subsequent tick the parent
+/// has no `MassChildOf` edge), and reverts the parent's
+/// `MassPropertiesC` to its `CoreMassPropertiesC` cache. Reading
+/// `parent_pre_composite_props` from `MassPropertiesC` after that
+/// revert pulls the parent's *core* mass props (specifically
+/// `position` = core CoM, typically zero) instead of the live
+/// post-attach composite CoM, corrupting the CoM-shift formula
+/// `parent_pre.position − parent_post.position` and leaving the
+/// parent's post-detach inertial position equal to its pre-detach
+/// inertial position (zero shift) instead of the JEOD-faithful
+/// `−Δ_composite_struct` shift.
+///
+/// This test exercises that exact race with a non-trivial CoM
+/// offset between attach and detach: `parent.core.position = 0`,
+/// `child.position` offset by `(3, 0, 0)` along the structure
+/// frame. The merged composite CoM shifts to
+/// `(m_c · 3) / (m_p + m_c) = 80 · 3 / 500 = 0.48 m`. After detach,
+/// parent's composite CoM returns to zero. The parent's post-detach
+/// inertial position must therefore shift by
+/// `(0 − 0.48) m = −0.48 m` along x relative to the merged
+/// (post-attach) composite-body inertial position — JEOD's
+/// composite-CoM-tracks-struct invariant. Without the live-arena
+/// read in the detach handler, the shift is computed as
+/// `(0 − 0) m = 0` and the parent's post-detach position is wrong
+/// by `0.48 m`.
+///
+/// One step suffices: the bug surfaces in tick 2 — the first tick
+/// after attach, when `composite_mass_system` first reverts the
+/// parent's `MassPropertiesC` to core. No multi-step propagation
+/// needed.
+#[test]
+fn bevy_detach_reads_live_composite_through_mass_property_revert() {
+    let parent_mass = MassProperties::with_inertia(
+        420.0,
+        DMat3::from_diagonal(DVec3::new(150.0, 200.0, 250.0)),
+        DVec3::ZERO,
+    );
+    let child_mass = MassProperties::with_inertia(
+        80.0,
+        DMat3::from_diagonal(DVec3::new(40.0, 50.0, 60.0)),
+        DVec3::ZERO,
+    );
+    // Co-moving: identical velocity → no induced spin in the merge.
+    // Pure CoM-tracking case so the only thing the post-detach shift
+    // depends on is the composite-CoM delta in struct frame.
+    let v0 = DVec3::new(0.0, 7600.0, 0.0);
+    let parent_trans = TranslationalState {
+        position: DVec3::new(7e6, 0.0, 0.0),
+        velocity: v0,
+    };
+    let child_trans = TranslationalState {
+        position: DVec3::new(7e6 + 3.0, 0.0, 0.0),
+        velocity: v0,
+    };
+    let parent_rot = RotationalState {
+        quaternion: JeodQuat::identity(),
+        ang_vel_body: DVec3::ZERO,
+    };
+    let child_rot = parent_rot;
+    let offset = DVec3::new(3.0, 0.0, 0.0);
+    let dt = 1.0;
+
+    let (mut app, parent_entity, child_entity, _, _) = build_two_body_world(
+        dt,
+        parent_mass,
+        parent_trans,
+        parent_rot,
+        child_mass,
+        child_trans,
+        child_rot,
+    );
+
+    // Attach + step. The attach branch writes the merged composite
+    // into the parent's `TranslationalStateC` (post-attach inertial
+    // position = parent_pre.position + cm_delta_inertial).
+    app.world_mut()
+        .resource_mut::<bevy::ecs::message::Messages<AttachEvent>>()
+        .write(AttachEvent {
+            child: child_entity,
+            parent: parent_entity,
+            offset,
+            t_parent_child: DMat3::IDENTITY,
+        });
+    step(&mut app, 1, dt);
+
+    let parent_pos_post_attach = read_position(app.world(), parent_entity);
+    // Soft co-moving merge: cm_delta_struct = combined.position − 0
+    //   = (m_c · offset) / total = 80 · 3 / 500 = 0.48 m along x.
+    // With identity attitude, struct == body == inertial here.
+    let cm_delta_attach = DVec3::new(80.0 * 3.0 / 500.0, 0.0, 0.0);
+    let expected_parent_pos_post_attach = parent_trans.position + cm_delta_attach;
+    assert!(
+        (parent_pos_post_attach - expected_parent_pos_post_attach).length() < 1e-9,
+        "precondition: post-attach parent position must follow combined-CoM \
+         shift: bevy={parent_pos_post_attach:?} expected={expected_parent_pos_post_attach:?}"
+    );
+
+    // Detach + step. This is the tick where `composite_mass_system`
+    // reverts the parent's `MassPropertiesC` to core BEFORE
+    // `staging_system` runs. The detach handler must still see the
+    // live composite (cm = 0.48 m struct) — read from the arena —
+    // not the reverted core (cm = 0). The post-detach inertial
+    // position must shift by `−cm_delta_attach` from the post-attach
+    // value, then advance ballistically by `vel · dt`.
+    app.world_mut()
+        .resource_mut::<bevy::ecs::message::Messages<DetachEvent>>()
+        .write(DetachEvent {
+            child: child_entity,
+        });
+    step(&mut app, 1, dt);
+
+    let parent_pos_post_detach = read_position(app.world(), parent_entity);
+    // The parent has no integrator state in this minimal harness so
+    // `integration_system` does not advance `TranslationalStateC` —
+    // the only mutation between attach and detach is the staging
+    // handler's CoM-shift writeback. Expected value: post-attach
+    // position - cm_delta_attach == original pre-attach position.
+    let expected_parent_pos_post_detach = parent_trans.position;
+    assert!(
+        (parent_pos_post_detach - expected_parent_pos_post_detach).length() < 1e-9,
+        "post-detach parent position must shift by −cm_delta_struct \
+         (computed against the live arena composite, not the reverted \
+         MassPropertiesC core): bevy={parent_pos_post_detach:?} expected={expected_parent_pos_post_detach:?}\n\
+         If this fails by ~{}m along x, `staging_system`'s detach handler is \
+         reading `parent_pre_composite_props` from `MassPropertiesC` (which \
+         `composite_mass_system` reverted to core in this tick) instead of \
+         from `tree.get(tree_root_id).composite_properties`.",
+        cm_delta_attach.x,
+    );
+    let _ = v0;
+}
+
 // ════════════════════════════════════════════════════════════════════
 // Cross-runtime parity (sub-issue #297)
 // ════════════════════════════════════════════════════════════════════
@@ -1325,29 +1461,70 @@ fn bevy_runner_parity_attach_detach_momentum() {
         "post-detach child ang_vel differs"
     );
 
-    // Note: parent-side post-detach CoM shift parity is NOT asserted
-    // here. The runner's `Simulation::detach` writes the post-detach
-    // parent CoM-shift directly into `body.trans` (the runner's mass
-    // tree is the single source of truth, no dual-write race). The
-    // Bevy adapter writes the same shift into `TranslationalStateC`
-    // during `staging_system`, but the legacy `MassTreeR` arena path
-    // does not synchronise with the ECS-tree
-    // (`MassChildOf` + `composite_mass_system`); the latter reverts
-    // the parent's `MassPropertiesC` to its `CoreMassPropertiesC`
-    // each tick when the ECS tree is empty (the fast path in
-    // `composite_mass_system`), causing the next tick's
-    // `staging_system` detach handler to read the parent's
-    // `parent_pre_composite_props.position` as `(0, 0, 0)` instead of
-    // the post-attach combined CoM. This is the dual-write
-    // coordination bug tracked under sub-issue #308 (mass-tree
-    // dual-write coordination — `composite_mass_system` reverts
-    // `MassPropertiesC` for detached entities before the detach
-    // handler reads it) — not in scope for this PR (sub-issue #297 is
-    // runner-side momentum conservation only). Sub-issue #299 covers
-    // a separate frame-tree-reparent question and is not the
-    // mechanism above. Once the Bevy adapter resolves the #308 race
-    // (e.g. by capturing live composite state in `staging_system`
-    // before removing the `MassChildOf` edge), the parent-side
-    // post-detach parity assertion can be added as a follow-up.
-    let _ = runner_parent_post;
+    // Parent-side post-detach CoM-shift parity. The runner's
+    // `Simulation::detach` writes the post-detach parent CoM-shift
+    // directly into `body.trans` (the runner's mass tree is the
+    // single source of truth). The Bevy adapter writes the same
+    // shift into `TranslationalStateC` during `staging_system` —
+    // reading `parent_pre_composite_props` from the live
+    // `MassTreeR` arena rather than the entity's `MassPropertiesC`
+    // (which the ECS-tree fast path in `composite_mass_system`
+    // reverts to its `CoreMassPropertiesC` cache when no
+    // `MassChildOf` edge is present). With both adapters keying off
+    // the same arena composite, the parent-side CoM-shift is
+    // bit-identical across runtimes.
+    let bevy_parent_pos_post_detach = read_position(app.world(), parent_entity);
+    let bevy_parent_vel_post_detach = read_velocity(app.world(), parent_entity);
+    let bevy_parent_q_post_detach = app
+        .world()
+        .get::<RotationalStateC>(parent_entity)
+        .unwrap()
+        .0
+        .to_untyped()
+        .quaternion;
+    let bevy_parent_w_post_detach = read_ang_vel(app.world(), parent_entity);
+
+    assert_eq!(
+        bevy_parent_pos_post_detach.to_array().map(f64::to_bits),
+        runner_parent_post.trans.position.to_array().map(f64::to_bits),
+        "post-detach parent position differs across Bevy / runner: bevy={bevy_parent_pos_post_detach:?} runner={:?}",
+        runner_parent_post.trans.position
+    );
+    assert_eq!(
+        bevy_parent_vel_post_detach.to_array().map(f64::to_bits),
+        runner_parent_post
+            .trans
+            .velocity
+            .to_array()
+            .map(f64::to_bits),
+        "post-detach parent velocity differs: bevy={bevy_parent_vel_post_detach:?} runner={:?}",
+        runner_parent_post.trans.velocity
+    );
+    let runner_parent_post_rot = runner_parent_post
+        .rot
+        .expect("6-DOF runner parent must keep rot post-detach");
+    assert_eq!(
+        [
+            bevy_parent_q_post_detach.scalar().to_bits(),
+            bevy_parent_q_post_detach.vector().x.to_bits(),
+            bevy_parent_q_post_detach.vector().y.to_bits(),
+            bevy_parent_q_post_detach.vector().z.to_bits(),
+        ],
+        [
+            runner_parent_post_rot.quaternion.scalar().to_bits(),
+            runner_parent_post_rot.quaternion.vector().x.to_bits(),
+            runner_parent_post_rot.quaternion.vector().y.to_bits(),
+            runner_parent_post_rot.quaternion.vector().z.to_bits(),
+        ],
+        "post-detach parent quaternion differs"
+    );
+    assert_eq!(
+        bevy_parent_w_post_detach.to_array().map(f64::to_bits),
+        runner_parent_post_rot
+            .ang_vel_body
+            .to_array()
+            .map(f64::to_bits),
+        "post-detach parent ang_vel differs: bevy={bevy_parent_w_post_detach:?} runner={:?}",
+        runner_parent_post_rot.ang_vel_body
+    );
 }

--- a/tests/bevy_parity_attach_detach_momentum.rs
+++ b/tests/bevy_parity_attach_detach_momentum.rs
@@ -1162,8 +1162,10 @@ fn bevy_detach_reads_live_composite_through_mass_property_revert() {
     // `staging_system` runs. The detach handler must still see the
     // live composite (cm = 0.48 m struct) — read from the arena —
     // not the reverted core (cm = 0). The post-detach inertial
-    // position must shift by `−cm_delta_attach` from the post-attach
-    // value, then advance ballistically by `vel · dt`.
+    // position shifts by `−cm_delta_attach` from the post-attach
+    // value. There is no integrator state on the parent in this
+    // minimal harness, so `integration_system` does not advance
+    // `TranslationalStateC` — the CoM-shift is the only mutation.
     app.world_mut()
         .resource_mut::<bevy::ecs::message::Messages<DetachEvent>>()
         .write(DetachEvent {
@@ -1189,7 +1191,6 @@ fn bevy_detach_reads_live_composite_through_mass_property_revert() {
          from `tree.get(tree_root_id).composite_properties`.",
         cm_delta_attach.x,
     );
-    let _ = v0;
 }
 
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #308.

The Bevy adapter's `staging_system` detach handler was reading the parent's pre-detach composite-body mass properties from the entity's `MassPropertiesC`. The ECS-tree fast path in `composite_mass_system` runs earlier in the same `FixedUpdate` tick and reverts `MassPropertiesC` to its `CoreMassPropertiesC` cache for any entity that has no `MassChildOf` edge — which the legacy arena attach/detach path never adds. By the time the detach handler ran, it was reading the just-reverted *core* mass props (specifically `position` = 0) instead of the live post-attach composite CoM, zeroing the CoM-shift `parent_pre.position − parent_post.position` and leaving the parent's post-detach inertial position equal to its post-attach position (no CoM-tracks-struct shift).

**Fix** (option (a) per the issue body): in `staging_system`'s `DetachEvent` branch, read `parent_pre_composite_props` from the live `MassTreeR` arena via `tree.get(tree_root_id).composite_properties`. The arena is mutated in lock-step with the detach handler so its composite is the live pre-detach value at read time. This is the same source `Simulation::detach_subtree` reads — both adapters now key the parent-side CoM-shift formula off bit-identical inputs.

## Order of events (the race)

```
Tick N (attach):
  composite_mass_system: parents.is_empty() fast path; cores_q empty (cache not seeded yet).
  staging_system:        AttachEvent → tree.attach() → write merged composite into parent's
                         MassPropertiesC via bypass_change_detection.
Tick N+1 (detach):
  composite_mass_system: parents.is_empty() fast path; cores_q now has parent's core
                         (deferred Commands flushed). live=combined ≠ core → revert
                         parent's MassPropertiesC to core via bypass.    ← race window
  staging_system:        DetachEvent → reads parent_mass_c → gets reverted core
                         (position=0) instead of live composite (position=0.48).
                         CoM-shift = 0; parent's post-detach inertial position is wrong.
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1032/1032
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 21/21 (extended parity test passes; reproduces the race when the fix is reverted)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `bash scripts/check_no_escape_hatches.sh`
- [x] `cargo test --test invariant_coverage`

### Parity test extension

`bevy_runner_parity_attach_detach_momentum` now asserts post-detach **parent** state (position, velocity, quaternion, ang_vel) bit-identical between the Bevy adapter and `jeod_runner::Simulation` via `to_bits()`, alongside the pre-existing post-detach child-state parity. Without the fix, the parent-position bit-identity fails by exactly the combined-CoM offset (0.48 m for the test scenario):

```
post-detach parent position differs across Bevy / runner:
  bevy=DVec3(7000000.48, 0.0, 0.0) runner=DVec3(7000000.0, 0.0, 0.0)
```

### New regression test

`bevy_detach_reads_live_composite_through_mass_property_revert` exercises the dual-write race directly with an analytically-known CoM offset. It pins the parent's post-detach inertial position against a hand-computed `−cm_delta_struct` shift derived from the masses and structure-frame offset alone (no parity dependency). This test fails with the fix reverted (off by 0.48 m along x) and passes with the fix applied.

## JEOD invariant

Catalog row **MA.23** added: composite-property reads at detach must see the live (pre-detach) composite, not a downstream cache. JEOD's `mass_attach.cc::detach_update_properties` reads `parent->mass.composite_properties` straight from the value member; the value is the canonical store and no cache layer can shadow it. Tagged at the enforcement site (`src/systems.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)