### PR TITLE
[#382] Migrate canonical-template Tier 3 cadence-skip to is_on_integrator_cadence

### DIFF
--- a/crates/jeod_runner/tests/tier3_sim_ref_attach.rs
+++ b/crates/jeod_runner/tests/tier3_sim_ref_attach.rs
@@ -73,6 +73,7 @@ use jeod_sim::{
     JeodQuat, MassProperties, RotationalState, SimulationBuilder, TranslationalState,
     VehicleBuilder,
 };
+use jeod_test_data::crossval::CrossvalReport;
 
 const SIM_DURATION_S: f64 = 100.0;
 const ATTACH_TIME_S: f64 = 50.0;
@@ -297,7 +298,7 @@ fn tier3_sim_ref_attach_matrix() {
         // compare an integer-second state against the half-second
         // CSV row at indices that don't correspond to an
         // integration step.
-        if (row.time - row.time.round()).abs() > 1e-6 {
+        if !CrossvalReport::is_on_integrator_cadence(row.time, DT_S) {
             continue;
         }
         // Step until our sim time matches the row's logged time.
@@ -454,7 +455,7 @@ fn tier3_sim_ref_attach_pt2pt() {
         // 0.5 s, so the half-second rows hold the integrator output
         // from the previous integer second. Comparing only at integer
         // seconds keeps our integration cadence aligned with JEOD's.
-        if (row.time - row.time.round()).abs() > 1e-6 {
+        if !CrossvalReport::is_on_integrator_cadence(row.time, DT_S) {
             continue;
         }
         sim.step_until(row.time).expect("step_until must not fail");


### PR DESCRIPTION
## Summary

PR #369 (issue #355) shipped `CrossvalReport::is_on_integrator_cadence(row_time, integrator_dt) -> bool` and named `crates/jeod_runner/tests/tier3_sim_ref_attach.rs` as the canonical template for the per-row cadence-skip pattern in both `tests/README.md` and the helper's own docstring. The file itself, however, still used the pre-existing inline `(row.time - row.time.round()).abs() > 1e-6` form at both per-row skip sites — a documentation-vs-implementation drift that means future authors copying from the named template would copy the older inline form rather than the helper it documents.

This PR migrates the two call sites onto `CrossvalReport::is_on_integrator_cadence(row.time, DT_S)`. At this file's `dt = 1.0 s` the two are functionally equivalent (the helper docstring already acknowledges the coincidence), so behaviour is byte-identical.

## Changes

- `crates/jeod_runner/tests/tier3_sim_ref_attach.rs`:
  - Add `use jeod_test_data::crossval::CrossvalReport;`.
  - Replace the inline cadence skip at lines 300 and 457 with `if !CrossvalReport::is_on_integrator_cadence(row.time, DT_S) { continue; }`.
  - Surrounding rationale comments are preserved verbatim.

## Non-goals

- No new helper logic; this is a pure call-site migration.
- Other Tier 3 tests using the inline form (`tier3_sim_dyncomp_run*` recipe-delegating tests, etc.) are out of scope per the ticket — only the canonical-template file is migrated.

## Local checks

- `cargo fmt --check` clean
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` clean
- `cargo nextest run --workspace -E 'not test(tier3_)'` 1188 / 1188 pass
- `cargo nextest run --workspace -E 'test(bevy_parity_)'` 36 / 36 pass
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` clean
- `cargo test --test invariant_coverage` 6 / 6 pass
- `bash scripts/check_no_escape_hatches.sh` clean
- `cargo nextest run -p jeod_runner --test tier3_sim_ref_attach` 2 / 2 pass — the behavioural-equivalence safety net

## Test plan

- [x] Both `tier3_sim_ref_attach_matrix` and `tier3_sim_ref_attach_pt2pt` continue to pass with byte-identical behaviour.
- [x] README + `assert_cadence_matches`/`is_on_integrator_cadence` docstrings continue to point at this file as canonical template, now consistent with the helper they document.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)