### PR TITLE
[#301] Joint-kinematics enrichment: sinusoid, closure, multi-DOF

### DIFF
--- a/crates/jeod_dynamics/src/kinematic_joint.rs
+++ b/crates/jeod_dynamics/src/kinematic_joint.rs
@@ -32,6 +32,7 @@
 //! 10 deg/s" without writing a per-mission kinematics driver.
 
 use glam::DVec3;
+use jeod_frames::{RefFrameRot, RefFrameState, RefFrameTrans};
 use jeod_math::JeodQuat;
 
 /// Declarative specification for a kinematically driven single-axis
@@ -145,6 +146,442 @@ pub fn evaluate(spec: &JointKinematicsSpec, elapsed_seconds: f64) -> (JeodQuat, 
     // coordinates is therefore `rate · axis`.
     let ang_vel_this = spec.axis_in_parent * spec.rate_rad_per_s;
     (q_parent_this, ang_vel_this)
+}
+
+// ===========================================================================
+// Sinusoidal single-axis spec
+// ===========================================================================
+
+/// Declarative specification for a single-axis joint whose angle is a
+/// sinusoidal function of time:
+///
+/// ```text
+/// θ(t) = offset_rad + amplitude_rad · sin(omega_rad_per_s · t + phase_rad)
+/// ```
+///
+/// Useful for periodic articulation — e.g., a pointing dither, a
+/// cyclic gimbal sweep, a slosh-style oscillation about a nominal
+/// position. The joint frame's rotation about its parent is the
+/// left-transformation quaternion for `θ(t)` about `axis_in_parent`,
+/// matching [`JointKinematicsSpec`]'s convention so consumers that
+/// read frame triplets (the Bevy-side `FrameRotC` / `FrameAngVelC`
+/// or the `RefFrameState` storage) see a uniform sign convention
+/// regardless of which kinematic style drives the joint.
+///
+/// The instantaneous angular rate is the analytic derivative
+/// `dθ/dt = amplitude_rad · omega_rad_per_s · cos(omega_rad_per_s · t + phase_rad)`,
+/// and the angular velocity in this-frame coordinates is
+/// `(dθ/dt) · axis_in_parent` (the rotation axis is the eigenvector
+/// of the rotation, so it is invariant between parent and this-frame
+/// coordinates).
+///
+/// `evaluate_sinusoidal` panics on a non-unit `axis_in_parent` or any
+/// non-finite scalar, matching [`evaluate`]'s fail-loud contract.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SinusoidalJointKinematicsSpec {
+    /// Unit vector in the parent frame about which the joint rotates.
+    pub axis_in_parent: DVec3,
+    /// Amplitude `A` of the sinusoid (rad). May be negative — the
+    /// kernel does not alias `(-A, phase)` to `(A, phase + π)` because
+    /// preserving the caller's literal parametrization is more useful
+    /// for diagnostics than canonicalizing.
+    pub amplitude_rad: f64,
+    /// Angular frequency `ω` of the sinusoid (rad/s). May be negative;
+    /// the angle's time-derivative carries the sign.
+    pub omega_rad_per_s: f64,
+    /// Phase `φ` of the sinusoid (rad). The angle at `t = 0` is
+    /// `offset + A · sin(φ)`.
+    pub phase_rad: f64,
+    /// DC offset `θ₀` (rad). The sinusoid oscillates about this
+    /// nominal angle.
+    pub offset_rad: f64,
+}
+
+/// Evaluate a [`SinusoidalJointKinematicsSpec`] at elapsed time `t`
+/// (seconds since the joint's reference epoch).
+///
+/// Returns `(q_parent_this, ang_vel_this)` matching [`evaluate`]'s
+/// semantics — quaternion is the parent→this left-transformation, and
+/// angular velocity is in this-frame coordinates.
+///
+/// # Panics
+///
+/// - `axis_in_parent` is not a unit vector (within [`AXIS_NORM_TOL`]).
+/// - `t` or any spec scalar is non-finite.
+pub fn evaluate_sinusoidal(
+    spec: &SinusoidalJointKinematicsSpec,
+    elapsed_seconds: f64,
+) -> (JeodQuat, DVec3) {
+    let axis_norm_sq = spec.axis_in_parent.length_squared();
+    assert!(
+        (axis_norm_sq - 1.0).abs() < AXIS_NORM_TOL,
+        "SinusoidalJointKinematicsSpec.axis_in_parent must be a unit vector \
+         (found length² = {axis_norm_sq}, axis = {:?}). Normalize the axis once \
+         at vehicle-setup time, e.g. `axis_in_parent: DVec3::Z` or \
+         `axis_in_parent: raw.normalize()`.",
+        spec.axis_in_parent,
+    );
+    assert!(
+        elapsed_seconds.is_finite(),
+        "joint kinematics elapsed_seconds must be finite, got {elapsed_seconds}. \
+         The simulation time has gone non-finite — fix the time-update path."
+    );
+    assert!(
+        spec.amplitude_rad.is_finite(),
+        "SinusoidalJointKinematicsSpec.amplitude_rad must be finite, got {}. \
+         Replace the spec with a finite amplitude or remove the joint.",
+        spec.amplitude_rad,
+    );
+    assert!(
+        spec.omega_rad_per_s.is_finite(),
+        "SinusoidalJointKinematicsSpec.omega_rad_per_s must be finite, got {}. \
+         Replace the spec with a finite frequency or remove the joint.",
+        spec.omega_rad_per_s,
+    );
+    assert!(
+        spec.phase_rad.is_finite(),
+        "SinusoidalJointKinematicsSpec.phase_rad must be finite, got {}. \
+         Replace the spec with a finite phase.",
+        spec.phase_rad,
+    );
+    assert!(
+        spec.offset_rad.is_finite(),
+        "SinusoidalJointKinematicsSpec.offset_rad must be finite, got {}. \
+         Replace the spec with a finite offset.",
+        spec.offset_rad,
+    );
+
+    let phase = spec.omega_rad_per_s * elapsed_seconds + spec.phase_rad;
+    let angle = spec.offset_rad + spec.amplitude_rad * phase.sin();
+    let rate = spec.amplitude_rad * spec.omega_rad_per_s * phase.cos();
+    let q_parent_this = JeodQuat::left_quat_from_eigen_rotation(angle, spec.axis_in_parent);
+    let ang_vel_this = spec.axis_in_parent * rate;
+    (q_parent_this, ang_vel_this)
+}
+
+// ===========================================================================
+// Closure (fixed-transform) spec
+// ===========================================================================
+
+/// Declarative specification for a joint that pins a fixed rotation
+/// about a single axis with no time dependence — the kinematic-only
+/// degenerate case useful for closing kinematic loops.
+///
+/// The joint frame's rotation about its parent is constant
+/// `θ = fixed_angle_rad` about `axis_in_parent`; the angular velocity
+/// is identically zero. Mission code reaches for this when a joint in
+/// an articulated chain is *constrained* to a particular pose at
+/// declaration time — e.g., the second arm of a closed kinematic loop
+/// where the ring-closure constraint fixes the relative attitude
+/// between the two arms — but the constraint resolution itself
+/// (force-controlled or geometric) is not the kinematic driver's job.
+///
+/// `evaluate_closure` panics on a non-unit `axis_in_parent` or
+/// non-finite `fixed_angle_rad`, matching the fail-loud contract.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClosureJointKinematicsSpec {
+    /// Unit vector in the parent frame about which the joint is rotated.
+    pub axis_in_parent: DVec3,
+    /// Fixed joint angle (rad). The joint frame is rotated by this
+    /// angle about `axis_in_parent` for all time.
+    pub fixed_angle_rad: f64,
+}
+
+/// Evaluate a [`ClosureJointKinematicsSpec`].
+///
+/// `elapsed_seconds` is ignored (the spec is time-invariant by
+/// construction) but still validated as finite so a non-finite time
+/// upstream surfaces here rather than silently propagating into a
+/// later consumer.
+///
+/// Returns `(q_parent_this, DVec3::ZERO)` — the joint is stationary,
+/// so its angular velocity in this-frame coordinates is identically
+/// zero.
+///
+/// # Panics
+///
+/// - `axis_in_parent` is not a unit vector (within [`AXIS_NORM_TOL`]).
+/// - `t` or `fixed_angle_rad` is non-finite.
+pub fn evaluate_closure(
+    spec: &ClosureJointKinematicsSpec,
+    elapsed_seconds: f64,
+) -> (JeodQuat, DVec3) {
+    let axis_norm_sq = spec.axis_in_parent.length_squared();
+    assert!(
+        (axis_norm_sq - 1.0).abs() < AXIS_NORM_TOL,
+        "ClosureJointKinematicsSpec.axis_in_parent must be a unit vector \
+         (found length² = {axis_norm_sq}, axis = {:?}). Normalize the axis once \
+         at vehicle-setup time.",
+        spec.axis_in_parent,
+    );
+    assert!(
+        elapsed_seconds.is_finite(),
+        "joint kinematics elapsed_seconds must be finite, got {elapsed_seconds}. \
+         The simulation time has gone non-finite — fix the time-update path."
+    );
+    assert!(
+        spec.fixed_angle_rad.is_finite(),
+        "ClosureJointKinematicsSpec.fixed_angle_rad must be finite, got {}. \
+         Replace the spec with a finite angle.",
+        spec.fixed_angle_rad,
+    );
+
+    let q_parent_this =
+        JeodQuat::left_quat_from_eigen_rotation(spec.fixed_angle_rad, spec.axis_in_parent);
+    (q_parent_this, DVec3::ZERO)
+}
+
+// ===========================================================================
+// Multi-DOF spec (composed single-axis kinematic chain)
+// ===========================================================================
+
+/// Maximum number of DOFs a [`MultiDofJointKinematicsSpec`] can carry.
+///
+/// Sized to cover the realistic kinematic-only chains mission code
+/// declares — solar-array gimbals (2 DOF), antenna pointing gimbals
+/// (2-3 DOF), articulated robotic arms in their kinematic-driving
+/// regime (up to 6 DOF per chain). The fixed bound preserves
+/// `MultiDofJointKinematicsSpec: Copy`, which keeps its parent
+/// `JointKinematicsModel` trivially copyable and avoids per-tick
+/// allocation in the propagation path. Chains with more than 6 DOFs
+/// can be expressed as multiple chained joint frames in the frame
+/// tree (one frame per DOF, each carrying its own single-DOF spec) —
+/// which is also the JEOD-faithful pattern, since JEOD has no native
+/// multi-DOF joint primitive and chains articulation through
+/// successive `attach_to_frame` calls.
+pub const MAX_MULTI_DOF_AXES: usize = 6;
+
+/// Per-DOF kinematic style for a single axis inside a
+/// [`MultiDofJointKinematicsSpec`] chain.
+///
+/// Each axis i carries one of these variants. The variant determines
+/// how the axis's joint angle evolves with time; all variants share
+/// the "single axis with a unit `axis_in_parent`-ish direction" shape
+/// (the axis lives in the *intermediate* frame produced by axes
+/// `0..i`, not in the chain root's parent — see
+/// [`evaluate_multi_dof`]).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SingleDofKinematics {
+    /// Constant-rate rotation about `axis_in_parent`.
+    /// `θ_i(t) = initial_angle_rad + rate_rad_per_s · t`.
+    ConstantRate(JointKinematicsSpec),
+    /// Sinusoidal rotation about `axis_in_parent`.
+    /// `θ_i(t) = offset + amplitude · sin(ω · t + phase)`.
+    Sinusoidal(SinusoidalJointKinematicsSpec),
+    /// Time-invariant rotation about `axis_in_parent`. Useful as a
+    /// constant offset in a multi-DOF chain (e.g., a fixed mounting
+    /// twist between two articulated stages).
+    Closure(ClosureJointKinematicsSpec),
+}
+
+impl SingleDofKinematics {
+    /// Evaluate this DOF at `elapsed_seconds`, returning
+    /// `(q, ang_vel_this_axis_only)` — the rotation contribution and
+    /// the angular-velocity contribution of *this axis alone* in the
+    /// frame produced after this axis rotates. Composition with
+    /// preceding axes is the caller's responsibility (see
+    /// [`evaluate_multi_dof`]).
+    fn evaluate(&self, elapsed_seconds: f64) -> (JeodQuat, DVec3) {
+        match self {
+            SingleDofKinematics::ConstantRate(spec) => evaluate(spec, elapsed_seconds),
+            SingleDofKinematics::Sinusoidal(spec) => evaluate_sinusoidal(spec, elapsed_seconds),
+            SingleDofKinematics::Closure(spec) => evaluate_closure(spec, elapsed_seconds),
+        }
+    }
+}
+
+/// Declarative specification for a multi-DOF kinematic joint.
+///
+/// A multi-DOF joint composes up to [`MAX_MULTI_DOF_AXES`] single-axis
+/// kinematic stages. The semantics match a Denavit–Hartenberg–style
+/// kinematic chain *with no link offsets*: each stage rotates about
+/// its `axis_in_parent` declared in the *intermediate frame produced
+/// by the preceding stages*, and the composed `(rotation, angular
+/// velocity)` is the chain root → chain leaf state.
+///
+/// **Stage ordering**: stage 0 is closest to the chain's parent
+/// frame; stage `n-1` is closest to the chain's leaf frame. Filled
+/// stages must be a contiguous prefix — `axes[0..count]` are
+/// `Some(_)`, `axes[count..]` are `None`. The kernel asserts this; a
+/// "hole" in the middle is a configuration error.
+///
+/// **Composition** uses [`RefFrameState::incr_right`] (the same math
+/// the rest of the codebase walks for hierarchy traversals). Each
+/// stage's contribution is wrapped as a translation-free
+/// `RefFrameState` and folded left-to-right, so the math is
+/// bit-identical to a frame-tree walk through `n` joint entities each
+/// carrying a single-DOF spec — a deliberate equivalence that lets
+/// mission code pick whichever shape (one entity / N stages, or N
+/// entities / 1 stage each) is more ergonomic without changing the
+/// physics.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MultiDofJointKinematicsSpec {
+    /// Per-DOF specs, contiguous-prefix-filled. `axes[0]` is closest
+    /// to the chain's parent; the last `Some(_)` is closest to the
+    /// chain's leaf.
+    pub axes: [Option<SingleDofKinematics>; MAX_MULTI_DOF_AXES],
+}
+
+impl MultiDofJointKinematicsSpec {
+    /// Build a spec from a slice of per-DOF specs. Asserts the slice
+    /// length is `<= MAX_MULTI_DOF_AXES` so a caller that tries to
+    /// declare a chain longer than the kernel supports fails loudly
+    /// at construction rather than at evaluation.
+    ///
+    /// # Panics
+    ///
+    /// `dofs.len() > MAX_MULTI_DOF_AXES`.
+    pub fn from_slice(dofs: &[SingleDofKinematics]) -> Self {
+        assert!(
+            dofs.len() <= MAX_MULTI_DOF_AXES,
+            "MultiDofJointKinematicsSpec supports at most {} DOFs, got {}. \
+             Split the chain into multiple chained joint frame entities, \
+             one per DOF, so the frame-tree walk produces the same composed \
+             state.",
+            MAX_MULTI_DOF_AXES,
+            dofs.len(),
+        );
+        let mut axes = [None; MAX_MULTI_DOF_AXES];
+        for (i, dof) in dofs.iter().enumerate() {
+            axes[i] = Some(*dof);
+        }
+        Self { axes }
+    }
+
+    /// Number of populated DOFs (the contiguous-prefix count of
+    /// `Some(_)` entries).
+    pub fn count(&self) -> usize {
+        self.axes.iter().take_while(|a| a.is_some()).count()
+    }
+}
+
+/// Evaluate a [`MultiDofJointKinematicsSpec`] at elapsed time `t`.
+///
+/// Returns `(q_parent_this, ang_vel_this)` for the composed chain
+/// root → chain leaf, matching the convention of [`evaluate`] and
+/// [`evaluate_sinusoidal`]: quaternion is the parent→this left-
+/// transformation, angular velocity is in this-frame coordinates.
+///
+/// Stages are folded with [`RefFrameState::incr_right`] so the math
+/// is bit-identical to walking the equivalent N-entity chain through
+/// the frame tree. A spec with zero populated DOFs returns
+/// `(identity, zero)` — the no-op kinematic chain.
+///
+/// # Panics
+///
+/// - The populated DOFs are not a contiguous prefix
+///   (`axes[i]` is `None` followed by some `axes[j > i]` that is
+///   `Some(_)`). A hole in the middle of the chain is a configuration
+///   error.
+/// - Any underlying single-DOF eval panics (non-unit axis, non-finite
+///   scalars).
+pub fn evaluate_multi_dof(
+    spec: &MultiDofJointKinematicsSpec,
+    elapsed_seconds: f64,
+) -> (JeodQuat, DVec3) {
+    // Validate prefix-filled invariant: once we see a `None`, every
+    // subsequent slot must also be `None`. A hole in the middle would
+    // silently drop a stage from the composition without diagnostic.
+    let mut seen_gap = false;
+    for (i, slot) in spec.axes.iter().enumerate() {
+        match slot {
+            Some(_) => {
+                assert!(
+                    !seen_gap,
+                    "MultiDofJointKinematicsSpec.axes must be a contiguous \
+                     prefix of `Some(_)` followed by `None`, but axes[{i}] is \
+                     populated after a hole. Pack the populated stages into \
+                     axes[0..count].",
+                );
+            }
+            None => {
+                seen_gap = true;
+            }
+        }
+    }
+
+    // Fold from chain parent toward chain leaf using `incr_right`. The
+    // accumulator is the chain-root → stage-i state; for each stage,
+    // we wrap the per-stage `(q, ang_vel)` as a translation-free
+    // RefFrameState and compose. This produces the chain-root →
+    // chain-leaf state in bit-identical arithmetic to walking the
+    // equivalent N-entity frame chain.
+    let mut acc = RefFrameState {
+        trans: RefFrameTrans {
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+        },
+        rot: RefFrameRot {
+            q_parent_this: JeodQuat::identity(),
+            t_parent_this: JeodQuat::identity().left_quat_to_transformation(),
+            ang_vel_this: DVec3::ZERO,
+        },
+    };
+    for slot in spec.axes.iter() {
+        let Some(dof) = slot else { break };
+        let (q_stage, av_stage) = dof.evaluate(elapsed_seconds);
+        let stage_state = RefFrameState {
+            trans: RefFrameTrans {
+                position: DVec3::ZERO,
+                velocity: DVec3::ZERO,
+            },
+            rot: RefFrameRot {
+                q_parent_this: q_stage,
+                t_parent_this: q_stage.left_quat_to_transformation(),
+                ang_vel_this: av_stage,
+            },
+        };
+        acc = acc.incr_right(&stage_state);
+    }
+    (acc.rot.q_parent_this, acc.rot.ang_vel_this)
+}
+
+// ===========================================================================
+// Unifying enum
+// ===========================================================================
+
+/// Unifying enum over the kinematic-only joint specifications shipped
+/// today: constant-rate single-axis ([`JointKinematicsSpec`]),
+/// sinusoidal single-axis ([`SinusoidalJointKinematicsSpec`]),
+/// closure single-axis ([`ClosureJointKinematicsSpec`]), and
+/// multi-DOF chains ([`MultiDofJointKinematicsSpec`]).
+///
+/// Mission code that needs to store a heterogeneous collection of
+/// joints (or that passes the joint spec across abstractions that
+/// don't know which variant they hold) reaches for this enum;
+/// homogeneous collections of one variant are better expressed as
+/// the variant type directly.
+//
+// `large_enum_variant`: `MultiDofJointKinematicsSpec` is ~384 bytes
+// (six fixed slots), the other variants are <56 bytes. Boxing the
+// large variant would buy the enum size back at the cost of a heap
+// allocation per joint and the loss of `Copy` on the enum and on
+// every component / spec collection that holds it. The kinematic-
+// joint code path is intentionally `Copy`-friendly for per-tick
+// fast-path evaluation, so the size asymmetry is the deliberate
+// trade.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum JointKinematicsModel {
+    /// Constant-rate single-axis joint.
+    ConstantRate(JointKinematicsSpec),
+    /// Sinusoidal single-axis joint.
+    Sinusoidal(SinusoidalJointKinematicsSpec),
+    /// Closure (fixed-angle, no time dependence) single-axis joint.
+    Closure(ClosureJointKinematicsSpec),
+    /// Multi-DOF kinematic chain.
+    MultiDof(MultiDofJointKinematicsSpec),
+}
+
+/// Evaluate a [`JointKinematicsModel`] at elapsed time `t`, returning
+/// `(q_parent_this, ang_vel_this)` for whichever variant is held.
+pub fn evaluate_model(model: &JointKinematicsModel, elapsed_seconds: f64) -> (JeodQuat, DVec3) {
+    match model {
+        JointKinematicsModel::ConstantRate(spec) => evaluate(spec, elapsed_seconds),
+        JointKinematicsModel::Sinusoidal(spec) => evaluate_sinusoidal(spec, elapsed_seconds),
+        JointKinematicsModel::Closure(spec) => evaluate_closure(spec, elapsed_seconds),
+        JointKinematicsModel::MultiDof(spec) => evaluate_multi_dof(spec, elapsed_seconds),
+    }
 }
 
 #[cfg(test)]
