### PR TITLE
[#429] Typed point_mass / From entry points on TranslationalStateC<P>

### DIFF
--- a/crates/astrodyn_bevy/examples/kepler_orbit.rs
+++ b/crates/astrodyn_bevy/examples/kepler_orbit.rs
@@ -15,7 +15,7 @@
 
 use astrodyn::init_from_orbital_elements_typed;
 use astrodyn::recipes::{constants, earth, orbital_elements, vehicle};
-use astrodyn::{GravityControl, GravityControls, TranslationalState};
+use astrodyn::{GravityControl, GravityControls};
 use astrodyn_bevy::{
     AstrodynPlugin, AstrodynSet, DynamicsConfigC, FrameDerivativesC, GravityAccelerationC,
     GravityControlsC, GravitySourceC, MassPropertiesC, SourceInertialPositionC, TotalForceC,
@@ -115,8 +115,11 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
     // Pull the orbital-elements preset (`OrbitalElements` carries plain
     // `f64` SI fields — JEOD-faithful but not yet `uom`-typed) and
     // initialize a typed `TranslationalState` via the typed orbit-init
-    // helper. Phase 9 will introduce a `commands.spawn_scenario(s)`
-    // extension that hides this conversion.
+    // helper. The typed output is `<RootInertial>`; relabel to
+    // `<PlanetInertial<Earth>>` for the Bevy component (the numerics
+    // are bit-identical for the root-integrated body's planet).
+    // Phase 9 will introduce a `commands.spawn_scenario(s)` extension
+    // that hides this conversion.
     let oe = orbital_elements::iss();
     let trans_typed = init_from_orbital_elements_typed(
         Length::new::<meter>(oe.semi_major_axis),
@@ -127,11 +130,8 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
         Angle::new::<radian>(oe.true_anom),
         constants::mu_ggm05c(),
     );
-    // allowed: typed↔raw kernel boundary (#397)
-    let trans: TranslationalState = TranslationalState {
-        position: trans_typed.position.raw_si(),
-        velocity: trans_typed.velocity.raw_si(),
-    };
+    let trans_planet = trans_typed.relabel_to::<astrodyn::PlanetInertial<astrodyn::Earth>>();
+    let initial_radius_m: f64 = trans_planet.position.length().value;
 
     let mass_kg = vehicle::iss_mass().get::<kilogram>();
     let controls = GravityControls {
@@ -140,7 +140,10 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
 
     commands.spawn((
         Name::new("Satellite"),
-        TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
+        TranslationalStateC::<astrodyn::Earth>::point_mass(
+            trans_planet.position,
+            trans_planet.velocity,
+        ),
         // JEOD_INV: TS.01 — `<SelfRef>` is the storage-side wildcard for the spawned vehicle's MassPropertiesC.
         MassPropertiesC::from(astrodyn::MassPropertiesTyped::<astrodyn::SelfRef>::new(
             astrodyn::Mass::new::<astrodyn::kilogram>(mass_kg),
@@ -156,7 +159,7 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
     println!("==============================");
     println!(
         "Initial altitude: {:.1} km",
-        (trans.position.length() - r_eq_earth_m()) / 1000.0
+        (initial_radius_m - r_eq_earth_m()) / 1000.0
     );
 }
 

--- a/crates/astrodyn_bevy/src/components/state.rs
+++ b/crates/astrodyn_bevy/src/components/state.rs
@@ -32,12 +32,12 @@ use bevy::prelude::*;
 // `MassPropertiesTyped::<SelfRef>::with_inertia(...)`) and lifts to the
 // Component via the typed-side `From<RotationalStateTyped<SelfRef>>` /
 // `From<MassPropertiesTyped<SelfRef>>` impls (still present below).
-// The lone exception is `TranslationalStateC::<P>::from_untyped(state)`,
-// which remains as a named opt-in because the relabel from the gateway's
-// `TranslationalStateTyped<RootInertial>` to the Component's
-// `TranslationalStateTyped<PlanetInertial<P>>` storage requires the
-// caller to assert `P` — there is no information-preserving typed-side
-// `From` impl that can do that without a witness.
+// `TranslationalStateC::<P>::from_untyped(state)` likewise remains as a
+// named typed↔raw kernel-boundary helper, but mission code that already
+// has typed inputs should reach for `point_mass(pos, vel)` or the
+// `From<TranslationalStateTyped<PlanetInertial<P>>>` impl below — both
+// take typed planet-inertial inputs and never cross the typed/raw
+// boundary, which is what mission and parity-test code wants.
 
 /// Translational state (position, velocity) for the body being
 /// integrated. Wraps a typed
@@ -115,6 +115,14 @@ impl<P: Planet> TranslationalStateC<P> {
     /// the matching `From<TranslationalState>` impl was removed in
     /// #397, so callers must opt in by this named method rather than
     /// `.into()`.
+    ///
+    /// **Prefer the typed entry points** for mission and parity-test
+    /// code that already has typed inputs:
+    /// [`Self::point_mass`] for `(Position<PlanetInertial<P>>,
+    /// Velocity<PlanetInertial<P>>)` pairs, or the
+    /// `From<TranslationalStateTyped<PlanetInertial<P>>>` impl for an
+    /// already-bundled typed state. Both keep the typed/raw boundary
+    /// invisible at the call site.
     #[inline]
     pub fn from_untyped(state: TranslationalState) -> Self {
         // allowed: typed↔raw kernel boundary
@@ -122,6 +130,28 @@ impl<P: Planet> TranslationalStateC<P> {
             position: Position::<PlanetInertial<P>>::from_raw_si(state.position),
             velocity: Velocity::<PlanetInertial<P>>::from_raw_si(state.velocity),
         })
+    }
+
+    /// Construct from typed planet-inertial position and velocity.
+    ///
+    /// The frame phantoms on the inputs assert that the values are
+    /// expressed in `P`'s planet-inertial frame; the witness for `P`
+    /// is the caller's compile-time choice plus the matching phantoms
+    /// on `position` / `velocity`. No untyped escape hatch crosses
+    /// the signature, so mission and parity-test code that already
+    /// has typed building blocks (e.g. from
+    /// [`init_from_orbital_elements_typed`](astrodyn::init_from_orbital_elements_typed),
+    /// the
+    /// [`Vec3Ext::m_at`](astrodyn::Vec3Ext::m_at) /
+    /// [`Vec3Ext::m_per_s_at`](astrodyn::Vec3Ext::m_per_s_at) facade,
+    /// or recipe presets) reaches for this entry point instead of
+    /// the typed↔raw [`Self::from_untyped`] helper.
+    #[inline]
+    pub fn point_mass(
+        position: Position<PlanetInertial<P>>,
+        velocity: Velocity<PlanetInertial<P>>,
+    ) -> Self {
+        Self(TranslationalStateTyped::<PlanetInertial<P>> { position, velocity })
     }
 
     /// Witness-gated constructor: wrap an already-typed
@@ -161,6 +191,19 @@ impl<P: Planet> From<TranslationalStateTyped<RootInertial>> for TranslationalSta
     #[inline]
     fn from(state: TranslationalStateTyped<RootInertial>) -> Self {
         Self(state.relabel_to::<PlanetInertial<P>>())
+    }
+}
+
+impl<P: Planet> From<TranslationalStateTyped<PlanetInertial<P>>> for TranslationalStateC<P> {
+    /// Wrap an already-typed `<PlanetInertial<P>>` translational state
+    /// directly. The inner phantom matches the storage phantom — pure
+    /// no-op wrap (no relabel, no arithmetic). This is the production
+    /// path for callers whose typed-helper output is already tagged
+    /// with the matching planet phantom (e.g. typed parity-test
+    /// `common::*` helpers).
+    #[inline]
+    fn from(state: TranslationalStateTyped<PlanetInertial<P>>) -> Self {
+        Self(state)
     }
 }
 

--- a/crates/astrodyn_bevy/src/prelude.rs
+++ b/crates/astrodyn_bevy/src/prelude.rs
@@ -55,10 +55,10 @@ pub use crate::frame_param::{FrameOrigin, RelativeFrameState};
 pub use astrodyn::{
     Array3Ext, BodyAction, BodyFrame, ClosureJointKinematicsSpec, Earth, Ecef, F64Ext, Frame,
     FrameTransform, GravityControl, JeodQuat, JointKinematicsModel, JointKinematicsSpec, Lvlh,
-    Mars, Moon, MultiDofJointKinematicsSpec, Ned, OrbitalElementSet, Planet, PlanetFixed, Qty3,
-    RootInertial, SelfPlanet, SelfRef, SingleDofKinematics, SinusoidalJointKinematicsSpec,
-    StructuralFrame, Sun, Vec3Ext, Vehicle, VehicleBuilder, VehicleConfig, AXIS_NORM_TOL,
-    MAX_MULTI_DOF_AXES,
+    Mars, Moon, MultiDofJointKinematicsSpec, Ned, OrbitalElementSet, Planet, PlanetFixed,
+    PlanetInertial, Qty3, RootInertial, SelfPlanet, SelfRef, SingleDofKinematics,
+    SinusoidalJointKinematicsSpec, StructuralFrame, Sun, Vec3Ext, Vehicle, VehicleBuilder,
+    VehicleConfig, AXIS_NORM_TOL, MAX_MULTI_DOF_AXES,
 };
 // Mission-crate macros for defining additional `Vehicle` / `Planet`
 // markers. Re-exported so `use astrodyn_bevy::prelude::*;` brings them into

--- a/crates/astrodyn_bevy/tests/translational_state_typed_constructors.rs
+++ b/crates/astrodyn_bevy/tests/translational_state_typed_constructors.rs
@@ -1,0 +1,108 @@
+//! Round-trip tests for the typed entry points on
+//! [`TranslationalStateC`].
+//!
+//! Mission and parity-test code that already has typed planet-inertial
+//! inputs should reach the Bevy component without crossing the
+//! typed/raw kernel boundary. Two entry points provide that path:
+//!
+//! - [`TranslationalStateC::<P>::point_mass(position, velocity)`] —
+//!   takes the typed pair directly.
+//! - `TranslationalStateC::<P>::from(state)` for an already-bundled
+//!   [`TranslationalStateTyped<PlanetInertial<P>>`].
+//!
+//! Both must produce a component bit-identical to the `from_untyped`
+//! kernel-boundary helper given the same underlying SI numerics, since
+//! they all wrap the same `TranslationalStateTyped<PlanetInertial<P>>`
+//! storage. This test fences that invariant so a future refactor of
+//! either entry point can't silently drift from the others.
+//!
+//! The test uses non-trivial values (a 400 km ISS-like circular orbit
+//! state, not zeros or unit axes) so accidental field swaps surface
+//! immediately.
+
+use astrodyn::{Position, TranslationalState, TranslationalStateTyped, Velocity};
+use astrodyn_bevy::prelude::*;
+use glam::DVec3;
+
+/// Position and velocity for a circular ISS-like orbit at 400 km
+/// altitude in the equatorial plane. Values are non-trivial enough
+/// that a swapped `position`/`velocity` field would surface as a
+/// failed bit-equality check.
+fn iss_like_state_raw() -> (DVec3, DVec3) {
+    let r = DVec3::new(6_778_137.0, 0.0, 0.0); // m
+    let v = DVec3::new(0.0, 7668.56, 0.0); // m/s
+    (r, v)
+}
+
+#[test]
+fn point_mass_constructor_round_trip() {
+    let (r_raw, v_raw) = iss_like_state_raw();
+    let r: Position<PlanetInertial<Earth>> = r_raw.m_at::<PlanetInertial<Earth>>();
+    let v: Velocity<PlanetInertial<Earth>> = v_raw.m_per_s_at::<PlanetInertial<Earth>>();
+
+    let state = TranslationalStateC::<Earth>::point_mass(r, v);
+
+    // The component's underlying typed SI raw values must match the
+    // raw inputs bit-for-bit — `point_mass` is a no-op wrap.
+    assert_eq!(state.0.position.raw_si(), r_raw);
+    assert_eq!(state.0.velocity.raw_si(), v_raw);
+}
+
+#[test]
+fn from_planet_inertial_typed_state_round_trip() {
+    let (r_raw, v_raw) = iss_like_state_raw();
+    let typed = TranslationalStateTyped::<PlanetInertial<Earth>> {
+        position: r_raw.m_at::<PlanetInertial<Earth>>(),
+        velocity: v_raw.m_per_s_at::<PlanetInertial<Earth>>(),
+    };
+
+    let state = TranslationalStateC::<Earth>::from(typed);
+
+    assert_eq!(state.0.position.raw_si(), r_raw);
+    assert_eq!(state.0.velocity.raw_si(), v_raw);
+}
+
+#[test]
+fn point_mass_and_from_typed_produce_same_component() {
+    // Construct the same logical state through both typed entry points
+    // and confirm the component is field-equal. Pins the no-op-wrap
+    // invariant — neither path may diverge in framing or unit handling.
+    let (r_raw, v_raw) = iss_like_state_raw();
+    let r: Position<PlanetInertial<Earth>> = r_raw.m_at::<PlanetInertial<Earth>>();
+    let v: Velocity<PlanetInertial<Earth>> = v_raw.m_per_s_at::<PlanetInertial<Earth>>();
+
+    let via_point_mass = TranslationalStateC::<Earth>::point_mass(r, v);
+    let typed = TranslationalStateTyped::<PlanetInertial<Earth>> {
+        position: r,
+        velocity: v,
+    };
+    let via_from = TranslationalStateC::<Earth>::from(typed);
+
+    assert_eq!(via_point_mass.0, via_from.0);
+}
+
+#[test]
+fn point_mass_matches_from_untyped_numerics() {
+    // The new typed entry point and the `from_untyped` kernel-boundary
+    // helper must produce the same numeric storage when the inputs
+    // describe the same physical state — they only differ in which
+    // side of the typed/raw boundary the caller lives on.
+    let (r_raw, v_raw) = iss_like_state_raw();
+    let r: Position<PlanetInertial<Earth>> = r_raw.m_at::<PlanetInertial<Earth>>();
+    let v: Velocity<PlanetInertial<Earth>> = v_raw.m_per_s_at::<PlanetInertial<Earth>>();
+
+    let via_point_mass = TranslationalStateC::<Earth>::point_mass(r, v);
+    let via_from_untyped = TranslationalStateC::<Earth>::from_untyped(TranslationalState {
+        position: r_raw,
+        velocity: v_raw,
+    });
+
+    assert_eq!(
+        via_point_mass.0.position.raw_si(),
+        via_from_untyped.0.position.raw_si()
+    );
+    assert_eq!(
+        via_point_mass.0.velocity.raw_si(),
+        via_from_untyped.0.velocity.raw_si()
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `pub fn point_mass(position: Position<PlanetInertial<P>>, velocity: Velocity<PlanetInertial<P>>) -> Self` and a no-op `From<TranslationalStateTyped<PlanetInertial<P>>>` impl on `TranslationalStateC<P>`, so mission and parity-test code that already has typed planet-inertial inputs no longer crosses the typed/raw kernel boundary to land them on a Bevy entity.
- Updates the `from_untyped` doc comment to point readers at the new typed entries; `from_untyped` stays available as the named typed↔raw kernel-boundary helper for callers that genuinely live on the raw side.
- Re-exports `PlanetInertial` from `astrodyn_bevy::prelude` so the typed signature can be spelled without falling back to `astrodyn::` paths (matches the existing `RootInertial` re-export).
- Migrates `examples/kepler_orbit.rs` to the new constructor — the recipe path `init_from_orbital_elements_typed` already returns a typed `<RootInertial>` state, so the example drops a five-line typed→raw strip and constructs the component directly via `point_mass` after a phantom relabel.
- The parity-test `from_untyped` callsites are deliberately left in place — sibling issue #423 owns the `common::*` typed-helper migration that drops them in bulk.

Closes #429.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(/^bevy_parity_(dyncomp_run(2|4|5a|7)|solar_beta|srp_1st_order|tide_verif)/)'`
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo test --doc --workspace`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [x] New `crates/astrodyn_bevy/tests/translational_state_typed_constructors.rs` exercises both entry points with non-trivial values, fences `point_mass`/`From`/`from_untyped` numeric agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)