### PR TITLE
[#432] Reconcile stale #263 caveat in integ_source doc

### DIFF
--- a/src/vehicle_builder.rs
+++ b/src/vehicle_builder.rs
@@ -405,17 +405,22 @@ impl VehicleBuilder<Ready> {
     /// central body). `source_idx` is the index returned by
     /// `SimulationBuilder::add_source()`.
     ///
-    /// **Non-root caveat (issue #263).** Setting this to a non-root
-    /// source means the integrated translational state is
-    /// integ-frame-relative rather than root-inertial, but downstream
-    /// Bevy storage (`TranslationalStateC<RootInertial>`) is still
-    /// tagged `RootInertial` — issue #263 Section A.1. Derived-state
-    /// consumers that read the state as absolute root-inertial
-    /// (geodetic vs. another planet, solar-beta, SRP relative to a Sun
-    /// position not in the integ frame) will silently produce wrong
-    /// answers. Until #263 closes, mission code should either avoid
-    /// non-root integration or restrict derived states to ones
-    /// evaluated in the same source's frame.
+    /// When set to a non-root source, the body's translational state
+    /// lives in that source's planet-inertial frame rather than the
+    /// root inertial frame. The Bevy adapter expresses this
+    /// structurally: `TranslationalStateC<P>` carries the
+    /// `PlanetInertial<P>` phantom, and the caller pins `P` to the
+    /// integration source's planet via the `spawn_bevy::<P>(...)`
+    /// turbofish; the runner threads the same planet identity through
+    /// its per-body integration-frame plumbing. Shift-site consumers
+    /// that require root-inertial coordinates — gravity, SRP, solar
+    /// beta, earth lighting, relativistic corrections — lift the
+    /// integ-origin offset at the call site through
+    /// `FrameOrigin::shift_position` (`docs/JEOD_invariants.md` row
+    /// `RF.10`); non-shift consumers (atmosphere, drag, LVLH,
+    /// geodetic, orbital elements) stay in `PlanetInertial<P>`
+    /// throughout. Mismatching `P` against the integration source's
+    /// planet is a compile error, not a runtime convention.
     pub fn integ_source(mut self, source_idx: usize) -> Self {
         self.integ_source = Some(source_idx);
         self


### PR DESCRIPTION
Closes #432.

## Summary

The `integ_source(...)` doc comment warned that the integrated state was tagged `TranslationalStateC<RootInertial>` and that downstream derived-state consumers would silently produce wrong answers "until #263 closes." Both claims are no longer accurate: #263 closed on 2026-05-04, and the Bevy storage at `crates/astrodyn_bevy/src/components/state.rs` is now `TranslationalStateC<P>` with a `PlanetInertial<P>` phantom — the type-lie that motivated the caveat is gone.

This is the **reading (a)** outcome from #432: fully resolved. Per the issue's spike, the residual silent-wrong vector requires a body integrating around `source[idx]` while still tagged for a *different* planet. With the current `spawn_bevy::<P>(...)` turbofish pinning `P` to the integration source's planet, that mismatch is a compile error rather than a runtime convention — there is no remaining (b)-flavored case to file as a follow-up.

The replacement comment is a positive statement of the frame discipline:

- `TranslationalStateC<P>` carries a `PlanetInertial<P>` phantom; the runner pins the same planet identity through its per-body integration-frame plumbing.
- Shift-site consumers (gravity, SRP, solar beta, earth lighting, relativistic corrections) lift the integ-origin offset at the call site through `FrameOrigin::shift_position` per `docs/JEOD_invariants.md` row `RF.10`.
- Non-shift consumers (atmosphere, drag, LVLH, geodetic, orbital elements) stay in `PlanetInertial<P>` throughout.
- Mismatching `P` is a compile error, not a runtime convention.

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo test --doc -p astrodyn` — 54 passed
- [x] `cargo test -p astrodyn --test invariant_coverage` — 6 passed
- [ ] Full `clippy` / `nextest` / parity / escape-hatches gates run in CI (no behavioral change in this PR — pure docstring rewrite on one method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)