### PR TITLE
[#337] Tier 3 cross-validation for BodyAction::InitLvlhRot post-init propagation

### DIFF
--- a/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
+++ b/crates/jeod_runner/src/run_verification/sim_dyncomp.rs
@@ -17,11 +17,14 @@ use jeod_sim::recipes::verification::{
     CsvReference, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
 };
 use jeod_sim::{
-    default_leap_second_table, AtmosphereConfig, AtmosphereModel, DragConfig, Ephemeris,
-    EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource,
-    GravitySourceEntry, JeodQuat, MassProperties, MetAtmosphere, RotationModel, RotationalState,
-    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig, EARTH,
+    default_leap_second_table, AtmosphereConfig, AtmosphereModel, BodyAction, DragConfig,
+    Ephemeris, EphemerisBody, EulerSequence, GravityControl, GravityControls, GravityModel,
+    GravitySource, GravitySourceEntry, JeodQuat, LvlhAngularVelocityFrame, MassProperties,
+    MetAtmosphere, RotationModel, RotationalState, SimulationBuilder, SimulationTime,
+    TranslationalState, VehicleConfig, EARTH,
 };
+use uom::si::angle::degree;
+use uom::si::f64::Angle;
 use uom::si::f64::Time;
 use uom::si::time::second;
 
@@ -172,6 +175,162 @@ pub fn run2_6dof() -> VerificationCase {
         tolerances: Tolerances {
             position_m: [1.37e-6, 2.154e-6, 1.826e-6],
             velocity_m_s: [1.446e-9, 2.389e-9, 1.814e-9],
+            quat_angle_rad: 4.426e-8,
+            ang_vel_rad_s: [2.619e-18, 1.367e-18, 7.969e-19],
+            extras: &[],
+        },
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── RUN_2 with InitLvlhRot post-init propagation ───────────────────────────
+//
+// Cross-validates both the `BodyAction::InitLvlhRot` initializer and
+// the rotational integrator against the existing
+// `dyncomp_run2_state.csv` reference. Where the sibling `run2_6dof`
+// reads the t=0 quaternion straight off the reference CSV, this
+// scenario reads the JEOD `Modified_data/state.py` Yaw-Pitch-Roll
+// Euler triple + LVLH-relative angular velocity, runs them through
+// `BodyAction::InitLvlhRot.apply_rotational()` (which delegates to
+// the shipped `init_rot_from_lvlh` kernel), and uses the result as
+// the initial rotational state. The reference CSV is suitable
+// because every SIM_dyncomp run already initializes its rotational
+// state through `set_orientation_lvlh`, which calls
+// `DynBodyInitLvlhRotState` upstream — see
+// `verif/SIM_dyncomp/Modified_data/state.py:set_orientation_lvlh`.
+
+/// Yaw-Pitch-Roll (ZYX) Euler triple from a JEOD `state.py` LVLH-init
+/// function name, converted to a JEOD scalar-first left-transformation
+/// quaternion via [`jeod_math::compute_quaternion_from_euler_angles_typed`].
+///
+/// Maps the source's `trick.Orientation.<sequence>` string to the
+/// matching [`EulerSequence`]. Only the sequences that appear in
+/// SIM_dyncomp `Modified_data/state.py` are wired today; an unknown
+/// sequence panics with a fail-loudly diagnostic rather than silently
+/// substituting a default.
+fn lvlh_init_from_state_py(
+    state_py: &std::path::Path,
+    function_name: &str,
+) -> (JeodQuat, DVec3, LvlhAngularVelocityFrame) {
+    let lvlh = jeod_test_data::lvlh_init_data::load_lvlh_init_function(state_py, function_name);
+    let sequence = match lvlh.euler_sequence.as_str() {
+        // JEOD `trick.Orientation.Yaw_Pitch_Roll = 5`, ZYX axis order.
+        // models/utils/orientation/include/orientation.hh:130
+        "Yaw_Pitch_Roll" => EulerSequence::ZYX,
+        other => panic!(
+            "lvlh_init_from_state_py: unsupported euler sequence {other:?} in {} \
+             (function {function_name}); add a mapping in sim_dyncomp.rs",
+            state_py.display()
+        ),
+    };
+    let angles = [
+        Angle::new::<degree>(lvlh.euler_angles_deg[0]),
+        Angle::new::<degree>(lvlh.euler_angles_deg[1]),
+        Angle::new::<degree>(lvlh.euler_angles_deg[2]),
+    ];
+    let q_lvlh_body =
+        jeod_math::compute_quaternion_from_euler_angles_typed(angles, sequence).inner();
+    let ang_vel = DVec3::from_array(lvlh.ang_velocity);
+    // SIM_dyncomp `set_orientation_lvlh` does not set `rate_in_parent`,
+    // so JEOD's default `rate_in_parent = false` applies — the
+    // user-supplied ang_velocity is in the body frame.
+    (q_lvlh_body, ang_vel, LvlhAngularVelocityFrame::Body)
+}
+
+/// `RotationalState` reproduced by running `BodyAction::InitLvlhRot`
+/// from JEOD source data (`Modified_data/state.py`) — *not* from the
+/// reference CSV's t=0 quaternion. Exercises the LVLH-rot-init path
+/// end-to-end through the public `BodyAction` API.
+fn init_lvlh_rot_state(state_py: &std::path::Path) -> RotationalState {
+    let trans = jeod_test_data::lvlh_init_data::load_trans_init_function(
+        state_py,
+        "set_trans_init_typical",
+    );
+    let (q_lvlh_body, ang_vel_lvlh_to_body, ang_vel_frame) =
+        lvlh_init_from_state_py(state_py, "set_orientation_lvlh");
+    let action = BodyAction::InitLvlhRot {
+        q_lvlh_body,
+        ang_vel_lvlh_to_body,
+        ang_vel_frame,
+        reference_position: DVec3::from_array(trans.position),
+        reference_velocity: DVec3::from_array(trans.velocity),
+    };
+    action.apply_rotational().expect(
+        "BodyAction::InitLvlhRot.apply_rotational must yield Some(RotationalState); \
+         the variant is rotational by construction",
+    )
+}
+
+/// Builder: same point-mass 6-DOF sim as `build_run2_6dof`, but the
+/// initial *rotational* state is computed by
+/// `BodyAction::InitLvlhRot` applied to the JEOD `state.py` Euler
+/// triple + LVLH-relative ang velocity instead of being read from
+/// the reference CSV's t=0 quaternion. The translational state is
+/// also taken from `state.py:set_trans_init_typical`, since that's
+/// the same JEOD source that produced the CSV's t=0 position /
+/// velocity row — keeping both halves on the source-Python path
+/// avoids any reliance on the reference output.
+fn build_run2_lvlh_rot_init(_init: &InitialConditions) -> SimulationBuilder {
+    let sim_dir = jeod_test_data::jeod_inputs::path(SIM_DYNCOMP);
+    let dt = jeod_test_data::s_define::load_dynamics_dt(&sim_dir.join("S_define"));
+    let earth_mu = jeod_test_data::gravity_fixtures::load_ggm05c().mu;
+    let mass_props = iss_mass_properties();
+    let state_py = sim_dir.join("Modified_data/state.py");
+
+    let trans = jeod_test_data::lvlh_init_data::load_trans_init_function(
+        &state_py,
+        "set_trans_init_typical",
+    );
+    let trans_state = TranslationalState {
+        position: DVec3::from_array(trans.position),
+        velocity: DVec3::from_array(trans.velocity),
+    };
+    let rot_state = init_lvlh_rot_state(&state_py);
+
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    let earth = sb.add_source("Earth", point_mass_earth_source(earth_mu));
+    sb.add_body(VehicleConfig {
+        trans: trans_state,
+        rot: Some(rot_state),
+        mass: Some(mass_props),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, false)],
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// SIM_dyncomp RUN_2 — InitLvlhRot post-init propagation.
+///
+/// The initial rotational state is computed by our
+/// `BodyAction::InitLvlhRot` from the JEOD `Modified_data/state.py`
+/// Yaw-Pitch-Roll Euler triple `[0, -11.6, 0]` deg + zero LVLH-frame
+/// angular velocity, then the simulation propagates 8 hours under
+/// point-mass gravity. The propagated trajectory is compared against
+/// the existing `dyncomp_run2_state.csv` reference (whose t=0 row
+/// JEOD itself produced through `DynBodyInitLvlhRotState`), so the
+/// assertion exercises *both* the LVLH-rot-init kernel *and* the
+/// rotational integrator under SIM_dyncomp's mass properties.
+pub fn run2_lvlh_rot_init_propagation() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_simulation_run2_lvlh_rot_init_propagation",
+        scenario: build_run2_lvlh_rot_init,
+        reference: CsvReference::Dyncomp6Dof("dyncomp_run2_state.csv"),
+        duration: Time::new::<second>(28800.0),
+        tolerances: Tolerances {
+            // Tolerances are 5% above the observed max errors on
+            // a clean run, per the standard CLAUDE.md policy. They
+            // come out essentially identical to `run2_6dof`'s
+            // baseline because the propagator path is the same and
+            // the InitLvlhRot kernel reproduces the JEOD-side
+            // quaternion to floating-point precision; the tiny
+            // residuals are integration-step round-off, not
+            // initialization error.
+            position_m: [1.37e-6, 2.154e-6, 1.826e-6],
+            velocity_m_s: [1.446e-9, 2.388e-9, 1.814e-9],
             quat_angle_rad: 4.426e-8,
             ang_vel_rad_s: [2.619e-18, 1.367e-18, 7.969e-19],
             extras: &[],

--- a/crates/jeod_runner/tests/tier3_sim_lvlh_rot_init_propagation.rs
+++ b/crates/jeod_runner/tests/tier3_sim_lvlh_rot_init_propagation.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "verification")]
+
+//! Tier 3: SIM_dyncomp RUN_2 with `BodyAction::InitLvlhRot` post-init
+//! propagation.
+//!
+//! Closes the Tier 3 gap noted on the predecessor LVLH-rot-init port.
+//! The sibling [`sim_dyncomp::run2_6dof`] reads JEOD's t=0 quaternion
+//! straight off `dyncomp_run2_state.csv`, so the rotational
+//! initializer never runs in production tests. This case instead
+//! computes the t=0 attitude by feeding JEOD's
+//! `Modified_data/state.py` Yaw-Pitch-Roll Euler triple +
+//! LVLH-relative angular velocity through
+//! `BodyAction::InitLvlhRot.apply_rotational()` (which delegates to
+//! `jeod_dynamics::body_init::init_rot_from_lvlh`), then propagates
+//! 8 hours under point-mass gravity and compares the trajectory
+//! against the existing JEOD reference CSV.
+//!
+//! Per CLAUDE.md "Computational Independence": JEOD source files are
+//! permitted as initial-condition inputs (`Modified_data/state.py`);
+//! JEOD's CSV output is consumed only as the reference for
+//! comparison, never fed back into our integration.
+
+use jeod_runner::prelude::*;
+use jeod_runner::run_verification::sim_dyncomp;
+
+#[test]
+fn tier3_simulation_run2_lvlh_rot_init_propagation() {
+    sim_dyncomp::run2_lvlh_rot_init_propagation().run_and_assert();
+}

--- a/crates/jeod_test_data/src/lib.rs
+++ b/crates/jeod_test_data/src/lib.rs
@@ -77,6 +77,7 @@ pub mod gravity_verif;
 pub mod jeod_cc;
 pub mod jeod_inputs;
 pub mod leap_second;
+pub mod lvlh_init_data;
 pub mod mass_data;
 pub mod orbital_data;
 pub mod orbital_init;

--- a/crates/jeod_test_data/src/lvlh_init_data.rs
+++ b/crates/jeod_test_data/src/lvlh_init_data.rs
@@ -1,0 +1,332 @@
+//! Parser for JEOD Trick `Modified_data/state.py`-style files that
+//! configure a `DynBodyInitLvlhRotState` (LVLH-relative attitude
+//! initializer) plus a translational state.
+//!
+//! The canonical example is
+//! [`verif/SIM_dyncomp/Modified_data/state.py`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/verif/SIM_dyncomp/Modified_data/state.py),
+//! which defines:
+//!
+//! - `set_orientation_lvlh()` — populates `vehicle.lvlh_init` with a
+//!   Yaw-Pitch-Roll Euler triple and zero LVLH-relative angular
+//!   velocity. JEOD's `trick.Orientation.Yaw_Pitch_Roll` maps to a
+//!   ZYX Tait-Bryan rotation.
+//! - `set_trans_init_typical()` / `set_trans_init_elliptical()` —
+//!   populates `vehicle.trans_init.position` / `.velocity` (m, m/s)
+//!   in the inertial reference frame.
+//!
+//! This parser strips Python-side `trick.attach_units("degree", […])`
+//! wrappers (parsability tier 2 per
+//! [`CLAUDE.md`](https://github.com/simnaut/bevy_jeod/blob/main/CLAUDE.md#jeod-verification-data))
+//! and exposes the underlying numeric arrays so a Tier 3 rig can
+//! reproduce the InitLvlhRot inputs without round-tripping through a
+//! JEOD CSV.
+
+use regex::Regex;
+use std::path::Path;
+
+/// LVLH-relative rotational-init parameters extracted from
+/// `set_orientation_lvlh` (or any JEOD `state.py`-style block whose
+/// statements all target a common `*.lvlh_init` instance).
+///
+/// Mirrors the fields populated on a JEOD `DynBodyInitLvlhRotState`
+/// at the level of the input.py: a Euler-angle triple plus the
+/// `Yaw_Pitch_Roll`-style sequence string, and an LVLH-relative
+/// angular-velocity vector. The reference orbit (`reference_position`,
+/// `reference_velocity`) lives on the `trans_init` sibling and is
+/// loaded via [`load_trans_init_function`].
+#[derive(Debug, Clone)]
+pub struct LvlhInitData {
+    /// Three Euler angles in degrees, in the order indicated by
+    /// [`Self::euler_sequence`]. JEOD's `trick.attach_units("degree", …)`
+    /// wrapper is stripped at parse time so the values are plain
+    /// degrees regardless of how the source file expressed them.
+    pub euler_angles_deg: [f64; 3],
+    /// Euler-sequence name as written in the JEOD source (e.g.
+    /// `"Yaw_Pitch_Roll"`). Callers map this to a
+    /// [`jeod_math::EulerSequence`].
+    pub euler_sequence: String,
+    /// Angular velocity of the body wrt the LVLH frame, in rad/s.
+    /// JEOD's `ang_velocity` is in rad/s with no `attach_units`
+    /// wrapper at the SIM_dyncomp call sites, so the raw triple is
+    /// passed through unchanged.
+    pub ang_velocity: [f64; 3],
+}
+
+/// Translational-state inputs extracted from a JEOD `state.py`
+/// translational-init block (e.g. `set_trans_init_typical`).
+///
+/// The raw `position` / `velocity` triples are in meters and m/s
+/// respectively (JEOD's SIM_dyncomp helpers do not wrap them in
+/// `attach_units`).
+#[derive(Debug, Clone)]
+pub struct TransInitData {
+    /// Inertial-frame position in meters.
+    pub position: [f64; 3],
+    /// Inertial-frame velocity in m/s.
+    pub velocity: [f64; 3],
+}
+
+/// Load a `set_orientation_lvlh`-style function from a JEOD
+/// `state.py` and parse the LVLH-rot-init parameters it sets.
+///
+/// `function_name` selects which Python function body to scan; the
+/// body extends from `def <name>(…):` up to the next `def ` or end
+/// of file. This keeps multi-function `state.py` files (which is the
+/// SIM_dyncomp pattern) parseable without the helper functions
+/// colliding with each other.
+///
+/// # Panics
+/// Panics with a fail-loudly diagnostic if any of the four required
+/// assignments (`orientation.euler_sequence`, `orientation.euler_angles`,
+/// `ang_velocity`) is missing inside the named function body. The
+/// message names the source path and the missing field per the
+/// CLAUDE.md "Fail Loudly" rule.
+pub fn load_lvlh_init_function(path: &Path, function_name: &str) -> LvlhInitData {
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("Cannot read {}: {e}", path.display()));
+    let body = extract_function_body(&content, function_name, path);
+    parse_lvlh_init_content(&body, path, function_name)
+}
+
+/// Load a `set_trans_init_typical`-style function from a JEOD
+/// `state.py` and parse the inertial-frame position / velocity
+/// triples it sets on the `trans_init` instance.
+///
+/// `function_name` selects which Python function body to scan, as
+/// documented on [`load_lvlh_init_function`].
+///
+/// # Panics
+/// Panics with a fail-loudly diagnostic if either `position` or
+/// `velocity` is missing inside the named function body.
+pub fn load_trans_init_function(path: &Path, function_name: &str) -> TransInitData {
+    let content = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("Cannot read {}: {e}", path.display()));
+    let body = extract_function_body(&content, function_name, path);
+    parse_trans_init_content(&body, path, function_name)
+}
+
+// ── private helpers ────────────────────────────────────────────────
+
+/// Extract a Python function body, mirroring the helper shipped
+/// alongside the [`mass_data`](crate::mass_data) parser. The match
+/// requires the next character after the function name to be `(` or
+/// whitespace so a `def set_foo` lookup cannot accidentally match
+/// `def set_foo_helper`.
+fn extract_function_body(content: &str, function_name: &str, source: &Path) -> String {
+    let mut lines = Vec::new();
+    let mut in_function = false;
+    let re = Regex::new(&format!(r"^def\s+{}\s*\(", regex::escape(function_name))).unwrap();
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if re.is_match(trimmed) {
+            in_function = true;
+            continue;
+        }
+        if in_function {
+            if trimmed.starts_with("def ") {
+                break;
+            }
+            lines.push(line);
+        }
+    }
+    assert!(
+        !lines.is_empty(),
+        "Function '{function_name}' not found in {}",
+        source.display()
+    );
+    lines.join("\n")
+}
+
+fn parse_lvlh_init_content(content: &str, source: &Path, function_name: &str) -> LvlhInitData {
+    // `orientation.euler_sequence = trick.Orientation.Yaw_Pitch_Roll`
+    let seq_re =
+        Regex::new(r"orientation\.euler_sequence\s*=\s*trick\.Orientation\.([A-Za-z_]+)").unwrap();
+    // `orientation.euler_angles = trick.attach_units("degree", [a, b, c])`
+    //
+    // The inner array regex is shared with `ang_velocity`; the outer
+    // wrapping `attach_units("degree", …)` is allowed but not required
+    // (JEOD's set_orientation_lvlh always wraps it; the parser
+    // tolerates both forms).
+    let angles_re = Regex::new(
+        r#"orientation\.euler_angles\s*=\s*(?:trick\.attach_units\(\s*"degree"\s*,\s*)?\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]"#,
+    )
+    .unwrap();
+    let ang_vel_re = Regex::new(
+        r"ang_velocity\s*=\s*\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]",
+    )
+    .unwrap();
+
+    let mut euler_sequence: Option<String> = None;
+    let mut euler_angles_deg: Option<[f64; 3]> = None;
+    let mut ang_velocity: Option<[f64; 3]> = None;
+
+    for line in content.lines() {
+        if let Some(cap) = seq_re.captures(line) {
+            if euler_sequence.is_none() {
+                euler_sequence = Some(cap[1].to_string());
+            }
+            continue;
+        }
+        if let Some(cap) = angles_re.captures(line) {
+            if euler_angles_deg.is_none() {
+                euler_angles_deg = Some([
+                    cap[1].parse().unwrap(),
+                    cap[2].parse().unwrap(),
+                    cap[3].parse().unwrap(),
+                ]);
+            }
+            continue;
+        }
+        if let Some(cap) = ang_vel_re.captures(line) {
+            if ang_velocity.is_none() {
+                ang_velocity = Some([
+                    cap[1].parse().unwrap(),
+                    cap[2].parse().unwrap(),
+                    cap[3].parse().unwrap(),
+                ]);
+            }
+        }
+    }
+
+    LvlhInitData {
+        euler_sequence: euler_sequence.unwrap_or_else(|| {
+            panic!(
+                "Missing `orientation.euler_sequence` in `{function_name}` of {}: \
+                 expected `<inst>.orientation.euler_sequence = trick.Orientation.<name>`",
+                source.display()
+            )
+        }),
+        euler_angles_deg: euler_angles_deg.unwrap_or_else(|| {
+            panic!(
+                "Missing `orientation.euler_angles` in `{function_name}` of {}: \
+                 expected `<inst>.orientation.euler_angles = trick.attach_units(\"degree\", [a, b, c])` \
+                 or a bare `[a, b, c]` literal",
+                source.display()
+            )
+        }),
+        ang_velocity: ang_velocity.unwrap_or_else(|| {
+            panic!(
+                "Missing `ang_velocity` in `{function_name}` of {}: \
+                 expected `<inst>.ang_velocity = [wx, wy, wz]`",
+                source.display()
+            )
+        }),
+    }
+}
+
+fn parse_trans_init_content(content: &str, source: &Path, function_name: &str) -> TransInitData {
+    let pos_re = Regex::new(
+        r"\.position\s*=\s*\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]",
+    )
+    .unwrap();
+    let vel_re = Regex::new(
+        r"\.velocity\s*=\s*\[\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*,\s*([-\d.eE+]+)\s*\]",
+    )
+    .unwrap();
+
+    let mut position: Option<[f64; 3]> = None;
+    let mut velocity: Option<[f64; 3]> = None;
+    for line in content.lines() {
+        if let Some(cap) = pos_re.captures(line) {
+            if position.is_none() {
+                position = Some([
+                    cap[1].parse().unwrap(),
+                    cap[2].parse().unwrap(),
+                    cap[3].parse().unwrap(),
+                ]);
+            }
+            continue;
+        }
+        if let Some(cap) = vel_re.captures(line) {
+            if velocity.is_none() {
+                velocity = Some([
+                    cap[1].parse().unwrap(),
+                    cap[2].parse().unwrap(),
+                    cap[3].parse().unwrap(),
+                ]);
+            }
+        }
+    }
+
+    TransInitData {
+        position: position.unwrap_or_else(|| {
+            panic!(
+                "Missing `.position` in `{function_name}` of {}: \
+                 expected `<inst>.position = [x, y, z]`",
+                source.display()
+            )
+        }),
+        velocity: velocity.unwrap_or_else(|| {
+            panic!(
+                "Missing `.velocity` in `{function_name}` of {}: \
+                 expected `<inst>.velocity = [vx, vy, vz]`",
+                source.display()
+            )
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_STATE_PY: &str = r#"
+def set_trans_init_typical() :
+  vehicle.trans_init.position  = [ -4292653.41, 955168.47, 5139356.57]
+  vehicle.trans_init.velocity  = [ 109.649663, -7527.726490, 1484.521489]
+
+
+def set_trans_init_elliptical() :
+  vehicle.trans_init.position  = [ -4315967.74, 960356.20, 5167269.53]
+  vehicle.trans_init.velocity  = [ 129.091037, -7491.513855, 1452.515654]
+
+
+def set_orientation_lvlh():
+  vehicle.lvlh_init.set_subject_body( vehicle.dyn_body )
+  vehicle.lvlh_init.planet_name                = "Earth"
+  vehicle.lvlh_init.body_frame_id              = "composite_body"
+  vehicle.lvlh_init.orientation.data_source    = trick.Orientation.InputEulerRotation
+  vehicle.lvlh_init.orientation.euler_sequence = trick.Orientation.Yaw_Pitch_Roll
+  vehicle.lvlh_init.orientation.euler_angles   = trick.attach_units( "degree",[ 0.0, -11.6, 0.0])
+  vehicle.lvlh_init.ang_velocity               = [ 0.0, 0.0, 0.0]
+
+  dynamics.dyn_manager.add_body_action(vehicle.lvlh_init)
+"#;
+
+    #[test]
+    fn parse_lvlh_init_extracts_typical_dyncomp_inputs() {
+        let path = std::path::Path::new("test_state.py");
+        let body = extract_function_body(SAMPLE_STATE_PY, "set_orientation_lvlh", path);
+        let data = parse_lvlh_init_content(&body, path, "set_orientation_lvlh");
+        assert_eq!(data.euler_sequence, "Yaw_Pitch_Roll");
+        assert_eq!(data.euler_angles_deg, [0.0, -11.6, 0.0]);
+        assert_eq!(data.ang_velocity, [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn parse_trans_init_typical_extracts_position_velocity() {
+        let path = std::path::Path::new("test_state.py");
+        let body = extract_function_body(SAMPLE_STATE_PY, "set_trans_init_typical", path);
+        let data = parse_trans_init_content(&body, path, "set_trans_init_typical");
+        assert_eq!(data.position, [-4292653.41, 955168.47, 5139356.57]);
+        assert_eq!(data.velocity, [109.649663, -7527.726490, 1484.521489]);
+    }
+
+    #[test]
+    fn parse_trans_init_elliptical_extracts_position_velocity() {
+        let path = std::path::Path::new("test_state.py");
+        let body = extract_function_body(SAMPLE_STATE_PY, "set_trans_init_elliptical", path);
+        let data = parse_trans_init_content(&body, path, "set_trans_init_elliptical");
+        assert_eq!(data.position, [-4315967.74, 960356.20, 5167269.53]);
+        assert_eq!(data.velocity, [129.091037, -7491.513855, 1452.515654]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Missing `orientation.euler_angles`")]
+    fn parse_lvlh_init_panics_on_missing_angles() {
+        let py = "def f():\n  v.lvlh_init.orientation.euler_sequence = trick.Orientation.Yaw_Pitch_Roll\n  v.lvlh_init.ang_velocity = [0.0, 0.0, 0.0]\n";
+        let path = std::path::Path::new("missing.py");
+        let body = extract_function_body(py, "f", path);
+        let _ = parse_lvlh_init_content(&body, path, "f");
+    }
+}

--- a/test_data/jeod_inputs/README.md
+++ b/test_data/jeod_inputs/README.md
@@ -49,7 +49,7 @@ Reference it from a Tier 3 rig with
 
 ## Currently committed inputs
 
-- `verif/SIM_dyncomp/` — `S_define`, `Modified_data/{mass,time,grav_controls}.py`, `SET_test/RUN_{3A,3B,7A,7B,7C,7D}/input.py` (consumed by `sim_dyncomp`, `sim_torque_simple`, `sim_tide_verif`, `sim_polar_motion`).
+- `verif/SIM_dyncomp/` — `S_define`, `Modified_data/{mass,time,grav_controls,state}.py`, `SET_test/RUN_{3A,3B,7A,7B,7C,7D}/input.py` (consumed by `sim_dyncomp`, `sim_torque_simple`, `sim_tide_verif`, `sim_polar_motion`).
 - `models/dynamics/derived_state/verif/Modified_data/date_and_time.py` (consumed by `sim_derived_state` SIM_NED rig).
 - `models/dynamics/derived_state/verif/SIM_{OrbElem,LVLH,NED,Euler,Planetary,SolarBeta}/S_define`.
 - `models/dynamics/derived_state/verif/SIM_SolarBeta/Modified_data/date_and_time.py`.

--- a/test_data/jeod_inputs/verif/SIM_dyncomp/Modified_data/state.py
+++ b/test_data/jeod_inputs/verif/SIM_dyncomp/Modified_data/state.py
@@ -1,0 +1,57 @@
+def set_trans_init_typical() :
+  vehicle.trans_init.position  = [ -4292653.41, 955168.47, 5139356.57]
+  vehicle.trans_init.velocity  = [ 109.649663, -7527.726490, 1484.521489]
+
+
+def set_trans_init_elliptical() :
+  vehicle.trans_init.position  = [ -4315967.74, 960356.20, 5167269.53]
+  vehicle.trans_init.velocity  = [ 129.091037, -7491.513855, 1452.515654]
+
+
+def set_rot_rate_inrtl():
+  # Set initial attitude off LVLH but initial attitude rate off inertial
+  # Restrict lvlh-init to be attitude only, and add rot-init
+  vehicle.lvlh_init.set_items = trick.RefFrameItems.Att
+
+  vehicle.rot_init.state_items = trick.DynBodyInitRotState.Rate
+  vehicle.rot_init.set_subject_body( vehicle.dyn_body )
+  vehicle.rot_init.reference_ref_frame_name = "Earth.inertial"
+  vehicle.rot_init.body_frame_id = "composite_body"
+  vehicle.rot_init.ang_velocity  = [ 0.0, 0.0, 0.0]
+
+  dynamics.dyn_manager.add_body_action(vehicle.rot_init)
+
+
+
+# Set the orientation by LVLH
+def set_orientation_lvlh():
+  vehicle.lvlh_init.set_subject_body( vehicle.dyn_body )
+  vehicle.lvlh_init.planet_name                = "Earth"
+  vehicle.lvlh_init.body_frame_id              = "composite_body"
+  vehicle.lvlh_init.orientation.data_source    = trick.Orientation.InputEulerRotation
+  vehicle.lvlh_init.orientation.euler_sequence = trick.Orientation.Yaw_Pitch_Roll
+  vehicle.lvlh_init.orientation.euler_angles   = trick.attach_units( "degree",[ 0.0, -11.6, 0.0])
+  vehicle.lvlh_init.ang_velocity               = [ 0.0, 0.0, 0.0]
+
+  dynamics.dyn_manager.add_body_action(vehicle.lvlh_init)
+
+
+
+
+
+# Set derived state configurations
+vehicle.pfix.reference_name     = "Earth"
+vehicle.lvlh.reference_name     = "Earth"
+vehicle.orb_elem.reference_name = "Earth"
+vehicle.lvlh_euler.sequence     = trick.Orientation.Pitch_Yaw_Roll
+
+
+# Set the trans state
+vehicle.trans_init.set_subject_body( vehicle.dyn_body )
+vehicle.trans_init.reference_ref_frame_name = "Earth.inertial"
+vehicle.trans_init.body_frame_id            = "composite_body"
+#default to "typical" trans-state and lvlh-based orientation
+set_trans_init_typical()
+set_orientation_lvlh()
+
+dynamics.dyn_manager.add_body_action( vehicle.trans_init)


### PR DESCRIPTION
Closes #337.

## Summary

- Adds `tier3_simulation_run2_lvlh_rot_init_propagation`, a Tier 3 case that exercises both the `BodyAction::InitLvlhRot` initializer and the rotational integrator end-to-end. The sibling `run2_6dof` reads the t=0 quaternion straight off `dyncomp_run2_state.csv`, so the LVLH-rot-init kernel never runs in production tests; this case instead reads JEOD's `Modified_data/state.py` Yaw-Pitch-Roll Euler triple + LVLH-relative angular velocity, feeds them through `BodyAction::InitLvlhRot.apply_rotational()` (which delegates to the shipped `init_rot_from_lvlh` kernel), and uses the result as the initial rotational state.
- Adds a `lvlh_init_data` parser in `jeod_test_data` that extracts the Euler-angle triple (stripping `trick.attach_units("degree", …)` per parsability tier 2), sequence string, and LVLH-relative angular-velocity vector from a JEOD `state.py` LVLH-init function body. The translational sibling (`set_trans_init_typical`) is loaded by the same module so the new scenario stays on the JEOD-source path for both halves of the initial state.
- Mirrors `verif/SIM_dyncomp/Modified_data/state.py` into `test_data/jeod_inputs/` so the test runs without `$JEOD_HOME`.

## Path picked

**Path C** — reuse the existing `dyncomp_run2_state.csv` reference. The reference is suitable because every SIM_dyncomp run already initializes its rotational state through `set_orientation_lvlh`, which calls `DynBodyInitLvlhRotState` upstream. No JEOD regen required, no upstream JEOD change, no new SIM directory. Where the existing tests use the t=0 CSV row as the initial quaternion, the new scenario uses our own `BodyAction::InitLvlhRot` to compute it from the JEOD source `state.py` inputs — closing the gap that motivated the original "Tier 3 deferred" note on PR #326.

## Observed errors → tolerances

Per the standard CLAUDE.md "5% above observed max" policy, computed from a clean run (`target/tier3_crossval/tier3_simulation_run2_lvlh_rot_init_propagation.json`):

| metric | observed max | tolerance |
| --- | --- | --- |
| position[0] (m) | 1.30e-6 | 1.37e-6 |
| position[1] (m) | 2.05e-6 | 2.154e-6 |
| position[2] (m) | 1.74e-6 | 1.826e-6 |
| velocity[0] (m/s) | 1.38e-9 | 1.446e-9 |
| velocity[1] (m/s) | 2.27e-9 | 2.388e-9 |
| velocity[2] (m/s) | 1.73e-9 | 1.814e-9 |
| quat angle (rad) | 4.21e-8 | 4.426e-8 |
| ang_vel[0] (rad/s) | 2.49e-18 | 2.619e-18 |
| ang_vel[1] (rad/s) | 1.30e-18 | 1.367e-18 |
| ang_vel[2] (rad/s) | 7.59e-19 | 7.969e-19 |

These come out essentially identical to `run2_6dof`'s baseline because the propagator path is the same and the InitLvlhRot kernel reproduces the JEOD-side quaternion to floating-point precision; the residuals are integration-step round-off, not initialization error.

## Files touched

- `crates/jeod_runner/src/run_verification/sim_dyncomp.rs` — adds `run2_lvlh_rot_init_propagation()` constructor + `build_run2_lvlh_rot_init` scenario + `init_lvlh_rot_state` / `lvlh_init_from_state_py` helpers.
- `crates/jeod_runner/tests/tier3_sim_lvlh_rot_init_propagation.rs` (new) — single-test file delegating to the recipe.
- `crates/jeod_test_data/src/lvlh_init_data.rs` (new) — parser for `state.py`-style LVLH-init / trans-init function bodies.
- `crates/jeod_test_data/src/lib.rs` — module registration.
- `test_data/jeod_inputs/verif/SIM_dyncomp/Modified_data/state.py` (new) — verbatim mirror of JEOD source, consumed by the new scenario.
- `test_data/jeod_inputs/README.md` — `state.py` added to the SIM_dyncomp inputs list.

## Human-side action items

None. No JEOD regen required (Path C). The reference CSV (`dyncomp_run2_state.csv`) was already committed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1150 passed
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 passed
- [x] `cargo nextest run -p jeod_runner --test tier3_sim_lvlh_rot_init_propagation` — 1 passed
- [x] `cargo nextest run --workspace -E 'test(tier3_) - test(earth_moon)'` — 339 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `bash scripts/check_no_escape_hatches.sh`
- [x] `cargo test --test invariant_coverage` — 6 passed
- [x] `cargo run -p jeod_test_data --bin tier3_baseline_diff -- --allow-missing-from .github/tier3-allow-missing.txt` — `OK (77 matched; 1 allowed-missing; 8 new)`