@@ -304,5 +741,514 @@ mod tests {
                 axis[i],
             );
         }
+    }
+
+    // ===========================================================================
+    // Sinusoidal-spec tests
+    // ===========================================================================
+
+    /// At `t = 0` the angle is `offset + amplitude · sin(phase)` and the
+    /// rate is `amplitude · omega · cos(phase)`. Pinning numeric values
+    /// against the closed form catches sign / parameter-ordering bugs.
+    #[test]
+    fn sinusoidal_evaluates_at_t_zero_to_closed_form() {
+        let spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            amplitude_rad: 0.4,
+            omega_rad_per_s: 1.5,
+            phase_rad: PI / 3.0,
+            offset_rad: 0.1,
+        };
+        let (q, omega) = evaluate_sinusoidal(&spec, 0.0);
+        let expected_angle = 0.1 + 0.4 * (PI / 3.0).sin();
+        let expected_rate = 0.4 * 1.5 * (PI / 3.0).cos();
+        let expected_q = JeodQuat::left_quat_from_eigen_rotation(expected_angle, DVec3::Z);
+        for i in 0..4 {
+            assert!(
+                (q.data[i] - expected_q.data[i]).abs() < 1.0e-15,
+                "q[{i}]: got {}, expected {}",
+                q.data[i],
+                expected_q.data[i]
+            );
+        }
+        assert!((omega.x - 0.0).abs() < 1.0e-15);
+        assert!((omega.y - 0.0).abs() < 1.0e-15);
+        assert!((omega.z - expected_rate).abs() < 1.0e-15);
+    }
+
+    /// Sinusoidal pure-sin (offset=0, phase=0): at the quarter period
+    /// `t = π/(2ω)` the angle equals the amplitude and the rate is
+    /// zero (peak of the sinusoid). Different snapshot from `t = 0`,
+    /// so any sign / parameter swap surfaces here even if the t=0
+    /// case happens to land on a coincidence.
+    #[test]
+    fn sinusoidal_quarter_period_peak_angle_zero_rate() {
+        let amplitude = 0.7_f64;
+        let omega = 2.0_f64;
+        let spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::Y,
+            amplitude_rad: amplitude,
+            omega_rad_per_s: omega,
+            phase_rad: 0.0,
+            offset_rad: 0.0,
+        };
+        let t_peak = PI / (2.0 * omega);
+        let (q, ang_vel) = evaluate_sinusoidal(&spec, t_peak);
+        let expected_q = JeodQuat::left_quat_from_eigen_rotation(amplitude, DVec3::Y);
+        for i in 0..4 {
+            assert!(
+                (q.data[i] - expected_q.data[i]).abs() < 1.0e-12,
+                "q[{i}]: got {}, expected {}",
+                q.data[i],
+                expected_q.data[i]
+            );
+        }
+        // cos(π/2) ≈ 0, so the rate (and hence the angular velocity)
+        // is zero at the peak — within float-trig precision.
+        for i in 0..3 {
+            assert!(
+                ang_vel[i].abs() < 1.0e-12,
+                "ang_vel component {i}: got {}, expected 0",
+                ang_vel[i]
+            );
+        }
+    }
+
+    /// Sinusoidal with `amplitude = 0` reduces to a constant `offset`
+    /// for all time, with zero angular velocity. This is the
+    /// "stationary at non-zero angle" degenerate case.
+    #[test]
+    fn sinusoidal_zero_amplitude_is_constant_offset() {
+        let spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::X,
+            amplitude_rad: 0.0,
+            omega_rad_per_s: 1.0,
+            phase_rad: 1.5,
+            offset_rad: 0.3,
+        };
+        let expected_q = JeodQuat::left_quat_from_eigen_rotation(0.3, DVec3::X);
+        for &t in &[0.0_f64, 1.0, 7.5, 100.0] {
+            let (q, ang_vel) = evaluate_sinusoidal(&spec, t);
+            for i in 0..4 {
+                assert!(
+                    (q.data[i] - expected_q.data[i]).abs() < 1.0e-15,
+                    "t={t} q[{i}]: got {}, expected {}",
+                    q.data[i],
+                    expected_q.data[i]
+                );
+            }
+            assert_eq!(ang_vel, DVec3::ZERO, "t={t}: ang_vel must be zero");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a unit vector")]
+    fn sinusoidal_panics_on_non_unit_axis() {
+        let spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::new(0.0, 0.0, 2.0),
+            amplitude_rad: 0.1,
+            omega_rad_per_s: 1.0,
+            phase_rad: 0.0,
+            offset_rad: 0.0,
+        };
+        let _ = evaluate_sinusoidal(&spec, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "amplitude_rad must be finite")]
+    fn sinusoidal_panics_on_nan_amplitude() {
+        let spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            amplitude_rad: f64::NAN,
+            omega_rad_per_s: 1.0,
+            phase_rad: 0.0,
+            offset_rad: 0.0,
+        };
+        let _ = evaluate_sinusoidal(&spec, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "omega_rad_per_s must be finite")]
+    fn sinusoidal_panics_on_inf_omega() {
+        let spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            amplitude_rad: 0.1,
+            omega_rad_per_s: f64::INFINITY,
+            phase_rad: 0.0,
+            offset_rad: 0.0,
+        };
+        let _ = evaluate_sinusoidal(&spec, 0.0);
+    }
+
+    // ===========================================================================
+    // Closure-spec tests
+    // ===========================================================================
+
+    /// The transform a closure spec produces is constant over time —
+    /// asserted by sampling at multiple distinct elapsed times and
+    /// requiring bit-identical output (closed-form input means the
+    /// same bits come out at every t).
+    #[test]
+    fn closure_transform_is_time_invariant() {
+        let spec = ClosureJointKinematicsSpec {
+            axis_in_parent: DVec3::new(1.0, 1.0, 1.0).normalize(),
+            fixed_angle_rad: 0.42,
+        };
+        let (q0, av0) = evaluate_closure(&spec, 0.0);
+        for &t in &[1.0_f64, 5.5, 100.0, 1.0e6] {
+            let (q, av) = evaluate_closure(&spec, t);
+            for i in 0..4 {
+                assert_eq!(
+                    q.data[i].to_bits(),
+                    q0.data[i].to_bits(),
+                    "t={t} q[{i}]: not bit-identical"
+                );
+            }
+            assert_eq!(av, av0);
+            assert_eq!(av, DVec3::ZERO);
+        }
+    }
+
+    /// Closure spec with a known angle should produce the matching
+    /// left-quat about the requested axis, end-to-end sanity check.
+    #[test]
+    fn closure_produces_expected_quaternion() {
+        let spec = ClosureJointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            fixed_angle_rad: PI / 4.0,
+        };
+        let (q, av) = evaluate_closure(&spec, 0.0);
+        let expected = JeodQuat::left_quat_from_eigen_rotation(PI / 4.0, DVec3::Z);
+        assert_eq!(q, expected);
+        assert_eq!(av, DVec3::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a unit vector")]
+    fn closure_panics_on_non_unit_axis() {
+        let spec = ClosureJointKinematicsSpec {
+            axis_in_parent: DVec3::new(0.0, 0.0, 2.0),
+            fixed_angle_rad: 0.5,
+        };
+        let _ = evaluate_closure(&spec, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "fixed_angle_rad must be finite")]
+    fn closure_panics_on_nan_angle() {
+        let spec = ClosureJointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            fixed_angle_rad: f64::NAN,
+        };
+        let _ = evaluate_closure(&spec, 0.0);
+    }
+
+    // ===========================================================================
+    // Multi-DOF spec tests
+    // ===========================================================================
+
+    /// An empty multi-DOF chain (no populated DOFs) reduces to the
+    /// no-op identity transform with zero angular velocity.
+    #[test]
+    fn multi_dof_empty_chain_is_identity() {
+        let spec = MultiDofJointKinematicsSpec::from_slice(&[]);
+        assert_eq!(spec.count(), 0);
+        let (q, av) = evaluate_multi_dof(&spec, 5.0);
+        assert_eq!(q, JeodQuat::identity());
+        assert_eq!(av, DVec3::ZERO);
+    }
+
+    /// A 1-DOF chain matches the underlying single-axis evaluator
+    /// bit-for-bit — composing one stage with an identity accumulator
+    /// must not introduce any new arithmetic.
+    #[test]
+    fn multi_dof_single_stage_matches_constant_rate_kernel() {
+        let inner = JointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            rate_rad_per_s: 0.3,
+            initial_angle_rad: 0.1,
+        };
+        let spec =
+            MultiDofJointKinematicsSpec::from_slice(&[SingleDofKinematics::ConstantRate(inner)]);
+        for &t in &[0.0_f64, 1.0, 10.0] {
+            let (q_chain, av_chain) = evaluate_multi_dof(&spec, t);
+            let (q_single, av_single) = evaluate(&inner, t);
+            // `incr_right` re-derives `t_parent_this` from the
+            // normalized quaternion, which is the same closed-form
+            // expression as the single-axis kernel produces — the
+            // resulting quaternion is bit-identical (a single stage
+            // composed with identity is the stage itself).
+            for i in 0..4 {
+                assert!(
+                    (q_chain.data[i] - q_single.data[i]).abs() < 1.0e-15,
+                    "t={t} q[{i}]: chain {} vs single {}",
+                    q_chain.data[i],
+                    q_single.data[i]
+                );
+            }
+            for i in 0..3 {
+                assert!(
+                    (av_chain[i] - av_single[i]).abs() < 1.0e-15,
+                    "t={t} av[{i}]: chain {} vs single {}",
+                    av_chain[i],
+                    av_single[i]
+                );
+            }
+        }
+    }
+
+    /// 2-DOF chain: stage 0 is constant-rate about +Z, stage 1 is
+    /// sinusoidal about +Y. Asserts the composition matches manual
+    /// `incr_right` of the two stages — guarding against any silent
+    /// reordering or missing stage in the kernel.
+    #[test]
+    fn multi_dof_two_stage_matches_manual_incr_right() {
+        let stage0 = JointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            rate_rad_per_s: 0.5,
+            initial_angle_rad: 0.2,
+        };
+        let stage1 = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::Y,
+            amplitude_rad: 0.3,
+            omega_rad_per_s: 1.2,
+            phase_rad: 0.4,
+            offset_rad: 0.05,
+        };
+        let spec = MultiDofJointKinematicsSpec::from_slice(&[
+            SingleDofKinematics::ConstantRate(stage0),
+            SingleDofKinematics::Sinusoidal(stage1),
+        ]);
+
+        let t = 2.5_f64;
+        let (q_chain, av_chain) = evaluate_multi_dof(&spec, t);
+
+        // Manual composition: identity -> stage0 -> stage1.
+        let (q0, av0) = evaluate(&stage0, t);
+        let s0 = RefFrameState {
+            trans: RefFrameTrans {
+                position: DVec3::ZERO,
+                velocity: DVec3::ZERO,
+            },
+            rot: RefFrameRot {
+                q_parent_this: q0,
+                t_parent_this: q0.left_quat_to_transformation(),
+                ang_vel_this: av0,
+            },
+        };
+        let (q1, av1) = evaluate_sinusoidal(&stage1, t);
+        let s1 = RefFrameState {
+            trans: RefFrameTrans {
+                position: DVec3::ZERO,
+                velocity: DVec3::ZERO,
+            },
+            rot: RefFrameRot {
+                q_parent_this: q1,
+                t_parent_this: q1.left_quat_to_transformation(),
+                ang_vel_this: av1,
+            },
+        };
+        let identity = RefFrameState {
+            trans: RefFrameTrans {
+                position: DVec3::ZERO,
+                velocity: DVec3::ZERO,
+            },
+            rot: RefFrameRot {
+                q_parent_this: JeodQuat::identity(),
+                t_parent_this: JeodQuat::identity().left_quat_to_transformation(),
+                ang_vel_this: DVec3::ZERO,
+            },
+        };
+        let expected = identity.incr_right(&s0).incr_right(&s1);
+
+        for i in 0..4 {
+            assert!(
+                (q_chain.data[i] - expected.rot.q_parent_this.data[i]).abs() < 1.0e-15,
+                "q[{i}]: chain {} vs manual {}",
+                q_chain.data[i],
+                expected.rot.q_parent_this.data[i]
+            );
+        }
+        for i in 0..3 {
+            assert!(
+                (av_chain[i] - expected.rot.ang_vel_this[i]).abs() < 1.0e-15,
+                "av[{i}]: chain {} vs manual {}",
+                av_chain[i],
+                expected.rot.ang_vel_this[i]
+            );
+        }
+    }
+
+    /// Two stages about the *same axis* commute — their composition
+    /// is equivalent to a single stage whose angle is the sum and
+    /// whose rate is the sum. This is the cleanest correctness probe
+    /// for the multi-DOF evaluator: same axis, no rotation
+    /// inter-leaving, closed-form predictable answer.
+    #[test]
+    fn multi_dof_same_axis_stages_sum_to_aggregate() {
+        let axis = DVec3::Z;
+        let stage_a = JointKinematicsSpec {
+            axis_in_parent: axis,
+            rate_rad_per_s: 0.4,
+            initial_angle_rad: 0.1,
+        };
+        let stage_b = JointKinematicsSpec {
+            axis_in_parent: axis,
+            rate_rad_per_s: 0.7,
+            initial_angle_rad: 0.2,
+        };
+        let chain = MultiDofJointKinematicsSpec::from_slice(&[
+            SingleDofKinematics::ConstantRate(stage_a),
+            SingleDofKinematics::ConstantRate(stage_b),
+        ]);
+        let aggregate = JointKinematicsSpec {
+            axis_in_parent: axis,
+            rate_rad_per_s: 0.4 + 0.7,
+            initial_angle_rad: 0.1 + 0.2,
+        };
+        let t = 3.5_f64;
+        let (q_chain, av_chain) = evaluate_multi_dof(&chain, t);
+        let (q_agg, av_agg) = evaluate(&aggregate, t);
+        // Numerical: `incr_right` normalizes the composed quaternion
+        // each stage, the aggregate kernel does not — drifts by a
+        // few ULPs in the worst case but stays within trig precision.
+        for i in 0..4 {
+            assert!(
+                (q_chain.data[i] - q_agg.data[i]).abs() < 1.0e-12,
+                "q[{i}]: chain {} vs aggregate {}",
+                q_chain.data[i],
+                q_agg.data[i]
+            );
+        }
+        for i in 0..3 {
+            assert!(
+                (av_chain[i] - av_agg[i]).abs() < 1.0e-15,
+                "av[{i}]: chain {} vs aggregate {}",
+                av_chain[i],
+                av_agg[i]
+            );
+        }
+    }
+
+    /// A multi-DOF chain composed entirely of `Closure` stages is
+    /// time-invariant — sampling at distinct times produces the same
+    /// `(rotation, ang_vel)` snapshot. Composed angular velocity
+    /// must be exactly zero (each stage contributes zero, and
+    /// composing zero with zero in `incr_right` stays zero
+    /// bit-identically because `T * 0 + 0 = 0`).
+    #[test]
+    fn multi_dof_all_closure_is_time_invariant() {
+        let spec = MultiDofJointKinematicsSpec::from_slice(&[
+            SingleDofKinematics::Closure(ClosureJointKinematicsSpec {
+                axis_in_parent: DVec3::Z,
+                fixed_angle_rad: 0.5,
+            }),
+            SingleDofKinematics::Closure(ClosureJointKinematicsSpec {
+                axis_in_parent: DVec3::Y,
+                fixed_angle_rad: -0.3,
+            }),
+        ]);
+        let (q0, av0) = evaluate_multi_dof(&spec, 0.0);
+        for &t in &[1.0_f64, 100.0, 1.0e6] {
+            let (q, av) = evaluate_multi_dof(&spec, t);
+            for i in 0..4 {
+                assert_eq!(
+                    q.data[i].to_bits(),
+                    q0.data[i].to_bits(),
+                    "t={t} q[{i}] not bit-identical"
+                );
+            }
+            assert_eq!(av, av0);
+            assert_eq!(av, DVec3::ZERO);
+        }
+    }
+
+    /// A "hole" in the middle of the axes array (populated, then
+    /// `None`, then populated again) is a configuration error and
+    /// must panic. This invariant prevents a silent mid-chain stage
+    /// drop.
+    #[test]
+    #[should_panic(expected = "contiguous prefix")]
+    fn multi_dof_hole_in_middle_panics() {
+        let mut axes = [None; MAX_MULTI_DOF_AXES];
+        axes[0] = Some(SingleDofKinematics::ConstantRate(JointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            rate_rad_per_s: 0.1,
+            initial_angle_rad: 0.0,
+        }));
+        // axes[1] left as None.
+        axes[2] = Some(SingleDofKinematics::ConstantRate(JointKinematicsSpec {
+            axis_in_parent: DVec3::Y,
+            rate_rad_per_s: 0.2,
+            initial_angle_rad: 0.0,
+        }));
+        let spec = MultiDofJointKinematicsSpec { axes };
+        let _ = evaluate_multi_dof(&spec, 0.0);
+    }
+
+    /// `from_slice` panics when the caller asks for more DOFs than
+    /// `MAX_MULTI_DOF_AXES` supports.
+    #[test]
+    #[should_panic(expected = "supports at most")]
+    fn multi_dof_from_slice_too_many_panics() {
+        let dof = SingleDofKinematics::ConstantRate(JointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            rate_rad_per_s: 0.1,
+            initial_angle_rad: 0.0,
+        });
+        let too_many = vec![dof; MAX_MULTI_DOF_AXES + 1];
+        let _ = MultiDofJointKinematicsSpec::from_slice(&too_many);
+    }
+
+    // ===========================================================================
+    // JointKinematicsModel dispatch
+    // ===========================================================================
+
+    /// `evaluate_model` dispatches each variant to the right kernel,
+    /// returning bit-identical output to a direct call.
+    #[test]
+    fn evaluate_model_dispatches_to_each_variant() {
+        let t = 1.7_f64;
+
+        let const_spec = JointKinematicsSpec {
+            axis_in_parent: DVec3::Z,
+            rate_rad_per_s: 0.5,
+            initial_angle_rad: 0.1,
+        };
+        let (q_direct, av_direct) = evaluate(&const_spec, t);
+        let (q_model, av_model) =
+            evaluate_model(&JointKinematicsModel::ConstantRate(const_spec), t);
+        assert_eq!(q_model, q_direct);
+        assert_eq!(av_model, av_direct);
+
+        let sin_spec = SinusoidalJointKinematicsSpec {
+            axis_in_parent: DVec3::Y,
+            amplitude_rad: 0.4,
+            omega_rad_per_s: 2.0,
+            phase_rad: 0.3,
+            offset_rad: 0.0,
+        };
+        let (q_direct, av_direct) = evaluate_sinusoidal(&sin_spec, t);
+        let (q_model, av_model) = evaluate_model(&JointKinematicsModel::Sinusoidal(sin_spec), t);
+        assert_eq!(q_model, q_direct);
+        assert_eq!(av_model, av_direct);
+
+        let close_spec = ClosureJointKinematicsSpec {
+            axis_in_parent: DVec3::X,
+            fixed_angle_rad: 0.7,
+        };
+        let (q_direct, av_direct) = evaluate_closure(&close_spec, t);
+        let (q_model, av_model) = evaluate_model(&JointKinematicsModel::Closure(close_spec), t);
+        assert_eq!(q_model, q_direct);
+        assert_eq!(av_model, av_direct);
+
+        let multi_spec = MultiDofJointKinematicsSpec::from_slice(&[
+            SingleDofKinematics::ConstantRate(const_spec),
+            SingleDofKinematics::Sinusoidal(sin_spec),
+        ]);
+        let (q_direct, av_direct) = evaluate_multi_dof(&multi_spec, t);
+        let (q_model, av_model) = evaluate_model(&JointKinematicsModel::MultiDof(multi_spec), t);
+        assert_eq!(q_model, q_direct);
+        assert_eq!(av_model, av_direct);
     }
 }

