### PR TITLE
[#353] Add #[diagnostic::on_unimplemented] to Act 5 phantom-wrapped types

### DIFF
--- a/crates/jeod_interactions/src/radiation_pressure.rs
+++ b/crates/jeod_interactions/src/radiation_pressure.rs
@@ -120,6 +120,48 @@ pub struct FlatPlate<V: Vehicle> {
     pub position: Position<StructuralFrame<V>>,
 }
 
+impl<V: Vehicle> FlatPlate<V> {
+    /// Type-level witness that this plate's vehicle phantom matches the
+    /// caller's expected vehicle `W`. Compiles only when `V == W`; on
+    /// mismatch the [`jeod_quantities::diagnostics::CompatibleVehicles`]
+    /// bound fails and surfaces a physics-language diagnostic naming the
+    /// expected and found vehicles instead of a `PhantomData<…>` wall.
+    ///
+    /// Mission code that assembles a typed plate set for a specific
+    /// vehicle calls this at the boundary to make the cross-vehicle
+    /// guard explicit; the method itself is a no-op (returns `self`) and
+    /// has zero runtime cost.
+    ///
+    /// # Compile-time mismatch
+    ///
+    /// ```compile_fail
+    /// use glam::DVec3;
+    /// use jeod_interactions::FlatPlate;
+    /// use jeod_quantities::define_vehicle;
+    /// use jeod_quantities::ext::Vec3Ext;
+    /// use jeod_quantities::frame::StructuralFrame;
+    ///
+    /// define_vehicle!(Iss);
+    /// define_vehicle!(Soyuz);
+    ///
+    /// let plate: FlatPlate<Iss> = FlatPlate {
+    ///     area: 10.0,
+    ///     normal: DVec3::X,
+    ///     position: DVec3::ZERO.m_at::<StructuralFrame<Iss>>(),
+    /// };
+    /// // Asserting the wrong vehicle fires the `CompatibleVehicles`
+    /// // diagnostic naming `Iss` (found) and `Soyuz` (expected).
+    /// let _ = plate.assert_vehicle::<Soyuz>();
+    /// ```
+    #[inline]
+    pub fn assert_vehicle<W: Vehicle>(self) -> Self
+    where
+        (): jeod_quantities::diagnostics::CompatibleVehicles<V, W>,
+    {
+        self
+    }
+}
+
 /// Optical properties shared by one or more flat plates.
 ///
 /// Matches JEOD `RadiationParams` fields.
@@ -1583,5 +1625,26 @@ mod tests {
             (actual_diff - expected_diff).abs() < 1e-10,
             "Power dump should add {expected_diff:.4e} K/s, got {actual_diff:.4e}"
         );
+    }
+
+    /// `FlatPlate::assert_vehicle::<W>()` is a zero-cost type-witness
+    /// no-op when `V == W`. The negative branch (cross-vehicle
+    /// mismatch) is covered by the method's `compile_fail` doctest;
+    /// this `#[test]` confirms the positive branch round-trips.
+    #[test]
+    fn flat_plate_assert_vehicle_compiles_when_phantoms_match() {
+        use jeod_quantities::define_vehicle;
+        use jeod_quantities::ext::Vec3Ext;
+        use jeod_quantities::frame::StructuralFrame;
+
+        define_vehicle!(Iss);
+
+        let plate: FlatPlate<Iss> = FlatPlate {
+            area: 10.0,
+            normal: DVec3::X,
+            position: DVec3::ZERO.m_at::<StructuralFrame<Iss>>(),
+        };
+        let plate = plate.assert_vehicle::<Iss>();
+        assert_eq!(plate.area, 10.0);
     }
 }

--- a/crates/jeod_quantities/src/diagnostics.rs
+++ b/crates/jeod_quantities/src/diagnostics.rs
@@ -16,7 +16,7 @@ use core::marker::PhantomData;
 use uom::si::{f64::Angle, f64::Length};
 
 use crate::dims::GravParam;
-use crate::frame::{Frame, Planet};
+use crate::frame::{Frame, Planet, Vehicle};
 use crate::quat::{Layout, NormalizedQuat, Transform};
 use crate::time_scale::TimeScale;
 
