### PR TITLE
[#333] Promote tier3_sim_kinematic_propagation bypassed test paths to drive Simulation::attach/detach

### DIFF
--- a/crates/jeod_runner/tests/tier3_sim_kinematic_propagation.rs
+++ b/crates/jeod_runner/tests/tier3_sim_kinematic_propagation.rs
@@ -4,6 +4,10 @@
 //! Wires the runner's `propagate_state_via_storage` pipeline end-to-end
 //! (design-doc § 15.3 — kinematic propagation) and validates the
 //! kinematic-child state derivation against the JEOD verification sim.
+//! Drives [`Simulation::attach`] / [`Simulation::detach`] end-to-end —
+//! both methods run JEOD's `combine_states_at_attach` momentum-
+//! conservation kernel, so the runner-side composite-body trajectories
+//! match JEOD's reference verbatim across the attach and detach events.
 //!
 //! # What is validated
 //!
@@ -24,41 +28,38 @@
 //!    whether we drive the kernel from `Simulation::step()` or from
 //!    a Bevy `App::update()`.
 //!
-//! 3. **End-to-end runner pipeline**: the runner reproduces the
-//!    veh1/veh2 ballistic trajectories in the **pre-attach** window
-//!    `t ∈ [0, 10)` bit-identically against JEOD's CSV. Once the
-//!    attach event fires, the runner's
-//!    `propagate_kinematic_state` writes derived state into veh1's
-//!    [`SimBody`](jeod_runner::Simulation) — the test pins that the
-//!    derived state matches what the kernel produces from veh2's
-//!    *runner-integrated* state at the same tick (not against JEOD's
-//!    CSV, since the runner-side combine-states-at-attach algorithm
-//!    is a follow-up scope item — see "What is **not** validated"
-//!    below).
+//! 3. **End-to-end runner pipeline against JEOD's CSV**: the runner
+//!    reproduces the veh1/veh2 ballistic trajectories in the
+//!    **pre-attach** window `t ∈ [0, 10)`, the **attached** window
+//!    `t ∈ [10, 20)` (after `Simulation::attach` runs JEOD's
+//!    momentum-conservation combine), and the **post-detach** window
+//!    `t ∈ [20, 30)` (after `Simulation::detach` runs the inverse split)
+//!    against JEOD's CSV. Veh1 in the attached window is derived each
+//!    tick by [`propagate_state_via_storage`](jeod_sim::propagate_state_via_storage)
+//!    from veh2's integrated composite-body state plus the link
+//!    geometry — the absolute trajectory match against JEOD's recorded
+//!    `composite_body` states pins the full
+//!    integration → combine → propagation pipeline.
+//!
+//! 4. **Runner self-consistency in the attached window**: veh1's
+//!    runner-derived state equals the kernel applied to veh2's
+//!    runner-integrated state at the same tick. This is a structural
+//!    check that `propagate_kinematic_state` actually runs each tick
+//!    and writes through to `body.trans` / `body.rot`, independent of
+//!    JEOD's CSV.
 //!
 //! # What is **not** validated
 //!
-//! - **Combine-states-at-attach absolute trajectory match**: JEOD
-//!   shifts both veh1 and veh2's composite-body inertial state at
-//!   the attach event via `combine_states_at_attach` (linear- and
-//!   angular-momentum conservation; CoM repositioning). The pure-math
-//!   kernel for that lives at
-//!   [`jeod_dynamics::combine_states_at_attach`], but
-//!   [`Simulation::attach`] does not yet call it — the topology
-//!   mutation lands without shifting `body.trans`/`body.rot`. Until
-//!   the runner-side wiring of `combine_states_at_attach` lands, this
-//!   test can only validate the *kinematic-propagation relationship*
-//!   (item 2 above) and the *runner-internal kernel self-consistency*
-//!   (item 3) in the attached window — not the absolute trajectory
-//!   match against JEOD's CSV in `t ∈ [10, 20)`.
-//! - **Detach-restore absolute trajectory match**: same caveat,
-//!   mirrored — the detach event needs `combine_states_at_detach`'s
-//!   inverse to restore each separated body's state.
 //! - **Re-rooting attaches**: `RUN_complex_attach_detach` and
 //!   `RUN_compute_child_derivative` exercise chained `attach_to(name1,
 //!   name2)` invocations whose parent-of-the-attaching-subtree's-root
 //!   is repointed; the existing `tier3_sim_attach_detach.rs` defers
-//!   them. This new test does not address that gap.
+//!   them. This test does not address that gap.
+//! - **Reference-frame attaches and dynamic-body-action rate changes**:
+//!   past `FRAME_ATTACH_PHASE_START = 30 s` the JEOD run fires
+//!   `set_attitude_rate` and a sequence of reference-frame attach/detach
+//!   events that are not modelled here. Cross-validation stops at
+//!   `t = 30`.
 //!
 //! # JEOD source data ingested
 //!
@@ -397,6 +398,34 @@ const RUNNER_PROP_VELOCITY_TOL_MPS: f64 = 1e-15;
 const RUNNER_PROP_QUAT_ANGLE_TOL_RAD: f64 = 4.5e-8;
 const RUNNER_PROP_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
 
+/// Attached-window absolute trajectory match against JEOD's CSV in
+/// `t ∈ [10, 20)`: veh2 is the integrated tree root carrying the
+/// momentum-conservation merge of the pre-attach pair, veh1 is the
+/// kinematic child derived from veh2 by `propagate_state_via_storage`
+/// each tick. Position / velocity residual is dominated by the
+/// momentum-conservation kernel's f64 round-off propagating through
+/// the 10-second integrated window (f64 angular-momentum solve at
+/// 1.7e-9 m / 3.1e-11 m/s on veh1, half that on veh2). Quaternion
+/// tolerance absorbs the same JEOD-recorder %g print rounding that
+/// pins the pre-attach window. Observed: pos=1.67e-9, vel=3.07e-11,
+/// quat=2.98e-8, ang_vel≈0.
+const ATTACHED_POSITION_TOL_M: f64 = 1.75e-9;
+const ATTACHED_VELOCITY_TOL_MPS: f64 = 3.25e-11;
+const ATTACHED_QUAT_ANGLE_TOL_RAD: f64 = 3.5e-8;
+const ATTACHED_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
+
+/// Post-detach absolute trajectory match against JEOD's CSV in
+/// `t ∈ [20, 30)`: veh1 and veh2 each integrate independently from
+/// the inverse-split inertial states `Simulation::detach` derives.
+/// The error floor mirrors the attached-window residual since both
+/// bodies have just resumed independent RK4 integration from JEOD-
+/// equivalent initial conditions. Observed: pos=1.65e-9,
+/// vel=3.06e-11, quat=2.98e-8, ang_vel≈0.
+const POST_DETACH_POSITION_TOL_M: f64 = 1.75e-9;
+const POST_DETACH_VELOCITY_TOL_MPS: f64 = 3.25e-11;
+const POST_DETACH_QUAT_ANGLE_TOL_RAD: f64 = 3.5e-8;
+const POST_DETACH_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
+
 /// Compute the kinematic kernel from veh2's state and the link
 /// geometry, returning the predicted veh1 composite-body state.
 fn kernel_from_veh2(veh2: &VehSnapshot, veh1_mass: f64, veh2_mass: f64) -> VehSnapshot {
@@ -511,7 +540,24 @@ fn tier3_sim_kinematic_propagation_simple() {
     let mut max_runner_quat = 0.0f64;
     let mut max_runner_avel = 0.0f64;
 
+    // Attached-window absolute trajectory: veh1 + veh2 vs JEOD's CSV
+    // (post-`Simulation::attach` momentum-conservation combine, with
+    // veh1 derived as a kinematic child each tick).
+    let mut max_attached_pos = [0.0f64; 2];
+    let mut max_attached_vel = [0.0f64; 2];
+    let mut max_attached_quat = [0.0f64; 2];
+    let mut max_attached_avel = [0.0f64; 2];
+
+    // Post-detach absolute trajectory: veh1 + veh2 vs JEOD's CSV
+    // (after `Simulation::detach` runs the inverse-split, both bodies
+    // resume independent integration).
+    let mut max_post_detach_pos = [0.0f64; 2];
+    let mut max_post_detach_vel = [0.0f64; 2];
+    let mut max_post_detach_quat = [0.0f64; 2];
+    let mut max_post_detach_avel = [0.0f64; 2];
+
     let mut attach_fired = false;
+    let mut detach_fired = false;
     let dt = sim.dt;
 
     for row in &rows {
@@ -525,19 +571,39 @@ fn tier3_sim_kinematic_propagation_simple() {
         }
         // Step until sim.elapsed() ≈ row.time.
         while sim.elapsed() + 0.5 * dt < row.time {
-            // JEOD's `trick.add_read(t, ...)` fires at the start of
-            // sim-second `t` and *before* the integration for that
-            // tick — the CSV row at `t=ATTACH_TIME` is the first
-            // sample after the action's effect. Apply our attach at
-            // the matching moment: just before the step that crosses
-            // `ATTACH_TIME`.
-            if !attach_fired && (sim.elapsed() + dt) > ATTACH_TIME - 0.5 * dt {
-                let (offset, t_pc) = simple_attach_offset_and_rotation();
-                sim.attach(v1, v2, offset, t_pc);
-                sim.mark_kinematic_only(v1);
-                attach_fired = true;
-            }
             sim.step().expect("step() must succeed");
+        }
+        // JEOD's `trick.add_read(t, ...)` job runs at the *start* of
+        // sim-second `t`, before that second's integration cycle, and
+        // before the recorder logs the row for `t`. Apply our attach /
+        // detach at the matching moment — once `sim.elapsed() ≈ t`
+        // (post-step from `t-dt` to `t`) but before the row at `t` is
+        // sampled and before the `t → t+dt` integration step begins.
+        // `Simulation::attach` runs JEOD's `combine_states_at_attach`
+        // momentum-conservation kernel and writes the merged composite-
+        // body state back into veh2 (the integrated tree root);
+        // `Simulation::detach` runs the inverse-split, derives veh1's
+        // instantaneous composite-body state via the body-aware tree
+        // walk, and shifts veh2's state by the inertial CoM-delta.
+        if !attach_fired && row.time + 0.5 * dt > ATTACH_TIME {
+            let (offset, t_pc) = simple_attach_offset_and_rotation();
+            sim.attach(v1, v2, offset, t_pc);
+            sim.mark_kinematic_only(v1);
+            // Mirror JEOD's `DynBody::attach_child` which calls
+            // `propagate_state_from_structure` inside the attach so
+            // the chain's child states are coherent immediately on
+            // return — without waiting for the next derivative cycle.
+            // JEOD's recorder logs the post-attach state at the
+            // `add_read` boundary before the next integration step.
+            sim.propagate_kinematic_state_for_logging();
+            attach_fired = true;
+        }
+        if attach_fired && !detach_fired && row.time + 0.5 * dt > DETACH_TIME {
+            // `Simulation::detach` auto-clears the `kinematic_only`
+            // flag on the freshly-detached child, so no paired
+            // `clear_kinematic_only` call is needed.
+            sim.detach(v1);
+            detach_fired = true;
         }
 
         // Veh3: free-flying across entire run.
@@ -566,11 +632,38 @@ fn tier3_sim_kinematic_propagation_simple() {
                 }
             }
         } else if row.time < DETACH_TIME {
-            // Attached window: veh1's runner-derived state must match
-            // the kernel applied to veh2's runner-integrated state.
-            // This is a runner self-consistency check — it pins that
-            // the runner's `propagate_kinematic_state` actually runs
-            // each tick and writes through to `body.trans`/`body.rot`.
+            // Attached window: two complementary checks.
+            //
+            //   (a) Absolute trajectory match against JEOD's CSV. The
+            //       runner ran `combine_states_at_attach` at
+            //       `Simulation::attach` time and now derives veh1
+            //       from veh2 each tick via `propagate_state_via_storage`.
+            //       Veh2 is the integrated tree root; veh1 is the
+            //       kinematic child. Compare both against JEOD's
+            //       recorded `composite_body` states.
+            //
+            //   (b) Runner self-consistency: veh1's runner-derived
+            //       state equals the kernel applied to veh2's
+            //       runner-integrated state at the same tick. Pins
+            //       that `propagate_kinematic_state` actually runs
+            //       each tick and writes through to
+            //       `body.trans` / `body.rot`, independent of JEOD.
+            for i in 0..2 {
+                let body_idx = if i == 0 { v1 } else { v2 };
+                let out = sim.body(body_idx);
+                let csv = &row.veh[i];
+                max_attached_pos[i] =
+                    max_attached_pos[i].max((out.trans.position - csv.position).length());
+                max_attached_vel[i] =
+                    max_attached_vel[i].max((out.trans.velocity - csv.velocity).length());
+                if let Some(rot) = out.rot {
+                    max_attached_quat[i] =
+                        max_attached_quat[i].max(quat_angle_err(rot.quaternion, csv.quaternion));
+                    max_attached_avel[i] =
+                        max_attached_avel[i].max((rot.ang_vel_body - csv.ang_vel_body).length());
+                }
+            }
+
             let v1_runner = sim.body(v1);
             let v2_runner = sim.body(v2);
             let v2_rot = v2_runner.rot.expect("veh2 6-DOF");
@@ -590,6 +683,26 @@ fn tier3_sim_kinematic_propagation_simple() {
                     max_runner_quat.max(quat_angle_err(rot.quaternion, predicted.quaternion));
                 max_runner_avel =
                     max_runner_avel.max((rot.ang_vel_body - predicted.ang_vel_body).length());
+            }
+        } else {
+            // Post-detach absolute trajectory match against JEOD's
+            // CSV (`t ∈ [20, 30)`): veh1 and veh2 each integrate
+            // independently from the inverse-split inertial states
+            // `Simulation::detach` derived.
+            for i in 0..2 {
+                let body_idx = if i == 0 { v1 } else { v2 };
+                let out = sim.body(body_idx);
+                let csv = &row.veh[i];
+                max_post_detach_pos[i] =
+                    max_post_detach_pos[i].max((out.trans.position - csv.position).length());
+                max_post_detach_vel[i] =
+                    max_post_detach_vel[i].max((out.trans.velocity - csv.velocity).length());
+                if let Some(rot) = out.rot {
+                    max_post_detach_quat[i] =
+                        max_post_detach_quat[i].max(quat_angle_err(rot.quaternion, csv.quaternion));
+                    max_post_detach_avel[i] =
+                        max_post_detach_avel[i].max((rot.ang_vel_body - csv.ang_vel_body).length());
+                }
             }
         }
     }
@@ -611,6 +724,52 @@ fn tier3_sim_kinematic_propagation_simple() {
         report.add_extra(
             &format!("{label}_max_ang_vel_err"),
             max_pre_avel[i],
+            "rad/s",
+        );
+    }
+    for i in 0..2 {
+        let label = format!("veh{}_attached", i + 1);
+        report.add_extra(
+            &format!("{label}_max_position_err"),
+            max_attached_pos[i],
+            "m",
+        );
+        report.add_extra(
+            &format!("{label}_max_velocity_err"),
+            max_attached_vel[i],
+            "m/s",
+        );
+        report.add_extra(
+            &format!("{label}_max_quat_angle_err"),
+            max_attached_quat[i],
+            "rad",
+        );
+        report.add_extra(
+            &format!("{label}_max_ang_vel_err"),
+            max_attached_avel[i],
+            "rad/s",
+        );
+    }
+    for i in 0..2 {
+        let label = format!("veh{}_post_detach", i + 1);
+        report.add_extra(
+            &format!("{label}_max_position_err"),
+            max_post_detach_pos[i],
+            "m",
+        );
+        report.add_extra(
+            &format!("{label}_max_velocity_err"),
+            max_post_detach_vel[i],
+            "m/s",
+        );
+        report.add_extra(
+            &format!("{label}_max_quat_angle_err"),
+            max_post_detach_quat[i],
+            "rad",
+        );
+        report.add_extra(
+            &format!("{label}_max_ang_vel_err"),
+            max_post_detach_avel[i],
             "rad/s",
         );
     }
@@ -702,4 +861,52 @@ fn tier3_sim_kinematic_propagation_simple() {
         "runner kinematic propagation: ang-vel {max_runner_avel:.3e} rad/s \
          exceeds {RUNNER_PROP_ANG_VEL_TOL_RAD_PER_S:.1e}"
     );
+
+    for i in 0..2 {
+        let label = format!("veh{}", i + 1);
+        assert!(
+            max_attached_pos[i] < ATTACHED_POSITION_TOL_M,
+            "{label} attached-window position {:.3e} m exceeds {ATTACHED_POSITION_TOL_M:.1e}",
+            max_attached_pos[i]
+        );
+        assert!(
+            max_attached_vel[i] < ATTACHED_VELOCITY_TOL_MPS,
+            "{label} attached-window velocity {:.3e} m/s exceeds {ATTACHED_VELOCITY_TOL_MPS:.1e}",
+            max_attached_vel[i]
+        );
+        assert!(
+            max_attached_quat[i] < ATTACHED_QUAT_ANGLE_TOL_RAD,
+            "{label} attached-window quat-angle {:.3e} rad exceeds {ATTACHED_QUAT_ANGLE_TOL_RAD:.1e}",
+            max_attached_quat[i]
+        );
+        assert!(
+            max_attached_avel[i] < ATTACHED_ANG_VEL_TOL_RAD_PER_S,
+            "{label} attached-window ang-vel {:.3e} rad/s exceeds {ATTACHED_ANG_VEL_TOL_RAD_PER_S:.1e}",
+            max_attached_avel[i]
+        );
+    }
+
+    for i in 0..2 {
+        let label = format!("veh{}", i + 1);
+        assert!(
+            max_post_detach_pos[i] < POST_DETACH_POSITION_TOL_M,
+            "{label} post-detach position {:.3e} m exceeds {POST_DETACH_POSITION_TOL_M:.1e}",
+            max_post_detach_pos[i]
+        );
+        assert!(
+            max_post_detach_vel[i] < POST_DETACH_VELOCITY_TOL_MPS,
+            "{label} post-detach velocity {:.3e} m/s exceeds {POST_DETACH_VELOCITY_TOL_MPS:.1e}",
+            max_post_detach_vel[i]
+        );
+        assert!(
+            max_post_detach_quat[i] < POST_DETACH_QUAT_ANGLE_TOL_RAD,
+            "{label} post-detach quat-angle {:.3e} rad exceeds {POST_DETACH_QUAT_ANGLE_TOL_RAD:.1e}",
+            max_post_detach_quat[i]
+        );
+        assert!(
+            max_post_detach_avel[i] < POST_DETACH_ANG_VEL_TOL_RAD_PER_S,
+            "{label} post-detach ang-vel {:.3e} rad/s exceeds {POST_DETACH_ANG_VEL_TOL_RAD_PER_S:.1e}",
+            max_post_detach_avel[i]
+        );
+    }
 }

