### PR TITLE
[#364] Migrate SimBody.gravity_accel to GravityAccelerationTyped<RootInertial>

### DIFF
--- a/crates/jeod_runner/src/simulation/step/environment.rs
+++ b/crates/jeod_runner/src/simulation/step/environment.rs
@@ -74,11 +74,9 @@ impl Simulation {
         // Project each `(idx, &mut SimBody)` row into the
         // `(key, inputs, store)` triple `run_gravity_stage` expects.
         // The store closure captures `&mut body.gravity_accel` and
-        // lowers the typed kernel result back to raw `GravityAcceleration`
-        // because `SimBody.gravity_accel` still uses the untyped layout;
-        // the Bevy adapter, which stores the typed
-        // `GravityAccelerationTyped<RootInertial>` newtype, moves the
-        // value through unchanged.
+        // moves the typed kernel result through unchanged — both
+        // adapters now share the same
+        // `GravityAccelerationTyped<RootInertial>` storage type.
         let body_iter = self.bodies.iter_mut().enumerate().map(|(body_idx, body)| {
             let inputs = GravityBodyInputs {
                 position: body.trans.position,
@@ -89,9 +87,7 @@ impl Simulation {
             let gravity_accel_slot = &mut body.gravity_accel;
             let store =
                 move |result: jeod_sim::GravityAccelerationTyped<jeod_sim::RootInertial>| {
-                    gravity_accel_slot.grav_accel = result.grav_accel.raw_si();
-                    gravity_accel_slot.grav_grad = result.grav_grad;
-                    gravity_accel_slot.grav_pot = result.grav_pot;
+                    *gravity_accel_slot = result;
                 };
             (body_idx, inputs, store)
         });

--- a/crates/jeod_runner/src/simulation/step/integrate.rs
+++ b/crates/jeod_runner/src/simulation/step/integrate.rs
@@ -43,7 +43,10 @@ impl Simulation {
                 body.rot.as_ref(),
                 body.t_struct_body,
                 body.mass.as_ref(),
-                body.gravity_accel.grav_accel,
+                // allowed: typed→raw boundary — `collect_and_resolve_forces`
+                // is the untyped force-collection kernel; the runner stores
+                // gravity acceleration typed against `RootInertial`.
+                body.gravity_accel.grav_accel.raw_si(),
             );
             body.total_force = total;
             body.frame_derivs = derivs;
@@ -1010,9 +1013,14 @@ impl Simulation {
                 let torque_body = body.t_struct_body * agg.torque;
                 body.total_force.force = force_inertial;
                 body.total_force.torque = torque_body;
+                // allowed: typed→raw boundary — `frame_derivs` is the
+                // untyped derivative struct used by the integrator
+                // contract; the runner's gravity storage is typed
+                // against `RootInertial`.
+                let grav_accel_raw = body.gravity_accel.grav_accel.raw_si();
                 if let Some(mass) = &body.mass {
                     body.frame_derivs.trans_accel =
-                        body.gravity_accel.grav_accel + force_inertial * mass.inverse_mass;
+                        grav_accel_raw + force_inertial * mass.inverse_mass;
                     if let Some(rot) = body.rot.as_ref() {
                         // Refresh rotational dynamics with the
                         // aggregated body-frame torque. Matches
@@ -1025,7 +1033,7 @@ impl Simulation {
                         body.frame_derivs.rot_accel = DVec3::ZERO;
                     }
                 } else {
-                    body.frame_derivs.trans_accel = body.gravity_accel.grav_accel;
+                    body.frame_derivs.trans_accel = grav_accel_raw;
                     body.frame_derivs.rot_accel = DVec3::ZERO;
                 }
             } else {

--- a/crates/jeod_runner/src/simulation/types.rs
+++ b/crates/jeod_runner/src/simulation/types.rs
@@ -31,9 +31,9 @@ use jeod_dynamics::{MassBodyId, MassPointState};
 use jeod_frames::FrameId;
 use jeod_sim::{
     AerodynamicForce, AtmosphereState, ContactFacet, DragConfig, DynamicsConfig, EulerSequence,
-    FrameDerivatives, FrameSwitchConfig, GeodeticState, GravityAcceleration, GravityControls,
+    FrameDerivatives, FrameSwitchConfig, GeodeticState, GravityAccelerationTyped, GravityControls,
     GravitySource, GroundFacet, IntegrationFrame, LvlhFrame, MassProperties, OrbitalElements,
-    RadiationForce, RotationModel, RotationalState, SelfPlanet, SrpModel, TotalForce,
+    RadiationForce, RootInertial, RotationModel, RotationalState, SelfPlanet, SrpModel, TotalForce,
     TranslationalState, TranslationalStateTyped, VehicleConfig,
 };
 
@@ -275,7 +275,7 @@ pub(crate) struct SimBody {
     pub frame_switches: Vec<FrameSwitchConfig>,
 
     // ── Bookkeeping (written each step, not user-visible) ──
-    pub gravity_accel: GravityAcceleration,
+    pub gravity_accel: GravityAccelerationTyped<RootInertial>,
     pub total_force: TotalForce,
     pub frame_derivs: FrameDerivatives,
     pub aero_force: Option<AerodynamicForce>,
@@ -367,7 +367,7 @@ impl SimBody {
             body_frame_id,
             frame_switches: config.frame_switches,
 
-            gravity_accel: GravityAcceleration::default(),
+            gravity_accel: GravityAccelerationTyped::<RootInertial>::default(),
             total_force: TotalForce::default(),
             frame_derivs: FrameDerivatives::default(),
             aero_force: None,

--- a/crates/jeod_sim/src/gravity.rs
+++ b/crates/jeod_sim/src/gravity.rs
@@ -358,35 +358,6 @@ pub fn evaluate_body_gravity_typed<'a, S: Copy + std::fmt::Debug + PartialEq>(
     accel
 }
 
-/// Raw sibling of [`evaluate_body_gravity_typed`] for adapters that
-/// store gravity acceleration as the untyped [`GravityAcceleration`]
-/// (currently `jeod_runner::SimBody.gravity_accel`).
-///
-/// Same numerics — the RF.10 shift is performed in raw arithmetic, then
-/// [`accumulate_gravity`] and [`accumulate_relativistic_corrections`]
-/// run on the shifted coordinates. Once `SimBody.gravity_accel`
-/// migrates to the typed sibling (tracked separately), this raw entry
-/// point can be deleted in favor of `evaluate_body_gravity_typed` for
-/// both adapters.
-// JEOD_INV: RF.10 — integ-frame to root-inertial shift is encapsulated here.
-pub fn evaluate_body_gravity<'a, S: Copy + std::fmt::Debug + PartialEq>(
-    body_position: DVec3,
-    body_velocity: DVec3,
-    integ_origin: &IntegOrigin,
-    controls: &GravityControls<S>,
-    resolve_source: impl Fn(S) -> Option<ResolvedSource<'a>>,
-    resolve_rel_source: impl Fn(S) -> Option<ResolvedRelativisticSource>,
-) -> GravityAcceleration {
-    let origin_pos = integ_origin.position.raw_si();
-    let abs_pos = body_position + origin_pos;
-    let abs_vel = body_velocity + integ_origin.velocity.raw_si();
-
-    let mut accel = accumulate_gravity(abs_pos, controls, origin_pos, resolve_source);
-    accel.grav_accel +=
-        accumulate_relativistic_corrections(abs_pos, abs_vel, controls, resolve_rel_source);
-    accel
-}
-
 /// Per-body inputs the gravity stage driver consumes.
 ///
 /// Bundled together so adapter `.map(...)` projections over a `Query`
@@ -418,11 +389,10 @@ pub struct GravityBodyInputs<'a, S> {
 /// 1. Calls [`evaluate_body_gravity_typed`] (RF.10 shift + Newtonian
 ///    accumulation + post-Newtonian correction) for each body.
 /// 2. Hands the result to the per-body `store` closure, which writes
-///    it back into adapter-owned storage. Adapters that store typed
-///    `GravityAccelerationTyped<RootInertial>` (the Bevy newtype) move
-///    the value through; adapters that still store raw
-///    `GravityAcceleration` (the runner) lower via `.raw_si()` inside
-///    the closure.
+///    it back into adapter-owned storage. Both adapters now store
+///    `GravityAccelerationTyped<RootInertial>` (the Bevy
+///    `GravityAccelerationC` newtype and `SimBody.gravity_accel`),
+///    so the closure is a direct move.
 ///
 /// `resolve_source` and `resolve_rel_source` receive the body key
 /// alongside the source identifier so adapters that want to surface
@@ -431,9 +401,9 @@ pub struct GravityBodyInputs<'a, S> {
 ///
 /// The closure-based writer lets each adapter use whatever mutable
 /// handle its iterator yields (`Mut<'_, GravityAccelerationC>` for
-/// Bevy, `&mut GravityAcceleration` for the runner) without needing a
-/// trait impl on a foreign type — orphan rules block trait impls on
-/// `Mut<'_, T>` from outside `bevy_ecs`.
+/// Bevy, `&mut GravityAccelerationTyped<RootInertial>` for the runner)
+/// without needing a trait impl on a foreign type — orphan rules block
+/// trait impls on `Mut<'_, T>` from outside `bevy_ecs`.
 ///
 /// Both ECS adapters today route gravity through this function; future
 /// stage-shape changes (a new pre-step, a new gating condition, new
@@ -758,7 +728,7 @@ mod tests {
         assert!(!third_body.battin_method);
     }
 
-    /// `evaluate_body_gravity` (raw) is numerically equivalent to the
+    /// `evaluate_body_gravity_typed` is numerically equivalent to the
     /// open-coded shift-then-accumulate sequence the runner has carried
     /// since before the kernel existed: lift body coordinates to root
     /// inertial via the integ-origin, then call `accumulate_gravity` and
@@ -799,16 +769,17 @@ mod tests {
         };
 
         // New kernel.
-        let kernel = evaluate_body_gravity(
-            body_pos_integ,
-            body_vel_integ,
-            &integ_origin,
+        let kernel = evaluate_body_gravity_typed(
+            Position::<IntegrationFrame>::from_raw_si(body_pos_integ),
+            Velocity::<IntegrationFrame>::from_raw_si(body_vel_integ),
+            integ_origin,
             &controls,
             resolve_source,
             resolve_rel_source,
         );
 
-        // Manual composition — exactly what the runner does today.
+        // Manual composition — exactly what the runner did before the
+        // kernel landed.
         let abs_pos = body_pos_integ + integ_origin.position.raw_si();
         let abs_vel = body_vel_integ + integ_origin.velocity.raw_si();
         let mut manual = accumulate_gravity(
@@ -820,65 +791,9 @@ mod tests {
         manual.grav_accel +=
             accumulate_relativistic_corrections(abs_pos, abs_vel, &controls, resolve_rel_source);
 
-        assert_eq!(kernel.grav_accel, manual.grav_accel);
+        assert_eq!(kernel.grav_accel.raw_si(), manual.grav_accel);
         assert_eq!(kernel.grav_pot, manual.grav_pot);
         assert_eq!(kernel.grav_grad, manual.grav_grad);
-    }
-
-    /// Typed kernel produces the same numbers as the raw kernel —
-    /// the typed sibling is a relabel-only wrapper.
-    #[test]
-    fn evaluate_body_gravity_typed_matches_raw() {
-        let mu = 3.986e14;
-        let source = point_mass_source(mu);
-        let source_pos = DVec3::ZERO;
-
-        let body_pos_integ = DVec3::new(7e6, 1e5, -2e5);
-        let body_vel_integ = DVec3::new(-100.0, 7500.0, 50.0);
-        let integ_origin = IntegOrigin {
-            position: Position::<RootInertial>::from_raw_si(DVec3::new(1.5e11, 1e9, 0.0)),
-            velocity: Velocity::<RootInertial>::from_raw_si(DVec3::new(0.0, 30_000.0, 0.0)),
-        };
-        let controls = GravityControls {
-            controls: vec![GravityControl::new_spherical(0_usize, false)],
-        };
-        let resolve_source = |_: usize| {
-            Some(ResolvedSource {
-                source: &source,
-                rotation: None,
-                position: source_pos,
-                delta_c20: 0.0,
-                has_delta_coeffs: false,
-            })
-        };
-        let resolve_rel_source = |_: usize| {
-            Some(ResolvedRelativisticSource {
-                mu,
-                position: source_pos,
-                velocity: DVec3::ZERO,
-            })
-        };
-
-        let raw = evaluate_body_gravity(
-            body_pos_integ,
-            body_vel_integ,
-            &integ_origin,
-            &controls,
-            resolve_source,
-            resolve_rel_source,
-        );
-        let typed = evaluate_body_gravity_typed(
-            Position::<IntegrationFrame>::from_raw_si(body_pos_integ),
-            Velocity::<IntegrationFrame>::from_raw_si(body_vel_integ),
-            integ_origin,
-            &controls,
-            resolve_source,
-            resolve_rel_source,
-        );
-
-        assert_eq!(typed.grav_accel.raw_si(), raw.grav_accel);
-        assert_eq!(typed.grav_pot, raw.grav_pot);
-        assert_eq!(typed.grav_grad, raw.grav_grad);
     }
 
     /// `run_gravity_stage` over an iterator of two bodies produces the
@@ -1012,10 +927,10 @@ mod tests {
             })
         };
 
-        let kernel = evaluate_body_gravity(
-            body_pos,
-            body_vel,
-            &integ_origin,
+        let kernel = evaluate_body_gravity_typed(
+            Position::<IntegrationFrame>::from_raw_si(body_pos),
+            Velocity::<IntegrationFrame>::from_raw_si(body_vel),
+            integ_origin,
             &controls,
             resolve_source,
             resolve_rel_source,
@@ -1024,7 +939,7 @@ mod tests {
         plain.grav_accel +=
             accumulate_relativistic_corrections(body_pos, body_vel, &controls, resolve_rel_source);
 
-        assert_eq!(kernel.grav_accel, plain.grav_accel);
+        assert_eq!(kernel.grav_accel.raw_si(), plain.grav_accel);
         assert_eq!(kernel.grav_pot, plain.grav_pot);
         assert_eq!(kernel.grav_grad, plain.grav_grad);
     }

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -85,8 +85,8 @@ pub use frame_orchestration::{
 };
 pub use gravity::{
     accumulate_gravity, accumulate_gravity_typed, accumulate_relativistic_corrections,
-    accumulate_relativistic_corrections_typed, evaluate_body_gravity, evaluate_body_gravity_typed,
-    run_gravity_stage, GravityBodyInputs, ResolvedRelativisticSource, ResolvedSource,
+    accumulate_relativistic_corrections_typed, evaluate_body_gravity_typed, run_gravity_stage,
+    GravityBodyInputs, ResolvedRelativisticSource, ResolvedSource,
 };
 pub use integrable::IntegrableObject;
 pub use integration::{


### PR DESCRIPTION
Closes #364 — sub-issue of #365 (architectural remediation tracker for #352 audit).

## Summary

After the per-body gravity kernel landed in #366, the runner and the Bevy adapter ran the same `run_gravity_stage` driver but stored its output in two different shapes:

- **Bevy** (`GravityAccelerationC`): typed `GravityAccelerationTyped<RootInertial>` (the production shape).
- **Runner** (`SimBody.gravity_accel`): untyped `GravityAcceleration` (raw `DVec3` triple).

The split forced the runner's store closure to lower the typed kernel result back to raw fields (`result.grav_accel.raw_si()` / `result.grav_grad` / `result.grav_pot`) every step, and it forced `jeod_sim::gravity` to ship a raw `evaluate_body_gravity` sibling alongside `evaluate_body_gravity_typed` purely as a bridge for the runner's storage layout.

This PR aligns `SimBody.gravity_accel` with the Bevy adapter's typed shape, so both adapters now write the same `GravityAccelerationTyped<RootInertial>` value through their store closures. The runner's closure collapses from three field assignments to a single `*gravity_accel_slot = result`. The raw `evaluate_body_gravity` sibling has no remaining caller and is removed; only `evaluate_body_gravity_typed` is kept in `jeod_sim::gravity`.

## Concrete changes

### `crates/jeod_runner/src/simulation/types.rs`
- `SimBody.gravity_accel`: `GravityAcceleration` → `GravityAccelerationTyped<RootInertial>`.
- `SimBody::from_config` initializes via `GravityAccelerationTyped::<RootInertial>::default()`.
- Imports add `GravityAccelerationTyped` + `RootInertial` from `jeod_sim`, drop `GravityAcceleration`.

### `crates/jeod_runner/src/simulation/step/environment.rs`
- The store closure passed to `run_gravity_stage` becomes `*gravity_accel_slot = result;` (was three `.grav_accel`/`.grav_grad`/`.grav_pot` field assignments with a `result.grav_accel.raw_si()` lowering on the acceleration component).
- Comment updated: both adapters now share the same storage type, so the closure is a direct move on both sides.

### `crates/jeod_runner/src/simulation/step/integrate.rs`
- Three call sites read `body.gravity_accel.grav_accel` into raw `DVec3` arithmetic and gain `.raw_si()` at the typed→raw boundary:
  - `collect_and_resolve_forces` — untyped force-collection kernel.
  - Wrench-aggregation writeback (with-mass branch) — assigns into untyped `frame_derivs.trans_accel`.
  - Wrench-aggregation writeback (no-mass branch) — same.
- Each boundary hop is annotated with an `// allowed: typed→raw boundary` comment.

### `crates/jeod_sim/src/gravity.rs`
- Removes the raw `evaluate_body_gravity` function (no remaining caller).
- Folds the redundant `evaluate_body_gravity_typed_matches_raw` test (raw-vs-typed equivalence — obsolete with raw gone) into the existing `evaluate_body_gravity_matches_manual_composition` test, which now exercises the typed kernel against the open-coded shift-then-accumulate reference.
- Converts the `evaluate_body_gravity_zero_origin_matches_plain_accumulate` test to drive the typed kernel.
- Updates the `run_gravity_stage` rustdoc to drop the "raw runner / typed Bevy" distinction — both adapters move the typed value through.

### `crates/jeod_sim/src/lib.rs`
- Drops the `evaluate_body_gravity` re-export.

## Why the closure form survives

The closure-vs-trait choice in #366 was decided on orphan-rule grounds (a `GravityAccelOut` trait could not be impl'd on `Mut<'_, GravityAccelerationC>` from outside `bevy_ecs`). With this migration, both store sites write the same `GravityAccelerationTyped<RootInertial>` type, so a trait impl would now be feasible — but the closure form remains correct and idiomatic for what each adapter needs to do (Bevy writes through `Mut`, the runner writes through `&mut`). The trait would buy nothing the closure doesn't already.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` — clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1184 passed
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- [x] `cargo test --test invariant_coverage` — 6 passed
- [x] `cargo nextest run -p jeod_runner --test tier3_sim_dyncomp_run2` — 2 passed (Tier 3 spec smoke)
- [x] `cargo nextest run -p jeod_runner -E 'test(tier3_) and not test(tier3_simulation_earth_moon)'` — 190 passed
- [x] Tier 3 baselines byte-identical — pure type-level migration, no math change

🤖 Generated with [Claude Code](https://claude.com/claude-code)