### PR TITLE
[#361] Drop stale issue refs from jeod_sim curation comment

### DIFF
--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -142,13 +142,13 @@ pub use wrench::{aggregate_wrenches_via_storage, edge_geometry_from_composites, 
 
 // ── Re-exports from jeod_* crates ──
 //
-// Curation criteria (audit §2.4 — issue #361):
+// Curation criteria (audit §2.4):
 //
 // 1. `bevy_jeod` and any mission crate depend only on `jeod_sim` (per
 //    CLAUDE.md "Three-Layer Architecture"), so every type a mission
 //    crate reaches must be reachable through here.
 // 2. `jeod_runner` is a parallel non-Bevy consumer that *may* depend
-//    directly on the `jeod_*` physics crates (issue #360 / audit §2.3).
+//    directly on the `jeod_*` physics crates (audit §2.3).
 //    Items that are needed only by `jeod_runner` are imported there
 //    directly, not surfaced on the `jeod_sim` API.
 // 3. Items that no consumer reaches are dropped — every entry below


### PR DESCRIPTION
## Summary

Follow-up to #374 addressing the NEEDS_FIX verdict from the independent
review (https://github.com/simnaut/bevy_jeod/pull/374#issuecomment-4386955292).

#374 was merged before the fix landed, so this is a separate hygiene PR
on top of main.

The new curation-criteria block in `crates/jeod_sim/src/lib.rs`
introduced two `#NNN` issue references (`#361` on line 145, `#360` on
line 151), which violate the project's no-`#NNN`-in-source policy. The
audit-section refs (`audit §2.4`, `audit §2.3`) are stable doc anchors
and stay. The issue numbers — which the PR description and git log
already capture for archaeology — come out of the source comment.

## Changes

- `crates/jeod_sim/src/lib.rs`: drop `issue #361` and `issue #360`
  references from the curation-criteria block. No code change, no
  behavior change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (1185 passed)
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` (36 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --test invariant_coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)