--- a/crates/jeod_dynamics/src/kinematic_joint.rs
+++ b/crates/jeod_dynamics/src/kinematic_joint.rs
@@ -594,6 +594,29 @@ pub enum JointKinematicsModel {
 
 /// Evaluate a [`JointKinematicsModel`] at elapsed time `t`, returning
 /// `(q_parent_this, ang_vel_this)` for whichever variant is held.
+///
+/// # Panics
+///
+/// This is a thin dispatcher over the per-variant evaluators
+/// ([`evaluate`], [`evaluate_sinusoidal`], [`evaluate_closure`],
+/// [`evaluate_multi_dof`]); every panic those functions document is
+/// inherited verbatim. Specifically:
+///
+/// - Any single-axis variant (`ConstantRate` / `Sinusoidal` /
+///   `Closure`) whose `axis_in_parent` is not a unit vector (within
+///   [`AXIS_NORM_TOL`]). A non-unit axis would silently scale the
+///   resulting rotation angle and/or angular-velocity magnitude.
+/// - `elapsed_seconds` is non-finite (`NaN` or `±∞`). For the
+///   `MultiDof` variant this is enforced at the top of
+///   [`evaluate_multi_dof`] so the empty-chain fast path also fails
+///   loudly; the single-axis variants assert it inside their own
+///   kernels.
+/// - Any spec scalar (`rate_rad_per_s`, `initial_angle_rad`,
+///   sinusoid `amplitude_rad` / `omega_rad_per_s` / `phase_rad` /
+///   `offset_rad`, closure `fixed_angle_rad`) is non-finite.
+/// - `MultiDof` only: the populated DOFs are not a contiguous prefix
+///   (an `axes[i] = None` is followed by some `axes[j > i] = Some(_)`).
+///   A hole in the middle of the chain is a configuration error.
 pub fn evaluate_model(model: &JointKinematicsModel, elapsed_seconds: f64) -> (JeodQuat, DVec3) {
     match model {
         JointKinematicsModel::ConstantRate(spec) => evaluate(spec, elapsed_seconds),

--- a/crates/jeod_dynamics/src/kinematic_joint.rs
+++ b/crates/jeod_dynamics/src/kinematic_joint.rs
@@ -469,6 +469,12 @@ impl MultiDofJointKinematicsSpec {
 ///
 /// # Panics
 ///
+/// - `elapsed_seconds` is non-finite (`NaN` or `±∞`). The empty-chain
+///   fast path returns `(identity, zero)` without invoking any
+///   per-stage evaluator, so without this top-level guard a non-finite
+///   clock could silently propagate through the no-op chain and
+///   violate the fail-loud contract that the other joint evaluators
+///   uphold.
 /// - The populated DOFs are not a contiguous prefix
 ///   (`axes[i]` is `None` followed by some `axes[j > i]` that is
 ///   `Some(_)`). A hole in the middle of the chain is a configuration
@@ -479,6 +485,19 @@ pub fn evaluate_multi_dof(
     spec: &MultiDofJointKinematicsSpec,
     elapsed_seconds: f64,
 ) -> (JeodQuat, DVec3) {
+    // Top-level finite-time guard. The per-stage evaluators each
+    // assert `elapsed_seconds.is_finite()`, but for a chain with zero
+    // populated DOFs the loop below never enters and a non-finite
+    // clock would silently fall through to the `(identity, zero)`
+    // return. Asserting here makes the empty-chain fast path
+    // fail-loud, matching the contract the populated chain inherits
+    // from the per-stage evaluators.
+    assert!(
+        elapsed_seconds.is_finite(),
+        "joint kinematics elapsed_seconds must be finite, got {elapsed_seconds}. \
+         The simulation time has gone non-finite — fix the time-update path."
+    );
+
     // Validate prefix-filled invariant: once we see a `None`, every
     // subsequent slot must also be `None`. A hole in the middle would
     // silently drop a stage from the composition without diagnostic.
@@ -1167,6 +1186,21 @@ mod tests {
     /// `None`, then populated again) is a configuration error and
     /// must panic. This invariant prevents a silent mid-chain stage
     /// drop.
+    /// An empty multi-DOF chain (`axes` all `None`) returning the
+    /// no-op `(identity, zero)` must still fail loud when the clock
+    /// is non-finite. Without the top-level guard, the chain's
+    /// fast-path return would hide a `NaN` simulation time from
+    /// every per-stage evaluator and violate the fail-loud contract
+    /// the populated chain inherits.
+    #[test]
+    #[should_panic(expected = "elapsed_seconds must be finite")]
+    fn multi_dof_empty_chain_nan_time_panics() {
+        let spec = MultiDofJointKinematicsSpec {
+            axes: [None; MAX_MULTI_DOF_AXES],
+        };
+        let _ = evaluate_multi_dof(&spec, f64::NAN);
+    }
+
     #[test]
     #[should_panic(expected = "contiguous prefix")]
     fn multi_dof_hole_in_middle_panics() {

--- a/crates/jeod_dynamics/src/lib.rs
+++ b/crates/jeod_dynamics/src/lib.rs
@@ -74,7 +74,14 @@ pub use forces::{
 pub use gauss_jackson::config::GaussJacksonConfig;
 pub use gauss_jackson::{GaussJacksonState, IntegratorResult};
 pub use integration::{rk4_sixdof_step, rk4_translational_step, IntegratorType};
-pub use kinematic_joint::{evaluate as evaluate_joint_kinematics, JointKinematicsSpec};
+pub use kinematic_joint::{
+    evaluate as evaluate_joint_kinematics, evaluate_closure as evaluate_closure_kinematics,
+    evaluate_model as evaluate_joint_kinematics_model,
+    evaluate_multi_dof as evaluate_multi_dof_kinematics,
+    evaluate_sinusoidal as evaluate_sinusoidal_kinematics, ClosureJointKinematicsSpec,
+    JointKinematicsModel, JointKinematicsSpec, MultiDofJointKinematicsSpec, SingleDofKinematics,
+    SinusoidalJointKinematicsSpec, MAX_MULTI_DOF_AXES,
+};
 pub use kinematic_propagation::{
     compute_kinematic_child_state, compute_kinematic_child_state_dquat,
     compute_kinematic_child_state_typed, derive_kinematic_child_from_states, KinematicChildInputs,

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -95,7 +95,12 @@ pub use interactions::{
     GroundContactPairEval, ThermalIntegrationOrder,
 };
 pub use jeod_dynamics::kinematic_joint::{
-    evaluate as evaluate_joint_kinematics, JointKinematicsSpec, AXIS_NORM_TOL,
+    evaluate as evaluate_joint_kinematics, evaluate_closure as evaluate_closure_kinematics,
+    evaluate_model as evaluate_joint_kinematics_model,
+    evaluate_multi_dof as evaluate_multi_dof_kinematics,
+    evaluate_sinusoidal as evaluate_sinusoidal_kinematics, ClosureJointKinematicsSpec,
+    JointKinematicsModel, JointKinematicsSpec, MultiDofJointKinematicsSpec, SingleDofKinematics,
+    SinusoidalJointKinematicsSpec, AXIS_NORM_TOL, MAX_MULTI_DOF_AXES,
 };
 pub use jeod_dynamics::{
     Abm4State, GaussJacksonConfig, GaussJacksonState, IntegratorResult, IntegratorType,

--- a/src/components.rs
+++ b/src/components.rs
@@ -828,7 +828,7 @@ impl From<jeod_sim::JointKinematicsSpec> for JointKinematicsC {
 /// The `#[require]` triplet matches [`JointKinematicsC`] so spawning a
 /// joint frame entity carrying this component automatically materializes
 /// the [`FrameTransC`] / [`FrameRotC`] / [`FrameAngVelC`] frame-tree
-/// triplet — `RelativeFrameState` walks across the joint stay
+/// triplet, so `RelativeFrameState` walks across the joint remain
 /// well-defined.
 ///
 /// Wraps [`jeod_sim::SinusoidalJointKinematicsSpec`] one-to-one. Mission

--- a/src/components.rs
+++ b/src/components.rs
@@ -813,6 +813,99 @@ impl From<jeod_sim::JointKinematicsSpec> for JointKinematicsC {
     }
 }
 
+/// Declarative spec for a kinematically driven single-axis joint whose
+/// angle is a sinusoidal function of time
+/// (`θ(t) = offset + amplitude · sin(ω · t + phase)`).
+///
+/// Sibling component to [`JointKinematicsC`] for the periodic-articulation
+/// case — solar-array dither, antenna scan, gimbal sweep — that the
+/// constant-rate spec cannot express. The driving system writes the
+/// same [`FrameRotC`] / [`FrameAngVelC`] storage as
+/// [`JointKinematicsC`], so a downstream consumer that walks the
+/// frame tree sees a uniform rotation snapshot regardless of which
+/// kinematic style drives the joint.
+///
+/// The `#[require]` triplet matches [`JointKinematicsC`] so spawning a
+/// joint frame entity carrying this component automatically materializes
+/// the [`FrameTransC`] / [`FrameRotC`] / [`FrameAngVelC`] frame-tree
+/// triplet — `RelativeFrameState` walks across the joint stay
+/// well-defined.
+///
+/// Wraps [`jeod_sim::SinusoidalJointKinematicsSpec`] one-to-one. Mission
+/// code that needs richer kinematic styles than constant-rate /
+/// sinusoidal / closure (e.g., piecewise-linear angular splines) reaches
+/// for a custom system; the kinematic-only spec catalogue exposed here
+/// covers the periodic / loop-closing / multi-DOF cases.
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque, Component)]
+#[require(FrameTransC, FrameRotC, FrameAngVelC)]
+pub struct SinusoidalJointKinematicsC(pub jeod_sim::SinusoidalJointKinematicsSpec);
+
+impl From<jeod_sim::SinusoidalJointKinematicsSpec> for SinusoidalJointKinematicsC {
+    #[inline]
+    fn from(spec: jeod_sim::SinusoidalJointKinematicsSpec) -> Self {
+        Self(spec)
+    }
+}
+
+/// Declarative spec for a *closure* joint — one pinned to a fixed
+/// rotation about a single axis with no time dependence.
+///
+/// The kinematic-only degenerate case useful for closing kinematic
+/// loops where one joint's pose is constrained at declaration time
+/// rather than driven through `θ(t)`. The system writes a constant
+/// `FrameRotC` and zero `FrameAngVelC` every tick, so the joint
+/// frame's contribution to a `RelativeFrameState` walk is the same
+/// every step (cheap; the per-tick reassignment is the same value
+/// each time).
+///
+/// Wraps [`jeod_sim::ClosureJointKinematicsSpec`] one-to-one and
+/// auto-inserts the frame-tree triplet via `#[require]`, matching
+/// [`JointKinematicsC`].
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque, Component)]
+#[require(FrameTransC, FrameRotC, FrameAngVelC)]
+pub struct ClosureJointKinematicsC(pub jeod_sim::ClosureJointKinematicsSpec);
+
+impl From<jeod_sim::ClosureJointKinematicsSpec> for ClosureJointKinematicsC {
+    #[inline]
+    fn from(spec: jeod_sim::ClosureJointKinematicsSpec) -> Self {
+        Self(spec)
+    }
+}
+
+/// Declarative spec for a multi-DOF kinematic joint — up to
+/// [`jeod_sim::MAX_MULTI_DOF_AXES`] single-axis stages composed into
+/// one chain.
+///
+/// Each stage is a `SingleDofKinematics` variant
+/// (`ConstantRate`/`Sinusoidal`/`Closure`) that rotates about its
+/// declared axis in the *intermediate frame produced by the
+/// preceding stages*. Stages must be a contiguous prefix of the
+/// fixed-size axes array; the kernel asserts this.
+///
+/// The semantic equivalence is deliberate: a multi-DOF joint with N
+/// stages on a single entity produces the same `(rotation, angular
+/// velocity)` snapshot as a chain of N single-DOF joint entities
+/// linked by `ChildOf`. Mission code picks whichever shape is more
+/// ergonomic — a long arm benefits from N entities (each with its
+/// own name + frame-tree slot for inspection); a tightly-coupled 2-3
+/// DOF gimbal benefits from one entity.
+///
+/// Wraps [`jeod_sim::MultiDofJointKinematicsSpec`] one-to-one and
+/// auto-inserts the frame-tree triplet via `#[require]`.
+#[derive(Component, Debug, Clone, Copy, Deref, DerefMut, Reflect)]
+#[reflect(opaque, Component)]
+#[require(FrameTransC, FrameRotC, FrameAngVelC)]
+pub struct MultiDofJointKinematicsC(pub jeod_sim::MultiDofJointKinematicsSpec);
+
+impl From<jeod_sim::MultiDofJointKinematicsSpec> for MultiDofJointKinematicsC {
+    #[inline]
+    fn from(spec: jeod_sim::MultiDofJointKinematicsSpec) -> Self {
+        Self(spec)
+    }
+}
+
 /// Tidal configuration for a gravity source entity.
 ///
 /// When present on a gravity source entity alongside `PlanetFixedRotationC`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,15 @@ impl Plugin for JeodPlugin {
                 // body-frame registration pass.
                 systems::sync_body_mass_point_ref_system
                     .after(systems::register_body_frames_system),
+                // Reject startup configs where a single frame entity
+                // carries multiple kinematic-spec components: the four
+                // driver systems use `Without<...>` filters to advertise
+                // pairwise-disjoint queries to the scheduler, so an
+                // entity with two specs would be silently dropped from
+                // every driver and propagate stale `FrameRotC` /
+                // `FrameAngVelC` instead of panicking. The fail-loud
+                // rule forbids that silent path.
+                systems::validate_joint_kinematics_exclusivity,
             ),
         );
         app.add_systems(
@@ -423,13 +432,31 @@ impl Plugin for JeodPlugin {
                 // `add_systems` call carries the system.
                 systems::joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
                 // Sibling kinematic-joint drivers for the richer specs
-                // (sinusoidal, closure, multi-DOF). Same scheduling
-                // story as `joint_kinematics_system`: all four write
-                // `FrameRotC` / `FrameAngVelC` on disjoint entity sets
-                // (each entity carries at most one of the four
-                // kinematic-spec components — the components are
-                // semantic alternatives, not stackable), so they
-                // commute under EphemerisUpdate's parallelism.
+                // (sinusoidal, closure, multi-DOF). All four write
+                // `FrameRotC` / `FrameAngVelC` and run inside the same
+                // `EphemerisUpdate` set; pairwise disjointness on
+                // those mutable accesses is enforced two ways so the
+                // scheduler can dispatch them in parallel without a
+                // borrow conflict and so a misconfigured entity can't
+                // silently drop out of the pipeline:
+                //
+                // * **Per-system `Without<...>` filters** — each
+                //   driver excludes the other three spec components,
+                //   so the queries are structurally disjoint at the
+                //   `Query` level. This is the signal Bevy needs to
+                //   parallelize the four systems on the same set.
+                // * **Startup validation** —
+                //   `validate_joint_kinematics_exclusivity` walks
+                //   every frame entity once at `Startup` and panics
+                //   loudly if any entity carries more than one spec.
+                //   Without this, the `Without<...>` filters would
+                //   turn a stacked-spec misconfiguration into a
+                //   silent stale-state read; the fail-loud rule
+                //   forbids that.
+                //
+                // Spec components are semantic alternatives, not
+                // stackable: a joint is *either* constant-rate, *or*
+                // sinusoidal, *or* closure, *or* multi-DOF.
                 systems::sinusoidal_joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
                 systems::closure_joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
                 systems::multi_dof_joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,17 +271,24 @@ impl Plugin for JeodPlugin {
                 // body-frame registration pass.
                 systems::sync_body_mass_point_ref_system
                     .after(systems::register_body_frames_system),
-                // Reject startup configs where a single frame entity
-                // carries multiple kinematic-spec components: the four
-                // driver systems use `Without<...>` filters to advertise
-                // pairwise-disjoint queries to the scheduler, so an
-                // entity with two specs would be silently dropped from
-                // every driver and propagate stale `FrameRotC` /
-                // `FrameAngVelC` instead of panicking. The fail-loud
-                // rule forbids that silent path.
-                systems::validate_joint_kinematics_exclusivity,
             ),
         );
+        // Reject startup configs where a single frame entity carries
+        // multiple kinematic-spec components: the four driver systems
+        // use `Without<...>` filters to advertise pairwise-disjoint
+        // queries to the scheduler, so an entity with two specs would
+        // be silently dropped from every driver and propagate stale
+        // `FrameRotC` / `FrameAngVelC` instead of panicking. The
+        // fail-loud rule forbids that silent path.
+        //
+        // Wired into `PostStartup` (not `Startup`) so the validator
+        // runs after all user `Startup` systems and after Bevy's
+        // auto-inserted command flush between the two schedules.
+        // Mission code typically spawns joint entities via `Commands`
+        // in a user `Startup` system added after `JeodPlugin`; placing
+        // the guard in `Startup` would let it observe an empty world
+        // and miss the stacked-spec misconfiguration entirely.
+        app.add_systems(PostStartup, systems::validate_joint_kinematics_exclusivity);
         app.add_systems(
             PreUpdate,
             (
@@ -445,14 +452,15 @@ impl Plugin for JeodPlugin {
                 //   so the queries are structurally disjoint at the
                 //   `Query` level. This is the signal Bevy needs to
                 //   parallelize the four systems on the same set.
-                // * **Startup validation** —
+                // * **PostStartup validation** —
                 //   `validate_joint_kinematics_exclusivity` walks
-                //   every frame entity once at `Startup` and panics
-                //   loudly if any entity carries more than one spec.
-                //   Without this, the `Without<...>` filters would
-                //   turn a stacked-spec misconfiguration into a
-                //   silent stale-state read; the fail-loud rule
-                //   forbids that.
+                //   every frame entity once at `PostStartup` (after
+                //   user `Startup` systems and the auto-inserted
+                //   command flush) and panics loudly if any entity
+                //   carries more than one spec. Without this, the
+                //   `Without<...>` filters would turn a stacked-spec
+                //   misconfiguration into a silent stale-state read;
+                //   the fail-loud rule forbids that.
                 //
                 // Spec components are semantic alternatives, not
                 // stackable: a joint is *either* constant-rate, *or*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,21 +273,36 @@ impl Plugin for JeodPlugin {
                     .after(systems::register_body_frames_system),
             ),
         );
-        // Reject startup configs where a single frame entity carries
-        // multiple kinematic-spec components: the four driver systems
-        // use `Without<...>` filters to advertise pairwise-disjoint
+        // Reject configs where a single frame entity carries multiple
+        // kinematic-spec components: the four driver systems use
+        // `Without<...>` filters to advertise pairwise-disjoint
         // queries to the scheduler, so an entity with two specs would
         // be silently dropped from every driver and propagate stale
         // `FrameRotC` / `FrameAngVelC` instead of panicking. The
         // fail-loud rule forbids that silent path.
         //
-        // Wired into `PostStartup` (not `Startup`) so the validator
-        // runs after all user `Startup` systems and after Bevy's
-        // auto-inserted command flush between the two schedules.
-        // Mission code typically spawns joint entities via `Commands`
-        // in a user `Startup` system added after `JeodPlugin`; placing
-        // the guard in `Startup` would let it observe an empty world
-        // and miss the stacked-spec misconfiguration entirely.
+        // Two layers of enforcement:
+        //
+        // 1. **Component `on_insert` hooks** —
+        //    `register_joint_kinematics_exclusivity_hooks` installs a
+        //    Bevy lifecycle hook on each of the four spec components
+        //    that fires the moment an insertion lands a second spec
+        //    on an entity, regardless of which schedule the insert
+        //    happened in (`Startup`, `Update`, `FixedUpdate`, an
+        //    observer, …). This is the primary guard: it catches
+        //    runtime spawns / inserts that the `PostStartup`
+        //    validator never sees.
+        //
+        // 2. **`PostStartup` validator** — defense in depth, kept so
+        //    a startup-time misconfiguration panics with a single
+        //    aggregated message that lists every offending entity at
+        //    once (the per-insert hooks panic on the *first* offender
+        //    they observe, which is the right shape for runtime but
+        //    less helpful when several stacked-spec entities are
+        //    declared together at startup). Wired into `PostStartup`
+        //    (not `Startup`) so it observes commands flushed at the
+        //    end of `Startup`.
+        systems::register_joint_kinematics_exclusivity_hooks(app);
         app.add_systems(PostStartup, systems::validate_joint_kinematics_exclusivity);
         app.add_systems(
             PreUpdate,
@@ -442,25 +457,28 @@ impl Plugin for JeodPlugin {
                 // (sinusoidal, closure, multi-DOF). All four write
                 // `FrameRotC` / `FrameAngVelC` and run inside the same
                 // `EphemerisUpdate` set; pairwise disjointness on
-                // those mutable accesses is enforced two ways so the
-                // scheduler can dispatch them in parallel without a
-                // borrow conflict and so a misconfigured entity can't
-                // silently drop out of the pipeline:
+                // those mutable accesses is enforced three ways so
+                // the scheduler can dispatch them in parallel without
+                // a borrow conflict and so a misconfigured entity
+                // can't silently drop out of the pipeline:
                 //
                 // * **Per-system `Without<...>` filters** — each
                 //   driver excludes the other three spec components,
                 //   so the queries are structurally disjoint at the
                 //   `Query` level. This is the signal Bevy needs to
                 //   parallelize the four systems on the same set.
+                // * **Component `on_insert` hooks** —
+                //   `register_joint_kinematics_exclusivity_hooks`
+                //   panics at insertion time when a stacked-spec
+                //   entity is created or mutated, including spawns
+                //   that happen long after `Startup` (FixedUpdate,
+                //   Update, observers, …).
                 // * **PostStartup validation** —
                 //   `validate_joint_kinematics_exclusivity` walks
-                //   every frame entity once at `PostStartup` (after
-                //   user `Startup` systems and the auto-inserted
-                //   command flush) and panics loudly if any entity
-                //   carries more than one spec. Without this, the
-                //   `Without<...>` filters would turn a stacked-spec
-                //   misconfiguration into a silent stale-state read;
-                //   the fail-loud rule forbids that.
+                //   every frame entity once at `PostStartup` and
+                //   reports *every* offender at startup in one
+                //   aggregated message; defense in depth alongside
+                //   the hooks.
                 //
                 // Spec components are semantic alternatives, not
                 // stackable: a joint is *either* constant-rate, *or*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,6 +422,17 @@ impl Plugin for JeodPlugin {
                 // limit; set membership controls ordering, not which
                 // `add_systems` call carries the system.
                 systems::joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
+                // Sibling kinematic-joint drivers for the richer specs
+                // (sinusoidal, closure, multi-DOF). Same scheduling
+                // story as `joint_kinematics_system`: all four write
+                // `FrameRotC` / `FrameAngVelC` on disjoint entity sets
+                // (each entity carries at most one of the four
+                // kinematic-spec components — the components are
+                // semantic alternatives, not stackable), so they
+                // commute under EphemerisUpdate's parallelism.
+                systems::sinusoidal_joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
+                systems::closure_joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
+                systems::multi_dof_joint_kinematics_system.in_set(JeodSet::EphemerisUpdate),
                 // Force collection and integration
                 systems::force_collection_system.in_set(JeodSet::ForceCollection),
                 // Kinematic state propagation: walks MassChildOf
@@ -530,6 +541,9 @@ pub fn register_jeod_component_types(app: &mut App) {
     app.register_type::<components::PfixFrameEntityC>();
     app.register_type::<components::RetiredPfixFrameEntityC>();
     app.register_type::<components::JointKinematicsC>();
+    app.register_type::<components::SinusoidalJointKinematicsC>();
+    app.register_type::<components::ClosureJointKinematicsC>();
+    app.register_type::<components::MultiDofJointKinematicsC>();
     // Tidal
     app.register_type::<components::TidalConfigC>();
     app.register_type::<components::TidalDeltaC20C>();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,12 +25,13 @@
 //! ```
 
 pub use crate::{
-    Abm4StateC, AerodynamicForceC, AtmosphericStateC, BodyFrameMarker, DetachedSubtreeStateC,
-    DynamicsConfigC, FrameAngVelC, FrameDerivativesC, FrameEntityC, FrameRotC, FrameTransC,
-    GaussJacksonStateC, GravityAccelerationC, GravityControlsC, GravitySourceC, GravityTorqueC,
-    InertialFrameMarker, IntegrationFrameMarker, IntegratorTypeC, JeodPlugin, JeodSet,
-    JointKinematicsC, MassPropertiesC, PfixFrameEntityC, PlanetFixedFrameMarker,
-    PlanetFixedRotationC, RadiationForceC, RootFrameEntityR, RotationalStateC, SimulationTimeR,
+    Abm4StateC, AerodynamicForceC, AtmosphericStateC, BodyFrameMarker, ClosureJointKinematicsC,
+    DetachedSubtreeStateC, DynamicsConfigC, FrameAngVelC, FrameDerivativesC, FrameEntityC,
+    FrameRotC, FrameTransC, GaussJacksonStateC, GravityAccelerationC, GravityControlsC,
+    GravitySourceC, GravityTorqueC, InertialFrameMarker, IntegrationFrameMarker, IntegratorTypeC,
+    JeodPlugin, JeodSet, JointKinematicsC, MassPropertiesC, MultiDofJointKinematicsC,
+    PfixFrameEntityC, PlanetFixedFrameMarker, PlanetFixedRotationC, RadiationForceC,
+    RootFrameEntityR, RotationalStateC, SimulationTimeR, SinusoidalJointKinematicsC,
     SourceInertialPositionC, SourceInertialVelocityC, StructuralTransformC, TotalForceC,
     TranslationalStateC, VehicleConfigBevyExt,
 };
@@ -50,9 +51,11 @@ pub use crate::frame_param::{FrameOrigin, RelativeFrameState};
 // (per CLAUDE.md "Three-Layer Architecture": the root package depends
 // only on `jeod_sim` + `bevy`).
 pub use jeod_sim::{
-    Array3Ext, BodyFrame, Ecef, F64Ext, Frame, FrameTransform, GravityControl, JeodQuat,
-    JointKinematicsSpec, Lvlh, Ned, Planet, PlanetFixed, Qty3, RootInertial, SelfPlanet, SelfRef,
-    StructuralFrame, Vec3Ext, Vehicle, VehicleBuilder, VehicleConfig, AXIS_NORM_TOL,
+    Array3Ext, BodyFrame, ClosureJointKinematicsSpec, Ecef, F64Ext, Frame, FrameTransform,
+    GravityControl, JeodQuat, JointKinematicsModel, JointKinematicsSpec, Lvlh,
+    MultiDofJointKinematicsSpec, Ned, Planet, PlanetFixed, Qty3, RootInertial, SelfPlanet, SelfRef,
+    SingleDofKinematics, SinusoidalJointKinematicsSpec, StructuralFrame, Vec3Ext, Vehicle,
+    VehicleBuilder, VehicleConfig, AXIS_NORM_TOL, MAX_MULTI_DOF_AXES,
 };
 // Mission-crate macros for defining additional `Vehicle` / `Planet`
 // markers. Re-exported so `use bevy_jeod::prelude::*;` brings them into

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1389,14 +1389,19 @@ pub fn multi_dof_joint_kinematics_system(
 ///
 /// Per the project's fail-loud rule, that misconfiguration must
 /// panic at the earliest detection point with a diagnostic that
-/// names the offending entity and the specs it carries. This guard
-/// runs at `PostStartup` (after every user `Startup` system and the
-/// auto-inserted command flush, but before the first `FixedUpdate`
-/// tick) so any joint entity spawned via `Commands` from a user
-/// `Startup` system is materialized in the world by the time the
-/// guard observes it. It walks every entity carrying at least one
-/// kinematic spec via [`Has<...>`] flags; any entity with more than
-/// one spec is reported in a single panic message.
+/// names the offending entity and the specs it carries. The primary
+/// guard is the per-component `on_insert` hook installed by
+/// [`register_joint_kinematics_exclusivity_hooks`], which fires at
+/// insertion time and catches every stacking pattern (Startup,
+/// FixedUpdate, observers, …). This `PostStartup` validator is
+/// defense in depth: it walks every entity that already carries at
+/// least one kinematic spec once before the first `FixedUpdate` tick
+/// and emits a *single* aggregated panic message that lists every
+/// offending entity at once. The `on_insert` hooks panic on the
+/// first stacked insertion they observe, which is right for runtime
+/// but less informative when the user declares several stacked
+/// entities together at startup; the aggregated startup pass keeps
+/// that path actionable.
 ///
 /// The four spec components are declarative alternatives — a joint
 /// is *either* constant-rate, *or* sinusoidal, *or* a closure pose,
@@ -1462,6 +1467,154 @@ pub fn validate_joint_kinematics_exclusivity(
          use MultiDofJointKinematicsC with a chain of SingleDofKinematics stages.",
         offenders.join("; ")
     );
+}
+
+/// Format a "stacked specs" panic diagnostic for a single offending
+/// entity. Centralized so the `on_insert` hooks below and any future
+/// detection site share one message shape — a mission engineer reading
+/// the panic always sees the same actionable instructions regardless
+/// of which path tripped the check.
+fn format_stacked_specs_panic(entity: Entity, names: &[&'static str]) -> String {
+    format!(
+        "Joint-kinematics spec components are mutually exclusive — each frame entity \
+         must carry at most one of JointKinematicsC, SinusoidalJointKinematicsC, \
+         ClosureJointKinematicsC, MultiDofJointKinematicsC. Offending entity: \
+         {entity:?} carries [{}]. \
+         Fix: pick a single kinematic style per joint frame; for composed motions \
+         use MultiDofJointKinematicsC with a chain of SingleDofKinematics stages.",
+        names.join(", ")
+    )
+}
+
+/// Shared body of the four joint-kinematics `on_insert` hooks. Reads
+/// every spec flag off the entity's post-insertion archetype, counts
+/// how many distinct specs are present, and panics with
+/// [`format_stacked_specs_panic`] if more than one is. `self_name`
+/// is the spec component whose hook is firing — included in the
+/// panic so a mission engineer reading the backtrace sees which
+/// insertion attempt tripped the check.
+///
+/// `on_insert` runs after the bundle's components are already added
+/// to the entity's archetype, so the four `contains::<...>` reads
+/// on the `DeferredWorld` reflect the full post-insertion state.
+fn check_stacked_specs(
+    world: bevy::ecs::world::DeferredWorld<'_>,
+    entity: Entity,
+    self_name: &'static str,
+) {
+    let entity_ref = world.get_entity(entity).expect(
+        "joint-kinematics on_insert hook: entity must exist when its component is inserted",
+    );
+    let has_const = entity_ref.contains::<JointKinematicsC>();
+    let has_sin = entity_ref.contains::<SinusoidalJointKinematicsC>();
+    let has_close = entity_ref.contains::<ClosureJointKinematicsC>();
+    let has_multi = entity_ref.contains::<MultiDofJointKinematicsC>();
+    let count = usize::from(has_const)
+        + usize::from(has_sin)
+        + usize::from(has_close)
+        + usize::from(has_multi);
+    if count <= 1 {
+        return;
+    }
+    let mut names: Vec<&'static str> = Vec::new();
+    if has_const {
+        names.push("JointKinematicsC");
+    }
+    if has_sin {
+        names.push("SinusoidalJointKinematicsC");
+    }
+    if has_close {
+        names.push("ClosureJointKinematicsC");
+    }
+    if has_multi {
+        names.push("MultiDofJointKinematicsC");
+    }
+    panic!(
+        "{} (triggered while inserting {self_name})",
+        format_stacked_specs_panic(entity, &names)
+    );
+}
+
+// `ComponentHook` is `fn(DeferredWorld, HookContext)` — a plain
+// function pointer with no captures. Each spec component therefore
+// gets its own dedicated `fn` item that forwards to
+// `check_stacked_specs` with a hard-coded `self_name`.
+
+fn on_insert_joint_kinematics_c(
+    world: bevy::ecs::world::DeferredWorld<'_>,
+    ctx: bevy::ecs::lifecycle::HookContext,
+) {
+    check_stacked_specs(world, ctx.entity, "JointKinematicsC");
+}
+
+fn on_insert_sinusoidal_joint_kinematics_c(
+    world: bevy::ecs::world::DeferredWorld<'_>,
+    ctx: bevy::ecs::lifecycle::HookContext,
+) {
+    check_stacked_specs(world, ctx.entity, "SinusoidalJointKinematicsC");
+}
+
+fn on_insert_closure_joint_kinematics_c(
+    world: bevy::ecs::world::DeferredWorld<'_>,
+    ctx: bevy::ecs::lifecycle::HookContext,
+) {
+    check_stacked_specs(world, ctx.entity, "ClosureJointKinematicsC");
+}
+
+fn on_insert_multi_dof_joint_kinematics_c(
+    world: bevy::ecs::world::DeferredWorld<'_>,
+    ctx: bevy::ecs::lifecycle::HookContext,
+) {
+    check_stacked_specs(world, ctx.entity, "MultiDofJointKinematicsC");
+}
+
+/// Register `on_insert` hooks on every joint-kinematics spec component
+/// so any insertion that lands a second spec on an entity panics
+/// immediately.
+///
+/// The `PostStartup` validator
+/// ([`validate_joint_kinematics_exclusivity`]) is a startup-time
+/// safety net: it walks the world *once* before the first
+/// `FixedUpdate` tick and catches misconfigurations declared in
+/// `Startup` systems. It cannot observe entities spawned after
+/// `PostStartup` — for example, a `Commands::spawn(...)` issued from
+/// a `FixedUpdate` user system, an `Update` system, or an event
+/// handler. Without a runtime guard those late spawns slip past every
+/// driver's `Without<...>` filter and silently propagate stale
+/// `FrameRotC` / `FrameAngVelC`, which the project's fail-loud rule
+/// forbids.
+///
+/// Bevy 0.18 component lifecycle hooks (`on_insert`) close that gap:
+/// every kinematic-spec insertion — `spawn`, `insert`, or `replace`
+/// — fires its hook before the next system observes the new
+/// component, so a bad insertion panics at the insertion site rather
+/// than silently propagating bad state. The hook reads the entity's
+/// post-insertion archetype to count how many of the four spec
+/// components are present and panics with the same diagnostic shape
+/// as [`validate_joint_kinematics_exclusivity`] if more than one is.
+///
+/// Idempotent re-registration of the *same* spec component (insert A
+/// onto an entity that already has A) does not trip the hook: the
+/// count of distinct kinematic specs is unchanged. Only stacking
+/// distinct specs panics.
+///
+/// `JeodPlugin::build` calls this once during plugin setup. Tests
+/// that exercise the joint-kinematics pipeline without `JeodPlugin`
+/// can call this directly to install the same guard.
+pub fn register_joint_kinematics_exclusivity_hooks(app: &mut App) {
+    let world = app.world_mut();
+    world
+        .register_component_hooks::<JointKinematicsC>()
+        .on_insert(on_insert_joint_kinematics_c);
+    world
+        .register_component_hooks::<SinusoidalJointKinematicsC>()
+        .on_insert(on_insert_sinusoidal_joint_kinematics_c);
+    world
+        .register_component_hooks::<ClosureJointKinematicsC>()
+        .on_insert(on_insert_closure_joint_kinematics_c);
+    world
+        .register_component_hooks::<MultiDofJointKinematicsC>()
+        .on_insert(on_insert_multi_dof_joint_kinematics_c);
 }
 
 /// Computes tidal ΔC20 for each gravity source that has a `TidalConfigC`.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1233,6 +1233,84 @@ pub fn joint_kinematics_system(
     }
 }
 
+/// Drives sinusoidal kinematic joint frames each tick.
+///
+/// Sibling of [`joint_kinematics_system`] that handles
+/// [`SinusoidalJointKinematicsC`]-tagged frame entities. Reads the
+/// same `tai_seconds` clock and writes the same
+/// [`FrameRotC`] / [`FrameAngVelC`] storage, so downstream consumers
+/// that walk the frame tree see uniform output across the kinematic
+/// styles.
+///
+/// Scheduled in [`crate::JeodSet::EphemerisUpdate`] alongside
+/// `planet_fixed_rotation_system` and `joint_kinematics_system` —
+/// the joint frame's rotation / angular velocity must be current
+/// before any consumer that walks the frame tree (gravity, derived
+/// state, integration) reads them.
+pub fn sinusoidal_joint_kinematics_system(
+    sim_time: Res<SimulationTimeR>,
+    mut query: Query<(
+        &SinusoidalJointKinematicsC,
+        &mut FrameRotC,
+        &mut FrameAngVelC,
+    )>,
+) {
+    let elapsed = sim_time.tai_seconds;
+    for (spec, mut rot, mut ang_vel) in &mut query {
+        let (q_parent_this, ang_vel_this) =
+            jeod_sim::evaluate_sinusoidal_kinematics(&spec.0, elapsed);
+        rot.q_parent_this = q_parent_this;
+        rot.t_parent_this = q_parent_this.left_quat_to_transformation();
+        ang_vel.0 = ang_vel_this;
+    }
+}
+
+/// Drives closure (fixed-pose) kinematic joint frames each tick.
+///
+/// Sibling of [`joint_kinematics_system`] that handles
+/// [`ClosureJointKinematicsC`]-tagged frame entities. The output is
+/// constant in time, so the system writes the same `FrameRotC` /
+/// `FrameAngVelC` value every step. Scheduled in
+/// [`crate::JeodSet::EphemerisUpdate`] alongside
+/// `joint_kinematics_system` so the closure-pinned frame's rotation
+/// is materialized before any frame-tree consumer reads it.
+pub fn closure_joint_kinematics_system(
+    sim_time: Res<SimulationTimeR>,
+    mut query: Query<(&ClosureJointKinematicsC, &mut FrameRotC, &mut FrameAngVelC)>,
+) {
+    let elapsed = sim_time.tai_seconds;
+    for (spec, mut rot, mut ang_vel) in &mut query {
+        let (q_parent_this, ang_vel_this) = jeod_sim::evaluate_closure_kinematics(&spec.0, elapsed);
+        rot.q_parent_this = q_parent_this;
+        rot.t_parent_this = q_parent_this.left_quat_to_transformation();
+        ang_vel.0 = ang_vel_this;
+    }
+}
+
+/// Drives multi-DOF kinematic joint frames each tick.
+///
+/// Sibling of [`joint_kinematics_system`] that handles
+/// [`MultiDofJointKinematicsC`]-tagged frame entities. Each entity
+/// carries an N-stage chain (`N <= MAX_MULTI_DOF_AXES`); the kernel
+/// folds the per-stage `(rotation, ang_vel)` contributions through
+/// `RefFrameState::incr_right` so the output is bit-identical to a
+/// chain of N single-DOF joint entities walked through the frame
+/// tree. Scheduled in [`crate::JeodSet::EphemerisUpdate`] for the
+/// same reason as the other joint-kinematics systems.
+pub fn multi_dof_joint_kinematics_system(
+    sim_time: Res<SimulationTimeR>,
+    mut query: Query<(&MultiDofJointKinematicsC, &mut FrameRotC, &mut FrameAngVelC)>,
+) {
+    let elapsed = sim_time.tai_seconds;
+    for (spec, mut rot, mut ang_vel) in &mut query {
+        let (q_parent_this, ang_vel_this) =
+            jeod_sim::evaluate_multi_dof_kinematics(&spec.0, elapsed);
+        rot.q_parent_this = q_parent_this;
+        rot.t_parent_this = q_parent_this.left_quat_to_transformation();
+        ang_vel.0 = ang_vel_this;
+    }
+}
+
 /// Computes tidal ΔC20 for each gravity source that has a `TidalConfigC`.
 ///
 /// Runs after `planet_fixed_rotation_system` so the rotation matrix is current.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1220,9 +1220,28 @@ pub fn planet_fixed_rotation_system(
 /// state — there is no torque, inertia, or momentum. Joint dynamics
 /// (free-swinging joints, IK, constraint-derived joint forces) are
 /// out of scope; see the deferred-dynamics meta.
+///
+/// The `Without<...>` filters on the three sibling kinematic-spec
+/// components make this query structurally disjoint from the
+/// sinusoidal / closure / multi-DOF drivers, so Bevy's scheduler
+/// can dispatch the four systems in parallel under
+/// `JeodSet::EphemerisUpdate` without a runtime borrow conflict on
+/// `FrameRotC` / `FrameAngVelC`. An entity that accidentally carries
+/// more than one kinematic spec is silently dropped from every
+/// driver's query — `validate_joint_kinematics_exclusivity` runs at
+/// `Startup` to reject such misconfigurations loudly before any
+/// driver tick can mask them.
+#[allow(clippy::type_complexity)]
 pub fn joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
-    mut query: Query<(&JointKinematicsC, &mut FrameRotC, &mut FrameAngVelC)>,
+    mut query: Query<
+        (&JointKinematicsC, &mut FrameRotC, &mut FrameAngVelC),
+        (
+            Without<SinusoidalJointKinematicsC>,
+            Without<ClosureJointKinematicsC>,
+            Without<MultiDofJointKinematicsC>,
+        ),
+    >,
 ) {
     let elapsed = sim_time.tai_seconds;
     for (spec, mut rot, mut ang_vel) in &mut query {
@@ -1247,13 +1266,27 @@ pub fn joint_kinematics_system(
 /// the joint frame's rotation / angular velocity must be current
 /// before any consumer that walks the frame tree (gravity, derived
 /// state, integration) reads them.
+///
+/// The `Without<...>` filters mirror the contract documented on
+/// [`joint_kinematics_system`]: the four kinematic-spec drivers are
+/// pairwise-disjoint at the query level so Bevy can schedule them in
+/// parallel; `validate_joint_kinematics_exclusivity` rejects
+/// stacked-spec misconfigurations at `Startup`.
+#[allow(clippy::type_complexity)]
 pub fn sinusoidal_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
-    mut query: Query<(
-        &SinusoidalJointKinematicsC,
-        &mut FrameRotC,
-        &mut FrameAngVelC,
-    )>,
+    mut query: Query<
+        (
+            &SinusoidalJointKinematicsC,
+            &mut FrameRotC,
+            &mut FrameAngVelC,
+        ),
+        (
+            Without<JointKinematicsC>,
+            Without<ClosureJointKinematicsC>,
+            Without<MultiDofJointKinematicsC>,
+        ),
+    >,
 ) {
     let elapsed = sim_time.tai_seconds;
     for (spec, mut rot, mut ang_vel) in &mut query {
@@ -1274,9 +1307,23 @@ pub fn sinusoidal_joint_kinematics_system(
 /// [`crate::JeodSet::EphemerisUpdate`] alongside
 /// `joint_kinematics_system` so the closure-pinned frame's rotation
 /// is materialized before any frame-tree consumer reads it.
+///
+/// The `Without<...>` filters mirror the contract documented on
+/// [`joint_kinematics_system`]: the four kinematic-spec drivers are
+/// pairwise-disjoint at the query level so Bevy can schedule them in
+/// parallel; `validate_joint_kinematics_exclusivity` rejects
+/// stacked-spec misconfigurations at `Startup`.
+#[allow(clippy::type_complexity)]
 pub fn closure_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
-    mut query: Query<(&ClosureJointKinematicsC, &mut FrameRotC, &mut FrameAngVelC)>,
+    mut query: Query<
+        (&ClosureJointKinematicsC, &mut FrameRotC, &mut FrameAngVelC),
+        (
+            Without<JointKinematicsC>,
+            Without<SinusoidalJointKinematicsC>,
+            Without<MultiDofJointKinematicsC>,
+        ),
+    >,
 ) {
     let elapsed = sim_time.tai_seconds;
     for (spec, mut rot, mut ang_vel) in &mut query {
@@ -1297,9 +1344,23 @@ pub fn closure_joint_kinematics_system(
 /// chain of N single-DOF joint entities walked through the frame
 /// tree. Scheduled in [`crate::JeodSet::EphemerisUpdate`] for the
 /// same reason as the other joint-kinematics systems.
+///
+/// The `Without<...>` filters mirror the contract documented on
+/// [`joint_kinematics_system`]: the four kinematic-spec drivers are
+/// pairwise-disjoint at the query level so Bevy can schedule them in
+/// parallel; `validate_joint_kinematics_exclusivity` rejects
+/// stacked-spec misconfigurations at `Startup`.
+#[allow(clippy::type_complexity)]
 pub fn multi_dof_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
-    mut query: Query<(&MultiDofJointKinematicsC, &mut FrameRotC, &mut FrameAngVelC)>,
+    mut query: Query<
+        (&MultiDofJointKinematicsC, &mut FrameRotC, &mut FrameAngVelC),
+        (
+            Without<JointKinematicsC>,
+            Without<SinusoidalJointKinematicsC>,
+            Without<ClosureJointKinematicsC>,
+        ),
+    >,
 ) {
     let elapsed = sim_time.tai_seconds;
     for (spec, mut rot, mut ang_vel) in &mut query {
@@ -1309,6 +1370,95 @@ pub fn multi_dof_joint_kinematics_system(
         rot.t_parent_this = q_parent_this.left_quat_to_transformation();
         ang_vel.0 = ang_vel_this;
     }
+}
+
+/// Startup-time guard that asserts at most one of the four
+/// joint-kinematic spec components is present on any single entity.
+///
+/// The four joint-kinematic drivers
+/// ([`joint_kinematics_system`], [`sinusoidal_joint_kinematics_system`],
+/// [`closure_joint_kinematics_system`], [`multi_dof_joint_kinematics_system`])
+/// each carry `Without<...>` filters for the other three spec
+/// components so Bevy's scheduler can dispatch them in parallel under
+/// `JeodSet::EphemerisUpdate` without contending for `FrameRotC` /
+/// `FrameAngVelC`. That filter discipline turns an entity that
+/// accidentally carries two specs into a *silent drop* from every
+/// driver — its `FrameRotC` would never be written and the joint
+/// frame would advertise stale (or default-identity) state to every
+/// downstream `RelativeFrameState` walk.
+///
+/// Per the project's fail-loud rule, that misconfiguration must
+/// panic at the earliest detection point with a diagnostic that
+/// names the offending entity and the specs it carries. This guard
+/// runs at `Startup` (before the first `FixedUpdate` tick) and walks
+/// every entity carrying at least one kinematic spec via
+/// [`Has<...>`] flags; any entity with more than one spec is
+/// reported in a single panic message.
+///
+/// The four spec components are declarative alternatives — a joint
+/// is *either* constant-rate, *or* sinusoidal, *or* a closure pose,
+/// *or* a multi-DOF chain — so stacking two of them has no
+/// meaningful semantics. If a future kinematic style needs to
+/// compose with an existing one, that composition belongs in a new
+/// dedicated spec (e.g., extend `SingleDofKinematics` and route
+/// through `MultiDofJointKinematicsC`), not in two parallel
+/// drivers racing for the same storage.
+///
+/// # Panics
+/// Panics if any entity carries more than one of `JointKinematicsC`,
+/// [`SinusoidalJointKinematicsC`], [`ClosureJointKinematicsC`], or
+/// [`MultiDofJointKinematicsC`]. The message lists every offending
+/// entity together with the specs it carries.
+#[allow(clippy::type_complexity)]
+pub fn validate_joint_kinematics_exclusivity(
+    query: Query<
+        (
+            Entity,
+            Has<JointKinematicsC>,
+            Has<SinusoidalJointKinematicsC>,
+            Has<ClosureJointKinematicsC>,
+            Has<MultiDofJointKinematicsC>,
+        ),
+        Or<(
+            With<JointKinematicsC>,
+            With<SinusoidalJointKinematicsC>,
+            With<ClosureJointKinematicsC>,
+            With<MultiDofJointKinematicsC>,
+        )>,
+    >,
+) {
+    let mut offenders: Vec<String> = Vec::new();
+    for (entity, has_const, has_sin, has_close, has_multi) in &query {
+        let count = usize::from(has_const)
+            + usize::from(has_sin)
+            + usize::from(has_close)
+            + usize::from(has_multi);
+        if count > 1 {
+            let mut names: Vec<&'static str> = Vec::new();
+            if has_const {
+                names.push("JointKinematicsC");
+            }
+            if has_sin {
+                names.push("SinusoidalJointKinematicsC");
+            }
+            if has_close {
+                names.push("ClosureJointKinematicsC");
+            }
+            if has_multi {
+                names.push("MultiDofJointKinematicsC");
+            }
+            offenders.push(format!("{entity:?} carries [{}]", names.join(", ")));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "Joint-kinematics spec components are mutually exclusive — each frame entity \
+         must carry at most one of JointKinematicsC, SinusoidalJointKinematicsC, \
+         ClosureJointKinematicsC, MultiDofJointKinematicsC. Offending entities: {}. \
+         Fix: pick a single kinematic style per joint frame; for composed motions \
+         use MultiDofJointKinematicsC with a chain of SingleDofKinematics stages.",
+        offenders.join("; ")
+    );
 }
 
 /// Computes tidal ΔC20 for each gravity source that has a `TidalConfigC`.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1229,7 +1229,7 @@ pub fn planet_fixed_rotation_system(
 /// `FrameRotC` / `FrameAngVelC`. An entity that accidentally carries
 /// more than one kinematic spec is silently dropped from every
 /// driver's query — `validate_joint_kinematics_exclusivity` runs at
-/// `Startup` to reject such misconfigurations loudly before any
+/// `PostStartup` to reject such misconfigurations loudly before any
 /// driver tick can mask them.
 #[allow(clippy::type_complexity)]
 pub fn joint_kinematics_system(
@@ -1271,7 +1271,7 @@ pub fn joint_kinematics_system(
 /// [`joint_kinematics_system`]: the four kinematic-spec drivers are
 /// pairwise-disjoint at the query level so Bevy can schedule them in
 /// parallel; `validate_joint_kinematics_exclusivity` rejects
-/// stacked-spec misconfigurations at `Startup`.
+/// stacked-spec misconfigurations at `PostStartup`.
 #[allow(clippy::type_complexity)]
 pub fn sinusoidal_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
@@ -1312,7 +1312,7 @@ pub fn sinusoidal_joint_kinematics_system(
 /// [`joint_kinematics_system`]: the four kinematic-spec drivers are
 /// pairwise-disjoint at the query level so Bevy can schedule them in
 /// parallel; `validate_joint_kinematics_exclusivity` rejects
-/// stacked-spec misconfigurations at `Startup`.
+/// stacked-spec misconfigurations at `PostStartup`.
 #[allow(clippy::type_complexity)]
 pub fn closure_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
@@ -1349,7 +1349,7 @@ pub fn closure_joint_kinematics_system(
 /// [`joint_kinematics_system`]: the four kinematic-spec drivers are
 /// pairwise-disjoint at the query level so Bevy can schedule them in
 /// parallel; `validate_joint_kinematics_exclusivity` rejects
-/// stacked-spec misconfigurations at `Startup`.
+/// stacked-spec misconfigurations at `PostStartup`.
 #[allow(clippy::type_complexity)]
 pub fn multi_dof_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
@@ -1372,7 +1372,7 @@ pub fn multi_dof_joint_kinematics_system(
     }
 }
 
-/// Startup-time guard that asserts at most one of the four
+/// PostStartup-time guard that asserts at most one of the four
 /// joint-kinematic spec components is present on any single entity.
 ///
 /// The four joint-kinematic drivers
@@ -1390,10 +1390,13 @@ pub fn multi_dof_joint_kinematics_system(
 /// Per the project's fail-loud rule, that misconfiguration must
 /// panic at the earliest detection point with a diagnostic that
 /// names the offending entity and the specs it carries. This guard
-/// runs at `Startup` (before the first `FixedUpdate` tick) and walks
-/// every entity carrying at least one kinematic spec via
-/// [`Has<...>`] flags; any entity with more than one spec is
-/// reported in a single panic message.
+/// runs at `PostStartup` (after every user `Startup` system and the
+/// auto-inserted command flush, but before the first `FixedUpdate`
+/// tick) so any joint entity spawned via `Commands` from a user
+/// `Startup` system is materialized in the world by the time the
+/// guard observes it. It walks every entity carrying at least one
+/// kinematic spec via [`Has<...>`] flags; any entity with more than
+/// one spec is reported in a single panic message.
 ///
 /// The four spec components are declarative alternatives — a joint
 /// is *either* constant-rate, *or* sinusoidal, *or* a closure pose,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1222,15 +1222,24 @@ pub fn planet_fixed_rotation_system(
 /// out of scope; see the deferred-dynamics meta.
 ///
 /// The `Without<...>` filters on the three sibling kinematic-spec
-/// components make this query structurally disjoint from the
-/// sinusoidal / closure / multi-DOF drivers, so Bevy's scheduler
-/// can dispatch the four systems in parallel under
-/// `JeodSet::EphemerisUpdate` without a runtime borrow conflict on
-/// `FrameRotC` / `FrameAngVelC`. An entity that accidentally carries
-/// more than one kinematic spec is silently dropped from every
-/// driver's query — `validate_joint_kinematics_exclusivity` runs at
-/// `PostStartup` to reject such misconfigurations loudly before any
-/// driver tick can mask them.
+/// components are a *parallelism signal* for Bevy's scheduler — they
+/// make this query structurally disjoint from the sinusoidal /
+/// closure / multi-DOF drivers so the four systems can dispatch in
+/// parallel under `JeodSet::EphemerisUpdate` without a runtime borrow
+/// conflict on `FrameRotC` / `FrameAngVelC`. They are *not* the
+/// correctness mechanism that rejects stacked-spec entities.
+///
+/// Stacked-spec rejection is enforced by the per-component
+/// `on_insert` hooks installed via
+/// [`register_joint_kinematics_exclusivity_hooks`]: inserting a
+/// second kinematic-spec component on an entity that already carries
+/// one panics immediately, naming the entity and both spec
+/// components, before any driver query ever runs. The PostStartup
+/// [`validate_joint_kinematics_exclusivity`] pass is defense in
+/// depth — it catches stacking patterns that bypass the hook order
+/// (e.g., a `Bundle` whose components arrive in the same archetype
+/// move, or future spec components added without registering a hook)
+/// and aggregates every offender into a single startup-time panic.
 #[allow(clippy::type_complexity)]
 pub fn joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
@@ -1268,10 +1277,13 @@ pub fn joint_kinematics_system(
 /// state, integration) reads them.
 ///
 /// The `Without<...>` filters mirror the contract documented on
-/// [`joint_kinematics_system`]: the four kinematic-spec drivers are
-/// pairwise-disjoint at the query level so Bevy can schedule them in
-/// parallel; `validate_joint_kinematics_exclusivity` rejects
-/// stacked-spec misconfigurations at `PostStartup`.
+/// [`joint_kinematics_system`]: they are a parallelism signal that
+/// keeps the four kinematic-spec drivers pairwise-disjoint at the
+/// query level. The correctness mechanism that rejects stacked-spec
+/// entities is the on_insert hooks installed by
+/// [`register_joint_kinematics_exclusivity_hooks`] (panic at
+/// insertion); [`validate_joint_kinematics_exclusivity`] is
+/// PostStartup defense in depth.
 #[allow(clippy::type_complexity)]
 pub fn sinusoidal_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
@@ -1309,10 +1321,13 @@ pub fn sinusoidal_joint_kinematics_system(
 /// is materialized before any frame-tree consumer reads it.
 ///
 /// The `Without<...>` filters mirror the contract documented on
-/// [`joint_kinematics_system`]: the four kinematic-spec drivers are
-/// pairwise-disjoint at the query level so Bevy can schedule them in
-/// parallel; `validate_joint_kinematics_exclusivity` rejects
-/// stacked-spec misconfigurations at `PostStartup`.
+/// [`joint_kinematics_system`]: they are a parallelism signal that
+/// keeps the four kinematic-spec drivers pairwise-disjoint at the
+/// query level. The correctness mechanism that rejects stacked-spec
+/// entities is the on_insert hooks installed by
+/// [`register_joint_kinematics_exclusivity_hooks`] (panic at
+/// insertion); [`validate_joint_kinematics_exclusivity`] is
+/// PostStartup defense in depth.
 #[allow(clippy::type_complexity)]
 pub fn closure_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,
@@ -1346,10 +1361,13 @@ pub fn closure_joint_kinematics_system(
 /// same reason as the other joint-kinematics systems.
 ///
 /// The `Without<...>` filters mirror the contract documented on
-/// [`joint_kinematics_system`]: the four kinematic-spec drivers are
-/// pairwise-disjoint at the query level so Bevy can schedule them in
-/// parallel; `validate_joint_kinematics_exclusivity` rejects
-/// stacked-spec misconfigurations at `PostStartup`.
+/// [`joint_kinematics_system`]: they are a parallelism signal that
+/// keeps the four kinematic-spec drivers pairwise-disjoint at the
+/// query level. The correctness mechanism that rejects stacked-spec
+/// entities is the on_insert hooks installed by
+/// [`register_joint_kinematics_exclusivity_hooks`] (panic at
+/// insertion); [`validate_joint_kinematics_exclusivity`] is
+/// PostStartup defense in depth.
 #[allow(clippy::type_complexity)]
 pub fn multi_dof_joint_kinematics_system(
     sim_time: Res<SimulationTimeR>,

--- a/tests/bevy_reflect_smoke.rs
+++ b/tests/bevy_reflect_smoke.rs
@@ -74,6 +74,9 @@ const EXPECTED_REGISTERED_TYPE_PATHS: &[&str] = &[
     "bevy_jeod::components::PfixFrameEntityC",
     "bevy_jeod::components::RetiredPfixFrameEntityC",
     "bevy_jeod::components::JointKinematicsC",
+    "bevy_jeod::components::SinusoidalJointKinematicsC",
+    "bevy_jeod::components::ClosureJointKinematicsC",
+    "bevy_jeod::components::MultiDofJointKinematicsC",
     // Tidal
     "bevy_jeod::components::TidalConfigC",
     "bevy_jeod::components::TidalDeltaC20C",

--- a/tests/joint_kinematics.rs
+++ b/tests/joint_kinematics.rs
@@ -917,3 +917,113 @@ fn sibling_joint_kinematics_systems_are_public() {
     }
     _assert_is_system_fn();
 }
+
+/// An entity carrying two kinematic-spec components must be rejected
+/// at `Startup`. The four driver systems use `Without<...>` filters
+/// for parallel scheduling, which would otherwise turn this
+/// misconfiguration into a silent stale-state read; the fail-loud
+/// guard prevents that.
+#[test]
+#[should_panic(expected = "mutually exclusive")]
+fn stacked_joint_specs_panic_at_startup() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.5,
+    };
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.world_mut().spawn((
+        JointKinematicsC(const_spec),
+        ClosureJointKinematicsC(close_spec),
+    ));
+    // Run the Startup schedule explicitly; the validation system
+    // panics inside it before any FixedUpdate tick begins.
+    app.world_mut().run_schedule(Startup);
+}
+
+/// Three stacked specs must surface every offending component name in
+/// the diagnostic so a mission engineer can identify and remove them
+/// without bisecting.
+#[test]
+#[should_panic(expected = "JointKinematicsC")]
+fn stacked_joint_specs_diagnostic_names_all_components() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let sin_spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.2,
+        omega_rad_per_s: 0.05,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.5,
+    };
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.world_mut().spawn((
+        JointKinematicsC(const_spec),
+        SinusoidalJointKinematicsC(sin_spec),
+        ClosureJointKinematicsC(close_spec),
+    ));
+    app.world_mut().run_schedule(Startup);
+}
+
+/// A correctly-configured config — every kinematic spec on a
+/// distinct entity — must pass the validation guard. This guards
+/// against false positives that would block legitimate multi-joint
+/// articulation chains.
+#[test]
+fn distinct_kinematic_entities_pass_startup_validation() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let sin_spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.2,
+        omega_rad_per_s: 0.05,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.5,
+    };
+    let multi_spec = MultiDofJointKinematicsSpec::from_slice(&[
+        SingleDofKinematics::ConstantRate(const_spec),
+        SingleDofKinematics::Closure(close_spec),
+    ]);
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.world_mut().spawn(JointKinematicsC(const_spec));
+    app.world_mut().spawn(SinusoidalJointKinematicsC(sin_spec));
+    app.world_mut().spawn(ClosureJointKinematicsC(close_spec));
+    app.world_mut().spawn(MultiDofJointKinematicsC(multi_spec));
+
+    // Startup must not panic; the four entities each carry a single
+    // spec.
+    app.world_mut().run_schedule(Startup);
+
+    // A subsequent FixedUpdate tick should also succeed: the
+    // `Without<...>` filters mean each driver writes its own
+    // entity's storage and skips the others'.
+    step_once(&mut app);
+}

--- a/tests/joint_kinematics.rs
+++ b/tests/joint_kinematics.rs
@@ -919,13 +919,13 @@ fn sibling_joint_kinematics_systems_are_public() {
 }
 
 /// An entity carrying two kinematic-spec components must be rejected
-/// at `Startup`. The four driver systems use `Without<...>` filters
-/// for parallel scheduling, which would otherwise turn this
+/// at `PostStartup`. The four driver systems use `Without<...>`
+/// filters for parallel scheduling, which would otherwise turn this
 /// misconfiguration into a silent stale-state read; the fail-loud
 /// guard prevents that.
 #[test]
 #[should_panic(expected = "mutually exclusive")]
-fn stacked_joint_specs_panic_at_startup() {
+fn stacked_joint_specs_panic_at_post_startup() {
     let const_spec = JointKinematicsSpec {
         axis_in_parent: DVec3::Z,
         rate_rad_per_s: 0.1,
@@ -943,9 +943,10 @@ fn stacked_joint_specs_panic_at_startup() {
         JointKinematicsC(const_spec),
         ClosureJointKinematicsC(close_spec),
     ));
-    // Run the Startup schedule explicitly; the validation system
-    // panics inside it before any FixedUpdate tick begins.
+    // Run Startup then PostStartup; the validation system runs in
+    // PostStartup and panics before any FixedUpdate tick begins.
     app.world_mut().run_schedule(Startup);
+    app.world_mut().run_schedule(PostStartup);
 }
 
 /// Three stacked specs must surface every offending component name in
@@ -980,6 +981,7 @@ fn stacked_joint_specs_diagnostic_names_all_components() {
         ClosureJointKinematicsC(close_spec),
     ));
     app.world_mut().run_schedule(Startup);
+    app.world_mut().run_schedule(PostStartup);
 }
 
 /// A correctly-configured config — every kinematic spec on a
@@ -1018,12 +1020,81 @@ fn distinct_kinematic_entities_pass_startup_validation() {
     app.world_mut().spawn(ClosureJointKinematicsC(close_spec));
     app.world_mut().spawn(MultiDofJointKinematicsC(multi_spec));
 
-    // Startup must not panic; the four entities each carry a single
-    // spec.
+    // Startup + PostStartup must not panic; the four entities each
+    // carry a single spec.
     app.world_mut().run_schedule(Startup);
+    app.world_mut().run_schedule(PostStartup);
 
     // A subsequent FixedUpdate tick should also succeed: the
     // `Without<...>` filters mean each driver writes its own
     // entity's storage and skips the others'.
     step_once(&mut app);
+}
+
+/// A user `Startup` system that spawns a stacked-spec entity via
+/// `Commands` must still trip the validator. Bevy applies queued
+/// commands at the end of each schedule, so the entity does not
+/// exist in the world until after the `Startup` schedule finishes.
+/// A validator wired into `Startup` would observe an empty world and
+/// miss the misconfiguration; placing it in `PostStartup` guarantees
+/// the spawn is materialized before the guard runs. This test fails
+/// loudly if the validator regresses to `Startup`.
+#[test]
+#[should_panic(expected = "mutually exclusive")]
+fn stacked_joint_specs_from_user_startup_commands_panic() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.5,
+    };
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.add_systems(Startup, move |mut commands: Commands| {
+        commands.spawn((
+            JointKinematicsC(const_spec),
+            ClosureJointKinematicsC(close_spec),
+        ));
+    });
+    app.world_mut().run_schedule(Startup);
+    app.world_mut().run_schedule(PostStartup);
+}
+
+/// Confirms the validator runs in `PostStartup`, not `Startup`: an
+/// entity spawned via `Commands` from a user `Startup` system is
+/// absent from the world for the duration of `Startup` (commands
+/// apply after the schedule completes), so running `Startup` alone
+/// must not panic. The same configuration *does* panic once
+/// `PostStartup` runs (covered by
+/// [`stacked_joint_specs_from_user_startup_commands_panic`]).
+#[test]
+fn stacked_joint_specs_from_user_startup_commands_do_not_panic_in_startup() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.5,
+    };
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.add_systems(Startup, move |mut commands: Commands| {
+        commands.spawn((
+            JointKinematicsC(const_spec),
+            ClosureJointKinematicsC(close_spec),
+        ));
+    });
+    // Running only Startup must not panic — the validator lives in
+    // PostStartup. (Calling PostStartup here would panic; that case
+    // is covered by the sibling test above.)
+    app.world_mut().run_schedule(Startup);
 }

--- a/tests/joint_kinematics.rs
+++ b/tests/joint_kinematics.rs
@@ -539,3 +539,381 @@ fn joint_kinematics_relative_frame_state_walk_matches_analytical() {
         );
     }
 }
+
+// ===========================================================================
+// Bevy integration tests for the enriched kinematic-only spec catalogue.
+//
+// These mirror the existing constant-rate tests above (single entity, single
+// system, FixedUpdate ticked manually) for the three new spec shapes:
+// sinusoidal, closure, multi-DOF. Each test bypasses the full vehicle /
+// planet machinery — the joint-kinematics systems only depend on
+// `SimulationTimeR` (advanced by `time_advance_system`) plus the per-entity
+// spec component and the `FrameRotC` / `FrameAngVelC` storage triplet.
+// ===========================================================================
+
+/// Build a bare Bevy app carrying a single sinusoidal joint frame
+/// entity. Mirrors `build_app_with_joint` for the sinusoidal spec.
+fn build_app_with_sinusoidal_joint(spec: SinusoidalJointKinematicsSpec) -> (App, Entity) {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    let entity = app.world_mut().spawn(SinusoidalJointKinematicsC(spec)).id();
+    (app, entity)
+}
+
+/// On each tick, the sinusoidal-driven joint frame's `FrameRotC` and
+/// `FrameAngVelC` must agree (per-component, within float-trig
+/// precision) with a direct kernel call at the same elapsed time.
+/// Sampling N ticks across a non-trivial section of the period
+/// catches sign / parameter-ordering bugs that would only surface
+/// past `t = 0`.
+#[test]
+fn sinusoidal_joint_kinematics_matches_kernel_each_tick() {
+    let spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        amplitude_rad: 0.3,
+        omega_rad_per_s: 0.05,
+        phase_rad: 0.4,
+        offset_rad: 0.1,
+    };
+    let (mut app, entity) = build_app_with_sinusoidal_joint(spec);
+
+    let n_ticks = 30_usize;
+    for _ in 1..=n_ticks {
+        step_once(&mut app);
+        let elapsed = app.world().resource::<SimulationTimeR>().tai_seconds;
+        let (q_kernel, av_kernel) = jeod_sim::evaluate_sinusoidal_kinematics(&spec, elapsed);
+        let (q, av) = read_rot_ang_vel(&app, entity);
+        for i in 0..4 {
+            let qa = q.data[i];
+            let qe = q_kernel.data[i];
+            assert!(
+                (qa - qe).abs() < TOL,
+                "elapsed={elapsed}: q[{i}] drift exceeds TOL: \
+                 got {qa}, expected {qe}, diff {}",
+                qa - qe
+            );
+        }
+        for i in 0..3 {
+            assert!(
+                (av[i] - av_kernel[i]).abs() < TOL,
+                "elapsed={elapsed}: ang_vel[{i}] drift exceeds TOL: \
+                 got {}, expected {}",
+                av[i],
+                av_kernel[i]
+            );
+        }
+    }
+}
+
+/// At the peak of the sinusoid (`t · ω + phase = π/2`) the angle
+/// equals `offset + amplitude` and the rate is zero — closed-form
+/// snapshot that's distinct from `t = 0`. Tick the schedule until
+/// the peak is straddled and verify the angular velocity passes
+/// through zero at that point.
+#[test]
+fn sinusoidal_joint_angular_velocity_zero_at_peak() {
+    // Pick parameters so the peak lands exactly on a tick boundary
+    // (no fractional-tick interpolation). With phase = 0 the peak is
+    // at `ω · t = π/2` ⇒ `t = π/(2ω)`. With ω = π / (2 · DT) the
+    // first peak is at t = DT, i.e. tick 1.
+    let omega = std::f64::consts::FRAC_PI_2 / DT;
+    let amplitude = 0.5_f64;
+    let spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: amplitude,
+        omega_rad_per_s: omega,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let (mut app, entity) = build_app_with_sinusoidal_joint(spec);
+
+    step_once(&mut app);
+    let (q, av) = read_rot_ang_vel(&app, entity);
+    // Angle at peak = amplitude.
+    let expected_q = JeodQuat::left_quat_from_eigen_rotation(amplitude, DVec3::Y);
+    for i in 0..4 {
+        assert!(
+            (q.data[i] - expected_q.data[i]).abs() < 1.0e-12,
+            "peak q[{i}]: got {}, expected {}",
+            q.data[i],
+            expected_q.data[i]
+        );
+    }
+    // Rate at peak = amplitude · ω · cos(π/2) ≈ 0.
+    for i in 0..3 {
+        assert!(
+            av[i].abs() < 1.0e-12,
+            "peak ang_vel[{i}]: got {}, expected 0",
+            av[i]
+        );
+    }
+}
+
+/// The closure-driven joint frame is constant in time — sampling at
+/// multiple ticks must produce the same `FrameRotC` (bit-identical
+/// each tick — the kernel's `JeodQuat::left_quat_from_eigen_rotation`
+/// is deterministic in `(angle, axis)`) and a zero `FrameAngVelC`.
+#[test]
+fn closure_joint_kinematics_is_time_invariant_across_ticks() {
+    let spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::new(1.0, 1.0, 1.0).normalize(),
+        fixed_angle_rad: 0.42,
+    };
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    let entity = app.world_mut().spawn(ClosureJointKinematicsC(spec)).id();
+
+    step_once(&mut app);
+    let (q1, av1) = read_rot_ang_vel(&app, entity);
+    for _ in 0..10 {
+        step_once(&mut app);
+        let (q, av) = read_rot_ang_vel(&app, entity);
+        for i in 0..4 {
+            assert_eq!(
+                q.data[i].to_bits(),
+                q1.data[i].to_bits(),
+                "closure q[{i}] not bit-identical across ticks"
+            );
+        }
+        assert_eq!(av, av1);
+        assert_eq!(av, DVec3::ZERO);
+    }
+    let expected = JeodQuat::left_quat_from_eigen_rotation(0.42, spec.axis_in_parent);
+    assert_eq!(q1, expected);
+}
+
+/// 2-DOF chain: stage 0 constant-rate about Z, stage 1 sinusoidal
+/// about Y. The Bevy adapter must dispatch the multi-DOF spec to the
+/// kernel and write the composed `(rotation, angular velocity)` into
+/// the entity's frame triplet. Comparison against a direct kernel
+/// call at the same elapsed time pins the dispatch correctness, and
+/// composing two qualitatively different kinematic styles in one
+/// chain exercises the `evaluate_multi_dof` branch on a non-trivial
+/// case.
+#[test]
+fn multi_dof_joint_kinematics_two_stage_matches_kernel() {
+    let stage0 = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.4,
+        initial_angle_rad: 0.1,
+    };
+    let stage1 = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.25,
+        omega_rad_per_s: 0.07,
+        phase_rad: 0.3,
+        offset_rad: 0.05,
+    };
+    let chain = MultiDofJointKinematicsSpec::from_slice(&[
+        SingleDofKinematics::ConstantRate(stage0),
+        SingleDofKinematics::Sinusoidal(stage1),
+    ]);
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    let entity = app.world_mut().spawn(MultiDofJointKinematicsC(chain)).id();
+
+    let n_ticks = 8_usize;
+    for _ in 0..n_ticks {
+        step_once(&mut app);
+    }
+    let elapsed = app.world().resource::<SimulationTimeR>().tai_seconds;
+    let (q_kernel, av_kernel) = jeod_sim::evaluate_multi_dof_kinematics(&chain, elapsed);
+    let (q, av) = read_rot_ang_vel(&app, entity);
+    for i in 0..4 {
+        assert_eq!(
+            q.data[i].to_bits(),
+            q_kernel.data[i].to_bits(),
+            "multi-DOF q[{i}] not bit-identical to kernel"
+        );
+    }
+    for i in 0..3 {
+        assert_eq!(
+            av[i].to_bits(),
+            av_kernel[i].to_bits(),
+            "multi-DOF ang_vel[{i}] not bit-identical to kernel"
+        );
+    }
+}
+
+/// Each kinematic-spec component is *semantically alternative* —
+/// each disjoint entity sets the same `FrameRotC` / `FrameAngVelC`
+/// storage from its own driver. Spawning four entities, one carrying
+/// each variant, must produce four distinct snapshots that each
+/// match their respective kernel call. This guards against any
+/// accidental cross-driver write ordering: if e.g. the sinusoidal
+/// system queried `JointKinematicsC`-tagged entities by mistake, a
+/// constant-rate entity's frame state would be overwritten with
+/// sinusoidal output and the assertions would surface it.
+#[test]
+fn sibling_kinematic_drivers_dispatch_disjoint_entity_sets() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.5,
+        initial_angle_rad: 0.0,
+    };
+    let sin_spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.4,
+        omega_rad_per_s: 0.1,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.7,
+    };
+    let multi_spec = MultiDofJointKinematicsSpec::from_slice(&[
+        SingleDofKinematics::ConstantRate(const_spec),
+        SingleDofKinematics::Closure(close_spec),
+    ]);
+
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+
+    let const_e = app.world_mut().spawn(JointKinematicsC(const_spec)).id();
+    let sin_e = app
+        .world_mut()
+        .spawn(SinusoidalJointKinematicsC(sin_spec))
+        .id();
+    let close_e = app
+        .world_mut()
+        .spawn(ClosureJointKinematicsC(close_spec))
+        .id();
+    let multi_e = app
+        .world_mut()
+        .spawn(MultiDofJointKinematicsC(multi_spec))
+        .id();
+
+    let n_ticks = 5_usize;
+    for _ in 0..n_ticks {
+        step_once(&mut app);
+    }
+    let elapsed = app.world().resource::<SimulationTimeR>().tai_seconds;
+
+    // Each entity must match its own driver's kernel output.
+    let (qc, avc) = read_rot_ang_vel(&app, const_e);
+    let (qc_k, avc_k) = jeod_sim::evaluate_joint_kinematics(&const_spec, elapsed);
+    assert_eq!(qc, qc_k);
+    assert_eq!(avc, avc_k);
+
+    let (qs, avs) = read_rot_ang_vel(&app, sin_e);
+    let (qs_k, avs_k) = jeod_sim::evaluate_sinusoidal_kinematics(&sin_spec, elapsed);
+    assert_eq!(qs, qs_k);
+    assert_eq!(avs, avs_k);
+
+    let (qcl, avcl) = read_rot_ang_vel(&app, close_e);
+    let (qcl_k, avcl_k) = jeod_sim::evaluate_closure_kinematics(&close_spec, elapsed);
+    assert_eq!(qcl, qcl_k);
+    assert_eq!(avcl, avcl_k);
+
+    let (qm, avm) = read_rot_ang_vel(&app, multi_e);
+    let (qm_k, avm_k) = jeod_sim::evaluate_multi_dof_kinematics(&multi_spec, elapsed);
+    assert_eq!(qm, qm_k);
+    assert_eq!(avm, avm_k);
+
+    // The four snapshots must not collapse onto each other (would
+    // signal a query mis-tagging or a system overwriting another's
+    // state). We check at least that each pair differs in at least
+    // one quaternion component — distinct kernels with these
+    // parameters cannot coincidentally match.
+    let snapshots = [(qc, "const"), (qs, "sin"), (qcl, "close"), (qm, "multi")];
+    for i in 0..snapshots.len() {
+        for j in (i + 1)..snapshots.len() {
+            let (qa, na) = snapshots[i];
+            let (qb, nb) = snapshots[j];
+            let differs = (0..4).any(|k| (qa.data[k] - qb.data[k]).abs() > TOL);
+            assert!(
+                differs,
+                "{na} and {nb} produced indistinguishable rotations — \
+                 a sibling system likely tagged the wrong entity set"
+            );
+        }
+    }
+}
+
+/// A non-unit axis on the sinusoidal spec must panic at the kernel
+/// boundary the first tick the system runs — same fail-loud
+/// guarantee as the constant-rate spec.
+#[test]
+#[should_panic(expected = "must be a unit vector")]
+fn sinusoidal_joint_kinematics_panics_on_non_unit_axis() {
+    let spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::new(0.0, 0.0, 2.0),
+        amplitude_rad: 0.1,
+        omega_rad_per_s: 1.0,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let (mut app, _entity) = build_app_with_sinusoidal_joint(spec);
+    step_once(&mut app);
+}
+
+/// A non-unit axis on the closure spec must panic the first tick.
+#[test]
+#[should_panic(expected = "must be a unit vector")]
+fn closure_joint_kinematics_panics_on_non_unit_axis() {
+    let spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::new(0.0, 0.0, 2.0),
+        fixed_angle_rad: 0.5,
+    };
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.world_mut().spawn(ClosureJointKinematicsC(spec));
+    step_once(&mut app);
+}
+
+/// A non-unit axis on any DOF inside the multi-DOF chain must panic
+/// the first tick — the kernel walks each stage and asserts at the
+/// per-stage level.
+#[test]
+#[should_panic(expected = "must be a unit vector")]
+fn multi_dof_joint_kinematics_panics_on_non_unit_axis_in_stage() {
+    let bad_stage = JointKinematicsSpec {
+        axis_in_parent: DVec3::new(0.0, 0.0, 2.0),
+        rate_rad_per_s: 1.0,
+        initial_angle_rad: 0.0,
+    };
+    let chain =
+        MultiDofJointKinematicsSpec::from_slice(&[SingleDofKinematics::ConstantRate(bad_stage)]);
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app.world_mut().spawn(MultiDofJointKinematicsC(chain));
+    step_once(&mut app);
+}
+
+/// Sibling joint-kinematics systems must be reachable by name from
+/// outside the crate — mission code that wants a custom schedule
+/// must be able to re-add them without re-importing through the
+/// `JeodPlugin` umbrella, matching the existing
+/// `joint_kinematics_system` contract.
+#[test]
+fn sibling_joint_kinematics_systems_are_public() {
+    fn _assert_is_system_fn() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(Time::<Fixed>::from_seconds(DT));
+        app.insert_resource(SimulationTimeR::default());
+        app.add_systems(
+            FixedUpdate,
+            (
+                systems::sinusoidal_joint_kinematics_system,
+                systems::closure_joint_kinematics_system,
+                systems::multi_dof_joint_kinematics_system,
+            ),
+        );
+    }
+    _assert_is_system_fn();
+}

--- a/tests/joint_kinematics.rs
+++ b/tests/joint_kinematics.rs
@@ -968,6 +968,48 @@ fn assert_diagnostic_lists(msg: &str, components: &[&str], entity: Entity) {
     }
 }
 