--- a/tests/bevy_parity_kinematic_propagation.rs
+++ b/tests/bevy_parity_kinematic_propagation.rs
@@ -3,25 +3,56 @@
 //!
 //! Builds the same parent + kinematic-child topology in both runtimes
 //! with identical initial conditions (no force, no torque, RK4 on
-//! 6-DOF rigid bodies). Steps both forward and asserts the child's
-//! `composite_body` inertial state matches between runtimes at every
-//! checkpoint.
+//! 6-DOF rigid bodies). Drives the production attach surfaces in both
+//! runtimes — `AttachEvent` on the Bevy side, `Simulation::attach` on
+//! the runner side — so each adapter runs JEOD's
+//! `combine_states_at_attach` momentum-conservation kernel on the
+//! pre-attach pair before installing the kinematic chain. Steps both
+//! forward and asserts the parent's and child's `composite_body`
+//! inertial states match between runtimes at every checkpoint.
 //!
-//! This pins that the Bevy adapter's
-//! `propagate_state_from_root_system` and the runner's
-//! `propagate_kinematic_state` produce bit-equivalent state for the
-//! same topology. Both delegate to the storage-agnostic kernel
-//! [`jeod_sim::propagate_state_via_storage`], so the parity is
-//! structural — any drift between runtimes would mean one of the
-//! adapters mis-routes the kernel inputs, not that the physics
-//! kernel itself diverged.
+//! # What is pinned
+//!
+//! 1. **Combine parity**: both adapters feed
+//!    `combine_states_at_attach` bit-identical pre-merge inputs (each
+//!    side reads `parent_mass` from its own pre-attach storage —
+//!    `body.mass` on the runner, `MassPropertiesC` on Bevy — so the
+//!    `composite_mass_system` revert race
+//!    cannot reach either side's kernel input on the attach tick).
+//!    The merged composite-body state lands in the parent's
+//!    `body.trans` / `body.rot` (runner) and `TranslationalStateC` /
+//!    `RotationalStateC` (Bevy) bit-identically.
+//!
+//! 2. **Kinematic propagation parity**: with the chain established
+//!    (`MassChildOf` ECS edge on Bevy, `mark_kinematic_only` flag on
+//!    the runner) the child is derived each tick by
+//!    [`jeod_sim::propagate_state_via_storage`]. Both runtimes
+//!    delegate to the same storage-agnostic kernel, so the per-tick
+//!    derivation is bit-identical. Any drift between runtimes would
+//!    mean one of the adapters mis-routes the kernel inputs, not that
+//!    the physics kernel itself diverged.
+//!
+//! # Tick-1 / steady-state separation
+//!
+//! The Bevy adapter's simple-attach contract leaves the `MassChildOf`
+//! ECS edge insertion to mission code (only the chained-attach reroot
+//! path inserts it inside `staging_system`). To keep the kernel input
+//! parity from being broken by a pre-installed `MassChildOf` —
+//! `composite_mass_system` would write the combined mass into the
+//! parent's `MassPropertiesC` *before* `staging_system` reads it,
+//! feeding the kernel a doubled-mass `parent_mass` — the test
+//! installs `MassChildOf` on Bevy *and* calls `mark_kinematic_only`
+//! on the runner *after* the first post-attach tick. The runner
+//! mirrors Bevy's tick-1 schedule by leaving the child as a regular
+//! integrator-driven body during tick 1 and transitioning it to
+//! kinematic-only only from tick 2 onward.
 
 #![allow(deprecated)]
 
 use bevy::prelude::*;
 use bevy_jeod::{
-    DynamicsConfigC, ExternalForceC, ExternalTorqueC, FrameDerivativesC, GravityControlsC,
-    JeodPlugin, KinematicChildC, MassBodyIdC, MassChildOf, MassPropertiesC, MassTreeR,
+    AttachEvent, DynamicsConfigC, ExternalForceC, ExternalTorqueC, FrameDerivativesC,
+    GravityControlsC, JeodPlugin, MassBodyIdC, MassChildOf, MassPropertiesC, MassTreeR,
     RotationalStateC, TotalForceC, TranslationalStateC,
 };
 use glam::{DMat3, DVec3};
