### PR TITLE
[#421] PlanetBundle::point_mass_only — 4-component variant for tests

### DIFF
--- a/crates/astrodyn_bevy/src/bundles.rs
+++ b/crates/astrodyn_bevy/src/bundles.rs
@@ -81,6 +81,63 @@ impl<P: Planet> PlanetBundle<P> {
             },
         )
     }
+
+    /// Bundle with only the components needed for point-mass gravity:
+    /// [`Name`], [`GravitySourceC`], [`SourceInertialPositionC`], and
+    /// [`TranslationalStateC<P>`].
+    ///
+    /// Omits the rotation/shape/RNP components that the full
+    /// [`Self::point_mass`] / [`Self::from_config`] bundles insert
+    /// ([`PlanetFixedRotationC`], [`PlanetOmegaC`],
+    /// [`PlanetAngularVelocityC`], [`RotationModelC`], [`PlanetC`]). Those
+    /// extra components are what activate the planet-fixed-rotation,
+    /// atmosphere, and geodetic systems each step; tests and missions that
+    /// model point-mass gravity only must not insert them or the schedule
+    /// will run physics they aren't configured for.
+    ///
+    /// Use [`Self::point_mass`] for a planet that participates in rotation
+    /// or geodetic computation.
+    ///
+    /// # Example
+    /// ```
+    /// use bevy::prelude::*;
+    /// use astrodyn_bevy::{
+    ///     GravitySourceC, PlanetBundle, SourceInertialPositionC, TranslationalStateC,
+    /// };
+    /// use astrodyn::EARTH;
+    ///
+    /// let mut world = World::new();
+    /// let earth = world
+    ///     .spawn(PlanetBundle::<astrodyn::Earth>::point_mass_only(
+    ///         "Earth",
+    ///         astrodyn::GravitySource {
+    ///             mu: EARTH.shape.mu,
+    ///             model: astrodyn::GravityModel::PointMass,
+    ///         },
+    ///     ))
+    ///     .id();
+    /// let e = world.entity(earth);
+    /// assert!(e.contains::<Name>());
+    /// assert!(e.contains::<GravitySourceC>());
+    /// assert!(e.contains::<SourceInertialPositionC>());
+    /// assert!(e.contains::<TranslationalStateC<astrodyn::Earth>>());
+    /// ```
+    pub fn point_mass_only(
+        name: impl Into<Name>,
+        source: GravitySource,
+    ) -> (
+        Name,
+        GravitySourceC,
+        SourceInertialPositionC,
+        TranslationalStateC<P>,
+    ) {
+        (
+            name.into(),
+            GravitySourceC(source),
+            SourceInertialPositionC::default(),
+            TranslationalStateC::<P>::default(),
+        )
+    }
 }
 
 /// Bundle for spawning the Sun entity.