@@ -190,3 +190,88 @@ pub trait NoVectorVectorMul<D1, D2, F: Frame> {
     /// its three type parameters into the compiler diagnostic.
     fn _do_not_call(&self) -> PhantomData<(D1, D2, F)>;
 }
+
+/// Fires when two distinct vehicle phantoms appear in a slot that demands
+/// a single shared identity. Vehicle-side analog of [`CompatibleFrames`]
+/// — implemented only when `VL` and `VR` resolve to the same vehicle
+/// marker, so a mismatch surfaces a tailored physics-language message
+/// instead of a `PhantomData<…>` type-mismatch wall.
+///
+/// Used as the `where` bound that gates "carries a single vehicle"
+/// methods on the Act-5 phantom-wrapped types
+/// (`FlatPlate<V>`, `RelativeTranslation<Reference>`,
+/// `LvlhRelativeState<Chief>`, …): a method that requires the caller's
+/// turbofish vehicle to match the receiver's vehicle takes
+/// `(): CompatibleVehicles<VHere, VThere>` and the bound only resolves
+/// when the two phantoms agree.
+///
+/// ```compile_fail
+/// use jeod_quantities::define_vehicle;
+/// use jeod_quantities::diagnostics::CompatibleVehicles;
+///
+/// define_vehicle!(Iss);
+/// define_vehicle!(Soyuz);
+///
+/// fn require_match<VL, VR>()
+/// where
+///     VL: jeod_quantities::frame::Vehicle,
+///     VR: jeod_quantities::frame::Vehicle,
+///     (): CompatibleVehicles<VL, VR>,
+/// {
+/// }
+///
+/// // Same vehicle on both sides — compiles.
+/// require_match::<Iss, Iss>();
+/// // Mismatched vehicles — bound fails with the tailored diagnostic.
+/// require_match::<Iss, Soyuz>();
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "vehicle mismatch: cannot combine values tagged `{VL}` with values tagged `{VR}`",
+    label = "mismatched vehicle: `{VL}` vs `{VR}`",
+    note = "the two vehicle phantoms must agree — pin the same `Vehicle` marker on both sides (e.g. via `define_vehicle!`), or rebuild the value for the right vehicle if it was constructed for a different one"
+)]
+pub trait CompatibleVehicles<VL: Vehicle, VR: Vehicle> {}
+
+impl<V: Vehicle> CompatibleVehicles<V, V> for () {}
+
+/// Paired-vehicle compatibility: fires when a `(Subject, Reference)` (or
+/// `(Parent, Child)`) pair on one value does not match the pair on the
+/// slot it's being passed into.
+///
+/// Implemented only when both the subject phantoms and the reference
+/// phantoms agree. Used by types that carry two independent vehicle
+/// identities — `RelativeState<Subject, Reference>` and
+/// `AttachEvent<VParent, VChild>` — so a `<Iss, Soyuz>` value cannot
+/// silently flow into a `<Iss, Cygnus>` slot.
+///
+/// ```compile_fail
+/// use jeod_quantities::define_vehicle;
+/// use jeod_quantities::diagnostics::CompatibleVehiclePair;
+///
+/// define_vehicle!(Iss);
+/// define_vehicle!(Soyuz);
+/// define_vehicle!(Cygnus);
+///
+/// fn require_match<S1, R1, S2, R2>()
+/// where
+///     S1: jeod_quantities::frame::Vehicle,
+///     R1: jeod_quantities::frame::Vehicle,
+///     S2: jeod_quantities::frame::Vehicle,
+///     R2: jeod_quantities::frame::Vehicle,
+///     (): CompatibleVehiclePair<S1, R1, S2, R2>,
+/// {
+/// }
+///
+/// // Both pairs match — compiles.
+/// require_match::<Iss, Soyuz, Iss, Soyuz>();
+/// // Reference half mismatches — bound fails with the tailored diagnostic.
+/// require_match::<Iss, Soyuz, Iss, Cygnus>();
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "paired-vehicle mismatch: cannot combine `<{S1}, {R1}>` with `<{S2}, {R2}>`",
+    label = "mismatched pair: `<{S1}, {R1}>` vs `<{S2}, {R2}>`",
+    note = "both phantoms in the pair must match — the subject (or parent) and the reference (or child) are independent identities, and a mismatch on either side means the value was built for a different physical relationship"
+)]
+pub trait CompatibleVehiclePair<S1: Vehicle, R1: Vehicle, S2: Vehicle, R2: Vehicle> {}
+
+impl<S: Vehicle, R: Vehicle> CompatibleVehiclePair<S, R, S, R> for () {}