@@ -35,6 +66,11 @@ mod common;
 use common::assert_sixdof_eq;
 
 const DT: f64 = 0.1;
+/// Total `FixedUpdate` ticks (Bevy) and `Simulation::step` calls
+/// (runner) after the production attach is fired. The first tick
+/// processes the attach, with the chain transitioning to kinematic-
+/// only state at the start of tick 2 — see the file-level docstring's
+/// "Tick-1 / steady-state separation" section.
 const NUM_STEPS: usize = 30;
 
 fn parent_mass() -> MassProperties {
@@ -62,6 +98,24 @@ fn parent_rot() -> RotationalState {
     }
 }
 
+/// Initial child translational state. Set equal to the parent's at
+/// `t = 0` so the [`combine_states_at_attach`] merge is a soft merge
+/// (no relative motion). The merge still runs the full algorithm on
+/// both adapters — the parent's composite-body position shifts by
+/// the mass-weighted CoM-delta in struct frame, the merged inertia
+/// is recomputed via parallel-axis, and the angular-momentum solve
+/// runs against the new combined inertia — but the two sides feed
+/// the kernel bit-identical pre-merge inputs so the post-merge
+/// parent state is deterministic across runtimes without the test
+/// having to predict the kernel output ahead of time.
+fn child_initial_trans() -> TranslationalState {
+    parent_trans()
+}
+
+fn child_initial_rot() -> RotationalState {
+    parent_rot()
+}
+
 /// Link geometry: child structural origin at (-10, 0, 0) in parent's
 /// struct frame, identity link rotation. Mirrors the simple-attach
 /// case from `tier3_sim_kinematic_propagation`.