+/// Pull the entity-id token out of the `Offending entity: <token> carries [...]`
+/// span of the diagnostic. Splits on the literal anchors, so a hook regression
+/// that emits `Offending entity:  carries [...]` (whitespace only between the
+/// two anchors) yields an empty token and trips
+/// [`assert_entity_debug_shape`].
+#[track_caller]
+fn extract_offending_entity_token(msg: &str) -> String {
+    let after_label = msg
+        .split_once("Offending entity:")
+        .unwrap_or_else(|| {
+            panic!("panic message missing 'Offending entity:' phrase: {msg}");
+        })
+        .1;
+    let (token_span, _) = after_label.split_once(" carries [").unwrap_or_else(|| {
+        panic!("panic message missing ' carries [' tail after entity id: {msg}");
+    });
+    token_span.trim().to_string()
+}
+
+/// Assert `token` matches Bevy's `Entity` Debug formatting:
+/// `{index}v{generation}` with non-empty digit runs on either side of the
+/// single literal `'v'`. Catches the regression where the hook formats with
+/// the wrong specifier, drops the id, or reports a placeholder.
+#[track_caller]
+fn assert_entity_debug_shape(token: &str, msg: &str) {
+    assert!(
+        !token.is_empty(),
+        "expected an entity id token after 'Offending entity:', got empty string in: {msg}"
+    );
+    let (index, generation) = token.split_once('v').unwrap_or_else(|| {
+        panic!("entity id token {token:?} is not in `{{index}}v{{generation}}` form: {msg}");
+    });
+    assert!(
+        !index.is_empty() && index.chars().all(|c| c.is_ascii_digit()),
+        "entity id index portion {index:?} of token {token:?} is not all digits: {msg}"
+    );
+    assert!(
+        !generation.is_empty() && generation.chars().all(|c| c.is_ascii_digit()),
+        "entity id generation portion {generation:?} of token {token:?} is not all digits: {msg}"
+    );
+}
+
 /// Build a fully-wired Bevy app with `JeodPlugin` so the
 /// joint-kinematics `on_insert` hooks and the `PostStartup`
 /// validator are both installed.