--- a/crates/jeod_quantities/src/lib.rs
+++ b/crates/jeod_quantities/src/lib.rs
@@ -84,6 +84,19 @@
 //!   flow into root-inertial-only consumers (gravity, SRP, relativistic);
 //!   the only safe transition is via [`IntegOrigin`].
 //!
+//! - **Vehicle-phantom mismatch** on the Act-5 phantom-wrapped types
+//!   (`FlatPlate<V>`, `AttachEvent<VParent, VChild>`,
+//!   `RelativeState<Subject, Reference>`,
+//!   `RelativeTranslation<Reference>`, `LvlhRelativeState<Chief>`) is
+//!   surfaced via the [`diagnostics::CompatibleVehicles`] /
+//!   [`diagnostics::CompatibleVehiclePair`] markers. Each type exposes
+//!   a zero-cost `assert_*` witness method whose `where` bound resolves
+//!   only when the vehicle phantoms agree; on mismatch the diagnostic
+//!   names the expected and found vehicles in physics language instead
+//!   of a `PhantomData<…>` wall. Mission code reaches for the witness
+//!   at the boundary that hands the value to a slot of a specific
+//!   identity (e.g. `plate.assert_vehicle::<Iss>()`).
+//!
 //! ### Scaffolded but not currently wired
 //!
 //! [`diagnostics::IntoLength`], [`diagnostics::IntoAngle`],

--- a/crates/jeod_sim/src/derived.rs
+++ b/crates/jeod_sim/src/derived.rs
@@ -78,6 +78,45 @@ pub struct RelativeState<Subject: Vehicle, Reference: Vehicle> {
     pub ang_vel: jeod_quantities::aliases::AngularVelocity<BodyFrame<Subject>>,
 }
 
+impl<Subject: Vehicle, Reference: Vehicle> RelativeState<Subject, Reference> {
+    /// Type-level witness that this relative state carries the caller's
+    /// expected `(Subject, Reference)` vehicle phantoms. Compiles only
+    /// when both phantoms agree; on mismatch the
+    /// [`jeod_quantities::diagnostics::CompatibleVehiclePair`] bound
+    /// fails and surfaces a physics-language diagnostic naming both
+    /// expected and found pairs instead of a `PhantomData<…>` wall.
+    ///
+    /// The method is a no-op (returns `self`) and has zero runtime
+    /// cost; it exists to thread the diagnostic into call sites that
+    /// would otherwise see only a generic type-mismatch error.
+    ///
+    /// # Compile-time mismatch
+    ///
+    /// ```compile_fail
+    /// use jeod_quantities::define_vehicle;
+    /// use jeod_sim::{compute_relative_state, RelativeState, RotationalState, TranslationalState};
+    /// use glam::DVec3;
+    ///
+    /// define_vehicle!(Iss);
+    /// define_vehicle!(Soyuz);
+    /// define_vehicle!(Cygnus);
+    ///
+    /// let trans = TranslationalState { position: DVec3::ZERO, velocity: DVec3::ZERO };
+    /// let rel: RelativeState<Iss, Soyuz> =
+    ///     compute_relative_state::<Iss, Soyuz>(&trans, None, &trans, None);
+    /// // Asserting the wrong reference vehicle fires the
+    /// // `CompatibleVehiclePair` diagnostic.
+    /// let _ = rel.assert_pair::<Iss, Cygnus>();
+    /// ```
+    #[inline]
+    pub fn assert_pair<S: Vehicle, R: Vehicle>(self) -> Self
+    where
+        (): jeod_quantities::diagnostics::CompatibleVehiclePair<Subject, Reference, S, R>,
+    {
+        self
+    }
+}
+
 /// Frame-tagged translational state inside a [`RelativeState`].
 ///
 /// The [`compute_relative_state`] producer chooses the variant based on
@@ -225,6 +264,43 @@ impl<Reference: Vehicle> RelativeTranslation<Reference> {
             Self::Inertial { velocity, .. } => velocity.raw_si(),
         }
     }
