### PR TITLE
[#389] Add 9 parity wrappers for tier3 topics; coverage redundancy check

### DIFF
--- a/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run10.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run10.rs
@@ -1,0 +1,22 @@
+//! Bevy ↔ runner parity for SIM_dyncomp RUN_10 family — gravity-
+//! gradient torque (circular, elliptical, and elliptical with initial
+//! body rate). All three are `pre_step: None`; wrappers land as part
+//! of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_dyncomp_run10a_gravity_torque() {
+    sim_dyncomp::run10a_gravity_torque().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run10c_gravity_torque_elliptical() {
+    sim_dyncomp::run10c_gravity_torque_elliptical().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run10d_gravity_torque_elliptical_rate() {
+    sim_dyncomp::run10d_gravity_torque_elliptical_rate().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run3.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run3.rs
@@ -1,0 +1,17 @@
+//! Bevy ↔ runner parity for SIM_dyncomp RUN_3 (4×4 and 8×8 spherical
+//! harmonics gravity, 3-DOF ISS, 8 hours). Both variants are
+//! `pre_step: None` recipes already in `sim_dyncomp`; the wrapper
+//! lands as part of issue #389.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_dyncomp_run3a_sh4x4() {
+    sim_dyncomp::run3a_sh4x4().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run3b_sh8x8() {
+    sim_dyncomp::run3b_sh8x8().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run5.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run5.rs
@@ -1,0 +1,17 @@
+//! Bevy ↔ runner parity for SIM_dyncomp RUN_5b/c (mean / max
+//! atmosphere-density variants). The MET-atmosphere variant
+//! (`run5a_met`) lives in `bevy_parity_met.rs` to match its
+//! tier3 sibling `tier3_sim_met.rs`. Wrappers land as part of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_dyncomp_run5b_atmosphere_mean() {
+    sim_dyncomp::run5b_atmosphere_mean().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run5c_atmosphere_max() {
+    sim_dyncomp::run5c_atmosphere_max().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_euler.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_euler.rs
@@ -1,0 +1,22 @@
+//! Bevy ↔ runner parity for SIM_Euler (Euler-angle derived state along
+//! the SIM_dyncomp RUN_2 trajectory plus `_ecc` and `_equ` orbit
+//! variants). Recipes live in `sim_derived_state`; wrappers land as
+//! part of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_euler_run2() {
+    sim_derived_state::euler_run2().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_euler_ecc() {
+    sim_derived_state::euler_ecc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_euler_equ() {
+    sim_derived_state::euler_equ().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lvlh.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lvlh.rs
@@ -1,0 +1,20 @@
+//! Bevy ↔ runner parity for SIM_LVLH (inclined / eccentric / equatorial
+//! LVLH-frame derived-state recipes). Wrappers land as part of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_lvlh_inc() {
+    sim_derived_state::lvlh_inc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_lvlh_ecc() {
+    sim_derived_state::lvlh_ecc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_lvlh_equ() {
+    sim_derived_state::lvlh_equ().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lvlh_rot_init_propagation.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lvlh_rot_init_propagation.rs
@@ -1,0 +1,12 @@
+//! Bevy ↔ runner parity for SIM_dyncomp RUN_2 with LVLH-frame
+//! rotational initial conditions. Validates the LVLH attitude-init
+//! path is bit-identical between the two runtimes; wrapper lands as
+//! part of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_lvlh_rot_init_propagation() {
+    sim_dyncomp::run2_lvlh_rot_init_propagation().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_ned.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_ned.rs
@@ -1,0 +1,26 @@
+//! Bevy ↔ runner parity for SIM_NED (geodetic + spherical NED on
+//! ellipsoidal and spherical Earth, inclined and polar orbits).
+//! Wrappers land as part of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_ned_ell_inc() {
+    sim_derived_state::ned_ell_inc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_ned_ell_polar() {
+    sim_derived_state::ned_ell_polar().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_ned_sph_inc() {
+    sim_derived_state::ned_sph_inc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_ned_sph_polar() {
+    sim_derived_state::ned_sph_polar().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_orbelem.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_orbelem.rs
@@ -1,0 +1,10 @@
+//! Bevy ↔ runner parity for SIM_OrbElem (eccentric orbit with classical
+//! orbital-element extras). Wrapper lands as part of #389.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_orbelem_ecc() {
+    sim_derived_state::orbelem_ecc().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_polar_motion.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_polar_motion.rs
@@ -1,0 +1,11 @@
+//! Bevy ↔ runner parity for SIM_polar_motion RUN_2P (polar-motion
+//! corrections applied to Earth rotation). Wrapper lands as part of
+//! #389.
+
+use astrodyn_verif_jeod::run_verification::sim_polar_motion;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_polar_motion_run2p() {
+    sim_polar_motion::run2p_polar_motion().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -148,12 +148,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          (#389 follow-up)",
     ),
     (
-        "euler",
-        "pre-recipe sibling — Euler recipe factories exist in \
-         sim_derived_state but no parity wrapper has been added yet \
-         (#389 follow-up)",
-    ),
-    (
         "euler_edge",
         "pre-recipe edge-case sibling — recipe factory not yet defined \
          (#389 follow-up)",
@@ -170,12 +164,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          per-step state component on the Bevy side",
     ),
     (
-        "lvlh",
-        "pre-recipe sibling — LVLH recipe factories exist in \
-         sim_derived_state but no parity wrapper has been added yet \
-         (#389 follow-up)",
-    ),
-    (
         "lvlh_edge",
         "pre-recipe edge-case sibling — recipe factory not yet defined \
          (#389 follow-up)",
@@ -185,24 +173,9 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
         "pre-recipe sibling — recipe factory not yet defined (#389 follow-up)",
     ),
     (
-        "lvlh_rot_init_propagation",
-        "pre-recipe sibling — overlaps with sim_dyncomp::run2_lvlh_rot_init_propagation \
-         but no parity wrapper yet (#389 follow-up)",
-    ),
-    (
-        "ned",
-        "pre-recipe sibling — NED recipe factories exist in sim_derived_state \
-         but no parity wrapper has been added yet (#389 follow-up)",
-    ),
-    (
         "ned_edge",
         "pre-recipe edge-case sibling — recipe factory not yet defined \
          (#389 follow-up)",
-    ),
-    (
-        "orbelem",
-        "pre-recipe sibling — orbelem recipe exists (sim_derived_state::orbelem_ecc) \
-         but no parity wrapper has been added yet (#389 follow-up)",
     ),
     (
         "orbelem_comprehensive",
@@ -228,11 +201,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
         "orbinit_roundtrip",
         "pre-recipe sibling — Cartesian↔Keplerian round-trip, recipe not yet \
          defined (#389 follow-up)",
-    ),
-    (
-        "polar_motion",
-        "pre-recipe sibling — recipe exists (sim_polar_motion::run2p_polar_motion) \
-         but no parity wrapper has been added yet (#389 follow-up)",
     ),
     (
         "ref_attach",
@@ -283,27 +251,10 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
     //    wrapper hasn't been added yet. Tracked individually so each
     //    can be dropped from the gap list as its wrapper lands.
     (
-        "dyncomp_run3",
-        "recipes exist (sim_dyncomp::run3a_sh4x4, run3b_sh8x8) — wrapper \
-         not yet added (#389 follow-up)",
-    ),
-    (
-        "dyncomp_run5",
-        "recipes exist (sim_dyncomp::run5a_met, run5b/c_atmosphere_*) — \
-         atmosphere variants need verification; wrapper not yet added \
-         (#389 follow-up)",
-    ),
-    (
         "dyncomp_run6",
         "recipes exist (sim_dyncomp::run6a_const_density_drag, run6b_drag, \
          run6b_drag_rotated_struct, run6b_drag_aero_traj) — wrapper not yet \
          added (#389 follow-up)",
-    ),
-    (
-        "dyncomp_run10",
-        "recipes exist (sim_dyncomp::run10a_gravity_torque, \
-         run10c_gravity_torque_elliptical, run10d_gravity_torque_elliptical_rate) \
-         — wrapper not yet added (#389 follow-up)",
     ),
     // dyncomp_run2 covered by `bevy_parity_dyncomp_run2_3dof.rs` (the
     // pilot wrapper); the prefix-match in `is_covered_by_parity` lets
@@ -371,6 +322,22 @@ fn parity_topics_are_a_superset_of_tier3_topics() {
         stale.is_empty(),
         "KNOWN_PARITY_GAPS contains topics that no longer exist in tier3_*.rs: {stale:?}\n  \
          Either restore the missing tier3 test or drop the exemption.",
+    );
+
+    // Cross-list redundancy: a topic with an existing parity wrapper
+    // shouldn't *also* be in `KNOWN_PARITY_GAPS` (the gap entry would
+    // be a lie). Catches the "added the wrapper but forgot to drop the
+    // gap entry" failure mode.
+    let mut redundant: Vec<&str> = Vec::new();
+    for (topic, _reason) in KNOWN_PARITY_GAPS {
+        if is_covered_by_parity(topic, &parity_topics) {
+            redundant.push(topic);
+        }
+    }
+    assert!(
+        redundant.is_empty(),
+        "KNOWN_PARITY_GAPS lists topics that already have a parity wrapper: {redundant:?}\n  \
+         Drop the redundant gap entry — the wrapper supersedes it.",
     );
 }
 

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -25,13 +25,25 @@ use std::path::Path;
 
 /// Topics whose Tier 3 sibling exists but whose parity counterpart is
 /// deliberately absent (or `#[ignore]`d) for a documented structural
-/// reason. Each entry MUST link to the tracking note that explains the
-/// gap; the entries here are the "intentional gap" set the
+/// reason. The entries here are the "intentional gap" set the
 /// `parity_coverage` test exempts.
 ///
+/// Two flavors of gap live in this list:
+///
+/// 1. **Deferred** — the bridge or recipe layer doesn't cover the
+///    topic *yet*, but a parity wrapper is expected once the blocker
+///    lifts. These entries MUST link to the tracking issue (typically
+///    `#389` or a follow-up) so the gap can be closed and the entry
+///    dropped when the issue lands.
+/// 2. **Permanent** — the topic is structurally out of scope for the
+///    `VerificationCaseParityExt` trait (no trajectory CSV, pure
+///    analytical/solver test, structural mass-tree composition). The
+///    reason field states *why* the topic doesn't fit; no issue link
+///    is required because there is no follow-up planned.
+///
 /// The set is intentionally small. Issue #389 closes the bulk of the
-/// gap; entries that remain are the long-tail features the bridge
-/// doesn't cover yet.
+/// deferred cluster; entries that remain are either narrowly-scoped
+/// follow-ups or permanent out-of-scope cases.
 const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
     // ── Multi-planet scenarios: the bridge spawns all bodies under a
     //    single `<P>` today, so cases that integrate in two


### PR DESCRIPTION
## Summary

Adds the next batch of `bevy_parity_*` wrappers for issue #389. Every recipe driven here is `pre_step: None` and ships a factory in either `sim_dyncomp` / `sim_derived_state` / `sim_polar_motion` already; the gap was just a missing one-liner test file. Drops the matching entries from `KNOWN_PARITY_GAPS` and adds a cross-list redundancy check so future PRs that add a wrapper without dropping the gap entry fail CI immediately.

| New wrapper | Tests | Recipe(s) |
|---|---|---|
| `bevy_parity_dyncomp_run3.rs` | 2 | `run3a_sh4x4`, `run3b_sh8x8` |
| `bevy_parity_dyncomp_run5.rs` | 2 | `run5b_atmosphere_mean`, `run5c_atmosphere_max` |
| `bevy_parity_dyncomp_run10.rs` | 3 | `run10a_gravity_torque`, `run10c_…_elliptical`, `run10d_…_elliptical_rate` |
| `bevy_parity_euler.rs` | 3 | `euler_run2`, `euler_ecc`, `euler_equ` |
| `bevy_parity_lvlh.rs` | 3 | `lvlh_inc`, `lvlh_ecc`, `lvlh_equ` |
| `bevy_parity_lvlh_rot_init_propagation.rs` | 1 | `run2_lvlh_rot_init_propagation` |
| `bevy_parity_ned.rs` | 4 | 4 ellipsoidal/spherical NED variants |
| `bevy_parity_orbelem.rs` | 1 | `orbelem_ecc` |
| `bevy_parity_polar_motion.rs` | 1 | `run2p_polar_motion` |

`tier3_bevy_orbelem_ecc` smoke-tested locally — passes bit-identical at every CSV checkpoint over the full propagation duration (67s release wall-clock).

## Coverage redundancy check

`parity_coverage.rs` already enforces `tier3_topics ⊂ bevy_parity_topics ∪ KNOWN_PARITY_GAPS` and flags stale `KNOWN_PARITY_GAPS` entries. This PR adds a third invariant:

```rust
// Cross-list redundancy: a topic with an existing parity wrapper
// shouldn't *also* be in `KNOWN_PARITY_GAPS` (the gap entry would
// be a lie).
```

Catches the "added the wrapper but forgot to drop the gap entry" failure mode at CI time.

## Bug surfaces (filed separately, not in this PR)

While developing the broader Phase 2 wrapper batch I uncovered three real bridge / architectural issues; the wrappers in this PR specifically avoid those code paths so they can land cleanly. Tracked individually:

- **#411** — `bevy aero_drag_system` runs once per `FixedUpdate` tick; runner's RK4 re-evaluates drag per stage. Affects `dyncomp_run6` family + `run7c/run7d` (the drag-bearing variants of `run7`). Reproduces with bit-error at t=60s.
- **#412** — 1st-order thermal SRP (`ThermalIntegrationOrder::DerivativeFirstOrder`) diverges per stage; default-order SRP is bit-identical. Affects `srp_1st_order` only.
- **#413** — Multi-planet bridge dispatch (`populate_app_multi`). Affects apollo*, `earth_moon`, `mars_orbit`, `mercury`, `planetary`. Architectural lift; merits its own PR.

`tide_verif` still sits in `KNOWN_PARITY_GAPS` because `AppSimContext::set_tidal_body_position` is `default-panic` (per the gap-entry note that landed with #406); adding it is its own focused change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p astrodyn_verif_parity --tests --release -- -D warnings`
- [x] `cargo test -p astrodyn_verif_parity --test parity_coverage --release`
- [x] `cargo test -p astrodyn_verif_parity --test bevy_parity_orbelem --release` (bit-identical, 67s)
- [ ] CI runs the full `bevy_parity_*` suite — every wrapper in this PR should pass bit-identically at every CSV checkpoint.

Closes the wrapper-add chunk of #389 for these 9 topics.

https://claude.ai/code/session_01XY94USeZBj9HYfpVjsZE3j

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY94USeZBj9HYfpVjsZE3j)_