### PR TITLE
[#411] Reinstate dyncomp_run6 parity wrapper; drop from KNOWN_PARITY_GAPS

### DIFF
--- a/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run6.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run6.rs
@@ -1,0 +1,29 @@
+//! Bevy ↔ runner parity for SIM_dyncomp RUN_6A / RUN_6B (atmospheric
+//! drag — constant-density and MET, with optional structural-frame
+//! rotation and aero-trajectory variants). All four cases share a
+//! `pre_step: None` recipe; the parity wrapper drives both runtimes
+//! through the same scenario factory and asserts bit-identical state
+//! at every reference-CSV checkpoint.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn tier3_bevy_dyncomp_run6a_const_density_drag() {
+    sim_dyncomp::run6a_const_density_drag().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run6b_drag() {
+    sim_dyncomp::run6b_drag().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run6b_drag_aero_traj() {
+    sim_dyncomp::run6b_drag_aero_traj().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn tier3_bevy_dyncomp_run6b_drag_rotated_struct() {
+    sim_dyncomp::run6b_drag_rotated_struct().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -262,15 +262,14 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
     //    but several rely on `pre_step` for ephemeris updates and the
     //    wrapper hasn't been added yet. Tracked individually so each
     //    can be dropped from the gap list as its wrapper lands.
-    (
-        "dyncomp_run6",
-        "recipes exist (sim_dyncomp::run6a_const_density_drag, run6b_drag, \
-         run6b_drag_rotated_struct, run6b_drag_aero_traj) — wrapper not yet \
-         added (#389 follow-up)",
-    ),
+    //
     // dyncomp_run2 covered by `bevy_parity_dyncomp_run2_3dof.rs` (the
     // pilot wrapper); the prefix-match in `is_covered_by_parity` lets
     // it satisfy this entry implicitly, so it is not listed here.
+    //
+    // dyncomp_run6 covered by `bevy_parity_dyncomp_run6.rs` — drag
+    // family (run6a_const_density_drag, run6b_drag,
+    // run6b_drag_rotated_struct, run6b_drag_aero_traj).
 ];
 
 #[test]


### PR DESCRIPTION
Closes #411.

## Summary

- Restore `crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_run6.rs` with the four drag cases (`run6a_const_density_drag`, `run6b_drag`, `run6b_drag_aero_traj`, `run6b_drag_rotated_struct`) as one-line wrappers driving `VerificationCaseParityExt::run_and_assert_parity::<astrodyn::Earth>()`.
- Drop the `dyncomp_run6` entry from `KNOWN_PARITY_GAPS` in `parity_coverage.rs`; the `parity_coverage` redundancy invariant ("wrapper present + gap entry forbidden") is now satisfied.

## Test plan

- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_dyncomp_run6` — all 4 tests pass bit-identical (verified in worktree).
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — `parity_topics_are_a_superset_of_tier3_topics` still passes after the gap-entry removal.
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — unit + tier 2 suite green.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

## Notes on scope

The issue described a bridge bug where `bevy aero_drag_system` was once-per-tick while `astrodyn_runner`'s RK4 integrator allegedly evaluated drag per stage, producing ~5e-8 m position drift in drag-bearing parity tests. Investigation on `main`:

- The runner does **not** evaluate drag per RK4 stage today: `aero_force` is set once in `step/interactions.rs:69` and the constant value flows through `collect_and_resolve_forces` into `total_force`, then into the integrator's `non_grav_force` parameter (held constant across the four RK4 stages by `integrate_body` / `integrate_body_typed`).
- The Bevy adapter is also once-per-tick (`aero_drag_system`).
- Both runtimes agree numerically at the bit-identity level — the four `bevy_parity_dyncomp_run6_*` tests pass without any runtime code change.

So the fix on `main` is just the test plumbing: restore the wrapper file, drop the gap entry. The deeper per-stage drag enhancement — porting JEOD's `DynamicsIntegrationGroup` derivative-class drag recompute, analogous to the existing per-stage gravity recompute in `astrodyn_bevy/src/systems/integration.rs` and `astrodyn_runner/src/simulation/step/integrate.rs` — would need to land in both runtimes simultaneously to preserve bit-identity, and is best tracked as its own follow-up issue.

`bevy_parity_dyncomp_run7c_*` and `..._run7d_*` are not currently `#[ignore]`d on main, so no action was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
