### PR TITLE
Split heavy bevy_parity_ trajectory tests into a dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,42 @@ jobs:
             echo "FATAL: JEOD_HOME / JEOD_PATH must be unset for the standalone-repo CI fence" >&2
             exit 1
           fi
-      - name: Run tests (skip Tier 3 trajectory validation)
-        run: cargo nextest run --workspace -E 'not test(tier3_)'
+      # Heavy bevy_parity_* trajectory tests run the same 8h–23-day
+      # propagations as their tier3_ siblings (twice, for runner-vs-bevy
+      # bit-identity), so they dominate this job's wall time. They run
+      # in the dedicated `test-parity-trajectory` job below; the cheap
+      # mechanism-only parity tests (mass attach/detach, kinematic
+      # propagation, body action lifecycle, …) stay here.
+      - name: Run tests (skip Tier 3 + heavy parity trajectory tests)
+        run: |
+          cargo nextest run --workspace \
+            -E 'not test(tier3_) and not test(/^bevy_parity_(dyncomp_run(2|4|5a|7)|solar_beta|srp_1st_order|tide_verif)/)'
+
+  test-parity-trajectory:
+    name: Test (parity trajectory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Verify JEOD env vars are unset (regression fence)
+        # Heavy parity tests propagate from committed JEOD fixtures
+        # (same regen path as tier3_), so $JEOD_HOME must be unset
+        # exactly like the other test jobs.
+        run: |
+          if [ -n "${JEOD_HOME:-}" ] || [ -n "${JEOD_PATH:-}" ]; then
+            echo "FATAL: JEOD_HOME / JEOD_PATH must be unset for the standalone-repo CI fence" >&2
+            exit 1
+          fi
+      # The 13 bevy_parity_* trajectory tests run the same 8h–23-day
+      # propagations as their tier3_ siblings, twice (runner + bevy)
+      # to assert per-checkpoint bit-identity. Keep this filter in sync
+      # with the inverse exclusion in the `test` job above.
+      - name: Run heavy parity trajectory tests
+        run: |
+          cargo nextest run --workspace \
+            -E 'test(/^bevy_parity_(dyncomp_run(2|4|5a|7)|solar_beta|srp_1st_order|tide_verif)/)'
 
   test-tier3:
     name: Test (Tier 3 fast)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,8 +406,16 @@ by default):
 ```bash
 cargo build --workspace
 cargo nextest run --workspace                                 # all tests
-cargo nextest run --workspace -E 'not test(tier3_)'           # unit + tier 2 (fast)
+# `unit + tier 2 (fast)` excludes Tier 3 *and* the heavy bevy_parity_*
+# trajectory tests (they run the same 8h–23-day propagations as
+# their tier3_ siblings, twice each). Keep this filter in sync
+# with the `test` and `test-parity-trajectory` jobs in CI.
+cargo nextest run --workspace \
+  -E 'not test(tier3_) and not test(/^bevy_parity_(dyncomp_run(2|4|5a|7)|solar_beta|srp_1st_order|tide_verif)/)'
 cargo nextest run --workspace -E 'test(tier3_)'               # tier 3 only
+# Heavy parity trajectory tests (the ones excluded above):
+cargo nextest run --workspace \
+  -E 'test(/^bevy_parity_(dyncomp_run(2|4|5a|7)|solar_beta|srp_1st_order|tide_verif)/)'
 cargo nextest run -p astrodyn_math                                # single crate
 cargo nextest run -p astrodyn_gravity -E 'test(verif)'            # gravity verification only
 cargo nextest run -p astrodyn_runner --test tier3_sim_dyncomp_run2  # single Tier 3 test
@@ -469,14 +477,28 @@ gating policy, the `tier3_baseline_diff` check, and the refreeze workflow.
 All Tier 3 test functions use the `tier3_` prefix, enabling cargo's name-based
 filtering. CI (`.github/workflows/ci.yml`) uses this:
 
-- **PRs**: `check` (fmt + clippy), `test` (unit + tier 2), and `test-tier3`
-  (tier 3 excluding `earth_moon`) run in parallel for fast feedback.
+- **PRs**: `check` (fmt + clippy), `test` (unit + tier 2 + cheap parity),
+  `test-parity-trajectory` (heavy `bevy_parity_*` trajectory tests),
+  and `test-tier3` (tier 3 excluding `earth_moon`) run in parallel for
+  fast feedback.
 - **Main push**: same jobs, plus `test-tier3-full` which includes the
   `earth_moon` test (~17 min) and generates the cross-validation report.
 - **Push to non-main branches**: no CI (only PRs and main trigger workflows).
 
 When adding new Tier 3 tests, always prefix the function name with `tier3_` so
 CI filtering picks it up automatically.
+
+The `test` and `test-parity-trajectory` jobs split the `bevy_parity_*`
+suite by cost: cheap mechanism-only parity tests (mass attach/detach,
+kinematic propagation, body action lifecycle, …) stay in `test`, while
+the trajectory tests that propagate 8 h–23 day simulations twice
+(`bevy_parity_dyncomp_run{2,4,5a,7}*`, `bevy_parity_solar_beta_*`,
+`bevy_parity_srp_1st_order_trajectory`, `bevy_parity_tide_verif_run01`)
+run in their own job. When adding a new heavy parity trajectory test,
+extend the regex in **both** the `test` (exclude) and
+`test-parity-trajectory` (include) filters in
+`.github/workflows/ci.yml`, or it will silently regress the
+`test` job's wall time.
 
 See `crates/astrodyn_bevy/tests/README.md` for tier conventions and the tolerance/baseline workflow.
 


### PR DESCRIPTION
## Why is `cargo nextest run --workspace -E 'not test(tier3_)'` slow?

The filter only matches test function names with the `tier3_` prefix.
`astrodyn_verif_parity` has `bevy_parity_*` tests that run the same
8h–23-day propagations as their `tier3_*` siblings — twice each, to
assert per-checkpoint runner-vs-bevy bit-identity (`crates/astrodyn_verif_parity/src/lib.rs:80-266`,
introduced in #389) — but they slip past the filter.

Observed wall times on a 4-core box (single run, partial; full runs were
killed at >9 / >7 min):

| Test | Wall time |
| --- | --- |
| `bevy_parity_srp_1st_order_trajectory` | >9 min (23-day GEO at dt=1.0s, 6-plate SRP + thermal + Sun ephemeris) |
| `bevy_parity_tide_verif_run01` | >7 min (8 h ISS at dt=0.03125s, GGM05C 8×8 + tides + 3rd-body) |
| `bevy_parity_solar_beta_obliquity` | 172.5s |
| `bevy_parity_dyncomp_run7d_sh8x8_3rd_body_drag` | 129.5s |
| `bevy_parity_dyncomp_run7c_sh4x4_3rd_body_drag` | 128.2s |
| `bevy_parity_dyncomp_run7a_sh4x4_3rd_body` | 121.8s |
| `bevy_parity_dyncomp_run7b_sh8x8_3rd_body` | 121.2s |
| `bevy_parity_solar_beta_equ` | 119.1s |
| `bevy_parity_dyncomp_run5a_met` | 113.0s |
| `bevy_parity_dyncomp_run4_3rd_body` | 104.7s |
| `bevy_parity_dyncomp_run2_6dof` | 99.1s |
| `bevy_parity_dyncomp_run2_3dof` | 97.1s |
| `bevy_parity_solar_beta_run2` | 95.7s |
| **12th slowest test in the whole `not test(tier3_)` set** | **0.287s** |

13 tests account for ≈30 minutes of CPU. Everything else is sub-second.

## Summary

- Tighten the `test` (unit + tier 2) job's filter to also exclude the 13
  heavy `bevy_parity_*` trajectory tests.
- Add a parallel `test-parity-trajectory` CI job that runs only those 13,
  modeled on the existing `test-tier3` job split (`#earth_moon` lives in
  `test-tier3-full`).
- Document the new filters and the maintenance contract in `CLAUDE.md`:
  a new heavy parity trajectory test must extend the regex in **both**
  jobs or the `test` job silently regresses.

The cheap mechanism-only parity tests (mass attach/detach, kinematic
propagation, body action lifecycle, …) stay in `test` — they're <0.3 s
each.

After this change `test` should drop from ~13 min to ~3 min, and
`test-parity-trajectory` runs in parallel with `test` and `test-tier3`,
so total PR feedback time is unchanged (governed by the slowest job).

## Test plan

- [x] `cargo nextest list --workspace -E '<new fast filter>'` reports 1224 tests (was 1237; 13 dropped).
- [x] `cargo nextest list --workspace -E '<new parity-trajectory filter>'` reports exactly the 13 heavy tests.
- [x] `cargo fmt --check` passes.
- [ ] CI on this PR shows `test`, `test-parity-trajectory`, and `test-tier3` running in parallel and all green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hpd66npJGDp6BWrnQo6i2h)_