+
+    /// Type-level witness that this translation carries the caller's
+    /// expected reference-vehicle phantom `R`. Compiles only when
+    /// `Reference == R`; on mismatch the
+    /// [`jeod_quantities::diagnostics::CompatibleVehicles`] bound fails
+    /// and surfaces a physics-language diagnostic naming the expected
+    /// and found vehicles instead of a `PhantomData<…>` wall.
+    ///
+    /// The method is a no-op (returns `self`) and has zero runtime
+    /// cost; it exists so a consumer holding a
+    /// `RelativeTranslation<Iss>` can refuse — at compile time, with a
+    /// physics-language message — a value built for a different
+    /// reference vehicle.
+    ///
+    /// # Compile-time mismatch
+    ///
+    /// ```compile_fail
+    /// use glam::DVec3;
+    /// use jeod_quantities::define_vehicle;
+    /// use jeod_sim::{compute_relative_state, RelativeTranslation, TranslationalState};
+    ///
+    /// define_vehicle!(Iss);
+    /// define_vehicle!(Soyuz);
+    ///
+    /// let trans = TranslationalState { position: DVec3::ZERO, velocity: DVec3::ZERO };
+    /// let rel = compute_relative_state::<Iss, Iss>(&trans, None, &trans, None);
+    /// // Asserting the wrong reference fires the `CompatibleVehicles`
+    /// // diagnostic naming `Iss` (found) and `Soyuz` (expected).
+    /// let _ = rel.trans.assert_reference::<Soyuz>();
+    /// ```
+    #[inline]
+    pub fn assert_reference<R: Vehicle>(self) -> Self
+    where
+        (): jeod_quantities::diagnostics::CompatibleVehicles<Reference, R>,
+    {
+        self
+    }
 }
 
 /// Relative state expressed in the LVLH frame of the reference vehicle.
@@ -249,6 +325,48 @@ pub struct LvlhRelativeState<Chief: Vehicle> {
     /// Velocity of subject relative to reference, in the chief
     /// vehicle's LVLH frame (m/s).
     pub velocity: Velocity<Lvlh<Chief>>,
+}
+
+impl<Chief: Vehicle> LvlhRelativeState<Chief> {
+    /// Type-level witness that this LVLH state carries the caller's
+    /// expected chief-vehicle phantom `C`. Compiles only when
+    /// `Chief == C`; on mismatch the
+    /// [`jeod_quantities::diagnostics::CompatibleVehicles`] bound fails
+    /// and surfaces a physics-language diagnostic naming the expected
+    /// and found chief instead of a `PhantomData<…>` wall.
+    ///
+    /// The method is a no-op (returns `self`) and has zero runtime
+    /// cost; it exists so a consumer holding an
+    /// `LvlhRelativeState<Iss>` can refuse — at compile time, with a
+    /// physics-language message — a value built for a different chief.
+    ///
+    /// # Compile-time mismatch
+    ///
+    /// ```compile_fail
+    /// use glam::DVec3;
+    /// use jeod_quantities::define_vehicle;
+    /// use jeod_sim::{compute_lvlh_relative_state, LvlhRelativeState};
+    ///
+    /// define_vehicle!(Iss);
+    /// define_vehicle!(Soyuz);
+    ///
+    /// let r_pos = DVec3::new(6.778e6, 0.0, 0.0);
+    /// let r_vel = DVec3::new(0.0, 7.668e3, 0.0);
+    /// let s_pos = DVec3::new(6.778e6 + 50.0, 0.0, 0.0);
+    /// let s_vel = DVec3::new(0.0, 7.668e3, 0.0);
+    /// let lvlh: LvlhRelativeState<Iss> =
+    ///     compute_lvlh_relative_state::<Iss>(r_pos, r_vel, s_pos, s_vel);
+    /// // Asserting a different chief fires the `CompatibleVehicles`
+    /// // diagnostic naming `Iss` (found) and `Soyuz` (expected).
+    /// let _ = lvlh.assert_chief::<Soyuz>();
+    /// ```
+    #[inline]
+    pub fn assert_chief<C: Vehicle>(self) -> Self
+    where
+        (): jeod_quantities::diagnostics::CompatibleVehicles<Chief, C>,
+    {
+        self
+    }
 }
 
 /// Compute orbital elements from translational state.