@@ -1060,15 +1102,17 @@ fn stacked_joint_specs_diagnostic_names_all_components() {
 }
 
 /// Three stacked specs landed in one bundle must list every name in
-/// the diagnostic. Uses a fresh app + dummy spawn to capture the
-/// entity id allocated by the panicking spawn.
+/// the diagnostic. Uses a fresh app and parses the entity id reported
+/// by the hook out of the panic message itself.
 ///
 /// We can't pre-allocate the entity via a separate `spawn` because
 /// any *single* spec there would not panic (only stacking > 1 specs
 /// does), and any prior bundle with two specs would already panic.
-/// Instead we observe the entity id reported by the hook itself by
-/// scanning the panic message for the `Offending entity: <id>`
-/// pattern and assert the listed names match the inputs.
+/// Instead we extract the token between `Offending entity: ` and
+/// ` carries [` and assert it parses as a Bevy `Entity` Debug string
+/// (`{index}v{generation}`). This catches regressions where the hook
+/// drops the entity id from the diagnostic, which the weaker
+/// `msg.contains("Offending entity:")` substring check would miss.
 #[test]
 fn stacked_joint_specs_diagnostic_names_three_components_in_one_bundle() {
     let const_spec = JointKinematicsSpec {
@@ -1115,17 +1159,15 @@ fn stacked_joint_specs_diagnostic_names_three_components_in_one_bundle() {
             "panic message did not mention {name}: {msg}"
         );
     }
-    assert!(
-        msg.contains("Offending entity:"),
-        "panic message missing 'Offending entity:' phrase: {msg}"
-    );
+    let id_token = extract_offending_entity_token(&msg);
+    assert_entity_debug_shape(&id_token, &msg);
 }
 
 /// All four spec components on one entity must list all four names
 /// in the diagnostic. Exercises the largest-fanout path through the
