### PR TITLE
[#424] #[doc(hidden)] on typed_bridge; audit typed->C From impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,14 @@ pub mod simulation_builder;
 pub mod source_frames;
 pub mod source_state;
 pub mod sources;
+// Internal bridge between typed `*Typed<F>` shapes and the underlying raw
+// `DVec3`/`DQuat`/`DMat3` shapes that the kernel functions still consume.
+// Adapters (`astrodyn_bevy`, `astrodyn_runner`, the verif crates) need the
+// symbols `pub` so they can translate at the kernel boundary, but mission
+// code shouldn't see them — the type-system promise is that mission code
+// never reaches raw `DVec3`/`DQuat`. Hidden from rustdoc to keep that
+// promise visible on docs.rs while preserving the adapter call sites.
+#[doc(hidden)] // allowed: structural adapter boundary — see preceding rationale block
 pub mod typed_bridge;
 pub mod validation;
 pub mod vehicle_builder;


### PR DESCRIPTION
## Summary

- Add `#[doc(hidden)]` to `pub mod typed_bridge;` in the `astrodyn` gateway. The functions remain `pub` so adapters (`astrodyn_bevy`, `astrodyn_runner`, the verif crates) keep working at every call site, but the module disappears from docs.rs as a recommended path so mission authors browsing the API surface never see it.
- Audit `crates/astrodyn_bevy/src/components/state.rs` typed-to-component `From` impls. `From<TranslationalStateTyped<RootInertial>>` for `TranslationalStateC<P>` (line 155), `From<RotationalStateTyped<SelfRef>>` for `RotationalStateC` (line 172), and `From<MassPropertiesTyped<SelfRef>>` for `MassPropertiesC` (line 189) are all present and reach `astrodyn_bevy::prelude` because the `*C` types are already re-exported there. No new impls needed — the audit residual lands when sibling #423 retypes the parity helpers in `crates/astrodyn_verif_parity/tests/common/mod.rs`.

The `#[doc(hidden)]` attribute carries an `// allowed: structural adapter boundary` annotation so `scripts/check_no_escape_hatches.sh`'s category-1 marker scan still passes. Rationale block above the attribute frames the bridge as the typed↔raw kernel-boundary adapter that mission code shouldn't see — internal to the workspace, never project-lifecycle.

Closes #424.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1196 passed, 0 failed
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — 1 passed
- [x] `cargo test --doc --workspace`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — `target/doc/astrodyn/index.html` no longer mentions `typed_bridge`
- [x] `scripts/check_no_escape_hatches.sh` — OK
- [x] `cargo test -p astrodyn --test invariant_coverage` — 6 passed, 1 ignored