### PR TITLE
[#355] Tier 3 cadence enforcement: README convention + CrossvalReport helper

### DIFF
--- a/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs
@@ -345,6 +345,13 @@ fn tier3_apollo8_eci_integ() {
         }
     }
 
+    // Tooling-enforced cadence check: dt = 0.5 s and JEOD's CSV samples
+    // at 0.5 s, so every reference row is an integrator-output instant.
+    // The assertion runs before tolerance checks so a future change
+    // that breaks the ratio fails on the cadence message rather than
+    // on a vacuously passing row-by-row comparison.
+    CrossvalReport::assert_cadence_matches(&ref_log, DT, 1e-6);
+
     let report = CrossvalReport::compute("tier3_apollo8_eci_integ", &our_log, &ref_log);
     report.write();
 

--- a/crates/jeod_runner/tests/tier3_sim_apollo_trajectory.rs
+++ b/crates/jeod_runner/tests/tier3_sim_apollo_trajectory.rs
@@ -725,6 +725,13 @@ fn tier3_sim_apollo_trajectory() {
     }
     assert!(!our_log.is_empty(), "trajectory log is empty");
 
+    // Tooling-enforced cadence check: dt = 0.02 s and JEOD's CSV
+    // samples at 0.1 s, so 0.1 / 0.02 = 5 — every reference row is an
+    // integrator-output instant. If a future edit drifts either side
+    // off the integer ratio, this fails loudly before the row loop
+    // quietly compares against held off-cadence samples.
+    CrossvalReport::assert_cadence_matches(&ref_log, DT, 1e-6);
+
     let report = CrossvalReport::compute("tier3_sim_apollo_trajectory", &our_log, &ref_log);
     report.write();
 

--- a/crates/jeod_runner/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+++ b/crates/jeod_runner/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
@@ -944,6 +944,15 @@ fn tier3_sim_dyncomp_run_attach_to_ref_frame() {
         "RUN_attach_to_ref_frame CSV row count drift: expected {EXPECTED_SAMPLES} (12000 s @ 60 s)"
     );
 
+    // Tooling-enforced cadence check: JEOD logs at 60 s and our
+    // integrator runs at 0.03125 s (32 Hz), so 60 / 0.03125 = 1920 —
+    // every CSV row lands on an integrator output instant. If a future
+    // edit drifts either side off the integer ratio (e.g. someone
+    // changes DT_S without re-deriving the cadence), this fails loudly
+    // before the row loop quietly compares against held off-cadence
+    // samples.
+    CrossvalReport::assert_cadence_matches_times(rows.iter().map(|r| r.time), DT_S, 1e-6);
+
     let (mut sim, body_idx, earth_idx) = build_sim(&rows[0]);
     // Match JEOD's `(LOW_RATE_ENV, "environment")` job-class cadence on
     // `Earth_GGM05C_SimObject::rnp.update_rnp`

--- a/crates/jeod_test_data/src/crossval.rs
+++ b/crates/jeod_test_data/src/crossval.rs
@@ -205,6 +205,111 @@ impl CrossvalReport {
         self.extras.push((var.to_string(), val, unit.to_string()));
     }
 