-/// hook's name-collection branches. Same id-capture caveat as the
-/// three-spec test: we assert names + structural phrases rather
-/// than the exact entity id.
+/// hook's name-collection branches. Same id-extraction strategy as
+/// the three-spec test: parse the token between `Offending entity: `
+/// and ` carries [` and verify it has Bevy's Entity Debug shape.
 #[test]
 fn stacked_joint_specs_diagnostic_names_all_four_components() {
     let const_spec = JointKinematicsSpec {
@@ -1175,10 +1217,8 @@ fn stacked_joint_specs_diagnostic_names_all_four_components() {
         "panic missing diagnostic header: {msg}"
     );
     assert!(msg.contains("Fix:"), "panic missing 'Fix:' tail: {msg}");
-    assert!(
-        msg.contains("Offending entity:"),
-        "panic missing 'Offending entity:' phrase: {msg}"
-    );
+    let id_token = extract_offending_entity_token(&msg);
+    assert_entity_debug_shape(&id_token, &msg);
 }
 
 /// A correctly-configured app — every kinematic spec on a distinct

--- a/tests/joint_kinematics.rs
+++ b/tests/joint_kinematics.rs
@@ -918,14 +918,80 @@ fn sibling_joint_kinematics_systems_are_public() {
     _assert_is_system_fn();
 }
 
+/// Capture the panic raised by `f` and downcast it to a `String`
+/// suitable for substring assertions. Mirrors the helper pattern
+/// used in `tests/validation_added_trigger.rs`. Returns the panic
+/// message verbatim or fails the test if `f` did not panic.
+fn capture_panic_message<F: FnOnce()>(f: F) -> String {
+    use std::panic::AssertUnwindSafe;
+    let result = std::panic::catch_unwind(AssertUnwindSafe(f));
+    let panic = result.expect_err(
+        "expected the operation to panic with the joint-kinematics exclusivity diagnostic, \
+         but it returned normally",
+    );
+    panic
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| {
+            panic
+                .downcast_ref::<&'static str>()
+                .map(|s| (*s).to_string())
+        })
+        .unwrap_or_else(|| "<non-string panic payload>".to_string())
+}
+
+/// Assert that `msg` mentions every named component, the literal
+/// "mutually exclusive" header, and the actionable "Fix:" tail.
+/// `#[should_panic(expected = "...")]` only checks for a single
+/// substring, so the multi-substring contract has to be expressed
+/// explicitly in test code.
+#[track_caller]
+fn assert_diagnostic_lists(msg: &str, components: &[&str], entity: Entity) {
+    assert!(
+        msg.contains("mutually exclusive"),
+        "panic message missing 'mutually exclusive' header: {msg}"
+    );
+    assert!(
+        msg.contains("Fix:"),
+        "panic message missing actionable 'Fix:' tail: {msg}"
+    );
+    let entity_str = format!("{entity:?}");
+    assert!(
+        msg.contains(&entity_str),
+        "panic message did not name the offending entity {entity_str}: {msg}"
+    );
+    for name in components {
+        assert!(
+            msg.contains(name),
+            "panic message did not mention {name}: {msg}"
+        );
+    }
+}
+
+/// Build a fully-wired Bevy app with `JeodPlugin` so the
+/// joint-kinematics `on_insert` hooks and the `PostStartup`
+/// validator are both installed.
+fn build_app_with_plugin() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.insert_resource(Time::<Fixed>::from_seconds(DT));
+    app.add_plugins(JeodPlugin);
+    app
+}
+
 /// An entity carrying two kinematic-spec components must be rejected
