### PR TITLE
[#144] Bundle gravity + ephemeris kernels; promote SH recipes to mission API

### DIFF
--- a/crates/astrodyn_ephemeris/Cargo.toml
+++ b/crates/astrodyn_ephemeris/Cargo.toml
@@ -8,12 +8,21 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-# Keep the published .crate lean: assets/ holds large binary ephemerides
-# (de421.bsp ~17 MB, moon PA BPC ~2 MB) used by in-workspace tests and
-# downstream consumers via `assets_path`. Those consumers can ship their
-# own copy or vendor these from JPL; we don't want to upload ~20 MB on
+# The DE421 SPK (~17 MB) and Moon PA BPC (~1.7 MB) are bundled into the
+# published .crate so downstream consumers can call
+# `Ephemeris::from_bsp_bytes(astrodyn_ephemeris::data::DE421_BSP)` (and
+# the higher-level `astrodyn::recipes::ephemeris::de421()`) without
+# vendoring kernels themselves. Cargo's default packager already ships
+# `assets/`; we only need to be explicit about the `Cargo.toml`-listed
+# include set so future additions to `assets/` don't accidentally bloat
 # every release.
-exclude = ["assets/*.bsp", "assets/*.bpc"]
+include = [
+    "src/**",
+    "assets/de421.bsp",
+    "assets/moon_pa_de421_1900-2050.bpc",
+    "README.md",
+    "Cargo.toml",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_ephemeris/src/assets.rs
+++ b/crates/astrodyn_ephemeris/src/assets.rs
@@ -4,35 +4,42 @@
 //! workspace's tests, examples, and downstream mission crates load by
 //! default:
 //!
-//! - `de421.bsp` (16.8 MB) — production JPL DE421 ephemeris.
-//! - `moon_pa_de421_1900-2050.bpc` (1.7 MB) — lunar PA orientation kernel.
+//! - `de421.bsp` (~17 MB) — production JPL DE421 ephemeris.
+//! - `moon_pa_de421_1900-2050.bpc` (~1.7 MB) — lunar PA orientation kernel.
 //!
-//! These are excluded from the published `.crate` (see `Cargo.toml`'s
-//! `exclude`) since they are large; downstream users that build against
-//! the published crate must provide their own paths to
-//! [`Ephemeris::from_bsp`](crate::Ephemeris::from_bsp).
+//! These are also embedded as `&'static [u8]` constants in
+//! [`crate::data`] (via `include_bytes!`) and ship inside the published
+//! `.crate`. New code should generally prefer
+//! [`Ephemeris::from_bsp_bytes`](crate::Ephemeris::from_bsp_bytes) over a
+//! path-based load — the bytes path works identically inside the
+//! workspace and from the published crate, with no `CARGO_MANIFEST_DIR`
+//! filesystem lookup.
 //!
-//! In-workspace consumers call these resolvers to find the committed
-//! fixtures via `CARGO_MANIFEST_DIR`. Each returns a path relative to
-//! the workspace root that the consumer can pass to `Ephemeris::from_bsp`.
+//! The path resolvers in this module remain useful when a caller needs a
+//! `Path` (e.g. shelling a kernel out to another tool, or passing it to
+//! an SPK loader the consumer manages itself). They resolve via
+//! `CARGO_MANIFEST_DIR` so they only work for in-workspace builds — they
+//! will *not* find the assets when called from a downstream consumer of
+//! the published crate.
+//!
+//! [`Ephemeris::from_bsp_bytes`]: crate::Ephemeris::from_bsp_bytes
 
 use std::path::PathBuf;
 
-/// Absolute path to the bundled `de421.bsp`.
+/// Absolute path to the bundled `de421.bsp` (in-workspace builds only).
 ///
-/// Resolves via `CARGO_MANIFEST_DIR`, so this works for any in-workspace
-/// crate (the assets sit at a stable path inside the `astrodyn_ephemeris`
-/// crate). Downstream consumers building against the published crate
-/// will not have this file (it is `exclude`d from publishes); they
-/// should ship their own `.bsp` and pass the path explicitly to
-/// [`Ephemeris::from_bsp`](crate::Ephemeris::from_bsp).
+/// Resolves via `CARGO_MANIFEST_DIR`. For builds that go through the
+/// published crate, prefer
+/// [`Ephemeris::from_bsp_bytes(crate::data::DE421_BSP)`](crate::Ephemeris::from_bsp_bytes)
+/// or the mission-facing `astrodyn::recipes::ephemeris::de421()`.
 pub fn de421_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/de421.bsp")
 }
 
-/// Absolute path to the bundled `moon_pa_de421_1900-2050.bpc`.
+/// Absolute path to the bundled `moon_pa_de421_1900-2050.bpc`
+/// (in-workspace builds only).
 ///
-/// See [`de421_path`] for the publishing caveat.
+/// See [`de421_path`] for the published-crate caveat.
 pub fn moon_pa_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/moon_pa_de421_1900-2050.bpc")
 }

--- a/crates/astrodyn_ephemeris/src/data.rs
+++ b/crates/astrodyn_ephemeris/src/data.rs
@@ -1,0 +1,28 @@
+//! Embedded planetary ephemeris and orientation kernels.
+//!
+//! Each constant is the raw bytes of one of the binary fixtures committed
+//! under `crates/astrodyn_ephemeris/assets/`. The bytes are pulled in at
+//! compile time via [`include_bytes!`], so consumers of the published
+//! `.crate` get the exact same kernels as in-workspace builds with no
+//! filesystem lookups, environment variables, or `JEOD_HOME` checkout.
+//!
+//! Pair these with [`Ephemeris::from_bsp_bytes`] /
+//! [`Ephemeris::load_bpc_bytes`](crate::Ephemeris::load_bpc_bytes), or use
+//! the higher-level mission-facing recipes in
+//! `astrodyn::recipes::ephemeris`.
+//!
+//! [`Ephemeris::from_bsp_bytes`]: crate::Ephemeris::from_bsp_bytes
+
+/// JPL DE421 planetary ephemeris (~17 MB).
+///
+/// Covers Sun, Moon, planets, and Earth–Moon barycenter from 1900 to 2050
+/// in J2000 ICRF. The same `.bsp` JEOD's SIM_dyncomp Tier 3 baselines
+/// were generated against.
+pub const DE421_BSP: &[u8] = include_bytes!("../assets/de421.bsp");
+
+/// Moon principal-axes orientation kernel (~1.7 MB).
+///
+/// Covers 1900–2050 and is required by consumers that need the Moon's
+/// physical orientation (libration); the SPK alone gives positions but
+/// not body-fixed attitude.
+pub const MOON_PA_BPC: &[u8] = include_bytes!("../assets/moon_pa_de421_1900-2050.bpc");