@@ -843,5 +961,47 @@ mod tests {
         };
         let _: Position<BodyFrame<Ref>> = position;
         let _: jeod_quantities::aliases::Velocity<BodyFrame<Ref>> = velocity;
+    }
+
+    /// `assert_pair` / `assert_reference` / `assert_chief` are zero-cost
+    /// type-witness no-ops that compile when the caller's vehicle
+    /// phantoms match the value's. The negative branch is covered by
+    /// the per-method `compile_fail` doctests; this `#[test]` confirms
+    /// the positive branch round-trips.
+    #[test]
+    fn vehicle_witness_methods_compile_when_phantoms_match() {
+        use jeod_math::JeodQuat;
+        use jeod_quantities::define_vehicle;
+
+        define_vehicle!(Iss);
+        define_vehicle!(Soyuz);
+
+        let trans = crate::TranslationalState {
+            position: DVec3::new(6_778_137.0, 0.0, 0.0),
+            velocity: DVec3::new(0.0, 7668.56, 0.0),
+        };
+        let rot = RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        };
+
+        // RelativeState<Iss, Soyuz>::assert_pair::<Iss, Soyuz>()
+        // compiles; constructed via the producer with both phantoms
+        // pinned to concrete vehicles.
+        let rel: RelativeState<Iss, Soyuz> =
+            compute_relative_state::<Iss, Soyuz>(&trans, Some(&rot), &trans, Some(&rot));
+        let rel = rel.assert_pair::<Iss, Soyuz>();
+
+        // RelativeTranslation<Soyuz>::assert_reference::<Soyuz>() compiles.
+        let _ = rel.trans.assert_reference::<Soyuz>();
+
+        // LvlhRelativeState<Iss>::assert_chief::<Iss>() compiles.
+        let lvlh: LvlhRelativeState<Iss> = compute_lvlh_relative_state::<Iss>(
+            DVec3::new(6.778e6, 0.0, 0.0),
+            DVec3::new(0.0, 7.668e3, 0.0),
+            DVec3::new(6.778e6 + 50.0, 0.0, 0.0),
+            DVec3::new(0.0, 7.668e3, 0.0),
+        );
+        let _ = lvlh.assert_chief::<Iss>();
     }
 }

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -231,6 +231,7 @@ pub use jeod_quantities::aliases::{
     Acceleration, AngularAcceleration, AngularMomentum, AngularVelocity, Force, Jerk, Position,
     Torque, Velocity,
 };