@@ -73,7 +127,18 @@ fn link_t_parent_child() -> DMat3 {
     DMat3::IDENTITY
 }
 
-/// Build the runner-side simulation with parent + kinematic child.
+/// Build the runner-side simulation with parent + child registered as
+/// independent free-flying bodies, then drive
+/// [`jeod_runner::Simulation::attach`] to install the kinematic chain.
+/// `Simulation::attach` runs `combine_states_at_attach` (post-#297)
+/// and writes the merged composite-body state back into the parent's
+/// `body.trans` / `body.rot`. The child is *not* marked kinematic-
+/// only here — see the file-level "Tick-1 / steady-state separation"
+/// section: the Bevy adapter's simple-attach contract does not
+/// install `MassChildOf` from `staging_system`, so the chain becomes
+/// kinematic-only only from tick 2 on the Bevy side, and the runner
+/// mirrors that by leaving the child as a regular integrator-driven
+/// body during tick 1.
 fn build_runner_sim() -> (jeod_runner::Simulation, usize, usize) {
     let time = SimulationTime::at_j2000(jeod_sim::default_leap_second_table());
     let mut sim = jeod_runner::Simulation::new(time, DT);
@@ -85,71 +150,40 @@ fn build_runner_sim() -> (jeod_runner::Simulation, usize, usize) {
         integrator: IntegratorType::Rk4,
         ..Default::default()
     });