+    /// Assert that every reference-CSV sample time falls on an integrator
+    /// output instant — i.e., that `row.time` is an integer multiple of
+    /// `integrator_dt` within a small tolerance.
+    ///
+    /// Tier 3 cross-validation compares our trajectory against JEOD's CSV
+    /// row-by-row. When JEOD's logger writes faster than the integrator
+    /// runs (e.g. CSV at 0.5 s while `IntegLoop ... DYNAMICS=1.0`), Trick
+    /// holds and re-emits the integrator's output from the previous
+    /// integer second on the off-cadence rows. A naive row-by-row
+    /// comparison passes vacuously on those held rows because both sides
+    /// quote the same earlier state, masking real residuals at the actual
+    /// integrator-output instants.
+    ///
+    /// Call this at the top of a Tier 3 test to fail loudly when the
+    /// integrator step does not divide the CSV cadence. If a test is
+    /// deliberately running an off-cadence integrator (e.g. dt=1.0 s
+    /// against a 0.5 s CSV), it must filter the off-cadence rows out
+    /// before logging — see [`CrossvalReport::is_on_integrator_cadence`]
+    /// for the per-row helper that the existing
+    /// `tier3_sim_ref_attach.rs` half-second skip pattern uses — and
+    /// then call `assert_cadence_matches` on the *filtered* sample
+    /// times so the helper still sees a clean cadence-aligned set.
+    ///
+    /// `tolerance_fraction` is the fraction of `integrator_dt` allowed
+    /// as f64 round-off slack on each row's modular residual; `1e-6` is
+    /// the conservative default used at the existing per-test skip
+    /// sites.
+    pub fn assert_cadence_matches(
+        reference: &[StateLog],
+        integrator_dt: f64,
+        tolerance_fraction: f64,
+    ) {
+        Self::assert_cadence_matches_times(
+            reference.iter().map(|s| s.time),
+            integrator_dt,
+            tolerance_fraction,
+        );
+    }
+
+    /// Same as [`CrossvalReport::assert_cadence_matches`] but takes a raw
+    /// iterator of CSV row times. Use this when the test holds the CSV
+    /// rows in a domain-specific record type (e.g. `DyncompRecord`)
+    /// rather than `StateLog`, so the cadence check can run before any
+    /// `StateLog` is built — turning the cadence assertion into the very
+    /// first thing the row loop sees.
+    pub fn assert_cadence_matches_times<I>(times: I, integrator_dt: f64, tolerance_fraction: f64)
+    where
+        I: IntoIterator<Item = f64>,
+    {
+        assert!(
+            integrator_dt > 0.0,
+            "assert_cadence_matches: integrator_dt must be positive, got {integrator_dt}"
+        );
+        assert!(
+            (0.0..1.0).contains(&tolerance_fraction),
+            "assert_cadence_matches: tolerance_fraction must be in [0, 1), got {tolerance_fraction}"
+        );
+        let abs_tol = (tolerance_fraction * integrator_dt).max(f64::EPSILON);
+        for (i, t) in times.into_iter().enumerate() {
+            let n = (t / integrator_dt).round();
+            let modular_err = (t - n * integrator_dt).abs();
+            assert!(
+                modular_err <= abs_tol,
+                "Tier 3 cadence mismatch at reference row {i} (t = {t:.9} s): \
+                 not an integer multiple of integrator_dt = {integrator_dt} s \
+                 (closest multiple = {:.9} s, residual = {modular_err:.3e} s, \
+                 tolerance = {abs_tol:.3e} s). \
+                 Either change the integrator dt to divide the CSV cadence, or \
+                 filter off-cadence rows out of `reference` before calling \
+                 `CrossvalReport::compute` — see `is_on_integrator_cadence` and \
+                 the half-second-skip pattern in \
+                 `crates/jeod_runner/tests/tier3_sim_ref_attach.rs`.",
+                n * integrator_dt
+            );
+        }
+    }
+
+    /// Per-row predicate: `true` iff `row_time` is an integer multiple of
+    /// `integrator_dt` within `1e-6 * integrator_dt` round-off slack.
+    ///
+    /// Use inside the test's main row loop as the standard cadence skip:
+    ///
+    /// ```ignore
+    /// for row in &rows {
+    ///     if !CrossvalReport::is_on_integrator_cadence(row.time, dt) {
+    ///         continue;  // off-cadence sample, Trick re-emits the prior step's state
+    ///     }
+    ///     // ...compare this row...
+    /// }
+    /// ```
+    ///
+    /// This is the catch-able tooling form of the
+    /// `(row.time - row.time.round()).abs() > 1e-6` skip already used in
+    /// `tier3_sim_ref_attach.rs` (whose dt happens to be 1.0 s, so
+    /// `.round()` and "integer multiple of dt" coincide).
+    pub fn is_on_integrator_cadence(row_time: f64, integrator_dt: f64) -> bool {
+        assert!(
+            integrator_dt > 0.0,
+            "is_on_integrator_cadence: integrator_dt must be positive, got {integrator_dt}"
+        );
+        let n = (row_time / integrator_dt).round();
+        let abs_tol = (1e-6 * integrator_dt).max(f64::EPSILON);
+        (row_time - n * integrator_dt).abs() <= abs_tol
+    }
+
     /// Worst-component position error (∞-norm, for assert! statements).
     pub fn max_position_component(&self) -> f64 {
         self.position
@@ -391,5 +496,68 @@ fn write_f64_field(json: &mut String, name: &str, val: &Option<f64>) {
         None => {
             json.push_str(&format!(r#","{name}":null"#));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ref_log_at(times: &[f64]) -> Vec<StateLog> {
+        times
+            .iter()
+            .map(|&t| StateLog {
+                time: t,
+                ..StateLog::default()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn cadence_matches_when_csv_is_integer_multiple_of_dt() {
+        // 60 s CSV cadence with a 0.03125 s integrator step (32 Hz):
+        // 60.0 / 0.03125 = 1920 — integer. Mirrors
+        // `tier3_sim_dyncomp_run_attach_to_ref_frame.rs`.
+        let times: Vec<f64> = (0..201).map(|i| i as f64 * 60.0).collect();
+        let reference = ref_log_at(&times);
+        CrossvalReport::assert_cadence_matches(&reference, 0.03125, 1e-6);
+    }
+
+    #[test]
+    fn cadence_matches_when_csv_equals_dt() {
+        // Apollo 8 test: dt=0.5 s and CSV at 0.5 s.
+        let times: Vec<f64> = (0..201).map(|i| i as f64 * 0.5).collect();
+        let reference = ref_log_at(&times);
+        CrossvalReport::assert_cadence_matches(&reference, 0.5, 1e-6);
+    }
+
+    #[test]
+    #[should_panic(expected = "Tier 3 cadence mismatch")]
+    fn cadence_panics_on_half_second_csv_with_one_second_integrator() {
+        // The exact bug shape #355 targets: CSV samples at 0.5 s but
+        // the integrator runs at 1.0 s. Half-second rows are not on
+        // any integrator-output instant.
+        let times: Vec<f64> = (0..101).map(|i| i as f64 * 0.5).collect();
+        let reference = ref_log_at(&times);
+        CrossvalReport::assert_cadence_matches(&reference, 1.0, 1e-6);
+    }
+
+    #[test]
+    fn is_on_cadence_filters_half_seconds_at_dt_one() {
+        // The half-second rows must skip; the integer-second rows pass.
+        assert!(CrossvalReport::is_on_integrator_cadence(0.0, 1.0));
+        assert!(CrossvalReport::is_on_integrator_cadence(50.0, 1.0));
+        assert!(!CrossvalReport::is_on_integrator_cadence(0.5, 1.0));
+        assert!(!CrossvalReport::is_on_integrator_cadence(50.5, 1.0));
+    }
+
+    #[test]
+    fn is_on_cadence_handles_f64_jitter_within_one_ppm_of_dt() {
+        // f64 round-off well below 1e-6 * dt should still register as
+        // on-cadence.
+        assert!(CrossvalReport::is_on_integrator_cadence(
+            60.0 + 1e-12,
+            0.03125
+        ));
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,43 @@ Match exactly:
   "Generating Tier 3 Reference Data").
 - New physics → usually all three.
 
+## Tier 3 conventions
+
+Every Tier 3 test must observe the following conventions in addition to
+the tier-and-naming rules above. Failing any of these is a correctness
+hazard, not a style preference.
+
+1. **Sample cadence must match the JEOD CSV log cadence.** JEOD's logger
+   frequently writes faster than the integrator runs (e.g. CSV rows at
+   0.5 s while `IntegLoop ... DYNAMICS=1.0`). On off-cadence rows Trick
+   re-emits the integrator's output from the previous integer second —
+   so naive row-by-row comparison passes vacuously on the off-cadence
+   rows and silently masks real residuals at the actual integrator-
+   output instants. Pick one of:
+   - **Cadence-aligned (preferred).** Choose an integrator step that
+     evenly divides the CSV cadence (e.g. dt = 0.03125 s against a 60 s
+     CSV — `60.0 / 0.03125 = 1920`). Then call
+     `CrossvalReport::assert_cadence_matches(&reference_log,
+     integrator_dt, 1e-6)` once before `compute` to fail loudly if the
+     ratio is ever non-integer.
+   - **Filter off-cadence rows.** When the integrator deliberately runs
+     coarser than the CSV (e.g. SIM_ref_attach's dt = 1.0 s against a
+     0.5 s CSV), skip rows that don't fall on an integrator-output
+     instant before logging into the `StateLog` slice that
+     `CrossvalReport::compute` sees. Use
+     `CrossvalReport::is_on_integrator_cadence(row.time, dt)` in the
+     row loop. The canonical template lives in
+     [`crates/jeod_runner/tests/tier3_sim_ref_attach.rs`][cadence-template].
+   - **Document the rationale.** Either choice must be justified in a
+     pure-rationale comment near the top of the test (or at the row
+     loop) that names the integrator step, the CSV cadence, the ratio,
+     and what Trick does on the off-cadence rows. The
+     [`tier3_sim_dyncomp_run_attach_to_ref_frame.rs`][cadence-rationale]
+     header block is the worked example.
+
+[cadence-template]: ../crates/jeod_runner/tests/tier3_sim_ref_attach.rs
+[cadence-rationale]: ../crates/jeod_runner/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+
 ## `CrossvalReport` API
 
 `crates/jeod_test_data/src/crossval.rs` is the harness for every Tier 3 test


### PR DESCRIPTION
## Summary

Promote the Tier 3 sample-cadence-matching discipline from per-test author judgement to a tooling-enforced pattern, so future Tier 3 tests cannot silently mask physics bugs by sampling at a cadence that misses integrator output rows.

The discipline already saved a 5.22 m surface-attach residual once (PR #351 / issue #350) but was implicit. This change makes it catch-able.

## Leg 1 — `tests/README.md` checklist item

Adds a new \"Tier 3 conventions\" section above the `CrossvalReport` API docs. The checklist item names three resolutions for the cadence question (cadence-aligned dt, filter off-cadence rows, document rationale) and points future authors at the working templates in `tier3_sim_ref_attach.rs` (per-row skip) and `tier3_sim_dyncomp_run_attach_to_ref_frame.rs` (cadence-rationale block).

## Leg 2 — `CrossvalReport` sample-cadence enforcement

Adds two opt-in helpers in `crates/jeod_test_data/src/crossval.rs`:

- `CrossvalReport::assert_cadence_matches(reference: &[StateLog], integrator_dt: f64, tolerance_fraction: f64)` — panics if any reference-row time is not an integer multiple of `integrator_dt` within `tolerance_fraction * integrator_dt` round-off slack. The diagnostic names the offending row, the closest cadence-aligned time, the residual, and the two valid fixes.
- `CrossvalReport::assert_cadence_matches_times<I: IntoIterator<Item = f64>>(...)` — same check but takes a raw time iterator, so tests holding domain-specific record types (`DyncompRecord`) can run the cadence check before any `StateLog` is constructed.
- `CrossvalReport::is_on_integrator_cadence(row_time: f64, integrator_dt: f64) -> bool` — per-row predicate that names what the existing `(row.time - row.time.round()).abs() > 1e-6` skip pattern is actually testing.

Five unit tests cover: integer-multiple cadences pass, equal cadences pass, half-second CSV against 1 s integrator panics with the new diagnostic, half-second filter at dt=1.0 returns the right boolean, and f64 jitter within 1 ppm of dt registers as on-cadence.

## Call sites that opted into the new check

Three representative Tier 3 tests, all of which already had cadence-aligned configurations and so pass cleanly with the assertion in place:

- `crates/jeod_runner/tests/tier3_apollo8_frame_switch.rs::tier3_apollo8_eci_integ` — dt = 0.5 s, CSV at 0.5 s.
- `crates/jeod_runner/tests/tier3_sim_apollo_trajectory.rs::tier3_sim_apollo_trajectory` — dt = 0.02 s, CSV at 0.1 s (ratio = 5).
- `crates/jeod_runner/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs::tier3_sim_dyncomp_run_attach_to_ref_frame` — dt = 0.03125 s, CSV at 60 s (ratio = 1920). The cadence assert runs against the raw `rows.iter().map(|r| r.time)` so it fires before any `Simulation` work happens.

Existing tests that do not opt in (the per-test inline cadence skip in `tier3_sim_ref_attach.rs`, the `tier3_sim_dyncomp_run*` recipe-delegating tests, etc.) are unchanged. The helper is additive.

## \"Deliberately mis-set the cadence\" verification

Locally swapped `DT` for `0.3` in the apollo8 opt-in site and ran the test. The result, before reverting:

```
thread 'tier3_apollo8_eci_integ' panicked at crates/jeod_test_data/src/crossval.rs:269:13:
Tier 3 cadence mismatch at reference row 0 (t = 0.500000000 s): not an integer multiple of integrator_dt = 0.3 s (closest multiple = 0.600000000 s, residual = 1.000e-1 s, tolerance = 3.000e-7 s). Either change the integrator dt to divide the CSV cadence, or filter off-cadence rows out of `reference` before calling `CrossvalReport::compute` — see `is_on_integrator_cadence` and the half-second-skip pattern in `crates/jeod_runner/tests/tier3_sim_ref_attach.rs`.
```

The message names the broken assumption, the offending row, the residual, the tolerance, and both valid fixes. After reverting, the test passes again.

## Local checks

- `cargo fmt --check` — clean
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` — clean (no-features and `--features verification` paths)
- `cargo nextest run --workspace -E 'not test(tier3_)'` — 1167 / 1167 pass
- `cargo nextest run --workspace -E 'test(tier3_) and not test(earth_moon)'` — 340 / 340 pass (full Tier 3 suite minus the long earth-moon test)
- `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 / 36 pass
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — clean
- `bash scripts/check_no_escape_hatches.sh` — clean
- `cargo test --test invariant_coverage` — 6 / 6 pass

## Test plan

- [x] `cargo nextest run -p jeod_test_data -E 'test(cadence)'` covers the new helper unit tests.
- [x] Three representative Tier 3 tests with the assert wired in pass.
- [x] Deliberate cadence-mismatch verification produces the fail-loud message above.
- [x] No regressions in the rest of Tier 3, bevy_parity, or unit + Tier 2 lanes.

Closes #355