### PR TITLE
Bring in-crate docs to crates.io publish-ready state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build workspace docs (no deps, deny warnings)
-        run: cargo doc --workspace --no-deps --quiet
+      - name: Build workspace docs (public + private, deny warnings)
+        # `--document-private-items` surfaces broken intra-doc links and
+        # invalid HTML tags inside private items (`fn`, `struct`, fields).
+        # The workspace's [workspace.lints.rustdoc] table already denies
+        # these; running the strict-warnings build keeps drift from landing.
+        run: cargo doc --workspace --no-deps --document-private-items --quiet
         env:
           RUSTDOCFLAGS: -D warnings
       - name: Run workspace doctests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ After the type-system refactor (#101), there are two layers to choose between:
 
 See the [Type-System wiki page](https://github.com/simnaut/astrodyn/wiki/Type-System) for the contributor primer (phantom-tag pattern,
 adding a new frame/scale/quantity, reading compiler errors, escape hatches)
-and `examples/typed_mission.rs` for the canonical worked example.
+and `crates/astrodyn_bevy/examples/typed_mission.rs` for the canonical worked example.
 
 ### Inertial-frame phantoms (#255 / RF.10)
 
@@ -648,7 +648,7 @@ language pointing to the missing `FrameTransform<Ecef, RootInertial>` step, not 
 PhantomData type-mismatch wall.
 
 **Reference**:
-- Canonical worked example: `examples/typed_mission.rs`.
+- Canonical worked example: `crates/astrodyn_bevy/examples/typed_mission.rs`.
 - Contributor primer (phantom tags, adding new dimensions, escape hatches):
   [Type-System wiki page](https://github.com/simnaut/astrodyn/wiki/Type-System).
 - Architecture and phase history:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,25 @@ thiserror = "2"
 uom = { version = "0.38", default-features = false, features = ["f64", "si", "std"] }
 typenum = "1.20"
 
+# Workspace-wide lint policy. Inherited by every member that adds
+# `[lints] workspace = true` to its Cargo.toml. Single point of truth
+# for doc and safety hygiene.
+#
+# `priority = -1` on `missing_docs` lets test files / examples override
+# with `#![allow(missing_docs)]` when a macro emits an undocumented item
+# in a non-library target. The workspace policy still denies missing
+# docs by default for `lib` targets.
+[workspace.lints.rust]
+unsafe_code = "forbid"
+missing_docs = { level = "deny", priority = -1 }
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+invalid_html_tags = "deny"
+
+[lints]
+workspace = true
+
 # Per-package opt-levels: hot numerical crates need optimization (spherical
 # harmonics is ~20× slower at opt-level=0), but orchestration crates can
 # compile faster at opt-level=1. Dependencies compile once at opt-level=3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,48 @@ crates into pipeline stages and re-exports their types so a downstream
 crate only needs `astrodyn` to access the entire physics surface.
 Pure Rust, zero Bevy dependency.
 
+**Status:** pre-1.0. Tier 3 cross-validated against JEOD Trick simulations
+(see the [Tier3-Regeneration wiki page](https://github.com/simnaut/astrodyn/wiki/Tier3-Regeneration)).
+API may change before 1.0.
+
+## Quick start
+
+Most users want one of the consumer crates rather than this orchestration
+layer directly:
+
+- `astrodyn_bevy` for the Bevy-ECS production runtime,
+- `astrodyn_runner` for plain-Rust batch propagation and Tier 3 tests.
+
+If you are building a custom adapter on top of the pipeline, depend on
+`astrodyn` directly:
+
+```toml
+[dependencies]
+astrodyn = "0.1"
+```
+
+```rust,no_run
+use astrodyn::{
+    recipes::{earth, orbital_elements, vehicle},
+    F64Ext, GravityControl, VehicleBuilder,
+};
+
+let mu = earth::point_mass().source.mu.m3_per_s2();
+let cfg = VehicleBuilder::new()
+    .from_orbital_elements(orbital_elements::iss(), mu)
+    .three_dof_point_mass(vehicle::iss_mass())
+    .rk4()
+    .gravity(GravityControl::new_spherical(0_usize, false))
+    .build();
+// `cfg` is a `VehicleConfig` ready to hand to either
+// `astrodyn_bevy::spawn_bevy::<Earth>(...)` or
+// `astrodyn_runner::Simulation::add_vehicle(...)`.
+# let _ = cfg;
+```
+
+The typestate `VehicleBuilder` rejects misuse at compile time
+(no integrator chosen, no state set, mismatched coordinate frames).
+
 ## Layered architecture
 
 ```
@@ -52,7 +94,7 @@ for the layered-architecture rules.
 
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
-- [`examples/typed_mission.rs`](https://github.com/simnaut/astrodyn/blob/main/examples/typed_mission.rs) —
-  canonical worked example.
+- [`crates/astrodyn_bevy/examples/typed_mission.rs`](https://github.com/simnaut/astrodyn/blob/main/crates/astrodyn_bevy/examples/typed_mission.rs)
+  — canonical worked example.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn/>
+  <https://docs.rs/astrodyn>

--- a/crates/astrodyn_atmosphere/Cargo.toml
+++ b/crates/astrodyn_atmosphere/Cargo.toml
@@ -19,3 +19,6 @@ uom = { workspace = true }
 
 [dev-dependencies]
 astrodyn_verif_jeod = { path = "../astrodyn_verif_jeod", version = "0.1.0" }
+
+[lints]
+workspace = true

--- a/crates/astrodyn_atmosphere/README.md
+++ b/crates/astrodyn_atmosphere/README.md
@@ -43,4 +43,4 @@ no Bevy dependency.
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_atmosphere/>
+  <https://docs.rs/astrodyn_atmosphere>

--- a/crates/astrodyn_atmosphere/src/lib.rs
+++ b/crates/astrodyn_atmosphere/src/lib.rs
@@ -47,6 +47,22 @@
 //! convention is documented in
 //! `models/environment/atmosphere/base_atmos/include/wind_velocity.hh`
 //! ("the inertial frame of the planet causing the wind velocity").
+//!
+//! ## Example
+//!
+//! Default exponential atmosphere with Earth sea-level reference values:
+//!
+//! ```
+//! use astrodyn_atmosphere::exponential::ExponentialAtmosphere;
+//!
+//! let atmos = ExponentialAtmosphere::default();
+//! let sea_level = atmos.density(0.0);
+//! assert!((sea_level.density - 1.225).abs() < 1e-9);
+//!
+//! // Density falls off exponentially with altitude.
+//! let one_scale_height = atmos.density(8_500.0);
+//! assert!(one_scale_height.density < sea_level.density);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_bevy/Cargo.toml
+++ b/crates/astrodyn_bevy/Cargo.toml
@@ -28,3 +28,6 @@ path = "examples/kepler_orbit.rs"
 [[example]]
 name = "typed_mission"
 path = "examples/typed_mission.rs"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_bevy/src/systems/glue/mass_update.rs
+++ b/crates/astrodyn_bevy/src/systems/glue/mass_update.rs
@@ -1,11 +1,10 @@
 //! Glue: per-step recompute of derived mass quantities.
 //!
 //! Recomputes `inverse_mass` / `inverse_inertia` for every entity
-//! whose [`MassPropertiesC`](crate::components::MassPropertiesC) is
-//! marked `dirty`. Runs between [`AstrodynSet::TimeUpdate`](crate::AstrodynSet::TimeUpdate)
-//! and [`AstrodynSet::EphemerisUpdate`](crate::AstrodynSet::EphemerisUpdate)
-//! so gravity, force collection, and integration see current mass
-//! properties.
+//! whose [`crate::components::MassPropertiesC`] is marked `dirty`.
+//! Runs between [`crate::AstrodynSet::TimeUpdate`] and
+//! [`crate::AstrodynSet::EphemerisUpdate`] so gravity, force
+//! collection, and integration see current mass properties.
 
 use bevy::prelude::*;
 

--- a/crates/astrodyn_bevy/tests/diagnostic_act5_witness_methods.rs
+++ b/crates/astrodyn_bevy/tests/diagnostic_act5_witness_methods.rs
@@ -20,6 +20,8 @@
 //! - `RelativeTranslation<Reference>` — `assert_reference::<R>()`
 //! - `LvlhRelativeState<Chief>` — `assert_chief::<C>()`
 
+#![allow(missing_docs)] // `define_vehicle!` emits structs without docs.
+
 use astrodyn::{
     compute_lvlh_relative_state, compute_relative_state, define_vehicle, FlatPlate, FrameTransform,
     LvlhRelativeState, RelativeState, RelativeTranslation, RotationalState, StructuralFrame,

--- a/crates/astrodyn_dynamics/Cargo.toml
+++ b/crates/astrodyn_dynamics/Cargo.toml
@@ -27,3 +27,6 @@ astrodyn_gravity = { path = "../astrodyn_gravity", version = "0.1.0" }
 astrodyn_planet = { path = "../astrodyn_planet", version = "0.1.0" }
 sha2 = "0.10"
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_dynamics/README.md
+++ b/crates/astrodyn_dynamics/README.md
@@ -58,4 +58,4 @@ astrodyn_math, astrodyn_frames, astrodyn_quantities
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_dynamics/>
+  <https://docs.rs/astrodyn_dynamics>

--- a/crates/astrodyn_dynamics/src/gauss_jackson/coefficients_pair.rs
+++ b/crates/astrodyn_dynamics/src/gauss_jackson/coefficients_pair.rs
@@ -40,10 +40,10 @@ impl CoefficientsPair {
     ///
     /// JEOD: `GaussJacksonCoefficientsPair::apply(nelem, ncoeff, acc_hist, state_sum)`.
     ///
-    /// Returns (vel_sum, pos_sum) where:
-    ///   vel_sum = Σ sa_coefs[i] * acc_hist[i]
-    ///   pos_sum = Σ gj_coefs[i] * acc_hist[i]
-    /// for i in 0..ncoeff.
+    /// Returns `(vel_sum, pos_sum)` where:
+    ///   `vel_sum = Σ sa_coefs[i] * acc_hist[i]`
+    ///   `pos_sum = Σ gj_coefs[i] * acc_hist[i]`
+    /// for `i` in `0..ncoeff`.
     pub fn apply(&self, acc_hist: &TwoDArray, ncoeff: usize) -> (DVec3, DVec3) {
         // JEOD: Initialize from first history point
         let acc_0 = acc_hist.get_dvec3(0);

--- a/crates/astrodyn_dynamics/src/gauss_jackson/mod.rs
+++ b/crates/astrodyn_dynamics/src/gauss_jackson/mod.rs
@@ -733,7 +733,7 @@ impl GaussJacksonState {
     /// Test for convergence.
     ///
     /// JEOD: `test_for_convergence(state, hist_data)`.
-    /// Compares state.position against pos_hist[target_idx], then updates pos_hist.
+    /// Compares `state.position` against `pos_hist[target_idx]`, then updates `pos_hist`.
     fn test_for_convergence(&mut self, new_pos: DVec3, target_idx: usize) -> bool {
         let old_pos = self.pos_hist.get_dvec3(target_idx);
         let mut passed = true;

--- a/crates/astrodyn_dynamics/src/gauss_jackson/ratio128.rs
+++ b/crates/astrodyn_dynamics/src/gauss_jackson/ratio128.rs
@@ -281,7 +281,7 @@ impl Div<Ratio128> for i32 {
     }
 }
 
-/// Copy of the `std::copy` pattern: convert Vec<Ratio128> → slice of f64.
+/// Copy of the `std::copy` pattern: convert `Vec<Ratio128>` → slice of `f64`.
 impl Ratio128 {
     /// Convert a slice of Ratio128 to f64 values.
     pub fn slice_to_f64(src: &[Self], dst: &mut [f64]) {

--- a/crates/astrodyn_dynamics/src/lib.rs
+++ b/crates/astrodyn_dynamics/src/lib.rs
@@ -36,6 +36,24 @@
 //! `models/dynamics/body_action/`, and `models/utils/integration/`. Pure
 //! Rust, zero Bevy dependency — orchestration lives in `astrodyn` and ECS
 //! wiring lives in the `astrodyn_bevy` root crate.
+//!
+//! ## Example
+//!
+//! Compute the parallel-axis (Steiner) inertia contribution of a 10 kg
+//! point mass offset 2 m along +X from the reference point. The
+//! resulting matrix has `0` on the (0,0) diagonal (no inertia about the
+//! axis through the offset) and `mass * r^2 = 40` on the perpendicular
+//! diagonal entries:
+//!
+//! ```
+//! use astrodyn_dynamics::point_mass_inertia;
+//! use glam::DVec3;
+//!
+//! let i = point_mass_inertia(10.0, DVec3::new(2.0, 0.0, 0.0));
+//! assert!(i.x_axis.x.abs() < 1e-12);
+//! assert!((i.y_axis.y - 40.0).abs() < 1e-12);
+//! assert!((i.z_axis.z - 40.0).abs() < 1e-12);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_ephemeris/Cargo.toml
+++ b/crates/astrodyn_ephemeris/Cargo.toml
@@ -32,3 +32,6 @@ astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0" }
 anise = "0.9"
 glam = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrodyn_ephemeris/README.md
+++ b/crates/astrodyn_ephemeris/README.md
@@ -46,4 +46,4 @@ for the layered architecture.
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture and
   conventions.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_ephemeris/>
+  <https://docs.rs/astrodyn_ephemeris>

--- a/crates/astrodyn_ephemeris/src/lib.rs
+++ b/crates/astrodyn_ephemeris/src/lib.rs
@@ -25,6 +25,27 @@
 //! interplanetary trajectories) and for radiation-pressure / shadow geometry
 //! in `astrodyn_interactions`. JEOD source: `models/environment/ephemerides/`.
 //! Pure Rust, zero Bevy dependency.
+//!
+//! ## Example
+//!
+//! Load DE421 from the bundled bytes, then query the Sun's position
+//! relative to the solar-system barycenter at J2000.0 (TDB Julian Day
+//! `2_451_545.0`):
+//!
+//! ```
+//! use astrodyn_ephemeris::{data::DE421_BSP, Ephemeris, EphemerisBody};
+//!
+//! let eph = Ephemeris::from_bsp_bytes(DE421_BSP).unwrap();
+//! let (pos, _vel) = eph
+//!     .get_state_typed(
+//!         EphemerisBody::Sun,
+//!         EphemerisBody::SolarSystemBarycenter,
+//!         2_451_545.0,
+//!     )
+//!     .unwrap();
+//! // The Sun is close to the barycenter (~1 solar radius offset).
+//! assert!(pos.raw_si().length() < 2.0e9);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_frames/Cargo.toml
+++ b/crates/astrodyn_frames/Cargo.toml
@@ -23,3 +23,6 @@ astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0", feat
 astrodyn_verif_jeod = { path = "../astrodyn_verif_jeod", version = "0.1.0" }
 astrodyn_time = { path = "../astrodyn_time", version = "0.1.0" }
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_frames/README.md
+++ b/crates/astrodyn_frames/README.md
@@ -56,4 +56,4 @@ Bevy dependency.
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_frames/>
+  <https://docs.rs/astrodyn_frames>

--- a/crates/astrodyn_frames/src/lib.rs
+++ b/crates/astrodyn_frames/src/lib.rs
@@ -30,6 +30,27 @@
 //!   the Mars and Moon target bodies used by JEOD verification sims.
 //!
 //! JEOD source: `models/utils/ref_frames/` and `models/environment/RNP/`.
+//!
+//! ## Example
+//!
+//! Build a minimal frame tree with one root inertial frame and a
+//! planet-fixed child, then look up a frame's state:
+//!
+//! ```
+//! use astrodyn_frames::{FrameTree, RefFrameKind, RefFrameState};
+//!
+//! let mut tree = FrameTree::new();
+//! let root = tree.add_root("J2000".to_string(), RefFrameKind::Inertial);
+//! let _ecef = tree.add_child(
+//!     root,
+//!     "ECEF".to_string(),
+//!     RefFrameKind::PlanetFixed,
+//!     RefFrameState::default(),
+//! );
+//!
+//! // Both frames live in the arena.
+//! assert_eq!(tree.len(), 2);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_gravity/Cargo.toml
+++ b/crates/astrodyn_gravity/Cargo.toml
@@ -37,3 +37,6 @@ astrodyn_time = { path = "../astrodyn_time", version = "0.1.0" }
 astrodyn_frames = { path = "../astrodyn_frames", version = "0.1.0" }
 astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0", features = ["test-utils"] }
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_gravity/README.md
+++ b/crates/astrodyn_gravity/README.md
@@ -54,4 +54,4 @@ JEOD source.
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_gravity/>
+  <https://docs.rs/astrodyn_gravity>

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -424,7 +424,7 @@ impl<SourceId> GravityControl<SourceId> {
         )
     }
 
-    /// Shared dispatch for [`evaluate`] and [`evaluate_accel_only`].
+    /// Shared dispatch for [`Self::evaluate`] and [`Self::evaluate_accel_only`].
     ///
     /// All four spherical-harmonic ordinals (`degree`, `order`,
     /// `gradient_degree`, `gradient_order`) are clamped to the source's

--- a/crates/astrodyn_gravity/src/lib.rs
+++ b/crates/astrodyn_gravity/src/lib.rs
@@ -34,6 +34,24 @@
 //! the C++ array headers into `Vec<Vec<f64>>` C and S coefficient tables.
 //! Coefficients are normalized as in JEOD; the recursion expects normalized
 //! input. Pure Rust, zero Bevy dependency.
+//!
+//! ## Example
+//!
+//! Point-mass gravity at the equator of a body with Earth's `mu` should
+//! point inward (toward the body's centre):
+//!
+//! ```
+//! use astrodyn_gravity::calc_spherical;
+//! use glam::DVec3;
+//!
+//! let mu = 3.986_004_415e14; // Earth GGM05C, m^3/s^2
+//! let r = DVec3::new(6_778_137.0, 0.0, 0.0); // 400 km altitude on +X axis
+//!
+//! let g = calc_spherical(mu, r);
+//! // Acceleration points back toward the origin (-X) at ~8.7 m/s^2.
+//! assert!(g.grav_accel.x < 0.0);
+//! assert!((g.grav_accel.length() - mu / r.length().powi(2)).abs() < 1e-6);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
+++ b/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
@@ -26,9 +26,9 @@ pub struct GottliebScratch {
     sin_mlambda: Vec<f64>,
     c_tilde: Vec<f64>,
     s_tilde: Vec<f64>,
-    /// Pnm[ii] has ii+3 elements; stored as a flat Vec with offsets.
+    /// `Pnm[ii]` has `ii+3` elements; stored as a flat Vec with offsets.
     pnm_flat: Vec<f64>,
-    /// pnm_offsets[ii] = start index of row ii in pnm_flat.
+    /// `pnm_offsets[ii]` = start index of row `ii` in `pnm_flat`.
     pnm_offsets: Vec<usize>,
     degree: usize,
 }

--- a/crates/astrodyn_interactions/Cargo.toml
+++ b/crates/astrodyn_interactions/Cargo.toml
@@ -28,3 +28,6 @@ astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0", feat
 astrodyn_verif_jeod = { path = "../astrodyn_verif_jeod", version = "0.1.0" }
 astrodyn_time = { path = "../astrodyn_time", version = "0.1.0" }
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_interactions/README.md
+++ b/crates/astrodyn_interactions/README.md
@@ -48,4 +48,4 @@ vehicle position. The orchestration that sums them into a body's
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_interactions/>
+  <https://docs.rs/astrodyn_interactions>

--- a/crates/astrodyn_interactions/src/lib.rs
+++ b/crates/astrodyn_interactions/src/lib.rs
@@ -37,6 +37,29 @@
 //!
 //! JEOD source: `models/interactions/` and surrounding utilities. Pure Rust,
 //! zero Bevy dependency.
+//!
+//! ## Example
+//!
+//! Compute ballistic aerodynamic drag for a 1 m² Cd=2.2 plate moving at
+//! 7.5 km/s through a thin LEO atmosphere:
+//!
+//! ```
+//! use astrodyn_atmosphere::AtmosphereState;
+//! use astrodyn_interactions::{compute_ballistic_drag, DragConfig};
+//! use astrodyn_quantities::frame::SelfPlanet;
+//! use glam::{DMat3, DVec3};
+//!
+//! let cfg = DragConfig { cd: 2.2, area: 1.0, constant_density: None };
+//! // 1e-12 kg/m^3 is roughly 400 km altitude.
+//! let atmos = AtmosphereState::<SelfPlanet>::from_raw(1.0e-12, 0.0, 0.0, DVec3::ZERO);
+//! // Velocity along +X at 7.5 km/s; identity rotation (inertial == body).
+//! let v = DVec3::new(7_500.0, 0.0, 0.0);
+//! let force = compute_ballistic_drag(&cfg, &atmos, v, &DMat3::IDENTITY);
+//!
+//! // Drag opposes motion (-X) and is small but non-zero.
+//! assert!(force.force.x < 0.0);
+//! assert!(force.force.length() > 0.0 && force.force.length() < 1.0);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_math/Cargo.toml
+++ b/crates/astrodyn_math/Cargo.toml
@@ -29,3 +29,6 @@ astrodyn_planet = { path = "../astrodyn_planet", version = "0.1.0" }
 # that need a phantom vehicle tag (Vehicle is sealed in production).
 astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0", features = ["test-utils"] }
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_math/README.md
+++ b/crates/astrodyn_math/README.md
@@ -60,4 +60,4 @@ Bevy dependency. After Phase 2 (#104) of the type-system refactor,
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture and
   conventions.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_math/>
+  <https://docs.rs/astrodyn_math>

--- a/crates/astrodyn_math/src/lib.rs
+++ b/crates/astrodyn_math/src/lib.rs
@@ -49,6 +49,28 @@
 //! `matrix3x3_product_transpose_transpose`).
 //!
 //! Pure Rust, zero Bevy dependency.
+//!
+//! ## Example
+//!
+//! Build a JEOD-convention left-transformation quaternion from an
+//! eigen-rotation (angle + axis) and verify the round-trip
+//! `q.conjugate(q.transform(v)) == v`:
+//!
+//! ```
+//! use astrodyn_math::JeodQuat;
+//! use glam::DVec3;
+//!
+//! // Arbitrary rotation: 0.7 rad about the (1, 1, 1)/√3 axis.
+//! let axis = DVec3::new(1.0, 1.0, 1.0).normalize();
+//! let q = JeodQuat::left_quat_from_eigen_rotation(0.7, axis);
+//!
+//! // Transform-then-inverse-transform recovers the original vector
+//! // (i.e. q.conjugate() reverses q).
+//! let v = DVec3::new(3.0, -2.0, 5.0);
+//! let v_rotated = q.left_quat_transform(v);
+//! let v_back = q.conjugate().left_quat_transform(v_rotated);
+//! assert!((v_back - v).length() < 1e-12);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_planet/Cargo.toml
+++ b/crates/astrodyn_planet/Cargo.toml
@@ -23,3 +23,6 @@ uom = { workspace = true }
 
 [dev-dependencies]
 astrodyn_math = { path = "../astrodyn_math", version = "0.1.0" }
+
+[lints]
+workspace = true

--- a/crates/astrodyn_planet/README.md
+++ b/crates/astrodyn_planet/README.md
@@ -46,4 +46,4 @@ than IERS 2010, to keep cross-validation faithful to JEOD source.
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_planet/>
+  <https://docs.rs/astrodyn_planet>

--- a/crates/astrodyn_planet/src/lib.rs
+++ b/crates/astrodyn_planet/src/lib.rs
@@ -26,6 +26,20 @@
 //! `astrodyn_gravity` when the gravity model needs the reference radius, and
 //! by `astrodyn_frames` for body-fixed rotation models. Pure Rust, zero Bevy
 //! dependency.
+//!
+//! ## Example
+//!
+//! ```
+//! use astrodyn_planet::{EARTH, MOON};
+//!
+//! // WGS84 equatorial radius, GGM05C gravitational parameter.
+//! assert!((EARTH.r_eq - 6_378_137.0).abs() < 1.0);
+//! assert!((EARTH.mu - 3.986_004_415e14).abs() < 1e6);
+//!
+//! // Moon is much smaller and lighter than Earth.
+//! assert!(MOON.r_eq < EARTH.r_eq);
+//! assert!(MOON.mu < EARTH.mu);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_quantities/Cargo.toml
+++ b/crates/astrodyn_quantities/Cargo.toml
@@ -26,3 +26,6 @@ proptest = "1"
 # can write frame-composition tests without needing to implement sealed
 # marker traits. Never enabled in production builds.
 test-utils = []
+
+[lints]
+workspace = true

--- a/crates/astrodyn_quantities/README.md
+++ b/crates/astrodyn_quantities/README.md
@@ -65,4 +65,4 @@ down to raw `glam::DVec3` / `f64` for arithmetic density via
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_quantities/>
+  <https://docs.rs/astrodyn_quantities>

--- a/crates/astrodyn_runner/Cargo.toml
+++ b/crates/astrodyn_runner/Cargo.toml
@@ -22,3 +22,6 @@ path = "examples/batch_propagation.rs"
 [[example]]
 name = "leo_drag"
 path = "examples/leo_drag.rs"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_runner/README.md
+++ b/crates/astrodyn_runner/README.md
@@ -27,11 +27,29 @@ graph — both depend on `astrodyn` and the wider `astrodyn_*` family;
 neither depends on the other. Mission code targeting the production
 Bevy runtime depends on `astrodyn_bevy`, never on `astrodyn_runner`.
 
-## Features
+## Quick start
 
-- `verification` (default) — pulls in `astrodyn_verif_jeod` and exposes the
-  `run_verification::*` Tier-3 case machinery. `--no-default-features`
-  drops the JEOD-source-backed fixtures and gives a smaller runner.
+```toml
+[dependencies]
+astrodyn = "0.1"
+astrodyn_runner = "0.1"
+```
+
+```rust,no_run
+use astrodyn_runner::SimulationBuilderExt;
+use astrodyn::recipes::Mission;
+
+let mut sim = Mission::iss_leo().into_builder().build().unwrap();
+sim.step_n(10);
+let body = sim.body(0);
+println!("altitude: {:.0} m", body.trans.position.raw_si().length() - 6_378_137.0);
+```
+
+`Mission::iss_leo()` is one of the canned scenarios in
+`astrodyn::recipes::scenarios`; see that module for the full list.
+For Tier 3 verification scaffolding (Trick CSV diff, JEOD-source-backed
+initial conditions), reach for `astrodyn_verif_jeod` in addition to this
+crate.
 
 ## See also
 
@@ -39,4 +57,4 @@ Bevy runtime depends on `astrodyn_bevy`, never on `astrodyn_runner`.
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture, Tier
   conventions, regen workflow.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_runner/>
+  <https://docs.rs/astrodyn_runner>

--- a/crates/astrodyn_time/Cargo.toml
+++ b/crates/astrodyn_time/Cargo.toml
@@ -16,3 +16,6 @@ all-features = true
 astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0" }
 log = { workspace = true }
 uom = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrodyn_time/README.md
+++ b/crates/astrodyn_time/README.md
@@ -45,4 +45,4 @@ Bevy dependency.
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
 - Rendered rustdoc:
-  <https://simnaut.github.io/astrodyn_bevy/astrodyn_time/>
+  <https://docs.rs/astrodyn_time>

--- a/crates/astrodyn_time/src/lib.rs
+++ b/crates/astrodyn_time/src/lib.rs
@@ -31,6 +31,22 @@
 //! JEOD source: `models/environment/time/` (and the
 //! `models/environment/time/data/` subdirectory for `Leap_Second.dat`). Pure
 //! Rust, zero Bevy dependency.
+//!
+//! ## Example
+//!
+//! Build a calendar date and round-trip it through the truncated Julian
+//! representation that the per-scale converters consume internally:
+//!
+//! ```
+//! use astrodyn_time::time_utc::{calendar_to_tjt, tjt_to_calendar, CalendarDate};
+//!
+//! let cal = CalendarDate::new(2025, 1, 1, 0, 0, 0.0);
+//! let tjt = calendar_to_tjt(&cal);
+//! let back = tjt_to_calendar(tjt);
+//! assert_eq!(back.year, cal.year);
+//! assert_eq!(back.month, cal.month);
+//! assert_eq!(back.day, cal.day);
+//! ```
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/crates/astrodyn_verif_jeod/Cargo.toml
+++ b/crates/astrodyn_verif_jeod/Cargo.toml
@@ -32,3 +32,6 @@ path = "examples/earth_moon.rs"
 [[example]]
 name = "mars_orbit"
 path = "examples/mars_orbit.rs"
+
+[lints]
+workspace = true

--- a/crates/astrodyn_verif_parity/Cargo.toml
+++ b/crates/astrodyn_verif_parity/Cargo.toml
@@ -19,3 +19,6 @@ bevy = { workspace = true }
 glam = { workspace = true }
 log = { workspace = true }
 uom = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrodyn_verif_parity/src/bevy_context.rs
+++ b/crates/astrodyn_verif_parity/src/bevy_context.rs
@@ -1,4 +1,5 @@
-//! Bevy-side [`SimContext`] adapter that lets a [`PreStepClosure`] mutate
+//! Bevy-side [`SimContext`] adapter that lets a
+//! [`astrodyn_verif_jeod::verification::PreStepClosure`] mutate
 //! a Bevy [`App`]'s world in lockstep with the runner-side
 //! `astrodyn_runner::Simulation`.
 //!
@@ -12,24 +13,27 @@
 //! lint at `tests/self_ref_self_planet_discipline.rs`.
 //!
 //! The parity trait drives both runtimes from the same scenario factory
-//! and the same [`PreStepClosure`]; on each per-tick iteration the
-//! closure is invoked twice — once with `&mut Simulation`, once with a
-//! freshly-constructed [`BevySimContext`] borrowing the app's world.
+//! and the same [`astrodyn_verif_jeod::verification::PreStepClosure`];
+//! on each per-tick iteration the closure is invoked twice — once with
+//! `&mut Simulation`, once with a freshly-constructed
+//! [`BevySimContext`] borrowing the app's world.
 //!
 //! ## Scope
 //!
-//! - **Source-state injection** ([`set_source_position`],
-//!   [`set_source_state`], [`set_tidal_body_position`]) — direct
-//!   `World::get_mut` writes mirroring `astrodyn_bevy::SourceMutator`.
-//! - **Mass-tree mid-flight attach/detach** ([`attach`], [`detach`])
-//!   — write `AttachEvent<SelfRef, SelfRef>` / `DetachEvent` onto the
+//! - **Source-state injection** ([`SimContext::set_source_position`],
+//!   [`SimContext::set_source_state`],
+//!   [`SimContext::set_tidal_body_position`]) — direct `World::get_mut`
+//!   writes mirroring `astrodyn_bevy::SourceMutator`.
+//! - **Mass-tree mid-flight attach/detach** ([`SimContext::attach`],
+//!   [`SimContext::detach`]) — write
+//!   `AttachEvent<SelfRef, SelfRef>` / `DetachEvent` onto the
 //!   message bus. The next `app.world_mut().run_schedule(FixedUpdate)`
 //!   drains the queue at the top of `staging_system`, before
 //!   integration runs that tick — so both runtimes feed the same
 //!   pre-attach state into the same `combine_states_at_attach` kernel
 //!   and the same integrator-reset path. Bit-identity holds.
-//! - **Kinematic-only gating** ([`mark_kinematic_only`]) — insert
-//!   `KinematicChildC` directly on the child entity. The runner sets
+//! - **Kinematic-only gating** ([`SimContext::mark_kinematic_only`]) —
+//!   insert `KinematicChildC` directly on the child entity. The runner sets
 //!   `bodies[idx].kinematic_only = true` synchronously; on the Bevy
 //!   side `wrench_aggregation_system` would also install
 //!   `KinematicChildC` once it observes the new mass-tree topology,

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -705,7 +705,8 @@ pub fn evaluate_ground_contact_pair(
 ///
 /// The material is unchanged. This yields a facet whose `position` / `start` /
 /// `end` values are expressed in the inertial frame so that
-/// [`compute_contact_force`] can operate on two inertial-aligned facets.
+/// [`astrodyn_interactions::compute_contact_force`] can operate on two
+/// inertial-aligned facets.
 fn rotate_facet(facet: &ContactFacet, t_inertial_from_struct: &DMat3) -> ContactFacet {
     use astrodyn_interactions::ContactShape;
     let shape = match facet.shape {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,34 @@
 //!
 //! See [`PipelineStage`] and [`PIPELINE_ORDER`] for the canonical stage
 //! execution order that any adapter must respect.
+//!
+//! ## Quick start
+//!
+//! Compose a vehicle through the typestate [`VehicleBuilder`] using only
+//! gateway re-exports — mission code never reaches into the physics
+//! crates directly:
+//!
+//! ```
+//! use astrodyn::{
+//!     recipes::{earth, orbital_elements, vehicle},
+//!     F64Ext, GravityControl, VehicleBuilder,
+//! };
+//!
+//! let mu = earth::point_mass().source.mu.m3_per_s2();
+//! let cfg = VehicleBuilder::new()
+//!     .from_orbital_elements(orbital_elements::iss(), mu)
+//!     .three_dof_point_mass(vehicle::iss_mass())
+//!     .rk4()
+//!     .gravity(GravityControl::new_spherical(0_usize, false))
+//!     .build();
+//! # let _ = cfg;
+//! ```
+//!
+//! `cfg` (a [`VehicleConfig`]) is then handed to either
+//! `astrodyn_bevy::VehicleConfigBevyExt::spawn_bevy` or
+//! `astrodyn_runner::Simulation::add_vehicle` — both consumers share the
+//! same configuration shape so a mission can swap between them without
+//! reauthoring its setup code.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

Three parallel audits (structural readiness, `cargo doc` warnings, accuracy) across the 13 publishable crates surfaced a small number of concrete blockers. This PR fixes them all and adds a CI gate so the polish doesn't drift.

### Workspace lints — single source of truth

`Cargo.toml` gains `[workspace.lints.rust]` (`unsafe_code = "forbid"`, `missing_docs = "deny"` with `priority = -1`) and `[workspace.lints.rustdoc]` (`broken_intra_doc_links = "deny"`, `invalid_html_tags = "deny"`). Every member crate adopts via `[lints] workspace = true`. The `priority = -1` lets test files override `missing_docs` when a macro emits an undocumented item.

### Rustdoc warnings — 11 fixes

These were silently skipped by docs.rs's default build but became hard errors as soon as the workspace lints landed:

- `astrodyn_gravity/src/gravity_controls.rs:427` — qualified `[Self::evaluate]` / `[Self::evaluate_accel_only]`
- `astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs:29-31` — backticked `Pnm[ii]` / `pnm_offsets[ii]`
- `astrodyn_dynamics/src/gauss_jackson/coefficients_pair.rs:44-45` — backticked the `Σ sa_coefs[i] * acc_hist[i]` summation prose
- `astrodyn_dynamics/src/gauss_jackson/mod.rs:736` — backticked `pos_hist[target_idx]`
- `astrodyn_dynamics/src/gauss_jackson/ratio128.rs:284` — backticked `Vec<Ratio128>` (was parsed as an HTML tag)
- `astrodyn/src/interactions.rs:708` — qualified `[astrodyn_interactions::compute_contact_force]`
- `astrodyn_bevy/src/systems/glue/mass_update.rs:4` — dropped redundant explicit link target
- `astrodyn_verif_parity/src/bevy_context.rs:1,15,21,22` — qualified 8 `SimContext::*` trait method links and the `astrodyn_verif_jeod::verification::PreStepClosure` type alias

### User-visible content fixes

- Replaced the dead `https://simnaut.github.io/astrodyn_bevy/<crate>/` URL with `https://docs.rs/<crate>` in 12 READMEs (root + 11 crate READMEs).
- Fixed broken `examples/typed_mission.rs` references in `README.md:55-56` and `CLAUDE.md:271`/`:651` — file is at `crates/astrodyn_bevy/examples/typed_mission.rs`, not at the workspace root.
- Removed the bogus `## Features — verification (default)` section from `astrodyn_runner/README.md`. No such feature exists; the runner has no `[features]` table and no `astrodyn_verif_jeod` dependency. The README now has an install snippet and a `Mission::iss_leo()` example instead.
- Root `README.md` gains a `[dependencies]` snippet, a pre-1.0 stability note (mirroring the one in `astrodyn_bevy`), and a `VehicleBuilder` use example.

### Doctests — +9 (117 → 126 passing)

Added a minimal compileable, asserted `//!` example to the root `astrodyn` crate plus the 9 physics crates that previously had narrative-only crate docs:

| Crate | Example |
| --- | --- |
| `astrodyn` (root) | `VehicleBuilder` via gateway re-exports only |
| `astrodyn_math` | quaternion-conjugate round-trip |
| `astrodyn_dynamics` | Steiner-axis (parallel-axis) inertia |
| `astrodyn_gravity` | `calc_spherical` at 400 km altitude |
| `astrodyn_frames` | `FrameTree` with one root + planet-fixed child |
| `astrodyn_time` | calendar ↔ TJT round-trip |
| `astrodyn_ephemeris` | load `DE421_BSP`, query Sun position |
| `astrodyn_atmosphere` | exponential model at sea level vs one scale-height |
| `astrodyn_interactions` | ballistic drag at 7.5 km/s |
| `astrodyn_planet` | `EARTH` / `MOON` preset constants |

### CI

The `docs-enforce` job now runs `cargo doc --workspace --no-deps --document-private-items` under `RUSTDOCFLAGS=-D warnings`, so private-item drift is caught at PR time, not on the next docs.rs build.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` — clean
- [x] `cargo test --workspace --doc` — 126 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` — clean
- [x] `cargo publish --dry-run -p astrodyn_quantities` (the leaf) — succeeded
- [x] `cargo package --list` for the other 12 publishable crates — all bundle cleanly
- [ ] Owner-crate unit + Tier 2 tests on CI
- [ ] Tier 3 cross-validation on CI

## Notes on publishing

To actually publish to crates.io, run `cargo publish -p <crate>` in dependency order: `astrodyn_quantities` → `astrodyn_math` → `astrodyn_planet` → `astrodyn_time` → `astrodyn_ephemeris` → `astrodyn_frames` → `astrodyn_atmosphere` → `astrodyn_gravity` → `astrodyn_dynamics` → `astrodyn_interactions` → `astrodyn` → `astrodyn_runner` → `astrodyn_bevy`. Six names are already reserved by `simnaut` at version `0.0.0`; the other seven are free. Path-dep dry-runs of non-leaf crates block on `astrodyn_quantities@0.1.0` reaching the index, which is normal first-time-publish chicken-and-egg.

https://claude.ai/code/session_01WPH1wWLVcdKoEe6epTAQqB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPH1wWLVcdKoEe6epTAQqB)_