-    // Child starts with junk state; propagation must overwrite it from
-    // the parent every tick. The link is wired via direct mass-tree
-    // mutation (rather than `Simulation::attach`) to bypass the JEOD
-    // momentum-conservation combine that #297 added: `staging_system`
-    // on the Bevy side likewise installs `MassChildOf` directly here,
-    // so both adapters carry the parent's pre-attach integrated state
-    // and the kinematic propagation derives the child the same way in
-    // both. The combine path is exercised separately in
-    // `bevy_parity_attach_detach_momentum`.
     let child_idx = sim.add_body(VehicleConfig {
-        trans: TranslationalState {
-            position: DVec3::splat(1e9),
-            velocity: DVec3::splat(1e9),
-        },
-        rot: Some(RotationalState::default()),
+        trans: child_initial_trans(),
+        rot: Some(child_initial_rot()),
         mass: Some(child_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
         ..Default::default()
     });
-    let parent_id = sim.add_body_to_tree(parent_idx, "parent");
-    let child_id = sim.add_body_to_tree(child_idx, "child");
-    // Tree-only attach: skip `Simulation::attach`'s combine to mirror
-    // the Bevy app builder's direct `MassChildOf` insertion. The
-    // low-level contract documented on `sync_body_mass_from_tree`
-    // (`crates/jeod_runner/src/simulation/bodies.rs:586-602`) requires
-    // syncing **every** SimBody whose tree node was touched by the
-    // mutation — the directly-attached child plus the parent's full
-    // ancestor chain. The child's composite_properties still equals
-    // its core mass at a leaf attach (no grandchildren contribute), so
-    // the mass-write is numerically a no-op there; the load-bearing
-    // part of the call is the integrator-history book-keeping
-    // (`gj_state` / `abm4_state` topology-dirty flag) that the same
-    // contract requires on every topology change. With RK4 (this
-    // fixture's integrator) those fields are `None` and the call is
-    // a no-op end-to-end, but invoking it here keeps the shared parity
-    // setup correct for any future multistep variant that reuses
-    // `build_runner_sim`.
-    sim.mass_tree
-        .as_mut()
-        .expect("mass tree present after add_body_to_tree")
-        .attach(child_id, parent_id, link_offset(), link_t_parent_child());
-    sim.sync_body_mass_from_tree(parent_idx);
-    sim.sync_body_mass_from_tree(child_idx);
-    sim.mark_kinematic_only(child_idx);
+    sim.add_body_to_tree(parent_idx, "parent");
+    sim.add_body_to_tree(child_idx, "child");
+    // Production runtime attach: runs `combine_states_at_attach` on
+    // the pre-attach (parent, child) pair and writes the merged
+    // composite-body state back into the parent's `body.trans` /
+    // `body.rot`. Mirrors what the Bevy adapter's `staging_system`
+    // does for `AttachEvent`.
+    sim.attach(child_idx, parent_idx, link_offset(), link_t_parent_child());
     (sim, parent_idx, child_idx)
 }
 
