### PR TITLE
[#379] jeod_sim-owned newtypes for integrator vocabulary (audit §2.4)

### DIFF
--- a/crates/jeod_runner/src/simulation/mass_tree.rs
+++ b/crates/jeod_runner/src/simulation/mass_tree.rs
@@ -2511,7 +2511,7 @@ mod tests {
         // Splice GJ8 state onto cm post-validate (validate forbids
         // GJ+6DOF; we're exercising the inline reset block defensively).
         let cfg = GaussJacksonConfig::with_order(8);
-        let mut gj = jeod_dynamics::GaussJacksonState::new(cfg);
+        let mut gj = jeod_dynamics::GaussJacksonState::new(cfg.into());
         drive_gj_past_priming(&mut gj);
         assert!(!gj.is_topology_dirty());
         sim.bodies[cm_idx].gj_state = Some(gj);
@@ -2609,7 +2609,7 @@ mod tests {
         // Splice GJ8 state onto cm AFTER the detach so
         // attach_subtree_aligned's reset block has something to clear.
         let cfg = GaussJacksonConfig::with_order(8);
-        let mut gj = jeod_dynamics::GaussJacksonState::new(cfg);
+        let mut gj = jeod_dynamics::GaussJacksonState::new(cfg.into());
         drive_gj_past_priming(&mut gj);
         assert!(!gj.is_topology_dirty());
         sim.bodies[cm_idx].gj_state = Some(gj);
@@ -2682,7 +2682,7 @@ mod tests {
     #[should_panic(expected = "topology")]
     fn dirty_gauss_jackson_state_panics_on_integrate() {
         let cfg = GaussJacksonConfig::with_order(8);
-        let mut gj = jeod_dynamics::GaussJacksonState::new(cfg);
+        let mut gj = jeod_dynamics::GaussJacksonState::new(cfg.into());
         drive_gj_past_priming(&mut gj);
 
         // Simulate a regression where Site A (mark) fired but Site B

--- a/crates/jeod_runner/src/simulation/step/integrate.rs
+++ b/crates/jeod_runner/src/simulation/step/integrate.rs
@@ -504,7 +504,10 @@ impl Simulation {
                         body.total_force.torque,
                         dt,
                         time_scale_factor,
-                        body.integrator,
+                        // Runner stores the raw jeod_dynamics enum; the
+                        // jeod_sim kernel takes the wrapped flavor —
+                        // convert at the boundary (cheap copy).
+                        body.integrator.into(),
                         body.gj_state.as_mut(),
                         body.abm4_state.as_mut(),
                     );

--- a/crates/jeod_runner/src/simulation/types.rs
+++ b/crates/jeod_runner/src/simulation/types.rs
@@ -352,7 +352,13 @@ impl SimBody {
             frame_attach: None,
             config: dynamics_config,
             gravity_controls: config.gravity_controls,
-            integrator: config.integrator,
+            // Convert at the runner boundary: VehicleConfig carries the
+            // jeod_sim-owned IntegratorType (mission-facing contract);
+            // SimBody stores jeod_dynamics::IntegratorType because the
+            // runner can depend on jeod_dynamics directly (#360) and
+            // wants the raw enum for its own integrate/validate
+            // dispatch.
+            integrator: config.integrator.into(),
             drag: config.drag,
             flat_plate_state,
             cannonball_srp,

--- a/crates/jeod_runner/src/simulation/types.rs
+++ b/crates/jeod_runner/src/simulation/types.rs
@@ -355,9 +355,8 @@ impl SimBody {
             // Convert at the runner boundary: VehicleConfig carries the
             // jeod_sim-owned IntegratorType (mission-facing contract);
             // SimBody stores jeod_dynamics::IntegratorType because the
-            // runner can depend on jeod_dynamics directly (#360) and
-            // wants the raw enum for its own integrate/validate
-            // dispatch.
+            // runner can depend on jeod_dynamics directly and wants the
+            // raw enum for its own integrate/validate dispatch.
             integrator: config.integrator.into(),
             drag: config.drag,
             flat_plate_state,

--- a/crates/jeod_runner/tests/tier3_sim_attach_detach_trajectory.rs
+++ b/crates/jeod_runner/tests/tier3_sim_attach_detach_trajectory.rs
@@ -55,8 +55,9 @@
 use std::path::PathBuf;
 
 use glam::{DMat3, DVec3};
-use jeod_dynamics::{IntegratorType, MassProperties};
+use jeod_dynamics::MassProperties;
 use jeod_runner::Simulation;
+use jeod_sim::IntegratorType;
 use jeod_sim::{
     GravityControls, JeodQuat, RotationalState, SimulationTime, TranslationalState, VehicleConfig,
 };

--- a/crates/jeod_runner/tests/tier3_sim_complex_attach_detach.rs
+++ b/crates/jeod_runner/tests/tier3_sim_complex_attach_detach.rs
@@ -64,8 +64,9 @@
 use std::path::PathBuf;
 
 use glam::{DMat3, DVec3};
-use jeod_dynamics::{IntegratorType, MassProperties};
+use jeod_dynamics::MassProperties;
 use jeod_runner::Simulation;
+use jeod_sim::IntegratorType;
 use jeod_sim::{
     GravityControls, JeodQuat, RotationalState, SimulationTime, TranslationalState, VehicleConfig,
 };

--- a/crates/jeod_runner/tests/tier3_sim_kinematic_propagation.rs
+++ b/crates/jeod_runner/tests/tier3_sim_kinematic_propagation.rs
@@ -74,8 +74,9 @@
 use std::path::PathBuf;
 
 use glam::{DMat3, DVec3};
-use jeod_dynamics::{IntegratorType, MassProperties};
+use jeod_dynamics::MassProperties;
 use jeod_runner::Simulation;
+use jeod_sim::IntegratorType;
 use jeod_sim::{
     GravityControls, JeodQuat, RotationalState, SimulationTime, TranslationalState, VehicleConfig,
 };

--- a/crates/jeod_sim/src/integration.rs
+++ b/crates/jeod_sim/src/integration.rs
@@ -7,9 +7,10 @@
 use glam::DVec3;
 use jeod_dynamics::state::TranslationalStateTyped;
 use jeod_dynamics::{
-    DynamicsConfig, IntegratorType, MassProperties, RotationalState, SixDofState,
-    TranslationalState,
+    DynamicsConfig, MassProperties, RotationalState, SixDofState, TranslationalState,
 };
+
+use crate::integrator::IntegratorType;
 use jeod_math::JeodQuat;
 use jeod_quantities::aliases::{Acceleration, Force, Position, Torque, Velocity};
 use jeod_quantities::frame::{BodyFrame, RootInertial, Vehicle};
@@ -628,9 +629,13 @@ pub fn integrate_body(
                 "GaussJackson integrator requires gj_state. \
                  Set SimBody::gj_state or call Simulation::validate() first.",
             );
+            // Convert the wrapper config once for the equality check; the
+            // raw kernel below operates on the underlying jeod_dynamics
+            // config that gj.config() returns.
+            let raw_cfg: jeod_dynamics::GaussJacksonConfig = cfg.into();
             debug_assert_eq!(
                 gj.config(),
-                &cfg,
+                &raw_cfg,
                 "GaussJacksonState config does not match IntegratorType config. \
                  Recreate the state from the same config or call Simulation::validate()."
             );
@@ -1204,7 +1209,7 @@ mod tests {
             DVec3::ZERO,
             dt,
             tsf,
-            jeod_dynamics::IntegratorType::Rk4,
+            IntegratorType::Rk4,
             None,
             None,
         );

--- a/crates/jeod_sim/src/integrator.rs
+++ b/crates/jeod_sim/src/integrator.rs
@@ -1,0 +1,289 @@
+//! `jeod_sim`-owned vocabulary for integrator selection and state.
+//!
+//! These types are the contract between mission crates / the `bevy_jeod`
+//! adapter and the integrator family. The wrapping insulates downstream
+//! code from internal field / variant renames inside the
+//! `jeod_dynamics::integration`, `jeod_dynamics::gauss_jackson`, and
+//! `jeod_dynamics::abm4` modules: a rename there only ripples to the
+//! delegating `From` / method bodies in this module, never to mission
+//! code or to the Bevy adapter's `IntegratorTypeC` /
+//! `GaussJacksonStateC` / `Abm4StateC` newtypes.
+//!
+//! The kernel in [`crate::integration`] still operates on the raw
+//! `jeod_dynamics::{GaussJacksonState, Abm4State}` storage internally —
+//! integrator runtime state is private scratch, not part of the
+//! mission-facing API. The wrappers expose only the methods consumers
+//! actually call, plus `inner_mut()` so the kernel can borrow into the
+//! raw state across the boundary.
+
+use jeod_dynamics::{
+    Abm4State as RawAbm4State, GaussJacksonConfig as RawGaussJacksonConfig,
+    GaussJacksonState as RawGaussJacksonState, IntegratorType as RawIntegratorType,
+};
+
+/// Integration method selection.
+///
+/// Mirrors [`jeod_dynamics::IntegratorType`] one-to-one. `jeod_sim`
+/// owns this name so a downstream rename inside `jeod_dynamics` does
+/// not ripple to mission code.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum IntegratorType {
+    /// Classical 4th-order Runge-Kutta (fixed step).
+    #[default]
+    Rk4,
+    /// Runge-Kutta-Fehlberg 4(5) (fixed step, 5th-order result).
+    Rkf45,
+    /// Gauss-Jackson (Störmer-Cowell) multi-step predictor-corrector.
+    ///
+    /// Carries a [`GaussJacksonConfig`]; persistent
+    /// [`GaussJacksonState`] must be retained externally.
+    /// Forward-time only — see [`jeod_dynamics::IntegratorType::GaussJackson`].
+    GaussJackson(GaussJacksonConfig),
+    /// Adams-Bashforth-Moulton 4th-order (PECE scheme, fixed step).
+    ///
+    /// Persistent [`Abm4State`] must be retained externally. Translational-
+    /// only; 6-DOF is not yet supported.
+    Abm4,
+}
+
+impl From<IntegratorType> for RawIntegratorType {
+    fn from(value: IntegratorType) -> Self {
+        match value {
+            IntegratorType::Rk4 => RawIntegratorType::Rk4,
+            IntegratorType::Rkf45 => RawIntegratorType::Rkf45,
+            IntegratorType::GaussJackson(cfg) => RawIntegratorType::GaussJackson(cfg.into()),
+            IntegratorType::Abm4 => RawIntegratorType::Abm4,
+        }
+    }
+}
+
+impl From<RawIntegratorType> for IntegratorType {
+    fn from(value: RawIntegratorType) -> Self {
+        match value {
+            RawIntegratorType::Rk4 => IntegratorType::Rk4,
+            RawIntegratorType::Rkf45 => IntegratorType::Rkf45,
+            RawIntegratorType::GaussJackson(cfg) => IntegratorType::GaussJackson(cfg.into()),
+            RawIntegratorType::Abm4 => IntegratorType::Abm4,
+        }
+    }
+}
+
+/// Configuration for the Gauss-Jackson integrator.
+///
+/// Opaque newtype over [`jeod_dynamics::GaussJacksonConfig`]. Construct
+/// via [`Self::default`], [`Self::with_order`], or [`Self::standard`]
+/// — the underlying field layout is intentionally not exposed, so a
+/// future field rename inside `jeod_dynamics` does not break the
+/// mission-facing surface.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct GaussJacksonConfig(RawGaussJacksonConfig);
+
+impl GaussJacksonConfig {
+    /// Create a config with fixed order, no step-doubling. Bootstrap
+    /// editing still runs; see
+    /// [`jeod_dynamics::GaussJacksonConfig::with_order`].
+    pub fn with_order(order: usize) -> Self {
+        Self(RawGaussJacksonConfig::with_order(order))
+    }
+
+    /// JEOD standard configuration.
+    /// See [`jeod_dynamics::GaussJacksonConfig::standard`].
+    pub fn standard() -> Self {
+        Self(RawGaussJacksonConfig::standard())
+    }
+
+    /// Non-panicking validation. See
+    /// [`jeod_dynamics::GaussJacksonConfig::check`].
+    pub fn check(&self) -> Vec<String> {
+        self.0.check()
+    }
+
+    /// Validate the configuration, panicking on invalid values. See
+    /// [`jeod_dynamics::GaussJacksonConfig::validate`].
+    pub fn validate(&self) {
+        self.0.validate()
+    }
+}
+
+impl From<GaussJacksonConfig> for RawGaussJacksonConfig {
+    #[inline]
+    fn from(value: GaussJacksonConfig) -> Self {
+        value.0
+    }
+}
+
+impl From<RawGaussJacksonConfig> for GaussJacksonConfig {
+    #[inline]
+    fn from(value: RawGaussJacksonConfig) -> Self {
+        Self(value)
+    }
+}
+
+/// Persistent Gauss-Jackson integrator state.
+///
+/// Opaque newtype over [`jeod_dynamics::GaussJacksonState`]. Only the
+/// methods consumers actually call across the boundary are exposed;
+/// the remaining surface (history arrays, FSM scratch, primer state)
+/// stays inside `jeod_dynamics` where it belongs.
+#[derive(Debug, Clone)]
+pub struct GaussJacksonState(RawGaussJacksonState);
+
+impl GaussJacksonState {
+    /// Create a new Gauss-Jackson integrator with the given configuration.
+    /// Delegates to [`jeod_dynamics::GaussJacksonState::new`].
+    pub fn new(config: GaussJacksonConfig) -> Self {
+        Self(RawGaussJacksonState::new(config.into()))
+    }
+
+    /// Reset the integrator to its initial state. Delegates to
+    /// [`jeod_dynamics::GaussJacksonState::reset`].
+    pub fn reset(&mut self) {
+        self.0.reset()
+    }
+
+    /// Reset the integrator and clear the topology-dirty flag. Delegates
+    /// to [`jeod_dynamics::GaussJacksonState::reset_for_topology_change`].
+    pub fn reset_for_topology_change(&mut self) {
+        self.0.reset_for_topology_change()
+    }
+
+    /// Mark the integrator as carrying stale predictor / corrector
+    /// history. Delegates to
+    /// [`jeod_dynamics::GaussJacksonState::mark_topology_dirty`].
+    pub fn mark_topology_dirty(&mut self) {
+        self.0.mark_topology_dirty()
+    }
+
+    /// Returns true if the integrator is carrying stale history.
+    /// Delegates to
+    /// [`jeod_dynamics::GaussJacksonState::is_topology_dirty`].
+    pub fn is_topology_dirty(&self) -> bool {
+        self.0.is_topology_dirty()
+    }
+
+    /// Returns the configuration this integrator was created with.
+    /// Returns the wrapped [`GaussJacksonConfig`] (not a reference) —
+    /// the type is `Copy`, so this incurs no allocation.
+    pub fn config(&self) -> GaussJacksonConfig {
+        GaussJacksonConfig(*self.0.config())
+    }
+
+    /// Returns true if the integrator is still in the priming phase.
+    /// Delegates to [`jeod_dynamics::GaussJacksonState::is_priming`].
+    pub fn is_priming(&self) -> bool {
+        self.0.is_priming()
+    }
+
+    /// Cumulative count of unconverged bootstrap-edit iterations.
+    /// Delegates to
+    /// [`jeod_dynamics::GaussJacksonState::bootstrap_unconverged_iterations`].
+    pub fn bootstrap_unconverged_iterations(&self) -> u32 {
+        self.0.bootstrap_unconverged_iterations()
+    }
+
+    /// Mutable reference to the wrapped raw state. Used by the
+    /// `jeod_sim` integration kernel to pass through to
+    /// `jeod_dynamics::abm4_translational_step` / GJ's `integrate`
+    /// without copying. Mission code should not need this.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut RawGaussJacksonState {
+        &mut self.0
+    }
+
+    /// Shared reference to the wrapped raw state. Symmetry partner of
+    /// [`Self::inner_mut`].
+    #[inline]
+    pub fn inner(&self) -> &RawGaussJacksonState {
+        &self.0
+    }
+}
+
+impl From<RawGaussJacksonState> for GaussJacksonState {
+    #[inline]
+    fn from(value: RawGaussJacksonState) -> Self {
+        Self(value)
+    }
+}
+
+impl From<GaussJacksonState> for RawGaussJacksonState {
+    #[inline]
+    fn from(value: GaussJacksonState) -> Self {
+        value.0
+    }
+}
+
+/// Persistent Adams-Bashforth-Moulton 4 integrator state.
+///
+/// Opaque newtype over [`jeod_dynamics::Abm4State`]. Only the methods
+/// consumers actually call across the boundary are exposed; the
+/// internal sliding-window history stays in `jeod_dynamics`.
+#[derive(Debug, Clone, Default)]
+pub struct Abm4State(RawAbm4State);
+
+impl Abm4State {
+    /// Create a fresh, unprimed integrator state.
+    /// Delegates to [`jeod_dynamics::Abm4State::new`].
+    pub fn new() -> Self {
+        Self(RawAbm4State::new())
+    }
+
+    /// Reset the integrator back to its unprimed state.
+    /// Delegates to [`jeod_dynamics::Abm4State::reset`].
+    pub fn reset(&mut self) {
+        self.0.reset()
+    }
+
+    /// Reset the integrator and clear the topology-dirty flag.
+    /// Delegates to [`jeod_dynamics::Abm4State::reset_for_topology_change`].
+    pub fn reset_for_topology_change(&mut self) {
+        self.0.reset_for_topology_change()
+    }
+
+    /// Mark the integrator as carrying stale predictor history.
+    /// Delegates to [`jeod_dynamics::Abm4State::mark_topology_dirty`].
+    pub fn mark_topology_dirty(&mut self) {
+        self.0.mark_topology_dirty()
+    }
+
+    /// Returns true if the integrator is carrying stale history.
+    /// Delegates to [`jeod_dynamics::Abm4State::is_topology_dirty`].
+    pub fn is_topology_dirty(&self) -> bool {
+        self.0.is_topology_dirty()
+    }
+
+    /// Returns true while the integrator is still priming with RK4.
+    /// Delegates to [`jeod_dynamics::Abm4State::is_priming`].
+    pub fn is_priming(&self) -> bool {
+        self.0.is_priming()
+    }
+
+    /// Mutable reference to the wrapped raw state. Used by the
+    /// `jeod_sim` integration kernel to pass through to
+    /// `jeod_dynamics::abm4_translational_step` without copying.
+    /// Mission code should not need this.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut RawAbm4State {
+        &mut self.0
+    }
+
+    /// Shared reference to the wrapped raw state. Symmetry partner of
+    /// [`Self::inner_mut`].
+    #[inline]
+    pub fn inner(&self) -> &RawAbm4State {
+        &self.0
+    }
+}
+
+impl From<RawAbm4State> for Abm4State {
+    #[inline]
+    fn from(value: RawAbm4State) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Abm4State> for RawAbm4State {
+    #[inline]
+    fn from(value: Abm4State) -> Self {
+        value.0
+    }
+}

--- a/crates/jeod_sim/src/lib.rs
+++ b/crates/jeod_sim/src/lib.rs
@@ -60,6 +60,7 @@ pub mod frame_orchestration;
 pub mod gravity;
 pub mod integrable;
 pub mod integration;
+pub mod integrator;
 pub mod interactions;
 pub mod kinematic_propagation;
 pub mod pipeline;
@@ -108,6 +109,7 @@ pub use integration::{
     integrate_bodies_contact_coupled, integrate_body, integrate_body_coupled, integrate_body_typed,
     reset_integrators, CoupledBodyInput, CoupledIntegScratch, CoupledStageEval,
 };
+pub use integrator::{Abm4State, GaussJacksonConfig, GaussJacksonState, IntegratorType};
 pub use interactions::{
     compute_cannonball_srp, compute_cannonball_srp_typed, compute_drag, compute_drag_typed,
     compute_gravity_torque, compute_gravity_torque_typed, evaluate_contact_pair,
@@ -121,7 +123,6 @@ pub use jeod_dynamics::kinematic_joint::{
     JointKinematicsModel, JointKinematicsSpec, MultiDofJointKinematicsSpec, SingleDofKinematics,
     SinusoidalJointKinematicsSpec, AXIS_NORM_TOL, MAX_MULTI_DOF_AXES,
 };
-pub use jeod_dynamics::{Abm4State, GaussJacksonConfig, GaussJacksonState, IntegratorType};
 pub use kinematic_propagation::{propagate_state_via_storage, KinematicEdge, KinematicNodeState};
 pub use pipeline::{PipelineStage, PIPELINE_ORDER};
 pub use planet_config::{PlanetConfig, EARTH, MARS, MOON, SUN};

--- a/crates/jeod_sim/src/vehicle_builder.rs
+++ b/crates/jeod_sim/src/vehicle_builder.rs
@@ -47,9 +47,9 @@ use glam::{DMat3, DVec3};
 
 use jeod_dynamics::body_init::init_from_orbital_elements_typed;
 use jeod_dynamics::state::TranslationalStateTyped;
-use jeod_dynamics::{
-    GaussJacksonConfig, IntegratorType, MassProperties, RotationalState, TranslationalState,
-};
+use jeod_dynamics::{MassProperties, RotationalState, TranslationalState};
+
+use crate::integrator::{GaussJacksonConfig, IntegratorType};
 use jeod_gravity::{GravityControl, GravityControls};
 use jeod_interactions::DragConfig;
 use jeod_math::{EulerSequence, OrbitalElements};

--- a/crates/jeod_sim/src/vehicle_config.rs
+++ b/crates/jeod_sim/src/vehicle_config.rs
@@ -11,9 +11,9 @@
 
 use glam::{DMat3, DVec3};
 
+use crate::integrator::IntegratorType;
 use crate::interactions::FlatPlateState;
 use crate::EulerSequence;
-use jeod_dynamics::IntegratorType;
 use jeod_gravity::GravityControls;
 use jeod_interactions::DragConfig;
 

--- a/crates/jeod_sim/tests/vehicle_builder_typestate.rs
+++ b/crates/jeod_sim/tests/vehicle_builder_typestate.rs
@@ -15,16 +15,16 @@
 
 use glam::{DMat3, DVec3};
 use jeod_dynamics::state::TranslationalStateTyped;
-use jeod_dynamics::{
-    GaussJacksonConfig, IntegratorType, MassProperties, RotationalState, TranslationalState,
-};
+use jeod_dynamics::{MassProperties, RotationalState, TranslationalState};
 use jeod_gravity::GravityControl;
 use jeod_interactions::DragConfig;
 use jeod_math::{JeodQuat, OrbitalElements};
 use jeod_quantities::ext::F64Ext;
 use jeod_sim::vehicle_builder::VehicleBuilder;
 use jeod_sim::vehicle_config::VehicleConfig;
-use jeod_sim::{Earth, PlanetInertial, Position, RootInertial, Velocity};
+use jeod_sim::{
+    Earth, GaussJacksonConfig, IntegratorType, PlanetInertial, Position, RootInertial, Velocity,
+};
 
 fn iss_trans() -> TranslationalStateTyped<RootInertial> {
     TranslationalStateTyped::<RootInertial>::from_untyped_unchecked(&TranslationalState {

--- a/src/body_action.rs
+++ b/src/body_action.rs
@@ -692,8 +692,8 @@ pub fn body_action_system<P: Planet>(
             // `None` on RK4 entities), so this branch is free for the
             // common path.
             jeod_sim::reset_integrators(
-                gj.as_deref_mut().map(|c| &mut c.0),
-                abm.as_deref_mut().map(|c| &mut c.0),
+                gj.as_deref_mut().map(|c| c.0.inner_mut()),
+                abm.as_deref_mut().map(|c| c.0.inner_mut()),
             );
         }
         // Do not advance idx: the queue shifted left by one when we

--- a/src/systems/integration.rs
+++ b/src/systems/integration.rs
@@ -729,8 +729,8 @@ pub fn integration_system<P: Planet>(
             dt,
             sim_time.0.time_scale_factor,
             integrator_type,
-            gj_state.as_mut().map(|g| &mut g.0),
-            abm4_state.as_mut().map(|a| &mut a.0),
+            gj_state.as_mut().map(|g| g.0.inner_mut()),
+            abm4_state.as_mut().map(|a| a.0.inner_mut()),
         );
         // Re-wrap kernel-mutated state back into typed components;
         // integrate_body signature is untyped, so re-wrapping is the
@@ -2937,8 +2937,8 @@ pub fn staging_system<P: Planet>(
     for (body_id, mut gj_opt, mut abm_opt) in &mut integrators {
         if affected_ids.binary_search(&body_id.0).is_ok() {
             jeod_sim::reset_integrators(
-                gj_opt.as_mut().map(|c| &mut c.0),
-                abm_opt.as_mut().map(|c| &mut c.0),
+                gj_opt.as_mut().map(|c| c.0.inner_mut()),
+                abm_opt.as_mut().map(|c| c.0.inner_mut()),
             );
         }
     }

--- a/src/wrench.rs
+++ b/src/wrench.rs
@@ -120,8 +120,8 @@ fn reset_multi_step_history(
     let mut gj = gj_q.get_mut(entity).ok();
     let mut abm = abm_q.get_mut(entity).ok();
     jeod_sim::reset_integrators(
-        gj.as_mut().map(|g| &mut g.0),
-        abm.as_mut().map(|a| &mut a.0),
+        gj.as_mut().map(|g| g.0.inner_mut()),
+        abm.as_mut().map(|a| a.0.inner_mut()),
     );
 }
 

--- a/tests/bevy_parity_attach_detach_trajectory.rs
+++ b/tests/bevy_parity_attach_detach_trajectory.rs
@@ -118,8 +118,9 @@ use bevy_jeod::{
     TotalForceC, TranslationalStateC,
 };
 use glam::{DMat3, DVec3};
-use jeod_dynamics::{IntegratorType, MassProperties};
+use jeod_dynamics::MassProperties;
 use jeod_runner::Simulation;
+use jeod_sim::IntegratorType;
 use jeod_sim::{
     DynamicsConfig, GravityControls, JeodQuat, MassTree, RotationalState, SimulationTime,
     SixDofState, TranslationalState, VehicleConfig,

--- a/tests/bevy_parity_chained_attach_event.rs
+++ b/tests/bevy_parity_chained_attach_event.rs
@@ -72,8 +72,9 @@ use bevy_jeod::{
     MassTreeR, RotationalStateC, TotalForceC, TranslationalStateC,
 };
 use glam::{DMat3, DVec3};
-use jeod_dynamics::{IntegratorType, MassProperties};
+use jeod_dynamics::MassProperties;
 use jeod_runner::Simulation;
+use jeod_sim::IntegratorType;
 use jeod_sim::{
     DynamicsConfig, GravityControls, JeodQuat, MassTree, RotationalState, SimulationTime,
     TranslationalState, VehicleConfig,

--- a/tests/bevy_parity_kinematic_propagation.rs
+++ b/tests/bevy_parity_kinematic_propagation.rs
@@ -57,7 +57,8 @@ use bevy_jeod::{
     RotationalStateC, TotalForceC, TranslationalStateC,
 };
 use glam::{DMat3, DVec3};
-use jeod_dynamics::{IntegratorType, MassProperties};
+use jeod_dynamics::MassProperties;
+use jeod_sim::IntegratorType;
 use jeod_sim::{
     DynamicsConfig, GravityControls, JeodQuat, MassTree, RotationalState, SimulationTime,
     SixDofState, TranslationalState, VehicleConfig,


### PR DESCRIPTION
## Summary

- Replace the four raw `pub use jeod_dynamics::{IntegratorType, Abm4State, GaussJacksonConfig, GaussJacksonState}` re-exports in `jeod_sim::lib.rs` with `jeod_sim`-owned wrappers in a new `jeod_sim::integrator` module — a future field/variant rename inside `jeod_dynamics` lands at the delegating bodies in `integrator.rs` and stops there.
- The kernel `jeod_sim::integrate_body` / `integrate_body_typed` now consume `jeod_sim::IntegratorType` (the GJ variant carries `jeod_sim::GaussJacksonConfig`); raw-kernel calls into `jeod_dynamics::*_step` happen behind a `.into()` at the boundary. Bevy components (`IntegratorTypeC` / `GaussJacksonStateC` / `Abm4StateC`) wrap the new `jeod_sim` types; reset / dispatch sites use `inner_mut()` to bridge into the raw kernel.
- Per #360, `jeod_runner` keeps storing `jeod_dynamics::IntegratorType` / `GaussJacksonState` / `Abm4State` internally on `SimBody` (the runner is allowed to depend on `jeod_dynamics` directly). Conversion lives at the boundaries — `SimBody::from_config` does `config.integrator.into()` once and `step::integrate` lifts `body.integrator.into()` for the kernel call; the runner's own internal references (validation, mass-tree splicing) stay on the raw types.

## Wrapping shape

Option A from the issue (mirror enum + opaque newtypes):

- `jeod_sim::IntegratorType` mirrors the four `jeod_dynamics` variants 1:1 with `From`/`Into` between the two flavors.
- `jeod_sim::GaussJacksonConfig` is an opaque newtype exposing only the three constructors (`default`/`with_order`/`standard`) and `validate`/`check`. The six `pub` fields stay invisible to consumers — a future field rename inside `jeod_dynamics` cannot ripple to mission code.
- `jeod_sim::GaussJacksonState` and `jeod_sim::Abm4State` are opaque newtypes exposing only the methods consumers actually call across the boundary (surveyed from the existing call sites): `new`, `reset`, `reset_for_topology_change`, `mark_topology_dirty`, `is_topology_dirty`, `is_priming`, `config` (GJ), `bootstrap_unconverged_iterations` (GJ). `inner_mut`/`inner` provide the controlled bridge so the `jeod_sim` integration kernel can forward into `jeod_dynamics::abm4_translational_step` / `GaussJacksonState::integrate` without copying.

## Why the wrap is going in

This PR supersedes the prior won't-do analysis on the issue: the [survey comment](https://github.com/simnaut/bevy_jeod/issues/379#issuecomment-4391537997) argued that the existing builder methods already insulated mission code today, but the [decision comment](https://github.com/simnaut/bevy_jeod/issues/379#issuecomment-4392709864) overruled that in favor of the audit §2.4 invariant — *future* contract stability for downstream mission crates that will name `jeod_sim::IntegratorType` once they exist. The one-time churn in adapter sites and parity tests is the cost of the wrap; the benefit is that future `jeod_dynamics` renames don't ripple to mission code.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1188 unit + tier 2 tests pass
- [x] `cargo nextest run --workspace -E 'test(bevy_parity_)'` — 36 Bevy parity tests pass
- [x] `cargo nextest run -p jeod_runner --test tier3_sim_dyncomp_run2` — 2 tests pass (byte-identical)
- [x] `cargo nextest run -p jeod_runner -E 'test(tier3_) and (test(run5) or test(drag) or test(gj))'` — 39 tests pass (byte-identical)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --test invariant_coverage`
- [x] `cargo build --examples --workspace`

Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)