### PR TITLE
[#362] Document JeodSet 9->7 stage collapse in CLAUDE.md (audit §2.6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,16 +303,25 @@ These Python files come in three parsability tiers:
 
 ## JEOD Integration Loop (maps to FixedUpdate)
 
+JEOD's per-step pipeline collapses to **seven** `JeodSet` variants
+(`src/sets.rs`), not nine. Two adjacent JEOD steps share a single set
+where the bundling is natural — gravity + atmosphere both run in
+`Environment`, and frame propagation rides inside the `Integration`
+system as its post-step rather than as a separate schedule pass.
+
 ```
-1. Time update         →  TimeUpdateSet
-2. Ephemeris update    →  EphemerisUpdateSet
-3. Gravity computation →  EnvironmentSet
-4. Atmosphere update   →  EnvironmentSet
-5. Aero/SRP/torque     →  InteractionSet
-6. Force collection    →  ForceCollectionSet
-7. State integration   →  IntegrationSet
-8. Frame propagation   →  IntegrationSet
-9. Derived states      →  DerivedStateSet
+JEOD step                        →  JeodSet variant
+1. Time update                   →  JeodSet::TimeUpdate
+2. Ephemeris update              →  JeodSet::EphemerisUpdate
+3. Gravity computation         ┐
+                               ├─→  JeodSet::Environment
+4. Atmosphere update           ┘
+5. Aero / SRP / gravity torque   →  JeodSet::Interaction
+6. Force collection              →  JeodSet::ForceCollection
+7. State integration           ┐
+                               ├─→  JeodSet::Integration
+8. Frame propagation           ┘    (post-step inside the integration system)
+9. Derived states                →  JeodSet::DerivedState
 ```
 
 Multi-stage integrators (RK4 = 4 stages) run as an inner loop within the


### PR DESCRIPTION
## Summary

- The `JEOD Integration Loop (maps to FixedUpdate)` table in `CLAUDE.md` listed **nine** numbered JEOD steps mapped to right-hand-column names like `EnvironmentSet`, `IntegrationSet`, etc. The actual `JeodSet` enum (`src/sets.rs:46-61`) has only **seven** variants — `TimeUpdate`, `EphemerisUpdate`, `Environment`, `Interaction`, `ForceCollection`, `Integration`, `DerivedState` — and none carry a `*Set` suffix.
- The mapping was correct (gravity + atmosphere both run in `Environment`; frame propagation runs as the post-step inside the integration system rather than a separate schedule pass), but the table didn't show the merge, so the count and names disagreed with the code. This is the documentation drift flagged in audit §2.6.
- Update the table to name the actual `JeodSet::*` variants, visibly bracket the two collapsed pairs (`Environment` and `Integration`), state the seven-stage count up front, and note that frame propagation is the integration system's post-step.

## What was checked / not changed

- `docs/JEOD_invariants.md`, `tests/README.md` — searched for stale stage counts and old `*Set`-suffix references; none found, no edits needed.
- `CHANGELOG.md` 0.1.0 entry mentions a "nine-stage integration loop" but is historical release-note text and stays as-is per Keep a Changelog convention.
- No Rust source changes — `src/sets.rs` already documents the 7-stage layout in its module rustdoc; the drift was only in `CLAUDE.md`.

## Test plan

Full check suite from `CLAUDE.md` ran clean locally:

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1183 passed
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 passed
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `cargo test --test invariant_coverage` — 6 passed

Closes #362.

Tracker: #365.
Audit: #352 §2.6.