+pub use jeod_quantities::diagnostics::{CompatibleVehiclePair, CompatibleVehicles};
 pub use jeod_quantities::dims::{GravParam, MassFlowRate, SpecificAngMom, SpecificEnergy};
 pub use jeod_quantities::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use jeod_quantities::frame::{

--- a/src/components.rs
+++ b/src/components.rs
@@ -1392,6 +1392,54 @@ pub struct AttachEvent<VParent: Vehicle, VChild: Vehicle> {
     pub t_parent_child: FrameTransform<StructuralFrame<VParent>, StructuralFrame<VChild>>,
 }
 
+impl<VParent: Vehicle, VChild: Vehicle> AttachEvent<VParent, VChild> {
+    /// Type-level witness that this attach pair carries the caller's
+    /// expected `(P, C)` vehicle phantoms. Compiles only when
+    /// `(VParent, VChild) == (P, C)`; on mismatch the
+    /// [`jeod_sim::CompatibleVehiclePair`] bound fails and surfaces a
+    /// physics-language diagnostic naming both expected and found pairs
+    /// instead of a `PhantomData<…>` wall.
+    ///
+    /// Mission code that wires a typed attach event for a specific
+    /// parent/child pair calls this at the boundary to make the
+    /// cross-pair guard explicit; the method itself is a no-op (returns
+    /// `self`) and has zero runtime cost.
+    ///
+    /// # Compile-time mismatch
+    ///
+    /// ```compile_fail
+    /// use bevy::prelude::Entity;
+    /// use bevy_jeod::AttachEvent;
+    /// use glam::{DMat3, DVec3};
+    /// use jeod_sim::{define_vehicle, FrameTransform, StructuralFrame, Vec3Ext};
+    ///
+    /// define_vehicle!(Iss);
+    /// define_vehicle!(Soyuz);
+    /// define_vehicle!(Cygnus);
+    ///
+    /// let evt: AttachEvent<Iss, Soyuz> = AttachEvent {
+    ///     child: Entity::PLACEHOLDER,
+    ///     parent: Entity::PLACEHOLDER,
+    ///     offset: DVec3::ZERO.m_at::<StructuralFrame<Iss>>(),
+    ///     t_parent_child: FrameTransform::<
+    ///         StructuralFrame<Iss>,
+    ///         StructuralFrame<Soyuz>,
+    ///     >::from_matrix(DMat3::IDENTITY),
+    /// };
+    /// // Asserting the wrong child vehicle fires the
+    /// // `CompatibleVehiclePair` diagnostic naming the found and
+    /// // expected pairs.
+    /// let _ = evt.assert_pair::<Iss, Cygnus>();
+    /// ```
+    #[inline]
+    pub fn assert_pair<P: Vehicle, C: Vehicle>(self) -> Self
+    where
+        (): jeod_sim::CompatibleVehiclePair<VParent, VChild, P, C>,
+    {
+        self
+    }
+}
+
 /// Message: detach a child body from its parent in the mass tree.
 ///
 /// The entity must have [`MassBodyIdC`] and be attached to a parent.

--- a/tests/diagnostic_act5_witness_methods.rs
+++ b/tests/diagnostic_act5_witness_methods.rs
@@ -1,0 +1,105 @@
+//! Positive-path tests for the Act-5 phantom-wrapped types' vehicle
+//! witness methods (`assert_vehicle`, `assert_pair`, `assert_reference`,
+//! `assert_chief`).
+//!
+//! Each method is a zero-cost type-level no-op whose `where` bound
+//! resolves only when the caller's vehicle phantoms match the value's.
+//! When they mismatch the
+//! `jeod_quantities::diagnostics::CompatibleVehicles` /
+//! `CompatibleVehiclePair` `#[diagnostic::on_unimplemented]` attributes
+//! surface a physics-language diagnostic instead of a `PhantomData<…>`
+//! type-mismatch wall. The negative branch is exercised by the
+//! `compile_fail` doctest on each method; this file confirms the
+//! positive branch round-trips at runtime.
+//!
+//! The five touch sites (per #353):
+//!
+//! - `FlatPlate<V>` — `assert_vehicle::<W>()`
+//! - `AttachEvent<VParent, VChild>` — `assert_pair::<P, C>()`
+//! - `RelativeState<Subject, Reference>` — `assert_pair::<S, R>()`
+//! - `RelativeTranslation<Reference>` — `assert_reference::<R>()`
+//! - `LvlhRelativeState<Chief>` — `assert_chief::<C>()`
+
+use bevy::prelude::Entity;
+use bevy_jeod::AttachEvent;
+use glam::{DMat3, DVec3};
+use jeod_sim::{
+    compute_lvlh_relative_state, compute_relative_state, define_vehicle, FlatPlate, FrameTransform,
+    LvlhRelativeState, RelativeState, RelativeTranslation, RotationalState, StructuralFrame,
+    TranslationalState, Vec3Ext,
+};
+
+define_vehicle!(Iss);
+define_vehicle!(Soyuz);
+
+#[test]
+fn flat_plate_assert_vehicle_round_trips() {
+    let plate: FlatPlate<Iss> = FlatPlate {
+        area: 10.0,
+        normal: DVec3::X,
+        position: DVec3::ZERO.m_at::<StructuralFrame<Iss>>(),
+    };
+    let plate = plate.assert_vehicle::<Iss>();
+    assert_eq!(plate.area, 10.0);
+}
+
+#[test]
+fn attach_event_assert_pair_round_trips() {
+    let evt: AttachEvent<Iss, Soyuz> = AttachEvent {
+        child: Entity::PLACEHOLDER,
+        parent: Entity::PLACEHOLDER,
+        offset: DVec3::ZERO.m_at::<StructuralFrame<Iss>>(),
+        // Cross-vehicle `FrameTransform::identity()` doesn't typecheck
+        // (it's defined only for `<F, F>`); use `from_matrix` to mint
+        // an identity-rotation transform across the two phantoms.
+        t_parent_child: FrameTransform::<StructuralFrame<Iss>, StructuralFrame<Soyuz>>::from_matrix(
+            DMat3::IDENTITY,
+        ),
+    };
+    let evt = evt.assert_pair::<Iss, Soyuz>();
+    assert_eq!(evt.parent, Entity::PLACEHOLDER);
+}
+
+#[test]
+fn relative_state_assert_pair_round_trips() {
+    let trans = TranslationalState {
+        position: DVec3::ZERO,
+        velocity: DVec3::ZERO,
+    };
+    let rel: RelativeState<Iss, Soyuz> =
+        compute_relative_state::<Iss, Soyuz>(&trans, None, &trans, None);
+    // assert_pair consumes self; round-trip and confirm the trans
+    // variant survived the no-op.
+    let rel = rel.assert_pair::<Iss, Soyuz>();
+    assert!(matches!(rel.trans, RelativeTranslation::Inertial { .. }));
+}
+
+#[test]
+fn relative_translation_assert_reference_round_trips() {
+    let trans_a = TranslationalState {
+        position: DVec3::new(6_778_137.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7668.56, 0.0),
+    };
+    let trans_b = TranslationalState {
+        position: DVec3::new(6_778_237.0, 100.0, -50.0),
+        velocity: DVec3::new(0.01, 7668.55, 0.005),
+    };
+    let rot = RotationalState {
+        quaternion: jeod_sim::JeodQuat::identity(),
+        ang_vel_body: DVec3::ZERO,
+    };
+    let rel = compute_relative_state::<Iss, Soyuz>(&trans_a, Some(&rot), &trans_b, Some(&rot));
+    // Reference phantom is `Soyuz`; asserting it through round-trips.
+    let _trans = rel.trans.assert_reference::<Soyuz>();
+}
+
+#[test]
+fn lvlh_relative_state_assert_chief_round_trips() {
+    let lvlh: LvlhRelativeState<Iss> = compute_lvlh_relative_state::<Iss>(
+        DVec3::new(6.778e6, 0.0, 0.0),
+        DVec3::new(0.0, 7.668e3, 0.0),
+        DVec3::new(6.778e6 + 50.0, 0.0, 0.0),
+        DVec3::new(0.0, 7.668e3, 0.0),
+    );
+    let _lvlh = lvlh.assert_chief::<Iss>();
+}


### PR DESCRIPTION
## Summary

Extends the physics-language compiler-error UX (the
`#[diagnostic::on_unimplemented]` idiom established in
`crates/jeod_quantities/src/diagnostics.rs`) to the five Act-5
phantom-wrapped types listed in #353:

| Type | Method added |
| --- | --- |
| `FlatPlate<V>` | `assert_vehicle::<W>()` |
| `AttachEvent<VParent, VChild>` | `assert_pair::<P, C>()` |
| `RelativeState<Subject, Reference>` | `assert_pair::<S, R>()` |
| `RelativeTranslation<Reference>` | `assert_reference::<R>()` |
| `LvlhRelativeState<Chief>` | `assert_chief::<C>()` |

Per type the change is small: a zero-cost type-level witness method
whose `where` bound carries the diagnostic. On mismatch the bound
fails and surfaces the new physics-language message instead of a
`PhantomData<…>` type-mismatch wall.

## What was added per type

The smallest trait addition that fits the existing
`jeod_quantities::diagnostics` pattern: two new zero-cost markers,

- `CompatibleVehicles<VL: Vehicle, VR: Vehicle>` — vehicle-side
  analog of `CompatibleFrames`, implemented only for `VL = VR`.
- `CompatibleVehiclePair<S1, R1, S2, R2>` — the paired-phantom form,
  implemented only when both sides agree.

Each carries a tailored `#[diagnostic::on_unimplemented]`. The
witness methods on each target type take the relevant compatibility
bound on `()` and are no-ops at runtime (they just return `self`).

Both markers are also re-exported from `jeod_sim` so the
`bevy_jeod` root crate satisfies the single-dependency invariant
(no direct dep on `jeod_quantities`).

## Touch sites

- `crates/jeod_quantities/src/diagnostics.rs` — add the two new
  marker traits + their `compile_fail` doctests.
- `crates/jeod_quantities/src/lib.rs` — document them in the
  "compile-time guards" section.
- `crates/jeod_sim/src/lib.rs` — re-export both markers.
- `crates/jeod_interactions/src/radiation_pressure.rs:102` —
  `FlatPlate<V>::assert_vehicle::<W>()` + `compile_fail` doctest.
- `src/components.rs:1382` —
  `AttachEvent<VParent, VChild>::assert_pair::<P, C>()` +
  `compile_fail` doctest.
- `crates/jeod_sim/src/derived.rs:61, 172, 245` —
  `RelativeState::assert_pair`,
  `RelativeTranslation::assert_reference`,
  `LvlhRelativeState::assert_chief` + per-method `compile_fail`
  doctests.
- `tests/diagnostic_act5_witness_methods.rs` (new) — positive-path
  unit tests for all five witness methods.

## Before / after compile error

The negative-branch confirmation, captured by hand from a real
build (the project has no `trybuild` infrastructure today, so each
`compile_fail` doctest exercises one direction of the diagnostic
and a temporary smoke test confirmed the user-facing message
content):

**Before** — mixing `RelativeTranslation<Iss>` and
`RelativeTranslation<Soyuz>` produced rustc's stock
type-mismatch error walking through `PhantomData<Soyuz>` vs
`PhantomData<Iss>` with no physics context.

**After**:

```text
error[E0277]: vehicle mismatch: cannot combine values tagged `Iss` with values tagged `Soyuz`
   --> tests/diagnostic_act5_witness_methods.rs:NN:18
    |
NN  |     let _ = lvlh.assert_chief::<Soyuz>();
    |                  ^^^^^^^^^^^^ mismatched vehicle: `Iss` vs `Soyuz`
    |
    = note: the two vehicle phantoms must agree — pin the same `Vehicle` marker on both sides (e.g. via `define_vehicle!`), or rebuild the value for the right vehicle if it was constructed for a different one
help: the trait `CompatibleVehicles<Iss, Soyuz>` is not implemented for `()`
      but trait `CompatibleVehicles<Iss, Iss>` is implemented for it
note: required by a bound in `LvlhRelativeState::<Chief>::assert_chief`
```

The paired form on `AttachEvent` / `RelativeState`:

```text
error[E0277]: paired-vehicle mismatch: cannot combine `<Iss, Soyuz>` with `<Iss, Cygnus>`
    |
    |     let _ = evt.assert_pair::<Iss, Cygnus>();
    |                 ^^^^^^^^^^^ mismatched pair: `<Iss, Soyuz>` vs `<Iss, Cygnus>`
    |
    = note: both phantoms in the pair must match — the subject (or parent) and the reference (or child) are independent identities, …
```

## Local checks passed

- `cargo fmt --check`
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- `cargo nextest run --workspace -E 'not test(tier3_)'` — 1169 tests passed
- `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 tests passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo test --doc -p jeod_quantities` / `-p jeod_sim` /
  `-p jeod_interactions` / `-p bevy_jeod` — all `compile_fail`
  doctests on the new diagnostics and witness methods pass
- `bash scripts/check_no_escape_hatches.sh`
- `cargo test --test invariant_coverage`

The negative branch (the diagnostic actually firing on cross-vehicle
mismatch) was verified by hand via a temporary smoke test — see the
"Before / after" snippet above. There is no `trybuild` snapshot
infrastructure in this repo today, so per-method `compile_fail`
doctests cover the negative branch and the new
`tests/diagnostic_act5_witness_methods.rs` covers the positive
branch.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` green
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` green
- [x] `cargo doc --workspace --no-deps` (with `RUSTDOCFLAGS="-D warnings"`) green
- [x] `cargo test --doc -p {jeod_quantities, jeod_sim, jeod_interactions, bevy_jeod}` green — `compile_fail` doctests on the new diagnostics fire
- [x] Manual smoke test confirms the new diagnostic message text renders as expected on cross-vehicle mismatch
- [x] `bash scripts/check_no_escape_hatches.sh` clean
- [x] `cargo test --test invariant_coverage` green

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)