-/// at `PostStartup`. The four driver systems use `Without<...>`
+/// at insertion time. The four driver systems use `Without<...>`
 /// filters for parallel scheduling, which would otherwise turn this
 /// misconfiguration into a silent stale-state read; the fail-loud
-/// guard prevents that.
+/// `on_insert` hook prevents that. The diagnostic must include both
+/// component names and the offending entity id.
+///
+/// Spawning a *single*-spec entity first and then inserting the
+/// second spec via `entity_mut().insert(...)` lets the test capture
+/// the entity id at spawn time so the substring assertion can verify
+/// the exact id appears in the panic message.
 #[test]
-#[should_panic(expected = "mutually exclusive")]
-fn stacked_joint_specs_panic_at_post_startup() {
+fn stacked_joint_specs_panic_at_insertion_two_specs() {
     let const_spec = JointKinematicsSpec {
         axis_in_parent: DVec3::Z,
         rate_rad_per_s: 0.1,
@@ -935,26 +1001,76 @@ fn stacked_joint_specs_panic_at_post_startup() {
         axis_in_parent: DVec3::X,
         fixed_angle_rad: 0.5,
     };
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.insert_resource(Time::<Fixed>::from_seconds(DT));
-    app.add_plugins(JeodPlugin);
-    app.world_mut().spawn((
-        JointKinematicsC(const_spec),
-        ClosureJointKinematicsC(close_spec),
-    ));
-    // Run Startup then PostStartup; the validation system runs in
-    // PostStartup and panics before any FixedUpdate tick begins.
-    app.world_mut().run_schedule(Startup);
-    app.world_mut().run_schedule(PostStartup);
+    let mut app = build_app_with_plugin();
+    let entity = app.world_mut().spawn(JointKinematicsC(const_spec)).id();
+
+    let msg = capture_panic_message(|| {
+        app.world_mut()
+            .entity_mut(entity)
+            .insert(ClosureJointKinematicsC(close_spec));
+    });
+
+    assert_diagnostic_lists(
+        &msg,
+        &["JointKinematicsC", "ClosureJointKinematicsC"],
+        entity,
+    );
 }
 
-/// Three stacked specs must surface every offending component name in
-/// the diagnostic so a mission engineer can identify and remove them
-/// without bisecting.
+/// Two stacked specs *and* the entity id must appear in the
+/// diagnostic. Builds the entity in stages so the test can capture
+/// its id before the hook fires (a freshly-spawned entity carrying
+/// only one spec is valid; inserting the second spec via
+/// `entity_mut().insert(...)` is what trips the hook).
+///
+/// `#[should_panic(expected = "X")]` only checks one substring; this
+/// test captures the panic and asserts every required substring —
+/// the diagnostic header, the actionable "Fix:" tail, both
+/// component names, and the exact offending entity id.
 #[test]
-#[should_panic(expected = "JointKinematicsC")]
 fn stacked_joint_specs_diagnostic_names_all_components() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let sin_spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.2,
+        omega_rad_per_s: 0.05,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let mut app = build_app_with_plugin();
+    let entity = app.world_mut().spawn(JointKinematicsC(const_spec)).id();
+
+    // Insert the second spec — this must panic; the diagnostic must
+    // mention both `JointKinematicsC` and
+    // `SinusoidalJointKinematicsC` and the entity id captured above.
+    let msg = capture_panic_message(|| {
+        app.world_mut()
+            .entity_mut(entity)
+            .insert(SinusoidalJointKinematicsC(sin_spec));
+    });
+    assert_diagnostic_lists(
+        &msg,
+        &["JointKinematicsC", "SinusoidalJointKinematicsC"],
+        entity,
+    );
+}
+
+/// Three stacked specs landed in one bundle must list every name in
+/// the diagnostic. Uses a fresh app + dummy spawn to capture the
+/// entity id allocated by the panicking spawn.
+///
+/// We can't pre-allocate the entity via a separate `spawn` because
+/// any *single* spec there would not panic (only stacking > 1 specs
+/// does), and any prior bundle with two specs would already panic.
+/// Instead we observe the entity id reported by the hook itself by
+/// scanning the panic message for the `Offending entity: <id>`
+/// pattern and assert the listed names match the inputs.
+#[test]
+fn stacked_joint_specs_diagnostic_names_three_components_in_one_bundle() {
     let const_spec = JointKinematicsSpec {
         axis_in_parent: DVec3::Z,
         rate_rad_per_s: 0.1,
@@ -971,23 +1087,104 @@ fn stacked_joint_specs_diagnostic_names_all_components() {
         axis_in_parent: DVec3::X,
         fixed_angle_rad: 0.5,
     };
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.insert_resource(Time::<Fixed>::from_seconds(DT));
-    app.add_plugins(JeodPlugin);
-    app.world_mut().spawn((
-        JointKinematicsC(const_spec),
-        SinusoidalJointKinematicsC(sin_spec),
-        ClosureJointKinematicsC(close_spec),
-    ));
-    app.world_mut().run_schedule(Startup);
-    app.world_mut().run_schedule(PostStartup);
+    let mut app = build_app_with_plugin();
+
+    let msg = capture_panic_message(|| {
+        app.world_mut().spawn((
+            JointKinematicsC(const_spec),
+            SinusoidalJointKinematicsC(sin_spec),
+            ClosureJointKinematicsC(close_spec),
+        ));
+    });
+
+    assert!(
+        msg.contains("mutually exclusive"),
+        "panic missing diagnostic header: {msg}"
+    );
+    assert!(
+        msg.contains("Fix:"),
+        "panic missing actionable Fix tail: {msg}"
+    );
+    for name in [
+        "JointKinematicsC",
+        "SinusoidalJointKinematicsC",
+        "ClosureJointKinematicsC",
+    ] {
+        assert!(
+            msg.contains(name),
+            "panic message did not mention {name}: {msg}"
+        );
+    }
+    assert!(
+        msg.contains("Offending entity:"),
+        "panic message missing 'Offending entity:' phrase: {msg}"
+    );
 }
 
-/// A correctly-configured config — every kinematic spec on a
-/// distinct entity — must pass the validation guard. This guards
-/// against false positives that would block legitimate multi-joint
-/// articulation chains.
+/// All four spec components on one entity must list all four names
+/// in the diagnostic. Exercises the largest-fanout path through the
+/// hook's name-collection branches. Same id-capture caveat as the
+/// three-spec test: we assert names + structural phrases rather
+/// than the exact entity id.
+#[test]
+fn stacked_joint_specs_diagnostic_names_all_four_components() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let sin_spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.2,
+        omega_rad_per_s: 0.05,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let close_spec = ClosureJointKinematicsSpec {
+        axis_in_parent: DVec3::X,
+        fixed_angle_rad: 0.5,
+    };
+    let multi_spec = MultiDofJointKinematicsSpec::from_slice(&[
+        SingleDofKinematics::ConstantRate(const_spec),
+        SingleDofKinematics::Closure(close_spec),
+    ]);
+    let mut app = build_app_with_plugin();
+
+    let msg = capture_panic_message(|| {
+        app.world_mut().spawn((
+            JointKinematicsC(const_spec),
+            SinusoidalJointKinematicsC(sin_spec),
+            ClosureJointKinematicsC(close_spec),
+            MultiDofJointKinematicsC(multi_spec),
+        ));
+    });
+
+    for name in [
+        "JointKinematicsC",
+        "SinusoidalJointKinematicsC",
+        "ClosureJointKinematicsC",
+        "MultiDofJointKinematicsC",
+    ] {
+        assert!(
+            msg.contains(name),
+            "panic message did not mention {name}: {msg}"
+        );
+    }
+    assert!(
+        msg.contains("mutually exclusive"),
+        "panic missing diagnostic header: {msg}"
+    );
+    assert!(msg.contains("Fix:"), "panic missing 'Fix:' tail: {msg}");
+    assert!(
+        msg.contains("Offending entity:"),
+        "panic missing 'Offending entity:' phrase: {msg}"
+    );
+}
+
+/// A correctly-configured app — every kinematic spec on a distinct
+/// entity — must pass both the `on_insert` hook and the
+/// `PostStartup` validator. Guards against false positives that
+/// would block legitimate multi-joint articulation chains.
 #[test]
 fn distinct_kinematic_entities_pass_startup_validation() {
     let const_spec = JointKinematicsSpec {
@@ -1011,10 +1208,7 @@ fn distinct_kinematic_entities_pass_startup_validation() {
         SingleDofKinematics::Closure(close_spec),
     ]);
 
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.insert_resource(Time::<Fixed>::from_seconds(DT));
-    app.add_plugins(JeodPlugin);
+    let mut app = build_app_with_plugin();
     app.world_mut().spawn(JointKinematicsC(const_spec));
     app.world_mut().spawn(SinusoidalJointKinematicsC(sin_spec));
     app.world_mut().spawn(ClosureJointKinematicsC(close_spec));
@@ -1032,15 +1226,11 @@ fn distinct_kinematic_entities_pass_startup_validation() {
 }
 
 /// A user `Startup` system that spawns a stacked-spec entity via
-/// `Commands` must still trip the validator. Bevy applies queued
-/// commands at the end of each schedule, so the entity does not
-/// exist in the world until after the `Startup` schedule finishes.
-/// A validator wired into `Startup` would observe an empty world and
-/// miss the misconfiguration; placing it in `PostStartup` guarantees
-/// the spawn is materialized before the guard runs. This test fails
-/// loudly if the validator regresses to `Startup`.
+/// `Commands` must trip the `on_insert` hook the moment the deferred
+/// spawn is applied (during `Startup`'s command flush). Verifies
+/// the diagnostic names every offending component, not just the one
+/// the hook attributed the panic to.
 #[test]
-#[should_panic(expected = "mutually exclusive")]
 fn stacked_joint_specs_from_user_startup_commands_panic() {
     let const_spec = JointKinematicsSpec {
         axis_in_parent: DVec3::Z,
@@ -1051,29 +1241,100 @@ fn stacked_joint_specs_from_user_startup_commands_panic() {
         axis_in_parent: DVec3::X,
         fixed_angle_rad: 0.5,
     };
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.insert_resource(Time::<Fixed>::from_seconds(DT));
-    app.add_plugins(JeodPlugin);
+    let mut app = build_app_with_plugin();
     app.add_systems(Startup, move |mut commands: Commands| {
         commands.spawn((
             JointKinematicsC(const_spec),
             ClosureJointKinematicsC(close_spec),
         ));
     });
-    app.world_mut().run_schedule(Startup);
-    app.world_mut().run_schedule(PostStartup);
+    let msg = capture_panic_message(|| {
+        // Running Startup is sufficient: deferred commands flush
+        // during the schedule and the on_insert hook fires there.
+        // Even if a future Bevy refactor moved the flush out of
+        // `Startup`, `PostStartup` would still catch it.
+        app.world_mut().run_schedule(Startup);
+        app.world_mut().run_schedule(PostStartup);
+    });
+    assert!(
+        msg.contains("JointKinematicsC") && msg.contains("ClosureJointKinematicsC"),
+        "panic message did not name both stacked specs: {msg}"
+    );
+    assert!(
+        msg.contains("mutually exclusive"),
+        "panic message missing diagnostic header: {msg}"
+    );
 }
 
-/// Confirms the validator runs in `PostStartup`, not `Startup`: an
-/// entity spawned via `Commands` from a user `Startup` system is
-/// absent from the world for the duration of `Startup` (commands
-/// apply after the schedule completes), so running `Startup` alone
-/// must not panic. The same configuration *does* panic once
-/// `PostStartup` runs (covered by
-/// [`stacked_joint_specs_from_user_startup_commands_panic`]).
+/// **Runtime-spawn regression test.** An entity spawned during
+/// `FixedUpdate` (long after `Startup`/`PostStartup` have run) with
+/// two kinematic specs must still trip the `on_insert` hook. This
+/// covers the gap the original `PostStartup`-only validator left:
+/// runtime spawns from `FixedUpdate` user systems would silently
+/// drop out of every driver's `Without<...>` filter without the
+/// hook.
+///
+/// The deferred `Commands::spawn` in the user system is applied at
+/// the end of that system, which is when the hook fires — inside
+/// `run_schedule(FixedUpdate)`. The test asserts the panic
+/// propagates and the diagnostic names every offending component.
 #[test]
-fn stacked_joint_specs_from_user_startup_commands_do_not_panic_in_startup() {
+fn stacked_joint_specs_from_runtime_fixed_update_panic() {
+    let const_spec = JointKinematicsSpec {
+        axis_in_parent: DVec3::Z,
+        rate_rad_per_s: 0.1,
+        initial_angle_rad: 0.0,
+    };
+    let sin_spec = SinusoidalJointKinematicsSpec {
+        axis_in_parent: DVec3::Y,
+        amplitude_rad: 0.2,
+        omega_rad_per_s: 0.05,
+        phase_rad: 0.0,
+        offset_rad: 0.0,
+    };
+    let mut app = build_app_with_plugin();
+
+    // First flush Startup + PostStartup with no joint entities so
+    // the validator passes. The runtime spawn happens later.
+    app.world_mut().run_schedule(Startup);
+    app.world_mut().run_schedule(PostStartup);
+
+    // Single-shot FixedUpdate user system that spawns a stacked-spec
+    // entity. Bevy applies the queued commands inside the schedule.
+    app.add_systems(FixedUpdate, move |mut commands: Commands| {
+        commands.spawn((
+            JointKinematicsC(const_spec),
+            SinusoidalJointKinematicsC(sin_spec),
+        ));
+    });
+
+    let msg = capture_panic_message(|| {
+        step_once(&mut app);
+    });
+
+    assert!(
+        msg.contains("JointKinematicsC"),
+        "runtime panic missing JointKinematicsC: {msg}"
+    );
+    assert!(
+        msg.contains("SinusoidalJointKinematicsC"),
+        "runtime panic missing SinusoidalJointKinematicsC: {msg}"
+    );
+    assert!(
+        msg.contains("mutually exclusive"),
+        "runtime panic missing diagnostic header: {msg}"
+    );
+}
+
+/// **Runtime-insert regression test.** An entity that already
+/// carries one kinematic spec must trip the `on_insert` hook the
+/// moment a *second* spec is inserted on it via
+/// `EntityCommands::insert` — even if that mutation happens in a
+/// `Update` system long after the entity was first spawned. This
+/// covers the late-mutation surface that a one-shot validator
+/// cannot cover at all.
+#[test]
+fn late_insert_of_second_spec_panics_via_hook() {
     let const_spec = JointKinematicsSpec {
         axis_in_parent: DVec3::Z,
         rate_rad_per_s: 0.1,
@@ -1083,18 +1344,22 @@ fn stacked_joint_specs_from_user_startup_commands_do_not_panic_in_startup() {
         axis_in_parent: DVec3::X,
         fixed_angle_rad: 0.5,
     };
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.insert_resource(Time::<Fixed>::from_seconds(DT));
-    app.add_plugins(JeodPlugin);
-    app.add_systems(Startup, move |mut commands: Commands| {
-        commands.spawn((
-            JointKinematicsC(const_spec),
-            ClosureJointKinematicsC(close_spec),
-        ));
-    });
-    // Running only Startup must not panic — the validator lives in
-    // PostStartup. (Calling PostStartup here would panic; that case
-    // is covered by the sibling test above.)
+    let mut app = build_app_with_plugin();
+    let entity = app.world_mut().spawn(JointKinematicsC(const_spec)).id();
+    // Validator passes: only one spec on the entity.
     app.world_mut().run_schedule(Startup);
+    app.world_mut().run_schedule(PostStartup);
+
+    let msg = capture_panic_message(|| {
+        // Direct world insertion, mirroring what `EntityCommands::insert`
+        // would do once the deferred queue flushes.
+        app.world_mut()
+            .entity_mut(entity)
+            .insert(ClosureJointKinematicsC(close_spec));
+    });
+    assert_diagnostic_lists(
+        &msg,
+        &["JointKinematicsC", "ClosureJointKinematicsC"],
+        entity,
+    );
 }


### PR DESCRIPTION
Closes #301.

Extends the kinematic-only joint spec catalogue beyond the constant-rate single-axis primitive that PR #289 shipped. Force-controlled joints (with reaction forces, integrated joint dynamics) remain deferred under #276 — this PR is kinematic-only enrichment.

## Summary

Three new spec variants, each shipped as a sibling spec type alongside the existing `JointKinematicsSpec` (rather than refactoring it into an enum) so existing struct-literal call sites in tests and recipes keep compiling unchanged. A new unifying `JointKinematicsModel` enum is provided for callers that need heterogeneous joint collections.

### `SinusoidalJointKinematicsSpec`

Single-axis joint whose angle is

```
θ(t) = offset_rad + amplitude_rad · sin(omega_rad_per_s · t + phase_rad)
```

The kernel computes the analytic time-derivative for the angular velocity, so `dθ/dt = amplitude · ω · cos(ω · t + phase)` and the angular velocity in this-frame coordinates is `(dθ/dt) · axis_in_parent`. Useful for periodic articulation (pointing dither, antenna scan, gimbal sweep, slosh-style oscillation).

### `ClosureJointKinematicsSpec`

Single-axis joint pinned to a fixed rotation with no time dependence (`θ(t) = fixed_angle_rad`, `ω = 0`). The kinematic-only degenerate case useful for closing kinematic loops where one joint's pose is constrained at declaration time rather than driven through `θ(t)`.

### `MultiDofJointKinematicsSpec`

Up to `MAX_MULTI_DOF_AXES` (= 6) DOF chain. Each stage is a `SingleDofKinematics` variant (`ConstantRate` / `Sinusoidal` / `Closure`) declared in the *intermediate frame* produced by the preceding stages, matching the standard kinematic-chain convention. The kernel folds stages with `RefFrameState::incr_right` so the composed `(rotation, angular velocity)` is bit-identical to walking the equivalent N-entity frame-tree chain. Stages must be a contiguous prefix of the fixed-size axes array — the kernel asserts this; a "hole" in the middle panics with a diagnostic.

The fixed-size axes array (`[Option<SingleDofKinematics>; MAX_MULTI_DOF_AXES]`) keeps the spec `Copy`, which keeps `JointKinematicsModel` `Copy` and avoids per-tick allocation in the propagation path. Chains longer than 6 DOFs can be expressed as multiple chained joint frame entities (one frame per DOF) — also the JEOD-faithful pattern, since JEOD has no native multi-DOF joint primitive.

### `JointKinematicsModel`

Unifying enum over the four variants (`ConstantRate` / `Sinusoidal` / `Closure` / `MultiDof`). `evaluate_model(&model, t)` dispatches each variant to the matching per-spec kernel.

## Three-layer split

- **`jeod_dynamics::kinematic_joint`** — pure-math kernels. Each new evaluator validates `axis_in_parent` is unit-norm (within `AXIS_NORM_TOL`) and every spec scalar is finite, panicking with a fix-this-by message on violation.
- **`jeod_sim`** — re-exports the new spec types, kernel evaluators, and `MAX_MULTI_DOF_AXES` so the Bevy adapter and any other `jeod_sim` consumer (mission crates, `jeod_runner`, ...) reach the kernel through the single API surface.
- **`bevy_jeod`** — `SinusoidalJointKinematicsC` / `ClosureJointKinematicsC` / `MultiDofJointKinematicsC` Components (each with the same `#[require(FrameTransC, FrameRotC, FrameAngVelC)]` triplet contract as `JointKinematicsC`) and three sibling driver systems scheduled in `JeodSet::EphemerisUpdate` alongside `joint_kinematics_system`. The four kinematic-spec components are semantic alternatives — each entity carries at most one — so the four driver systems write disjoint storage and commute under EphemerisUpdate's parallelism.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1060/1060 pass
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 21/21 pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `bash scripts/check_no_escape_hatches.sh`
- [x] `cargo test --test invariant_coverage`

New tests:

- 19 Tier-1 kernel tests in `kinematic_joint::tests` — closed-form values at known times (sinusoidal `t = 0` snapshot, sinusoidal quarter-period peak, closure constant over time, multi-DOF same-axis stages summing to aggregate, multi-DOF empty chain → identity, multi-DOF 1-stage matching constant-rate kernel, multi-DOF 2-stage matching manual `incr_right`), fail-loud on non-unit axes / non-finite scalars / hole-in-middle / over-`MAX_MULTI_DOF_AXES` slice length, and `JointKinematicsModel::evaluate_model` dispatch correctness.
- 7 Bevy integration tests in `tests/joint_kinematics.rs` ticking the `FixedUpdate` schedule end-to-end and pinning the per-component output bit-for-bit to direct kernel calls at the same elapsed time. Includes a sibling-driver test that spawns one entity per variant and asserts the four drivers tag disjoint entity sets without cross-write.
- `tests/bevy_reflect_smoke.rs` and `register_jeod_component_types` updated to cover the three new components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)