--- a/crates/astrodyn_ephemeris/src/ephemeris.rs
+++ b/crates/astrodyn_ephemeris/src/ephemeris.rs
@@ -41,6 +41,18 @@ impl Ephemeris {
         })
     }
 
+    /// Load an ephemeris from raw .bsp bytes (e.g. an `include_bytes!` blob).
+    ///
+    /// Equivalent to [`from_bsp`](Self::from_bsp) but skips the filesystem
+    /// lookup. Use this with [`crate::data::DE421_BSP`] to load the
+    /// embedded DE421 kernel without any path resolution.
+    pub fn from_bsp_bytes(bytes: &[u8]) -> Result<Self, EphemerisError> {
+        let spk = SPK::parse(bytes).map_err(|e| EphemerisError::LoadError(e.to_string()))?;
+        Ok(Self {
+            almanac: Almanac::from_spk(spk),
+        })
+    }
+
     /// Load a Binary PCK (orientation) kernel alongside existing data.
     ///
     /// Call after `from_bsp()` to add Moon libration or other body orientation
@@ -50,6 +62,19 @@ impl Ephemeris {
             .to_str()
             .ok_or_else(|| EphemerisError::LoadError("Path contains invalid UTF-8".to_string()))?;
         let bpc = BPC::load(path_str).map_err(|e| EphemerisError::LoadError(e.to_string()))?;
+        let almanac = std::mem::take(&mut self.almanac);
+        self.almanac = almanac.with_bpc(bpc);
+        Ok(())
+    }
+
+    /// Load a Binary PCK (orientation) kernel from raw bytes
+    /// (e.g. an `include_bytes!` blob).
+    ///
+    /// Equivalent to [`load_bpc`](Self::load_bpc) but skips the filesystem
+    /// lookup. Use this with [`crate::data::MOON_PA_BPC`] to merge the
+    /// embedded Moon principal-axes orientation kernel.
+    pub fn load_bpc_bytes(&mut self, bytes: &[u8]) -> Result<(), EphemerisError> {
+        let bpc = BPC::parse(bytes).map_err(|e| EphemerisError::LoadError(e.to_string()))?;
         let almanac = std::mem::take(&mut self.almanac);
         self.almanac = almanac.with_bpc(bpc);
         Ok(())

--- a/crates/astrodyn_ephemeris/src/lib.rs
+++ b/crates/astrodyn_ephemeris/src/lib.rs
@@ -33,6 +33,7 @@ pub use astrodyn_quantities::prelude::*;
 
 pub mod assets;
 pub mod bodies;
+pub mod data;
 pub mod ephemeris;
 
 pub use bodies::EphemerisBody;

--- a/crates/astrodyn_gravity/Cargo.toml
+++ b/crates/astrodyn_gravity/Cargo.toml
@@ -8,6 +8,17 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+# Cargo defaults to publishing only `src/` plus a few well-known files.
+# We need the binary gravity fixtures (~1.9 MB total) to ride along so
+# `include_bytes!` in `src/data.rs` resolves correctly when building
+# from the published .crate.
+include = [
+    "src/**",
+    "test_data/gravity/*.bin",
+    "test_data/gravity/*.json",
+    "README.md",
+    "Cargo.toml",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_gravity/src/data.rs
+++ b/crates/astrodyn_gravity/src/data.rs
@@ -1,0 +1,38 @@
+//! Embedded planetary gravity-coefficient blobs.
+//!
+//! Each `*_BIN` constant is the raw bytes of one of the `.bin` fixtures
+//! committed under `crates/astrodyn_gravity/test_data/gravity/`. The bytes are
+//! pulled in at compile time via [`include_bytes!`], so consumers of the
+//! published `.crate` get the exact same data as in-workspace builds without
+//! any filesystem lookups, environment variables, or `JEOD_HOME` checkout.
+//!
+//! The high-level API for loading a [`SphericalHarmonicsData`] from one of
+//! these blobs lives in [`crate::fixtures`]; downstream code generally
+//! prefers the `fixtures::load_*` helpers (or the mission-facing recipes
+//! in `astrodyn::recipes::{earth, moon, mars}`) to working with the byte
+//! constants directly.
+//!
+//! [`SphericalHarmonicsData`]: crate::SphericalHarmonicsData
+
+/// GGM05C Earth gravity coefficients (degree=order=360).
+pub const GGM05C_BIN: &[u8] = include_bytes!("../test_data/gravity/ggm05c.bin");
+
+/// GGM02C Earth gravity coefficients (degree=order=200).
+pub const GGM02C_BIN: &[u8] = include_bytes!("../test_data/gravity/ggm02c.bin");
+
+/// GEM-T1 Earth gravity coefficients (degree=order=36).
+pub const GEMT1_BIN: &[u8] = include_bytes!("../test_data/gravity/gemt1.bin");
+
+/// LP150Q Moon gravity coefficients (degree=order=150).
+pub const MOON_LP150Q_BIN: &[u8] = include_bytes!("../test_data/gravity/moon_lp150q.bin");
+
+/// GRAIL150 Moon gravity coefficients (degree=order=150).
+pub const MOON_GRAIL150_BIN: &[u8] = include_bytes!("../test_data/gravity/moon_grail150.bin");
+
+/// MRO110B2 Mars gravity coefficients (degree=order=110).
+pub const MARS_MRO110B2_BIN: &[u8] = include_bytes!("../test_data/gravity/mars_mro110b2.bin");
+
+/// Sun point-mass record encoded as a degree-1 zero-coefficient SH so the
+/// uniform binary loader works. Only `mu` and `radius` are physically
+/// meaningful; do not evaluate this as a non-spherical model.
+pub const SUN_SPHERICAL_BIN: &[u8] = include_bytes!("../test_data/gravity/sun_spherical.bin");

--- a/crates/astrodyn_gravity/src/fixtures.rs
+++ b/crates/astrodyn_gravity/src/fixtures.rs
@@ -2,15 +2,10 @@
 //!
 //! Loads spherical-harmonics coefficient sets (and point-mass `mu`
 //! values) from the binary fixtures committed under `test_data/gravity/`.
-//! These fixtures are produced by parsing JEOD's `.cc` source files into
-//! the production [`crate::coefficients::save_binary`] format —
-//! see the `extract_grav_coeffs` and `extract_mars_data` binaries in
-//! this crate for the regen step.
-//!
-//! Every test that previously called
-//! `astrodyn_gravity::jeod_cc::load_from_jeod_cc(...)` to read a JEOD
-//! checkout at test time should call one of these loaders instead so the
-//! test runs with `JEOD_HOME` unset.
+//! The bytes are embedded at compile time via the [`crate::data`] module,
+//! so these loaders work identically inside the workspace and from a
+//! published `.crate` — no filesystem lookups, no `JEOD_HOME`, no
+//! `CARGO_MANIFEST_DIR` resolution at runtime.
 //!
 //! ## Coverage
 //!
@@ -37,32 +32,21 @@
 //! ```
 //!
 //! Commit the updated `test_data/gravity/*.bin` and the sidecar
-//! `*.json` metadata files together.
+//! `*.json` metadata files together — `include_bytes!` re-reads them at
+//! every compile.
 
 use crate::SphericalHarmonicsData;
-use std::path::PathBuf;
 
-/// Resolve a fixture path under `astrodyn_gravity/test_data/gravity/`.
-fn fixture_path(filename: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("test_data/gravity")
-        .join(filename)
-}
-
-fn load_fixture(label: &str) -> SphericalHarmonicsData {
-    let path = fixture_path(&format!("{label}.bin"));
-    crate::coefficients::load_binary(&path).unwrap_or_else(|e| {
+fn load_embedded(label: &str, bytes: &[u8]) -> SphericalHarmonicsData {
+    crate::coefficients::load_binary_from_bytes(bytes).unwrap_or_else(|e| {
         let regen_bin = match label {
             "ggm02c" | "ggm05c" | "gemt1" => "extract_grav_coeffs",
-            "mars_mro110b2" | "moon_lp150q" | "moon_grail150" | "sun_spherical" => {
-                "extract_mars_data"
-            }
-            _ => "extract_grav_coeffs",
+            _ => "extract_mars_data",
         };
         panic!(
-            "Failed to load gravity fixture {label} from {}: {e:?}.\n\
-             Regenerate via: cargo run -p astrodyn_verif_jeod --bin {regen_bin}",
-            path.display(),
+            "Failed to decode embedded gravity fixture {label}: {e:?}.\n\
+             The committed binary is corrupt. Regenerate via: \
+             cargo run -p astrodyn_gravity --bin {regen_bin}"
         )
     })
 }
@@ -70,59 +54,59 @@ fn load_fixture(label: &str) -> SphericalHarmonicsData {
 /// Load the GGM02C Earth gravity coefficient set (degree=order=200).
 ///
 /// Equivalent to parsing `models/environment/gravity/data/src/earth_GGM02C.cc`
-/// from a JEOD checkout — but reads the committed binary fixture instead, so
+/// from a JEOD checkout, but reads the embedded binary fixture instead, so
 /// callers do not need `JEOD_HOME` set.
 pub fn load_ggm02c() -> SphericalHarmonicsData {
-    load_fixture("ggm02c")
+    load_embedded("ggm02c", crate::data::GGM02C_BIN)
 }
 
 /// Load the GGM05C Earth gravity coefficient set (degree=order=360).
 ///
 /// Equivalent to parsing `models/environment/gravity/data/src/earth_GGM05C.cc`
-/// from a JEOD checkout — but reads the committed binary fixture instead, so
+/// from a JEOD checkout, but reads the embedded binary fixture instead, so
 /// callers do not need `JEOD_HOME` set.
 pub fn load_ggm05c() -> SphericalHarmonicsData {
-    load_fixture("ggm05c")
+    load_embedded("ggm05c", crate::data::GGM05C_BIN)
 }
 
 /// Load the GEM-T1 Earth gravity coefficient set (degree=order=36).
 ///
 /// Equivalent to parsing `models/environment/gravity/data/src/earth_GEMT1.cc`
-/// from a JEOD checkout — but reads the committed binary fixture instead.
+/// from a JEOD checkout, but reads the embedded binary fixture instead.
 /// Used by `SIM_7_time_reversal` Tier 3 tests.
 pub fn load_gemt1() -> SphericalHarmonicsData {
-    load_fixture("gemt1")
+    load_embedded("gemt1", crate::data::GEMT1_BIN)
 }
 
 /// Load Mars MRO110B2 spherical harmonics coefficients (degree=order=110).
 ///
 /// Equivalent to parsing `models/environment/gravity/data/src/mars_MRO110B2.cc`
-/// from a JEOD checkout — but reads the committed binary fixture
+/// from a JEOD checkout, but reads the embedded binary fixture
 /// (regenerable via `extract_mars_data`).
 pub fn load_mars_mro110b2() -> SphericalHarmonicsData {
-    load_fixture("mars_mro110b2")
+    load_embedded("mars_mro110b2", crate::data::MARS_MRO110B2_BIN)
 }
 
 /// Load Moon LP150Q (Lunar Prospector) spherical harmonics coefficients
 /// (degree=order=150).
 ///
 /// Equivalent to parsing `models/environment/gravity/data/src/moon_LP150Q.cc`
-/// from a JEOD checkout — but reads the committed binary fixture
+/// from a JEOD checkout, but reads the embedded binary fixture
 /// (regenerable via `extract_mars_data`). Used by `SIM_Earth_Moon`.
 pub fn load_moon_lp150q() -> SphericalHarmonicsData {
-    load_fixture("moon_lp150q")
+    load_embedded("moon_lp150q", crate::data::MOON_LP150Q_BIN)
 }
 
 /// Load Moon GRAIL150 spherical harmonics coefficients (degree=order=150).
 ///
 /// Equivalent to parsing `models/environment/gravity/data/src/moon_GRAIL150.cc`
-/// from a JEOD checkout — but reads the committed binary fixture
+/// from a JEOD checkout, but reads the embedded binary fixture
 /// (regenerable via `extract_mars_data`). The GRAIL field is the newer
 /// JEOD default for the Moon and is used by SIM_dyncomp's third-body
 /// Moon source as well as the gravity-gradient torque rigs
 /// (`SIM_torque_compare_simple`, `SIM_tide_verif`).
 pub fn load_moon_grail150() -> SphericalHarmonicsData {
-    load_fixture("moon_grail150")
+    load_embedded("moon_grail150", crate::data::MOON_GRAIL150_BIN)
 }
 
 /// Load the Moon GRAIL150 gravitational parameter (mu, m³/s²).
@@ -136,14 +120,14 @@ pub fn load_moon_grail150_mu() -> f64 {
 /// Load the full Sun point-mass record (mu and reference radius).
 ///
 /// `sun_spherical.cc` is a JEOD point-mass entry — it has no Cnm/Snm
-/// coefficients. The committed fixture encodes it as a degree-1 SH with
+/// coefficients. The embedded fixture encodes it as a degree-1 SH with
 /// all-zero coefficients so the production binary loader works
 /// uniformly. Only `mu` and `radius` are physically meaningful; do not
 /// evaluate this as a non-spherical model.
 ///
 /// Regenerable via `extract_mars_data`.
 pub fn load_sun_spherical() -> SphericalHarmonicsData {
-    load_fixture("sun_spherical")
+    load_embedded("sun_spherical", crate::data::SUN_SPHERICAL_BIN)
 }
 
 /// Load the Sun point-mass gravitational parameter (mu, m³/s²).

--- a/crates/astrodyn_gravity/src/lib.rs
+++ b/crates/astrodyn_gravity/src/lib.rs
@@ -41,6 +41,7 @@
 pub mod accumulate;
 pub mod coefficients;
 pub mod compute;
+pub mod data;
 pub mod fixtures;
 pub mod gravity_controls;
 pub mod gravity_source;

--- a/crates/astrodyn_runner/examples/apollo.rs
+++ b/crates/astrodyn_runner/examples/apollo.rs
@@ -8,15 +8,15 @@
 //! `Simulation`. This is the "use a scenario as the starting point,
 //! then customize" archetype recipes are designed to support.
 //!
-//! Uses DE421 ephemeris from `crates/astrodyn_ephemeris/assets/de421.bsp` for Moon and Sun
-//! positions.
+//! Uses the bundled DE421 ephemeris (loaded via
+//! [`recipes::ephemeris::de421`]) for Moon and Sun positions.
 //!
 //! ```bash
 //! cargo run -p astrodyn_runner --example apollo
 //! ```
 
 use astrodyn::recipes::scenarios::apollo;
-use astrodyn::recipes::Mission;
+use astrodyn::recipes::{ephemeris as ephemeris_recipes, Mission};
 use astrodyn::{EphemerisBody, TranslationalState};
 use astrodyn_dynamics::MassProperties;
 use astrodyn_runner::SimulationBuilderExt;
@@ -57,13 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Override scenario state with Apollo parking orbit, attach DE421
     // ephemeris, then build.
 
-    let bsp_path = astrodyn::ephemeris_assets::de421_path();
-    assert!(
-        bsp_path.exists(),
-        "DE421 not found at {}",
-        bsp_path.display()
-    );
-    let ephemeris = astrodyn::Ephemeris::from_bsp(&bsp_path)?;
+    let ephemeris = ephemeris_recipes::de421()?;
 
     let r_park = R_EARTH + PARKING_ALT;
     let v_circ = (MU_EARTH / r_park).sqrt();

--- a/crates/astrodyn_verif_jeod/examples/earth_moon.rs
+++ b/crates/astrodyn_verif_jeod/examples/earth_moon.rs
@@ -8,23 +8,20 @@
 //! - Cannonball solar radiation pressure (no shadow body — illumination
 //!   stays at 1.0; matches the original example's behaviour)
 //!
-//! This example consumes
-//! [`recipes::verification::reference_data`](astrodyn_verif_jeod::verification::reference_data),
-//! which reads the committed `test_data/gravity/moon_lp150q.bin`
-//! fixture for the Moon LP150Q gravity model. DE421 ephemeris and Moon
-//! libration come from the committed `crates/astrodyn_ephemeris/assets/de421.bsp` and
-//! `crates/astrodyn_ephemeris/assets/moon_pa_de421_1900-2050.bpc`. No JEOD checkout is
-//! required to run the example.
+//! Moon LP150Q gravity, DE421 planetary positions, and the Moon
+//! principal-axes orientation kernel are all loaded from
+//! [`recipes::ephemeris::de421_with_moon_pa`] and
+//! [`recipes::moon::lp150q`], which embed the underlying binaries at
+//! compile time. No JEOD checkout is required.
 //!
 //! ```bash
-//! cargo run -p astrodyn_runner --example earth_moon
+//! cargo run -p astrodyn_verif_jeod --example earth_moon
 //! ```
 
-use astrodyn::recipes::{epoch, sun, vehicle};
+use astrodyn::recipes::{self, epoch, sun, vehicle};
 use astrodyn::vehicle_builder::VehicleBuilder;
-use astrodyn::{Ephemeris, EphemerisBody, GravityControl, SimulationBuilder, TranslationalState};
+use astrodyn::{EphemerisBody, GravityControl, SimulationBuilder, TranslationalState};
 use astrodyn_runner::SimulationBuilderExt;
-use astrodyn_verif_jeod::verification::reference_data;
 use glam::DVec3;
 
 // Initial state from JEOD SIM_Earth_Moon RUN_clem at t=0 (Moon-centered inertial).
@@ -57,30 +54,12 @@ fn parse_steps_arg(default: usize) -> usize {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Load DE421 + Moon BPC libration (committed at test_data/).
-
-    let bsp_path = astrodyn::ephemeris_assets::de421_path();
-    let bpc_path = astrodyn::ephemeris_assets::moon_pa_path();
-    assert!(
-        bsp_path.exists(),
-        "DE421 not found at {}",
-        bsp_path.display()
-    );
-    assert!(
-        bpc_path.exists(),
-        "Moon BPC not found at {}",
-        bpc_path.display()
-    );
-
-    let mut ephemeris = Ephemeris::from_bsp(&bsp_path)?;
-    ephemeris.load_bpc(&bpc_path)?;
+    let ephemeris = recipes::ephemeris::de421_with_moon_pa()?;
 
     let time = epoch::clementine_1994();
     let epoch_tdb_jd = time.tdb_julian_date();
 
-    // Moon central body with high-fidelity LP150Q SH gravity (verification
-    // reference data — requires $JEOD_HOME).
-    let mut moon_source = reference_data::moon_lp150q();
+    let mut moon_source = recipes::moon::lp150q();
     moon_source.t_inertial_pfix =
         Some(ephemeris.get_body_rotation(EphemerisBody::Moon, epoch_tdb_jd)?);
     let moon_mu = moon_source.source.mu;

--- a/crates/astrodyn_verif_jeod/examples/mars_orbit.rs
+++ b/crates/astrodyn_verif_jeod/examples/mars_orbit.rs
@@ -1,27 +1,25 @@
 //! Dawn spacecraft at Mars: high-fidelity spherical harmonics gravity.
 //!
 //! Verification-style example exercising:
-//! - Mars MRO110B2 110×110 spherical harmonics gravity (loaded from
-//!   the committed `test_data/gravity/mars_mro110b2.bin` fixture via
-//!   [`recipes::verification::reference_data`])
+//! - Mars MRO110B2 110×110 spherical harmonics gravity from
+//!   [`recipes::mars::mro110b2`]
 //! - Mars IAU rotation model
-//! - Sun as 3rd-body perturbation with DE421 ephemeris
-//!   (`crates/astrodyn_ephemeris/assets/de421.bsp`)
+//! - Sun as 3rd-body perturbation with DE421 ephemeris from
+//!   [`recipes::ephemeris::de421`]
 //!
-//! No JEOD checkout is required — both the gravity binary and the DE421
-//! ephemeris are committed under `test_data/`. Mission code that wants a
-//! lighter point-mass-only Mars source can use `recipes::mars::point_mass()`
-//! instead.
+//! No JEOD checkout is required — the gravity blob and the DE421
+//! ephemeris are embedded into the published crate via `include_bytes!`.
+//! Mission code that wants a lighter point-mass-only Mars source can
+//! use [`recipes::mars::point_mass`] instead.
 //!
 //! ```bash
-//! cargo run -p astrodyn_runner --example mars_orbit
+//! cargo run -p astrodyn_verif_jeod --example mars_orbit
 //! ```
 
-use astrodyn::recipes::{epoch, sun, vehicle};
+use astrodyn::recipes::{self, epoch, sun, vehicle};
 use astrodyn::vehicle_builder::VehicleBuilder;
 use astrodyn::{EphemerisBody, GravityControl, SimulationBuilder, TranslationalState};
 use astrodyn_runner::SimulationBuilderExt;
-use astrodyn_verif_jeod::verification::reference_data;
 use glam::DVec3;
 
 // Dawn spacecraft initial state at Mars (from JEOD SIM_Mars RUN_dawn, t=0).
@@ -50,23 +48,15 @@ fn parse_steps_arg(default: usize) -> usize {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let bsp_path = astrodyn::ephemeris_assets::de421_path();
-    assert!(
-        bsp_path.exists(),
-        "DE421 not found at {}",
-        bsp_path.display()
-    );
-
     let time = epoch::dawn_mars_2009();
     let epoch_tdb_jd = time.tdb_julian_date();
 
-    let ephemeris = astrodyn::Ephemeris::from_bsp(&bsp_path)?;
+    let ephemeris = recipes::ephemeris::de421()?;
     let (sun_pos_typed, _) =
         ephemeris.get_state_typed(EphemerisBody::Sun, EphemerisBody::Mars, epoch_tdb_jd)?;
     let sun_pos = sun_pos_typed.raw_si();
 
-    // Mars central body with MRO110B2 SH gravity (verification reference data).
-    let mars_source = reference_data::mars_mro110b2();
+    let mars_source = recipes::mars::mro110b2();
     let mars_mu = mars_source.source.mu;
 
     let mut sb = SimulationBuilder::new(time, DT);

--- a/crates/astrodyn_verif_jeod/src/verification/reference_data.rs
+++ b/crates/astrodyn_verif_jeod/src/verification/reference_data.rs
@@ -1,59 +1,44 @@
-//! High-fidelity gravity-source recipes backed by committed test
-//! fixtures **(workspace-internal — not for downstream mission code).**
+//! Deprecated thin shims over the mission-facing recipes.
 //!
-//! Functions here build [`GravitySourceEntry`] values populated with
-//! spherical-harmonics coefficient sets loaded from
-//! `test_data/gravity/*.bin` via `astrodyn_gravity::fixtures`.
-//! Those fixtures live at the workspace root of *this repository* and
-//! are not packaged with the crate — calling these recipes from a
-//! downstream workspace will panic at runtime when the loader can't
-//! find the binaries. The whole `verification` submodule is therefore
-//! hidden from rendered rustdoc; the only consumers are `astrodyn_runner`'s
-//! Tier 3 rigs and the in-repo examples that cross-validate against
-//! JEOD's reference data.
+//! Historically this module hosted the only path to high-fidelity SH
+//! gravity sources, since the `.cc` coefficient files were not
+//! reproducible without a JEOD checkout. After issue #144, the recipes
+//! were promoted to the mission-facing
+//! [`astrodyn::recipes::{earth, moon, mars}`] modules, backed by
+//! `include_bytes!` in `astrodyn_gravity` so they ship in the published
+//! `.crate`.
 //!
-//! Mission code should use the point-mass building blocks in
-//! [`earth`](super::super::earth), [`moon`](super::super::moon),
-//! [`mars`](super::super::mars), or supply its own
-//! [`SphericalHarmonicsData`](astrodyn_gravity::SphericalHarmonicsData) if
-//! a higher-fidelity field is needed.
-//!
-//! Fixtures here are regenerable via the `extract_*` binaries under
-//! `astrodyn_verif_jeod` (`cargo run -p astrodyn_verif_jeod --bin
-//! extract_grav_coeffs` for Earth fields, `extract_mars_data` for
-//! Moon/Mars/Sun).
-
-use astrodyn_gravity::fixtures;
+//! Each function here forwards to the new home; new call sites should
+//! call the recipe directly.
 
 use astrodyn::GravitySourceEntry;
-use astrodyn::{EARTH, MARS, MOON};
 
 /// Earth with the GGM05C spherical-harmonics gravity field
 /// (degree=order=360).
-///
-/// Reads `test_data/gravity/ggm05c.bin`, the committed mirror of
-/// `models/environment/gravity/data/src/earth_GGM05C.cc` (regenerable
-/// via `cargo run -p astrodyn_gravity --bin extract_grav_coeffs`).
+#[deprecated(
+    since = "0.2.0",
+    note = "use `astrodyn::recipes::earth::ggm05c` instead"
+)]
 pub fn earth_ggm05c() -> GravitySourceEntry {
-    GravitySourceEntry::central_body_sh(&EARTH, fixtures::load_ggm05c())
+    astrodyn::recipes::earth::ggm05c()
 }
 
 /// Moon with the LP150Q spherical-harmonics gravity field
 /// (degree=order=150).
-///
-/// Reads `test_data/gravity/moon_lp150q.bin`, the committed mirror of
-/// `models/environment/gravity/data/src/moon_LP150Q.cc` (regenerable
-/// via `cargo run -p astrodyn_gravity --bin extract_mars_data`).
+#[deprecated(
+    since = "0.2.0",
+    note = "use `astrodyn::recipes::moon::lp150q` instead"
+)]
 pub fn moon_lp150q() -> GravitySourceEntry {
-    GravitySourceEntry::central_body_sh(&MOON, fixtures::load_moon_lp150q())
+    astrodyn::recipes::moon::lp150q()
 }
 
 /// Mars with the MRO110B2 spherical-harmonics gravity field
 /// (degree=order=110).
-///
-/// Reads `test_data/gravity/mars_mro110b2.bin`, the committed mirror of
-/// `models/environment/gravity/data/src/mars_MRO110B2.cc` (regenerable
-/// via `cargo run -p astrodyn_gravity --bin extract_mars_data`).
+#[deprecated(
+    since = "0.2.0",
+    note = "use `astrodyn::recipes::mars::mro110b2` instead"
+)]
 pub fn mars_mro110b2() -> GravitySourceEntry {
-    GravitySourceEntry::central_body_sh(&MARS, fixtures::load_mars_mro110b2())
+    astrodyn::recipes::mars::mro110b2()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,9 @@ pub use astrodyn_frames::rotation_mars;
 pub use astrodyn_frames::rotation_moon;
 
 // astrodyn_ephemeris: ephemeris data
-pub use astrodyn_ephemeris::{assets as ephemeris_assets, Ephemeris, EphemerisBody};
+pub use astrodyn_ephemeris::{
+    assets as ephemeris_assets, Ephemeris, EphemerisBody, EphemerisError,
+};
 
 // astrodyn_gravity: relativistic-correction submodule consumed by mission
 // code that builds relativistic-source lists. The JEOD `.cc`

--- a/src/recipes/earth.rs
+++ b/src/recipes/earth.rs
@@ -10,17 +10,15 @@
 //! ```
 //!
 //! Recipes here are JEOD-source-independent — they describe Earth via
-//! constants the Rust port owns. High-fidelity spherical-harmonics
-//! gravity that requires loading JEOD coefficient files lives in
-//! `astrodyn_verif_jeod::verification::reference_data`,
-//! whose use is appropriate only for cross-validation against JEOD.
-//! Mission code that needs an SH source supplies its own
-//! [`SphericalHarmonicsData`](astrodyn_gravity::SphericalHarmonicsData) and
-//! constructs the entry manually via
-//! [`GravitySourceEntry::central_body_sh`].
+//! constants and binary fixtures the Rust port owns. The [`ggm05c`],
+//! [`ggm02c`], and [`gemt1`] high-fidelity spherical-harmonics variants
+//! load coefficient blobs that are embedded into the published crate
+//! (via `include_bytes!` in `astrodyn_gravity`), so they work without a
+//! JEOD checkout.
 
 use crate::sources::GravitySourceEntry;
 use crate::EARTH;
+use astrodyn_gravity::fixtures;
 
 /// Earth as a point-mass central body (no spherical harmonics).
 ///
@@ -28,6 +26,34 @@ use crate::EARTH;
 /// updates `t_inertial_pfix` from time each step.
 pub fn point_mass() -> GravitySourceEntry {
     GravitySourceEntry::central_body(&EARTH)
+}
+
+/// Earth with the GGM05C spherical-harmonics gravity field
+/// (degree=order=360).
+///
+/// JEOD-equivalent of `models/environment/gravity/data/src/earth_GGM05C.cc`.
+/// Coefficient bytes are embedded at compile time via `include_bytes!`,
+/// so this recipe works without a JEOD checkout and from the published
+/// `.crate`.
+pub fn ggm05c() -> GravitySourceEntry {
+    GravitySourceEntry::central_body_sh(&EARTH, fixtures::load_ggm05c())
+}
+
+/// Earth with the GGM02C spherical-harmonics gravity field
+/// (degree=order=200).
+///
+/// JEOD-equivalent of `models/environment/gravity/data/src/earth_GGM02C.cc`.
+pub fn ggm02c() -> GravitySourceEntry {
+    GravitySourceEntry::central_body_sh(&EARTH, fixtures::load_ggm02c())
+}
+
+/// Earth with the GEM-T1 spherical-harmonics gravity field
+/// (degree=order=36).
+///
+/// JEOD-equivalent of `models/environment/gravity/data/src/earth_GEMT1.cc`.
+/// Used by JEOD's `SIM_7_time_reversal` verification scenario.
+pub fn gemt1() -> GravitySourceEntry {
+    GravitySourceEntry::central_body_sh(&EARTH, fixtures::load_gemt1())
 }
 
 /// Earth as a point-mass third-body perturbation source at the given

--- a/src/recipes/ephemeris.rs
+++ b/src/recipes/ephemeris.rs
@@ -1,0 +1,37 @@
+//! Planetary ephemeris recipes backed by the bundled JPL kernels.
+//!
+//! Each recipe wraps an embedded SPK / BPC byte blob from
+//! [`astrodyn_ephemeris::data`] and returns an [`Ephemeris`] ready to
+//! plug into a [`SimulationBuilder`](crate::SimulationBuilder) via
+//! `.ephemeris(...)`. Because the kernels are pulled in with
+//! `include_bytes!`, these recipes work identically inside the
+//! workspace and from the published `.crate` — no filesystem lookups,
+//! no `JEOD_HOME`.
+//!
+//! ```ignore
+//! use astrodyn::recipes::ephemeris;
+//! let eph = ephemeris::de421()?;
+//! # Ok::<(), astrodyn::EphemerisError>(())
+//! ```
+
+use crate::{Ephemeris, EphemerisError};
+
+/// JPL DE421 planetary ephemeris (Sun, Moon, planets, 1900–2050).
+///
+/// Equivalent to `Ephemeris::from_bsp("de421.bsp")` against the JEOD-
+/// vendored kernel, but the bytes are embedded at compile time.
+pub fn de421() -> Result<Ephemeris, EphemerisError> {
+    Ephemeris::from_bsp_bytes(astrodyn_ephemeris::data::DE421_BSP)
+}
+
+/// DE421 ephemeris plus the Moon principal-axes orientation kernel.
+///
+/// Use this when the simulation needs the Moon's body-fixed attitude
+/// (libration) — e.g., lunar-fixed frames, lunar-surface targeting, or
+/// torque computations against the Moon. The plain [`de421`] recipe
+/// suffices when only Moon position/velocity are needed.
+pub fn de421_with_moon_pa() -> Result<Ephemeris, EphemerisError> {
+    let mut eph = de421()?;
+    eph.load_bpc_bytes(astrodyn_ephemeris::data::MOON_PA_BPC)?;
+    Ok(eph)
+}

--- a/src/recipes/mars.rs
+++ b/src/recipes/mars.rs
@@ -6,16 +6,26 @@
 //! assert!(m.source.mu > 4.28e13 && m.source.mu < 4.29e13);
 //! ```
 //!
-//! Spherical-harmonics gravity for Mars (MRO110B2 et al.) requires
-//! loading JEOD coefficient files; that loader lives in
-//! `astrodyn_verif_jeod::verification::reference_data`.
+//! [`mro110b2`] returns high-fidelity spherical-harmonics Mars gravity
+//! backed by a coefficient blob embedded into the published crate (via
+//! `include_bytes!` in `astrodyn_gravity`), so it works without a JEOD
+//! checkout.
 
 use crate::sources::GravitySourceEntry;
 use crate::MARS;
+use astrodyn_gravity::fixtures;
 
 /// Mars as a point-mass central body with the IAU rotation model.
 pub fn point_mass() -> GravitySourceEntry {
     GravitySourceEntry::central_body(&MARS)
+}
+
+/// Mars with the MRO110B2 spherical-harmonics gravity field
+/// (degree=order=110).
+///
+/// JEOD-equivalent of `models/environment/gravity/data/src/mars_MRO110B2.cc`.
+pub fn mro110b2() -> GravitySourceEntry {
+    GravitySourceEntry::central_body_sh(&MARS, fixtures::load_mars_mro110b2())
 }
 
 /// Mars as a third-body perturbation source at the given inertial position.

--- a/src/recipes/mod.rs
+++ b/src/recipes/mod.rs
@@ -32,6 +32,7 @@
 pub mod atmosphere;
 pub mod constants;
 pub mod earth;
+pub mod ephemeris;
 pub mod epoch;
 pub mod helpers;
 pub mod mars;

--- a/src/recipes/moon.rs
+++ b/src/recipes/moon.rs
@@ -6,18 +6,38 @@
 //! assert!(m.source.mu > 4.9e12 && m.source.mu < 4.91e12);
 //! ```
 //!
-//! Spherical-harmonics gravity for the Moon (LP150Q et al.) requires
-//! loading JEOD coefficient files; the loader lives in
-//! `astrodyn_verif_jeod::verification::reference_data`.
-//! Mission code that needs an SH source supplies its own data and
-//! builds the entry via [`GravitySourceEntry::central_body_sh`].
+//! [`lp150q`] and [`grail150`] return high-fidelity spherical-harmonics
+//! Moon gravity backed by coefficient blobs embedded into the published
+//! crate (via `include_bytes!` in `astrodyn_gravity`), so they work
+//! without a JEOD checkout.
 
 use crate::sources::GravitySourceEntry;
 use crate::MOON;
+use astrodyn_gravity::fixtures;
 
 /// Moon as a point-mass body with the JEOD IAU rotation model.
 pub fn point_mass() -> GravitySourceEntry {
     GravitySourceEntry::central_body(&MOON)
+}
+
+/// Moon with the LP150Q (Lunar Prospector) spherical-harmonics gravity
+/// field (degree=order=150).
+///
+/// JEOD-equivalent of `models/environment/gravity/data/src/moon_LP150Q.cc`.
+/// Used by JEOD's `SIM_Earth_Moon` verification scenario.
+pub fn lp150q() -> GravitySourceEntry {
+    GravitySourceEntry::central_body_sh(&MOON, fixtures::load_moon_lp150q())
+}
+
+/// Moon with the GRAIL150 spherical-harmonics gravity field
+/// (degree=order=150).
+///
+/// JEOD-equivalent of `models/environment/gravity/data/src/moon_GRAIL150.cc`.
+/// GRAIL is the newer JEOD default for the Moon and is used by
+/// SIM_dyncomp's third-body Moon source as well as the gravity-gradient
+/// torque rigs.
+pub fn grail150() -> GravitySourceEntry {
+    GravitySourceEntry::central_body_sh(&MOON, fixtures::load_moon_grail150())
 }
 
 /// Moon as a third-body perturbation source (point-mass, no rotation)

--- a/src/recipes/scenarios/clementine_lunar.rs
+++ b/src/recipes/scenarios/clementine_lunar.rs
@@ -23,10 +23,8 @@ use crate::SimulationBuilder;
 /// - Cannonball SRP (cx area 5 m², albedo 0.4, diffuse 0.4).
 ///
 /// Mission code that wants high-fidelity Moon gravity (LP150Q) replaces
-/// the Moon entry with
-/// `astrodyn_verif_jeod::verification::reference_data::moon_lp150q()` and
-/// adds a non-spherical control. That's appropriate only for Tier 3
-/// cross-validation (it requires `$JEOD_HOME`).
+/// the Moon entry with [`crate::recipes::moon::lp150q`] and adds a
+/// non-spherical [`GravityControl`].
 ///
 /// ```
 /// use astrodyn::recipes::scenarios::clementine_lunar;

--- a/src/recipes/scenarios/mars_orbit.rs
+++ b/src/recipes/scenarios/mars_orbit.rs
@@ -22,8 +22,8 @@ use crate::SimulationBuilder;
 /// trajectory than the JEOD reference (which uses the MRO110B2
 /// 110×110 SH model). Mission code wanting verification-grade
 /// accuracy substitutes the central-body source with
-/// `verification::reference_data::mars_mro110b2()` and adds a
-/// non-spherical [`GravityControl`].
+/// [`crate::recipes::mars::mro110b2`] and adds a non-spherical
+/// [`GravityControl`].
 ///
 /// ```
 /// use astrodyn::recipes::scenarios::mars_orbit;

--- a/src/recipes/scenarios/mod.rs
+++ b/src/recipes/scenarios/mod.rs
@@ -14,12 +14,14 @@
 //!
 //! Scenarios that mirror JEOD verification simulations (Tier 3
 //! reference cases) need high-fidelity gravity / ephemeris / rotation
-//! kernels. Phase 6 of #101 routed those data dependencies into
-//! `astrodyn_verif_jeod::verification::reference_data`
-//! so mission scenarios in this module function independently of any
-//! JEOD checkout. Tier 3 scenarios (and the examples that mirror
-//! them) compose `verification::reference_data::*` with the
-//! mission-side building blocks.
+//! kernels. Those binaries ship with the workspace (and inside the
+//! published `.crate`) via `include_bytes!` in `astrodyn_gravity` and
+//! `astrodyn_ephemeris`, exposed as the mission-facing recipes
+//! [`crate::recipes::earth::ggm05c`], [`crate::recipes::moon::lp150q`],
+//! [`crate::recipes::mars::mro110b2`], and
+//! [`crate::recipes::ephemeris::de421`]. Scenarios in this module
+//! compose those recipes with the mission-side building blocks; no JEOD
+//! checkout is required.
 
 pub mod apollo;
 pub mod clementine_lunar;


### PR DESCRIPTION
## Summary

Closes #144.

- Embed the 7 SH-gravity blobs (~1.9 MB) into `astrodyn_gravity` and DE421 + Moon PA BPC (~18.7 MB) into `astrodyn_ephemeris` via `include_bytes!`. Drop the `astrodyn_ephemeris` `exclude = [assets/*.bsp, assets/*.bpc]` and add explicit `include = [...]` to both crates so the binaries ship in the published `.crate`. Add `Ephemeris::from_bsp_bytes` / `load_bpc_bytes` wrapping anise's `SPK::parse` / `BPC::parse`.
- Promote the verification-only loaders to mission-facing recipes: `astrodyn::recipes::{earth::{ggm05c, ggm02c, gemt1}, moon::{lp150q, grail150}, mars::mro110b2}` and a new `astrodyn::recipes::ephemeris::{de421, de421_with_moon_pa}`. `astrodyn_verif_jeod::verification::reference_data::*` becomes `#[deprecated]` thin delegates to keep call sites green.
- Migrate `earth_moon` / `mars_orbit` / `apollo` examples off `ephemeris_assets::*_path()` + `Ephemeris::from_bsp` onto the new recipes.

### Why two gaps in one PR

The issue was framed as `$JEOD_HOME`-gated, but the real story split cleanly:

- **Gap A — mission-facing API surface.** SH gravity recipes only existed as `astrodyn_verif_jeod::verification::reference_data`, explicitly marked *workspace-internal — not for downstream mission code*. Mission code had no JEOD-free path to high-fidelity gravity.
- **Gap B — published-crate boundary.** `astrodyn_ephemeris/Cargo.toml` excluded `assets/*.bsp` / `*.bpc` and `astrodyn_gravity` did not include `test_data/`, so the `CARGO_MANIFEST_DIR`-based loaders would panic for downstream consumers of the published `.crate` even though `cargo nextest run --workspace` worked fine in-workspace.

Bundling via `include_bytes!` and routing through the recipe layer closes both. The verification reference_data delegates stay so unmigrated callers keep compiling with a deprecation hint.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1191 passed, 0 failed
- [x] `cargo test -p astrodyn --doc` — 54 passed
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_dyncomp_run9` — 3/3 passed (Tier 3 bit-level smoke)
- [x] `cargo run -p astrodyn_verif_jeod --example mars_orbit -- --steps 5` — runs JEOD-free with embedded MRO110B2 + DE421
- [x] `cargo run -p astrodyn_verif_jeod --example earth_moon -- --steps 5` — runs JEOD-free with embedded LP150Q + DE421 + Moon BPC
- [x] `cargo run -p astrodyn_runner --example apollo -- --steps 3` — runs JEOD-free with embedded DE421
- [x] `cargo package --list --allow-dirty -p astrodyn_gravity` — confirmed all `.bin` + `.json` fixtures ship
- [x] `cargo package --list --allow-dirty -p astrodyn_ephemeris` — confirmed `de421.bsp` + Moon PA BPC ship
- [ ] Full `cargo nextest run --workspace -E 'test(tier3_)'` — recommend running in CI before merge to confirm all Tier 3 baselines hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)