### PR TITLE
[#408] Return typed sibling from Simulation::body_mass

### DIFF
--- a/crates/astrodyn_runner/src/simulation/bodies.rs
+++ b/crates/astrodyn_runner/src/simulation/bodies.rs
@@ -17,8 +17,8 @@ use astrodyn::typed_bridge::{
 };
 use astrodyn::{
     evaluate_ground_contact_pair, ContactFacet, DragConfig, GroundFacet, IntegrationFrame,
-    MassBodyId, MassPointState, MassProperties, Phase, Position, RefFrameKind, RefFrameRot,
-    RefFrameState, RefFrameTrans, VehicleConfig, Velocity,
+    MassBodyId, MassPointState, MassProperties, MassPropertiesTyped, Phase, Position, RefFrameKind,
+    RefFrameRot, RefFrameState, RefFrameTrans, SelfRef, VehicleConfig, Velocity,
 };
 
 use super::types::{
@@ -347,25 +347,24 @@ impl Simulation {
 
     /// Mass / inertia / CoM-offset block for the body at index `idx`,
     /// or `None` for 3-DOF bodies that were configured without a
-    /// `MassProperties`. Mirrors JEOD's
+    /// `MassPropertiesTyped`. Mirrors JEOD's
     /// `dyn_body.mass.composite_properties` accessor for atomic
     /// (non-mass-tree) bodies — for tree-attached bodies the live
     /// composite is recomputed in the mass tree, but the per-body
-    /// `MassProperties` carried here still reflects the body's own
+    /// `MassPropertiesTyped` carried here still reflects the body's own
     /// mass properties at its structural origin. Used by the JEOD
     /// surface-attach test fixtures that need to compute the body's
     /// structure pose from its composite-body inertial state.
     ///
     /// # Panics
     /// Panics if `idx` is out of range.
-    pub fn body_mass(&self, idx: usize) -> Option<astrodyn::MassProperties> {
+    pub fn body_mass(&self, idx: usize) -> Option<&MassPropertiesTyped<SelfRef>> {
         assert!(
             idx < self.bodies.len(),
             "body_mass: body index {idx} out of range (have {} bodies)",
             self.bodies.len()
         );
-        // TODO(#408): expose typed sibling once callers migrate.
-        self.bodies[idx].mass.as_ref().map(mass_typed_to_raw)
+        self.bodies[idx].mass.as_ref()
     }
 
     /// Adjust an integrated body's `trans` from a `core_body` inertial

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
@@ -486,7 +486,7 @@ fn apply_event(
             // `T_inertial_pfix` gives the struct in pfix.
             let composite_offset_struct = sim
                 .body_mass(body_idx)
-                .map(|mp| mp.position)
+                .map(|mp| mp.center_of_mass.raw_si())
                 .unwrap_or(DVec3::ZERO);
             let struct_inertial = body_out.trans.position.raw_si()
                 - t_inertial_struct.transpose() * composite_offset_struct;


### PR DESCRIPTION
## Summary

- Change `Simulation::body_mass` to return `Option<&MassPropertiesTyped<SelfRef>>` and drop the `mass_typed_to_raw` boundary conversion at the accessor.
- Migrate the single caller (the `tier3_sim_dyncomp_run_attach_to_ref_frame` fixture) from `mp.position` to `mp.center_of_mass.raw_si()`.
- Remove the `// TODO(#408)` marker introduced in #397.

This is a thin one-site migration: the storage-side `SimBody.mass` is already `Option<MassPropertiesTyped<SelfRef>>` after #397, and the accessor was the last raw-conversion shim on that path. No callers in `astrodyn_bevy`, `astrodyn_verif_parity`, or `examples/` — only the single Tier 3 verif fixture.

Closes #408.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test -p astrodyn_runner --lib` (41 passed)
- [x] `cargo test -p astrodyn_verif_jeod --test tier3_sim_dyncomp_run_attach_to_ref_frame` (passes — exercises the migrated caller end-to-end through `Simulation::step()`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mov1yHR1vofnSCQaNbH6wA)_