--- a/crates/astrodyn_bevy/tests/planet_bundle_point_mass_only.rs
+++ b/crates/astrodyn_bevy/tests/planet_bundle_point_mass_only.rs
@@ -1,0 +1,107 @@
+//! Verifies [`PlanetBundle::point_mass_only`] inserts exactly the four
+//! components every "gravity source only" spawn site needs and nothing else.
+//!
+//! The omitted components ([`PlanetFixedRotationC`], [`PlanetOmegaC`],
+//! [`PlanetAngularVelocityC`], [`RotationModelC`], [`PlanetC`]) are what
+//! gate the planet-fixed-rotation, atmosphere, and geodetic systems each
+//! step. If a future edit silently expands the bundle's component set, a
+//! parity test that today inserts only the four components would start
+//! activating those systems and re-baseline its trajectory — this test
+//! pins the contract so that drift is caught at compile/test time on the
+//! bundle itself rather than buried in a parity tolerance miss.
+
+use astrodyn::{GravityModel, GravitySource, EARTH};
+use astrodyn_bevy::{
+    GravitySourceC, PlanetAngularVelocityC, PlanetBundle, PlanetC, PlanetFixedRotationC,
+    PlanetOmegaC, RotationModelC, SourceInertialPositionC, TranslationalStateC,
+};
+use bevy::prelude::*;
+
+fn earth_point_mass_source() -> GravitySource {
+    GravitySource {
+        mu: EARTH.shape.mu,
+        model: GravityModel::PointMass,
+    }
+}
+
+#[test]
+fn point_mass_only_inserts_exactly_the_four_required_components() {
+    let mut world = World::new();
+    let entity = world
+        .spawn(PlanetBundle::<astrodyn::Earth>::point_mass_only(
+            "Earth",
+            earth_point_mass_source(),
+        ))
+        .id();
+    let e = world.entity(entity);
+
+    // The four components every gravity-source spawn site needs.
+    assert!(e.contains::<Name>(), "Name missing from point_mass_only");
+    assert!(
+        e.contains::<GravitySourceC>(),
+        "GravitySourceC missing from point_mass_only",
+    );
+    assert!(
+        e.contains::<SourceInertialPositionC>(),
+        "SourceInertialPositionC missing from point_mass_only",
+    );
+    assert!(
+        e.contains::<TranslationalStateC<astrodyn::Earth>>(),
+        "TranslationalStateC<Earth> missing from point_mass_only",
+    );
+}
+
+#[test]
+fn point_mass_only_omits_rotation_shape_and_rnp_components() {
+    let mut world = World::new();
+    let entity = world
+        .spawn(PlanetBundle::<astrodyn::Earth>::point_mass_only(
+            "Earth",
+            earth_point_mass_source(),
+        ))
+        .id();
+    let e = world.entity(entity);
+
+    // None of the rotation/shape/RNP components the full PlanetBundle
+    // inserts may leak through point_mass_only; their presence would
+    // activate planet-fixed-rotation, atmosphere, and geodetic systems
+    // each step.
+    assert!(
+        !e.contains::<PlanetFixedRotationC<astrodyn::Earth>>(),
+        "PlanetFixedRotationC leaked into point_mass_only",
+    );
+    assert!(
+        !e.contains::<PlanetOmegaC>(),
+        "PlanetOmegaC leaked into point_mass_only",
+    );
+    assert!(
+        !e.contains::<PlanetAngularVelocityC<astrodyn::Earth>>(),
+        "PlanetAngularVelocityC leaked into point_mass_only",
+    );
+    assert!(
+        !e.contains::<RotationModelC>(),
+        "RotationModelC leaked into point_mass_only",
+    );
+    assert!(
+        !e.contains::<PlanetC>(),
+        "PlanetC leaked into point_mass_only",
+    );
+}
+
+#[test]
+fn point_mass_only_name_round_trips_through_into_name() {
+    // The `impl Into<Name>` parameter accepts both `&str` and `String`;
+    // verify the resulting Name reads back the caller-supplied string.
+    let mut world = World::new();
+    let entity = world
+        .spawn(PlanetBundle::<astrodyn::Earth>::point_mass_only(
+            String::from("Mars"),
+            earth_point_mass_source(),
+        ))
+        .id();
+    let name = world
+        .entity(entity)
+        .get::<Name>()
+        .expect("point_mass_only must insert Name");
+    assert_eq!(name.as_str(), "Mars");
+}


### PR DESCRIPTION
## Summary

- Add `PlanetBundle::<P>::point_mass_only(name, source)` returning only the 4 components every "gravity source only" spawn site actually needs: `Name`, `GravitySourceC`, `SourceInertialPositionC::default()`, `TranslationalStateC::<P>::default()`.
- The full `point_mass` / `from_config` constructors stay 9-component (they additionally insert `PlanetFixedRotationC`, `PlanetOmegaC`, `PlanetAngularVelocityC`, `RotationModelC`, `PlanetC`); those extra components are what gate planet-fixed-rotation, atmosphere, and geodetic systems each step. Tests and missions that model point-mass gravity only must not insert them or they'd re-baseline drag/atmosphere/rotation parity values.
- Returns a concrete tuple so the omitted components are visible in the signature rather than hidden behind `impl Bundle`.
- Per the issue, this lands the new variant only. The mechanical migration of ~70 hand-rolled spawn sites (parity tests under `bevy_parity_*`, `crates/astrodyn_bevy/tests/*.rs`, `kepler_orbit.rs`) is out of scope and tracked separately. `examples/typed_mission.rs` is intentionally left as the canonical "full PlanetBundle" mission example.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(/^bevy_parity_(dyncomp_run(2|4|5a|7)|solar_beta|srp_1st_order|tide_verif)/)'` — 1227 passed
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo test --doc --workspace`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo nextest run -p astrodyn --test invariant_coverage`
- [x] `cargo nextest run -p astrodyn_bevy --test planet_bundle_point_mass_only` (3 new tests covering the 4 required components, the 5 omitted components, and `impl Into<Name>` round-trip)

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)