### PR TITLE
[#391] Flip residual simnaut/bevy_jeod doc URLs to simnaut/astrodyn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Issue #389 stands up the infrastructure
 ([`VerificationCaseParityExt::run_and_assert_parity`] +
 [`SimulationBuilderBevyExt::populate_app`]) and seeds it with the
 common topics; a long tail of tier3 topics is tracked individually in
-[`KNOWN_PARITY_GAPS`](https://github.com/simnaut/bevy_jeod/blob/main/crates/astrodyn_verif_parity/tests/parity_coverage.rs)
+[`KNOWN_PARITY_GAPS`](https://github.com/simnaut/astrodyn/blob/main/crates/astrodyn_verif_parity/tests/parity_coverage.rs)
 for incremental closure (multi-planet scenarios, pre-recipe siblings,
 analytical-only tests, scenarios with `pre_step` ephemeris updates that
 need a Bevy-side `SimContext` impl — see issue #395). The

--- a/crates/astrodyn_verif_jeod/src/verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/verification/mod.rs
@@ -203,7 +203,7 @@ pub enum CsvReference {
     /// its own column layout — only the parity trait routes through
     /// this variant.
     ///
-    /// [`astrodyn_verif_parity::VerificationCaseParityExt::run_and_assert_parity`]: https://github.com/simnaut/bevy_jeod/blob/main/crates/astrodyn_verif_parity/src/lib.rs
+    /// [`astrodyn_verif_parity::VerificationCaseParityExt::run_and_assert_parity`]: https://github.com/simnaut/astrodyn/blob/main/crates/astrodyn_verif_parity/src/lib.rs
     TimesOnly(&'static str),
 }
 


### PR DESCRIPTION
## Summary

- Closes the last two stale `simnaut/bevy_jeod` doc URLs that survived the #387 rebrand sweep — the only items still keeping #391 open after #392/#393 landed.
- `CLAUDE.md:191` (KNOWN_PARITY_GAPS link) and `crates/astrodyn_verif_jeod/src/verification/mod.rs:206` (rustdoc intra-doc link target) now point at `simnaut/astrodyn`.

GitHub redirects today, but the canonical name belongs in contributor docs and rustdoc.

## Test plan

- [x] `grep -rn 'simnaut/bevy_jeod\|bevy_jeod/blob\|bevy_jeod/wiki\|bevy_jeod/tree\|bevy_jeod/issues\|bevy_jeod/pull'` across `*.md *.rs *.toml *.sh *.yml` — no hits
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` clean
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p astrodyn_verif_jeod --no-deps` clean (intra-doc link still resolves)

Closes #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)