### PR TITLE
[#360] CLAUDE.md: scope "single API surface" rule to the production path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,18 @@ stages, re-exports all types; zero Bevy dependency). Bevy wiring lives in the
 that delegate to `jeod_sim` functions, plugin registration).
 
 The root package depends **only** on `jeod_sim` + `bevy` — never on `jeod_*`
-crates directly. This makes `jeod_sim` the single API surface for any consumer
-(ECS adapter or otherwise).
+crates directly. **`jeod_sim` is the single API surface for the production
+path:** every Bevy system, every mission crate, every downstream consumer that
+ships in a real simulation reads the workspace through `jeod_sim` and only
+through `jeod_sim`. The narrower the production-path surface, the smaller the
+contract that has to stay stable across phases.
+
+This rule is scoped to the production path because the workspace also contains
+a non-shipping test harness (`jeod_runner`) whose role is the inverse: it owns
+its own state container and *needs* to construct concrete physics types
+itself. See [`bevy_jeod` vs `jeod_runner`](#bevy_jeod-vs-jeod_runner-two-parallel-consumers-of-jeod_sim)
+below for why that asymmetry is intentional and what each consumer is allowed
+to depend on.
 
 Never put physics algorithms directly in a Bevy system function. The system queries
 components, then calls a `jeod_sim` function. This keeps physics portable to other
@@ -88,9 +98,30 @@ mission code — so type-system work that targets a class of bugs
 (rather than a runner-internal helper) belongs in `jeod_quantities` or
 `jeod_dynamics`, not in `jeod_runner`.
 
+The two consumers have **deliberately different dep-graph rights**, and
+the difference is non-negotiable in both directions:
+
+- **`bevy_jeod` and any mission crate** (production path) depend only on
+  `jeod_sim` plus `bevy`. They **must not** add a direct `jeod_*` physics
+  dependency. The "single API surface" rule from the previous section
+  applies here, full stop — every physics type that the production path
+  needs has to be reachable through `jeod_sim`. If something isn't, the
+  fix is to widen `jeod_sim`'s curated re-export surface, not to bypass it.
+- **`jeod_runner`** (in-workspace test harness) is allowed to depend
+  directly on the physics crates it needs to populate its `Simulation`
+  state container — today that is `jeod_dynamics`, `jeod_gravity`,
+  `jeod_time`, `jeod_frames`, `jeod_interactions`, and `jeod_math`.
+  Those direct deps are intentional: the runner owns its own state and
+  constructs concrete physics types by hand at the kernel boundary;
+  routing them through `jeod_sim` would force `jeod_sim` to expose
+  internal vocabulary purely for one in-workspace consumer's benefit.
+  The runner is *not* a mission consumer and is never published as one.
+
 Mission crates that target the production runtime depend on
 `bevy_jeod` (and transitively `jeod_sim`). They never depend on
-`jeod_runner`.
+`jeod_runner`, and they never reach around `jeod_sim` to pull a
+physics crate directly — if you find yourself writing
+`jeod_dynamics = …` in a mission `Cargo.toml`, that is the bug.
 
 ## Computational Independence (non-negotiable)
 


### PR DESCRIPTION
## Summary

Formalize the asymmetry between the two `jeod_sim` consumers in the workspace so the rule's stated scope matches what the code does (audit #352 §2.3).

- `bevy_jeod` and any mission crate (production path) strictly depend on `jeod_sim` plus `bevy` — the "single API surface" rule applies here, full stop.
- `jeod_runner` is an in-workspace test harness that owns its own `Simulation` state container and is allowed to depend directly on the physics crates it constructs by hand (`jeod_dynamics`, `jeod_gravity`, `jeod_time`, `jeod_frames`, `jeod_interactions`, `jeod_math`). Routing those through `jeod_sim` would force `jeod_sim` to expose internal vocabulary purely for one in-workspace consumer's benefit.

This is the audit's recommended Option 2 ("tighten docs"). Crate dependencies are unchanged in this PR — Option 1 ("tighten reality") is out of scope here.

## What changed

- **"Three-Layer Architecture"**: rewrote the "single API surface" sentence to scope it to the production path (Bevy systems, mission crates, every downstream consumer that ships in a real simulation), and pointed the reader at the `bevy_jeod` vs `jeod_runner` subsection for the asymmetry rationale.
- **"`bevy_jeod` vs `jeod_runner`"**: added an explicit "deliberately different dep-graph rights" bullet pair stating exactly what each consumer is allowed to depend on, plus a closing sentence forbidding mission crates from reaching around `jeod_sim` to pull a physics crate directly.

The audit's leaning that `bevy_jeod` is "first-class" and `jeod_runner` is "the test-harness escape hatch" stays intact; this PR just writes the asymmetry down so future readers (and exploration agents) don't trip on the over-strong "any consumer" wording.

## Test plan

Docs-only change, but the full pre-commit check suite from CLAUDE.md was run:

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1162/1162 pass
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36/36 pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `./scripts/check_no_escape_hatches.sh`
- [x] `cargo test --test invariant_coverage`

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)