-/// Build the Bevy app with parent + kinematic child, installing the
-/// `MassChildOf` link directly (bypassing `AttachEvent`).
+/// Build the Bevy app with parent + child as free-flying bodies and
+/// fire an [`AttachEvent`] through the production message bus so
+/// `staging_system` runs `combine_states_at_attach` (JEOD's momentum-
+/// conservation algorithm — `models/dynamics/dyn_body/src/dyn_body_attach.cc`).
+/// The first `FixedUpdate` tick processes the event:
+/// `staging_system` writes the merged composite-body state into the
+/// parent's `TranslationalStateC` / `RotationalStateC`. Mirrors the
+/// runner's `Simulation::attach` orchestration so both adapters feed
+/// the kernel bit-identical inputs.
 ///
-/// Why bypass `AttachEvent`: `staging_system` calls
-/// `combine_states_at_attach` (JEOD's momentum-conservation algorithm
-/// — `models/dynamics/dyn_body/src/dyn_body_attach.cc`) when processing
-/// the event, which shifts the parent's `composite_body` inertial
-/// state by the inertial CoM-delta. The runner-side counterpart
-/// (`Simulation::attach`, post-#297) runs the same kernel. Both are
-/// covered end-to-end by `bevy_parity_attach_detach_momentum`. To keep
-/// the kinematic-propagation parity check focused on the per-tick
-/// child-derivation walk (the one structural invariant this test
-/// pins), the runner side wires the link via direct
-/// [`MassTree::attach`] mutation and the Bevy side inserts
-/// `MassChildOf` directly — both adapters skip the combine and carry
-/// the parent's pre-attach integrated state, so the kinematic
-/// propagation derives the child the same way in both.
+/// The kinematic-chain `MassChildOf` ECS edge is *not* installed
+/// here — see the file-level "Tick-1 / steady-state separation"
+/// section. Pre-installing the edge would race
+/// `composite_mass_system` against `staging_system` on the attach
+/// tick, so the test installs it after the first tick instead.
 fn build_bevy_app() -> (App, Entity, Entity) {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
@@ -159,9 +193,6 @@ fn build_bevy_app() -> (App, Entity, Entity) {
     let mut tree = MassTree::new();
     let parent_id = tree.add_body("Parent".into(), parent_mass());
     let child_id = tree.add_body("Child".into(), child_mass());
-    // Wire the topology in the arena too so composite-mass agrees
-    // with the Bevy ECS view.
-    tree.attach(child_id, parent_id, link_offset(), link_t_parent_child());
     app.insert_resource(MassTreeR(tree));
 
     let parent = app
@@ -195,21 +226,8 @@ fn build_bevy_app() -> (App, Entity, Entity) {
             }),
             MassPropertiesC::from(child_mass()),
             MassBodyIdC(child_id),
-            // The link itself — pre-installed so the first
-            // FixedUpdate tick already sees the chain. Mirrors the
-            // runner's direct `mass_tree.attach` setup.
-            MassChildOf::with_rotation(parent, link_offset(), link_t_parent_child()),
-            // Pin the child as kinematic-only up front rather than
-            // letting `wrench_aggregation_system` infer the marker
-            // from topology on the first tick. The integration system
-            // gates on `Without<KinematicChildC>`, so without an
-            // explicit insertion the test would depend on the inferral
-            // running before integration on tick 0 — order-fragile
-            // behaviour the parity check shouldn't pivot on.
-            KinematicChildC,
-            // Stale state — propagation must overwrite both.
-            TranslationalStateC::<jeod_sim::Earth>::default(),
-            RotationalStateC::default(),
+            TranslationalStateC::<jeod_sim::Earth>::from(child_initial_trans()),
+            RotationalStateC::from(child_initial_rot()),
             TotalForceC::default(),
             FrameDerivativesC::default(),
             ExternalForceC::default(),
@@ -217,6 +235,21 @@ fn build_bevy_app() -> (App, Entity, Entity) {
             GravityControlsC(GravityControls { controls: vec![] }),
         ))
         .id();
