### PR TITLE
[#380] Migrate SimBody.atmospheric_state to typed sibling, retire raw evaluate_body_atmosphere

### DIFF
--- a/crates/jeod_runner/src/simulation/bodies.rs
+++ b/crates/jeod_runner/src/simulation/bodies.rs
@@ -696,12 +696,13 @@ impl Simulation {
 
     /// Toggle a body's aerodynamic drag configuration mid-run.
     ///
-    /// `Some(cfg)` enables drag with the supplied parameters and primes
-    /// the body's per-step `AtmosphereState` storage so the next
-    /// `Simulation::step()` evaluates the atmosphere model. `None`
-    /// disables drag and clears the cached atmospheric state — the
-    /// body's drag and atmosphere-evaluation passes both no-op until
-    /// the setter is called again with `Some`.
+    /// `Some(cfg)` enables drag with the supplied parameters; the
+    /// body's atmospheric-state slot is unconditionally present and
+    /// the next `Simulation::step()` will fill it via the atmosphere
+    /// stage (gated on `body.drag.is_some()`). `None` disables drag
+    /// and resets the cached atmospheric state to `default()` so a
+    /// subsequent re-enable starts from a clean slot rather than a
+    /// stale density from before the toggle.
     ///
     /// Used by Tier 3 sims that toggle the atmosphere mid-trajectory
     /// (`SIM_dyncomp/RUN_attach_to_ref_frame` disables atmosphere at
@@ -720,21 +721,15 @@ impl Simulation {
             "set_body_drag: body index {idx} out of range (have {} bodies)",
             self.bodies.len()
         );
-        if drag.is_some() {
-            // Prime an `AtmosphereState` slot if one is missing so the
-            // first post-toggle step evaluates the atmosphere; existing
-            // state is left in place (the drag config change shouldn't
-            // discard a freshly evaluated density).
-            if self.bodies[idx].atmospheric_state.is_none() {
-                self.bodies[idx].atmospheric_state = Some(jeod_sim::AtmosphereState::default());
-            }
-        } else {
-            // Clear the atmospheric-state slot too — a `None` drag
-            // config combined with a `Some` atmospheric_state would
-            // leave the body's atmosphere-evaluation pass running each
-            // step without consuming the result, wasting work and
-            // confusing readers about the body's actual configuration.
-            self.bodies[idx].atmospheric_state = None;
+        if drag.is_none() {
+            // Reset the cached atmospheric state when drag is turned
+            // off so the slot doesn't leak stale density values into
+            // any later re-enable cycle. The atmosphere-evaluation
+            // pass is already gated on `body.drag.is_some()`, so the
+            // slot's contents are inert while drag is off — clearing
+            // is purely hygienic, mirroring the pre-migration
+            // `atmospheric_state = None` behavior.
+            self.bodies[idx].atmospheric_state = jeod_sim::AtmosphereState::default();
         }
         self.bodies[idx].drag = drag;
     }

--- a/crates/jeod_runner/src/simulation/step/environment.rs
+++ b/crates/jeod_runner/src/simulation/step/environment.rs
@@ -6,8 +6,8 @@
 //!
 //! JEOD_INV: TS.01 — this module is the atmosphere-stage adapter for
 //! the runner's planet-erased storage. `SimBody.atmospheric_state` is
-//! `Option<AtmosphereState<SelfPlanet>>` because the runner's
-//! atmosphere planet identity is keyed by a runtime source index
+//! `AtmosphereState<SelfPlanet>` because the runner's atmosphere
+//! planet identity is keyed by a runtime source index
 //! (`atmosphere_planet_source: Option<usize>`), not by a compile-time
 //! `<P: Planet>` parameter. The `<SelfPlanet>`-tagged kernel call and
 //! the `Position<PlanetInertial<SelfPlanet>>` relabel below are the
@@ -128,23 +128,22 @@ impl Simulation {
                 .map(|pfix_id| &self.frame_tree.get(pfix_id).state.rot.t_parent_this);
             let tai_tjt = Some(self.time.tai_tjt);
 
-            // Project each `(idx, &mut SimBody)` row that has an
-            // active `atmospheric_state` slot into the
-            // `(key, inputs, store)` triple `run_atmosphere_stage`
-            // expects. `body.atmospheric_state.is_some()` is the runner
-            // analog of "entity has `AtmosphericStateC`" in the Bevy
-            // adapter — both gate the kernel call so untouched bodies
-            // keep their stored `None` / absent component. The store
-            // closure captures `&mut body.atmospheric_state` and erases
-            // the typed `<SelfPlanet>` result back into the runner's
-            // planet-keyed-at-runtime storage; the Bevy adapter, which
-            // stores `AtmosphericStateC<P>`, moves the planet-tagged
-            // value through unchanged.
+            // Project each `(idx, &mut SimBody)` row whose drag config
+            // is active into the `(key, inputs, store)` triple
+            // `run_atmosphere_stage` expects. `body.drag.is_some()` is
+            // the runner analog of "entity has `DragConfigC`
+            // (auto-inserts `AtmosphericStateC`)" in the Bevy
+            // adapter — both gate the kernel call so non-drag bodies
+            // keep their stored default. The store closure captures
+            // `&mut body.atmospheric_state` and moves the typed
+            // `<SelfPlanet>` result through unchanged; the Bevy
+            // adapter, which stores `AtmosphericStateC<P>`, moves the
+            // planet-tagged value through unchanged.
             let body_iter = self
                 .bodies
                 .iter_mut()
                 .enumerate()
-                .filter(|(_, body)| body.atmospheric_state.is_some())
+                .filter(|(_, body)| body.drag.is_some())
                 .map(|(body_idx, body)| {
                     let inputs = AtmosphereBodyInputs {
                         position:
@@ -154,7 +153,7 @@ impl Simulation {
                     };
                     let slot = &mut body.atmospheric_state;
                     let store = move |result: jeod_sim::AtmosphereState<SelfPlanet>| {
-                        *slot = Some(result);
+                        *slot = result;
                     };
                     (body_idx, inputs, store)
                 });

--- a/crates/jeod_runner/src/simulation/step/interactions.rs
+++ b/crates/jeod_runner/src/simulation/step/interactions.rs
@@ -70,11 +70,10 @@ impl Simulation {
             // Aerodynamic drag — uses planet-centered velocity (NOT a
             // shift site; see comment above).
             body.aero_force = None;
-            if let (Some(ref drag_config), Some(ref atmos)) = (&body.drag, &body.atmospheric_state)
-            {
+            if let Some(ref drag_config) = body.drag {
                 body.aero_force = Some(jeod_sim::compute_drag(
                     drag_config,
-                    atmos,
+                    &body.atmospheric_state,
                     body.trans.velocity.raw_si(),
                     body.rot.as_ref(),
                     body.t_struct_body,

--- a/crates/jeod_runner/src/simulation/types.rs
+++ b/crates/jeod_runner/src/simulation/types.rs
@@ -251,7 +251,16 @@ pub(crate) struct SimBody {
     pub shadow_body: Option<(usize, f64)>,
     pub t_struct_body: DMat3,
     pub compute_gravity_torque: bool,
-    pub atmospheric_state: Option<AtmosphereState<SelfPlanet>>,
+    /// Per-body atmospheric state slot.
+    ///
+    /// Always present; the runner's atmosphere stage gates execution on
+    /// `body.drag.is_some()` (the same predicate that decides whether
+    /// the slot was previously primed). This mirrors the Bevy adapter's
+    /// `AtmosphericStateC<P>`, which `DragConfigC` auto-inserts via
+    /// `#[require(...)]` — both consumers now carry the typed slot
+    /// unconditionally and use a separate config-presence predicate to
+    /// decide whether to fill it.
+    pub atmospheric_state: AtmosphereState<SelfPlanet>,
     pub external_force: DVec3,
     pub external_torque: DVec3,
     /// Externally applied force in the body's structural frame (N).
@@ -331,13 +340,6 @@ impl SimBody {
 
         let shadow_body = config.shadow_body.map(|sb| (sb.source_idx, sb.radius));
 
-        let has_drag = config.drag.is_some();
-        let atmospheric_state = if has_drag {
-            Some(AtmosphereState::<SelfPlanet>::default())
-        } else {
-            None
-        };
-
         Self {
             // VehicleConfig::trans is documented as integration-frame; wrap
             // the untyped storage with the IntegrationFrame phantom so
@@ -359,7 +361,7 @@ impl SimBody {
             shadow_body,
             t_struct_body: config.t_struct_body,
             compute_gravity_torque: config.compute_gravity_gradient,
-            atmospheric_state,
+            atmospheric_state: AtmosphereState::<SelfPlanet>::default(),
             external_force: config.external_force,
             external_torque: config.external_torque,
             external_force_struct: DVec3::ZERO,

--- a/crates/jeod_runner/src/simulation/validate.rs
+++ b/crates/jeod_runner/src/simulation/validate.rs
@@ -101,8 +101,12 @@ impl Simulation {
                 }
             }
 
-            // Atmospheric state requires atmosphere config on the simulation
-            if body.atmospheric_state.is_some() && self.atmosphere.is_none() {
+            // Drag requires atmosphere config on the simulation. (After
+            // the typed-storage migration the per-body atmospheric
+            // state is unconditionally present; drag presence is the
+            // discriminator that decides whether the atmosphere stage
+            // fills it, so the validation key is now `body.drag`.)
+            if body.drag.is_some() && self.atmosphere.is_none() {
                 all_errors.push(ValidationError::AtmosphericStateWithoutAtmosphere { body_idx });
             }
 

--- a/crates/jeod_sim/src/atmosphere.rs
+++ b/crates/jeod_sim/src/atmosphere.rs
@@ -4,12 +4,13 @@
 //! the configured density / temperature / wind model.
 //!
 //! JEOD_INV: TS.01 — the `<SelfPlanet>`-tagged returns from the untyped
-//! [`evaluate_atmosphere`] entry point exist for runner storage whose
-//! planet identity is keyed by a dynamic source index. Mission code
-//! that knows the planet at compile time uses the
-//! [`evaluate_atmosphere_typed`] sibling, which carries `<P: Planet>`
-//! end-to-end. The lint at `tests/self_ref_self_planet_discipline.rs`
-//! enforces this discipline globally.
+//! [`evaluate_atmosphere`] entry point exist for adapter storage whose
+//! planet identity is keyed by a dynamic source index (the runner's
+//! `atmosphere_planet_source: Option<usize>`). Mission code that knows
+//! the planet at compile time uses the [`evaluate_atmosphere_typed`]
+//! sibling, which carries `<P: Planet>` end-to-end. The lint at
+//! `tests/self_ref_self_planet_discipline.rs` enforces this discipline
+//! globally.
 
 use glam::{DMat3, DVec3};
 use jeod_atmosphere::exponential::ExponentialAtmosphere;
@@ -226,24 +227,6 @@ pub fn evaluate_body_atmosphere_typed<P: Planet>(
     evaluate_atmosphere_typed::<P>(config, position, t_inertial_pfix, tai_tjt)
 }
 
-/// Raw sibling of [`evaluate_body_atmosphere_typed`] for adapters whose
-/// storage is the planet-erased [`AtmosphereState<SelfPlanet>`]
-/// (currently `jeod_runner::SimBody.atmospheric_state`). Same
-/// non-shift discipline as the typed entry point — `position` is
-/// already in the atmosphere planet's inertial frame.
-// JEOD_INV: AT.01 — active flag gates computation (caller checks presence)
-// JEOD_INV: AT.02 — atmosphere model pointer non-null (caller provides config)
-// JEOD_INV: AT.03 — planet-fixed position required for geodetic altitude
-// JEOD_INV: AT.04 — wind velocity computed as omega x position (co-rotation)
-pub fn evaluate_body_atmosphere(
-    config: &AtmosphereConfig,
-    position: DVec3,
-    t_inertial_pfix: Option<&DMat3>,
-    tai_tjt: Option<f64>,
-) -> AtmosphereState<SelfPlanet> {
-    evaluate_atmosphere(config, position, t_inertial_pfix, tai_tjt)
-}
-
 /// Per-body inputs the atmosphere stage driver consumes.
 ///
 /// Mirrors [`crate::gravity::GravityBodyInputs`] in shape: each adapter
@@ -272,11 +255,12 @@ pub struct AtmosphereBodyInputs<P: Planet> {
 ///    geodetic altitude must be measured against the atmosphere
 ///    planet's center, not against the simulation root.
 /// 2. Hands the result to the per-body `store` closure, which writes
-///    it back into adapter-owned storage. Adapters that store
-///    `AtmosphereState<P>` (the Bevy `AtmosphericStateC<P>` newtype)
-///    move the value through; adapters that store the planet-erased
-///    `AtmosphereState<SelfPlanet>` (the runner) erase via
-///    [`AtmosphereState::relabel`] inside the closure.
+///    it back into adapter-owned storage. Both adapters now store the
+///    typed [`AtmosphereState<P>`] (the Bevy `AtmosphericStateC<P>`
+///    newtype with `<P>` pinned at the type level, the runner with
+///    `<P> = SelfPlanet` because its planet identity is keyed by a
+///    runtime source index), so each closure is a direct move on the
+///    adapter's mutable handle.
 ///
 /// `config`, `t_inertial_pfix`, and `tai_tjt` are stage-level constants
 /// (planet-keyed atmosphere model, planet-fixed rotation, time tag) and
@@ -289,7 +273,7 @@ pub struct AtmosphereBodyInputs<P: Planet> {
 ///
 /// The closure-based writer mirrors the gravity stage: each adapter
 /// uses whatever mutable handle its iterator yields
-/// (`Mut<'_, AtmosphericStateC<P>>` for Bevy, `&mut Option<AtmosphereState<SelfPlanet>>`
+/// (`Mut<'_, AtmosphericStateC<P>>` for Bevy, `&mut AtmosphereState<SelfPlanet>`
 /// for the runner) without a trait impl on a foreign type.
 pub fn run_atmosphere_stage<P, K, Store, BodyIter>(
     bodies: BodyIter,
@@ -316,7 +300,8 @@ mod tests {
     use jeod_quantities::frame::Earth;
 
     /// Build a plain exponential-atmosphere config with no co-rotation
-    /// wind so the kernel-vs-raw comparisons are bit-identical.
+    /// wind so the typed-kernel-vs-`evaluate_atmosphere` comparison is
+    /// bit-identical.
     fn earth_exponential_config() -> AtmosphereConfig {
         AtmosphereConfig {
             model: AtmosphereModel::Exponential(ExponentialAtmosphere::default()),
@@ -326,39 +311,27 @@ mod tests {
         }
     }
 
-    /// `evaluate_body_atmosphere` (raw) reproduces the call sequence the
-    /// runner has carried since before the kernel existed: pass body
-    /// position in the atmosphere planet's inertial frame straight to
-    /// `evaluate_atmosphere` — *no* `IntegOrigin` shift.
+    /// `evaluate_body_atmosphere_typed` reproduces the open-coded
+    /// `evaluate_atmosphere` sequence the runner has carried since
+    /// before the kernel existed: pass body position in the atmosphere
+    /// planet's inertial frame straight to `evaluate_atmosphere` —
+    /// *no* `IntegOrigin` shift. The typed kernel is a relabel-only
+    /// wrapper, so `Position<PlanetInertial<P>> -> AtmosphereState<P>`
+    /// returns numerics bit-identical to the planet-erased
+    /// `evaluate_atmosphere` reference.
     #[test]
-    fn evaluate_body_atmosphere_matches_evaluate_atmosphere() {
-        let config = earth_exponential_config();
-        let position = DVec3::new(7e6, 1e5, -2e5);
-
-        let kernel = evaluate_body_atmosphere(&config, position, None, None);
-        let manual = evaluate_atmosphere(&config, position, None, None);
-
-        assert_eq!(kernel.density, manual.density);
-        assert_eq!(kernel.temperature, manual.temperature);
-        assert_eq!(kernel.pressure, manual.pressure);
-        assert_eq!(kernel.wind.raw_si(), manual.wind.raw_si());
-    }
-
-    /// Typed kernel produces the same numbers as the raw kernel — the
-    /// typed sibling is a relabel-only wrapper.
-    #[test]
-    fn evaluate_body_atmosphere_typed_matches_raw() {
+    fn evaluate_body_atmosphere_typed_matches_evaluate_atmosphere() {
         let config = earth_exponential_config();
         let raw_position = DVec3::new(7e6, 1e5, -2e5);
         let typed_position = Position::<PlanetInertial<Earth>>::from_raw_si(raw_position);
 
-        let raw = evaluate_body_atmosphere(&config, raw_position, None, None);
+        let manual = evaluate_atmosphere(&config, raw_position, None, None);
         let typed = evaluate_body_atmosphere_typed::<Earth>(&config, typed_position, None, None);
 
-        assert_eq!(typed.density, raw.density);
-        assert_eq!(typed.temperature, raw.temperature);
-        assert_eq!(typed.pressure, raw.pressure);
-        assert_eq!(typed.wind.raw_si(), raw.wind.raw_si());
+        assert_eq!(typed.density, manual.density);
+        assert_eq!(typed.temperature, manual.temperature);
+        assert_eq!(typed.pressure, manual.pressure);
+        assert_eq!(typed.wind.raw_si(), manual.wind.raw_si());
     }
 
     /// Type alias for the row-tuple shape `run_atmosphere_stage`

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -77,9 +77,8 @@ pub mod wrench;
 
 // ── Orchestration functions ──
 pub use atmosphere::{
-    evaluate_atmosphere, evaluate_atmosphere_typed, evaluate_body_atmosphere,
-    evaluate_body_atmosphere_typed, run_atmosphere_stage, AtmosphereBodyInputs, AtmosphereConfig,
-    AtmosphereModel,
+    evaluate_atmosphere, evaluate_atmosphere_typed, evaluate_body_atmosphere_typed,
+    run_atmosphere_stage, AtmosphereBodyInputs, AtmosphereConfig, AtmosphereModel,
 };
 pub use attach::{
     stage_attach_combine, stage_detach_capture, CrossIntegFrameStateShift, StageAttachInputs,

--- a/crates/jeod_sim/src/validation.rs
+++ b/crates/jeod_sim/src/validation.rs
@@ -61,7 +61,7 @@ pub enum ValidationError {
     GaussJacksonConfigInvalid { body_idx: usize, detail: String },
     /// ABM4 integrator with rotational_dynamics=true (6-DOF not supported).
     Abm4With6Dof { body_idx: usize },
-    /// Body has `atmospheric_state` but simulation has no atmosphere config.
+    /// Body has a drag config but simulation has no atmosphere config.
     AtmosphericStateWithoutAtmosphere { body_idx: usize },
     /// Body has `compute_solar_beta=true` but simulation has no `sun_source`.
     SolarBetaWithoutSunSource { body_idx: usize },
@@ -272,7 +272,7 @@ impl std::fmt::Display for ValidationError {
             Self::AtmosphericStateWithoutAtmosphere { body_idx } => {
                 write!(
                     f,
-                    "Body {body_idx}: atmospheric_state is set but simulation has no \
+                    "Body {body_idx}: drag is configured but simulation has no \
                      atmosphere config. Set Simulation::atmosphere to enable atmosphere \
                      evaluation."
                 )


### PR DESCRIPTION
Closes #380 — sub-issue of #365 (architectural remediation tracker for #352 audit).

## Summary

After the per-body atmosphere kernel landed in #376, the runner and the Bevy adapter ran the same `run_atmosphere_stage` driver but stored its output in two different shapes:

- **Bevy** (`AtmosphericStateC<P>`): typed `AtmosphereState<P>`, planet-pinned (the production shape).
- **Runner** (`SimBody.atmospheric_state`): `Option<AtmosphereState<SelfPlanet>>`, planet-erased because the runner's atmosphere planet identity is keyed by a runtime `atmosphere_planet_source: Option<usize>`.

The split forced the runner's store closure to wrap the typed kernel result in `Some(...)` every step, and it forced `jeod_sim::atmosphere` to ship a raw `evaluate_body_atmosphere` sibling alongside `evaluate_body_atmosphere_typed` purely as a bridge for the runner's storage layout.

This PR aligns `SimBody.atmospheric_state` with the Bevy adapter's typed shape (always-present, planet-pinned via `<SelfPlanet>`), so both adapters now write the same `AtmosphereState<P>` value through their store closures. The runner's closure collapses from `*slot = Some(result)` to `*slot = result`. The participation predicate moves from `body.atmospheric_state.is_some()` to `body.drag.is_some()` — the same predicate the Bevy adapter uses implicitly via `DragConfigC`'s `#[require(AtmosphericStateC<Earth>)]` auto-insert. The raw `evaluate_body_atmosphere` sibling has no remaining caller and is removed; only `evaluate_body_atmosphere_typed` is kept in `jeod_sim::atmosphere`.

## Concrete changes

### `crates/jeod_runner/src/simulation/types.rs`
- `SimBody.atmospheric_state`: `Option<AtmosphereState<SelfPlanet>>` → `AtmosphereState<SelfPlanet>` (always present).
- `SimBody::from_config` initializes via `AtmosphereState::<SelfPlanet>::default()` unconditionally, dropping the `has_drag`-keyed `Option` initialization.

### `crates/jeod_runner/src/simulation/step/environment.rs`
- Atmosphere stage participation predicate flips from `body.atmospheric_state.is_some()` to `body.drag.is_some()` — same semantic, but now keyed on the actual config field rather than on a slot the kernel was about to overwrite anyway.
- The store closure passed to `run_atmosphere_stage` becomes `*slot = result;` (was `*slot = Some(result);`).
- Comment updated: both adapters now share the same typed storage shape, so the closure is a direct move on both sides.
- Module-doc TS.01 marker updated to drop the `Option<...>` annotation.

### `crates/jeod_runner/src/simulation/step/interactions.rs`
- Drag's force-collection branch reads `body.atmospheric_state` directly (was `Some(ref atmos)` match arm). Single `if let Some(ref drag_config) = body.drag` gates the kernel call.

### `crates/jeod_runner/src/simulation/validate.rs`
- `AtmosphericStateWithoutAtmosphere` validation key flips from `body.atmospheric_state.is_some()` to `body.drag.is_some()` — same predicate, expressed against the actual config field.

### `crates/jeod_runner/src/simulation/bodies.rs`
- `set_body_drag` no longer manages an `Option` slot. On drag-off it resets the slot to `default()` (preserving the pre-migration "no stale density across re-enable" hygiene); on drag-on it does nothing slot-side because the slot is always present and the next step's atmosphere stage will overwrite it anyway.

### `crates/jeod_sim/src/atmosphere.rs`
- Removes the raw `evaluate_body_atmosphere` function (no remaining caller).
- Folds the obsolete `evaluate_body_atmosphere_matches_evaluate_atmosphere` and `evaluate_body_atmosphere_typed_matches_raw` tests into a single `evaluate_body_atmosphere_typed_matches_evaluate_atmosphere` test that exercises the typed kernel against the open-coded `evaluate_atmosphere` reference.
- Updates the `run_atmosphere_stage` rustdoc + closure-shape comment to drop the "raw runner / typed Bevy" distinction — both adapters move the typed value through.
- Module-doc TS.01 marker updated to drop the runner-specific `Option<...>` framing.

### `crates/jeod_sim/src/lib.rs`
- Drops the `evaluate_body_atmosphere` re-export.

### `crates/jeod_sim/src/validation.rs`
- `AtmosphericStateWithoutAtmosphere` doc + display reword to reflect the drag-keyed semantics ("drag is configured but simulation has no atmosphere config").

## Why the closure form survives

Same reason as #377's gravity migration: both store sites now write the same `AtmosphereState<P>` type, so a trait impl would be feasible — but the closure form remains correct and idiomatic for what each adapter needs to do (Bevy writes through `Mut`, the runner writes through `&mut`). The trait would buy nothing the closure doesn't already.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` — clean
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1187 passed
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- [x] `cargo test --test invariant_coverage` — 6 passed
- [x] `cargo nextest run -p jeod_runner -E 'test(tier3_) and (test(run5) or test(drag))'` — 28 passed
- [x] Tier 3 atmosphere/drag baselines byte-identical — pure type-level migration, no math change

🤖 Generated with [Claude Code](https://claude.com/claude-code)