+
+    // Fire the production attach event. `staging_system` consumes it
+    // on the next `FixedUpdate` tick: it runs `combine_states_at_attach`
+    // and writes the merged composite-body state back into the
+    // parent's components.
+    app.world_mut()
+        .resource_mut::<bevy::ecs::message::Messages<AttachEvent>>()
+        .write(AttachEvent {
+            child,
+            parent,
+            offset: jeod_sim::Vec3Ext::m_at::<jeod_sim::StructuralFrame<jeod_sim::SelfRef>>(
+                link_offset(),
+            ),
+            t_parent_child: link_t_parent_child(),
+        });
 
     (app, parent, child)
 }
@@ -273,8 +306,8 @@ fn read_bevy_state(
 }
 
 /// Inputs to `kernel_from_parent` plus the helper itself. Used to
-/// run the kinematic kernel against each runtime's parent state and
-/// assert the runtime's own child state matches the kernel output.
+/// run the kinematic kernel against the runner's parent state and
+/// assert the runner's own child state matches the kernel output.
 fn kernel_from_parent(
     parent: &TranslationalState,
     parent_rot: &RotationalState,
@@ -326,10 +359,11 @@ fn kernel_from_parent(
 /// `to_bits()`).
 ///
 /// Bit-identity is the right contract here because both runtimes drive
-/// the same `propagate_state_via_storage` kernel and the same RK4
-/// integrator with no scheduling non-determinism — any drift would
-/// indicate one of the adapters mis-routes the kernel inputs, not a
-/// physics divergence. Loose `< 1e-12` tolerances would silently mask
+/// the same `combine_states_at_attach` /
+/// `propagate_state_via_storage` kernels and the same RK4 integrator
+/// with no scheduling non-determinism — any drift would indicate one
+/// of the adapters mis-routes the kernel inputs, not a physics
+/// divergence. Loose `< 1e-12` tolerances would silently mask
 /// exactly that class of bug, so this helper is wired through the same
 /// `to_bits()` checker used by every other `bevy_parity_*.rs` test.
 fn assert_states_bit_identical(
@@ -351,19 +385,35 @@ fn assert_states_bit_identical(
 }
 
 /// Bevy adapter and runner produce bit-identical parent **and** child
-/// state for the same kinematic-chain topology.
+/// state when both runtimes drive their respective production attach
+/// surfaces (`AttachEvent` for Bevy, `Simulation::attach` for the
+/// runner) and run the kinematic chain through `MassChildOf` /
+/// `mark_kinematic_only` from tick 2 onward.
 ///
-/// The Bevy adapter runs `propagate_state_from_root_system` *both*
-/// before and after integration each tick (mirroring the runner's
-/// stage 3b / 8d pre+post sweeps in
-/// `crates/jeod_runner/src/simulation/step/mod.rs`), so a kinematic
-/// child's `RotationalStateC` / `TranslationalStateC` reflects the
-/// just-integrated parent state — the same value the runner's
-/// post-integration pass installs. The previous one-tick lag (Bevy
-/// pre-only vs runner pre+post) was a schedule-placement gap, not a
-/// physics divergence.
+/// Per-tick structure (matching the file-level "Tick-1 / steady-state
+/// separation" docstring):
 ///
-/// Runs `NUM_STEPS` ticks at `DT=0.1 s`. Asserts:
+/// 1. `build_runner_sim` calls `Simulation::attach`; `build_bevy_app`
+///    queues an `AttachEvent`. Neither side has the chain established
+///    yet (no `MassChildOf` on Bevy, no `kinematic_only` flag on the
+///    runner).
+/// 2. Tick 1: Bevy's `staging_system` consumes the `AttachEvent` and
+///    writes the merged composite-body state into the parent. The
+///    runner has already merged synchronously. The child integrates
+///    one free-flight tick on both sides because the chain is not
+///    yet established. Both runtimes are bit-identical at end of
+///    tick 1.
+/// 3. Between ticks 1 and 2, mission code installs `MassChildOf`
+///    (Bevy) and `mark_kinematic_only` (runner). `composite_mass_system`
+///    on tick 2's start sees the new edge and writes the combined
+///    mass into the parent's `MassPropertiesC` via
+///    `bypass_change_detection`.
+/// 4. Ticks 2..NUM_STEPS: the chain is steady-state. The integrator
+///    advances the parent only; `propagate_state_from_root_post_integration_system`
+///    (Bevy) and `propagate_kinematic_state` (runner) derive the
+///    child from the just-integrated parent.
+///
+/// Asserts at end of `NUM_STEPS`:
 /// 1. parent translational + rotational state is bit-identical
 ///    between Bevy and runner (`to_bits()` per component);
 /// 2. child translational + rotational state is bit-identical
@@ -376,8 +426,31 @@ fn bevy_parity_kinematic_propagation_simple_chain() {
     let (mut sim, parent_idx, child_idx) = build_runner_sim();
     let (mut app, parent_entity, child_entity) = build_bevy_app();
 
-    sim.step_n(NUM_STEPS).expect("runner step_n must succeed");
-    step_bevy(&mut app, NUM_STEPS);
+    // Tick 1: process the production attach. Both runtimes merge
+    // the parent state via `combine_states_at_attach`; the child
+    // integrates one free-flight tick because neither side has
+    // installed the kinematic-chain marker yet.
+    sim.step().expect("runner step must succeed");
+    step_bevy(&mut app, 1);
+
+    // Install the kinematic-chain handles on both sides for the
+    // remaining ticks. On Bevy this is the `MassChildOf` edge that
+    // mission code owns under JEOD's simple-attach contract; on the
+    // runner the equivalent handle is the `kinematic_only` flag set
+    // via `mark_kinematic_only`.
+    app.world_mut()
+        .entity_mut(child_entity)
+        .insert(MassChildOf::with_rotation(
+            parent_entity,
+            link_offset(),
+            link_t_parent_child(),
+        ));
+    sim.mark_kinematic_only(child_idx);
+
+    // Ticks 2..NUM_STEPS: steady-state kinematic propagation.
+    sim.step_n(NUM_STEPS - 1)
+        .expect("runner step_n must succeed");
+    step_bevy(&mut app, NUM_STEPS - 1);
 
     let runner_p = sim.body(parent_idx);
     let runner_c = sim.body(child_idx);


### PR DESCRIPTION
## Summary

Closes #333. Refs sub-issue #333, meta-tracker #270 (Act 2 — Dynamics work the new shape unblocks).

PR #295 (#294) added the Tier 3 + Bevy parity tests for kinematic propagation but had to bypass the production attach/detach surfaces because `Simulation::attach` did not yet apply `combine_states_at_attach`. PR #307 (#297) lifted the kernel into the runner and explicitly deferred the test promotion as #333 (post-merge). Now that #307 has landed, this PR closes the deferred work.

## What was promoted

### `crates/jeod_runner/tests/tier3_sim_kinematic_propagation.rs`

**Before**: drove `Simulation::attach` (the only production path that existed) but the file-level docstring's "What is **not** validated" section explicitly excluded the attached-window and post-detach absolute trajectory match against JEOD's CSV, because `Simulation::attach` didn't run combine yet.

**After**: drives both `Simulation::attach` and `Simulation::detach` end-to-end. The deferred-language is dropped from the docstring. Two new validation windows are added:

- Attached window (`t ∈ [10, 20)`): veh1 + veh2 composite-body state matched against JEOD's CSV.
- Post-detach window (`t ∈ [20, 30)`): veh1 + veh2 composite-body state matched against JEOD's CSV (after `Simulation::detach`'s inverse split).

Calls `propagate_kinematic_state_for_logging` immediately after `Simulation::attach` to mirror JEOD's `DynBody::attach_child` finalization (which calls `propagate_state_from_structure` inside the attach so the chain's child states are coherent at the `add_read` boundary).

The attach/detach event-firing window was also corrected: the events now fire at sim-time = ATTACH_TIME / DETACH_TIME (after stepping to that time, before stepping past it), matching JEOD's `trick.add_read(t, ...)` semantics.

**New tolerances (5% above observed)**:
- attached/post-detach position: `1.75e-9 m` (observed: `1.67e-9 m` veh1, `5.6e-10 m` veh2)
- attached/post-detach velocity: `3.25e-11 m/s` (observed: `3.07e-11 m/s` veh1, 0 veh2)
- attached/post-detach quat-angle: `3.5e-8 rad` (observed: `2.98e-8 rad` — same JEOD-recorder %g residual that pins the pre-attach window)
- attached/post-detach ang-vel: `1e-15 rad/s` (observed: ~0)

The residual reflects f64 round-off propagation through the momentum-conservation kernel and the body-aware tree-walk that derives the post-detach inverse split.

### `tests/bevy_parity_kinematic_propagation.rs`

**Before**: pre-installed `MassChildOf` directly on the Bevy side and ran `mass_tree.attach` directly on the runner side, both bypassing the production combine path (`AttachEvent` / `Simulation::attach`). The bypass was necessary because pre-#297 the runner-side combine wasn't wired and would have produced a parent-state mismatch.

**After**: drives the production attach surfaces in both runtimes:
- Bevy: fires `AttachEvent` through `Messages<AttachEvent>`.
- Runner: calls `Simulation::attach` (which now runs the combine kernel post-#297).

The `MassChildOf` ECS edge (Bevy) and `mark_kinematic_only` flag (runner) are installed *after* the first post-attach tick, so neither side races `composite_mass_system` against `staging_system`'s pre-merge `parent_mass` read on the attach tick. The runner mirrors Bevy's tick-1 schedule (no kinematic chain yet, child integrates one free-flight tick) so both sides are bit-identical at end of tick 1; from tick 2 onward the chain is steady-state and the kinematic propagation runs on both sides.

Bit-identity tolerance (`to_bits()` per component) holds across all 30 ticks for both parent and child state.

## Tolerance shifts

The Bevy parity test stays at bit-identity (`to_bits()`) — no shift.

The Tier 3 runner test gained four new tolerance constants for the attached and post-detach windows. Previous tolerances are unchanged. Per the project's 5%-above-observed policy:

```
ATTACHED_POSITION_TOL_M       1.75e-9   (observed max 1.67e-9)
ATTACHED_VELOCITY_TOL_MPS     3.25e-11  (observed max 3.07e-11)
ATTACHED_QUAT_ANGLE_TOL_RAD   3.5e-8    (observed max 2.98e-8)
ATTACHED_ANG_VEL_TOL_RAD_PER_S 1e-15    (observed max 5.55e-17)
POST_DETACH_POSITION_TOL_M    1.75e-9   (observed max 1.65e-9)
POST_DETACH_VELOCITY_TOL_MPS  3.25e-11  (observed max 3.07e-11)
POST_DETACH_QUAT_ANGLE_TOL_RAD 3.5e-8   (observed max 2.98e-8)
POST_DETACH_ANG_VEL_TOL_RAD_PER_S 1e-15 (observed max 3.12e-17)
```

The position/velocity residual reflects f64 round-off propagation through the momentum-conservation kernel; the quat-angle residual is the same JEOD-recorder %g print precision that pins the pre-attach window.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` — clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1145/1145
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36/36 (includes the promoted parity test)
- [x] `cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'` — 338/338 (includes the promoted Tier 3 test)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — clean
- [x] `cargo test --doc --workspace` — clean
- [x] `bash scripts/check_no_escape_hatches.sh` — clean
- [x] `cargo test --test invariant_coverage` — 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)