### PR TITLE
[#420] AstrodynAppExt trait for App setup + fixed-step advancement

### DIFF
--- a/crates/astrodyn_bevy/examples/kepler_orbit.rs
+++ b/crates/astrodyn_bevy/examples/kepler_orbit.rs
@@ -17,7 +17,7 @@ use astrodyn::init_from_orbital_elements_typed;
 use astrodyn::recipes::{constants, earth, orbital_elements, vehicle};
 use astrodyn::{GravityControl, GravityControls, TranslationalState};
 use astrodyn_bevy::{
-    AstrodynPlugin, AstrodynSet, DynamicsConfigC, FrameDerivativesC, GravityAccelerationC,
+    AstrodynAppExt, AstrodynSet, DynamicsConfigC, FrameDerivativesC, GravityAccelerationC,
     GravityControlsC, GravitySourceC, MassPropertiesC, SourceInertialPositionC, TotalForceC,
     TranslationalStateC,
 };
@@ -79,8 +79,7 @@ fn main() {
     let max_steps = parse_steps_arg();
     App::new()
         .add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_millis(0))))
-        .insert_resource(Time::<Fixed>::from_seconds(10.0))
-        .add_plugins(AstrodynPlugin)
+        .add_astrodyn(10.0)
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, print_state.after(AstrodynSet::Integration))
         .insert_resource(StepCounter(0))

--- a/crates/astrodyn_bevy/examples/typed_mission.rs
+++ b/crates/astrodyn_bevy/examples/typed_mission.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use astrodyn::recipes::{constants, earth, orbital_elements, vehicle};
 use astrodyn::{F64Ext, GravityControl, VehicleBuilder};
 use astrodyn_bevy::{
-    AstrodynPlugin, AstrodynSet, GravityAccelerationC, GravitySourceC, SourceInertialPositionC,
+    AstrodynAppExt, AstrodynSet, GravityAccelerationC, GravitySourceC, SourceInertialPositionC,
     TotalForceC, TranslationalStateC, VehicleConfigBevyExt,
 };
 use bevy::app::ScheduleRunnerPlugin;
@@ -62,8 +62,7 @@ fn main() {
     let max_steps = parse_steps_arg();
     App::new()
         .add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(Duration::from_millis(0))))
-        .insert_resource(Time::<Fixed>::from_seconds(10.0))
-        .add_plugins(AstrodynPlugin)
+        .add_astrodyn(10.0)
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, log_orbit.after(AstrodynSet::Integration))
         .insert_resource(StepCounter(0))

--- a/crates/astrodyn_bevy/src/app_ext.rs
+++ b/crates/astrodyn_bevy/src/app_ext.rs
@@ -1,0 +1,135 @@
+//! [`AstrodynAppExt`] — ergonomic [`App`] setup and fixed-step advancement.
+//!
+//! Mission code, examples, and tests routinely re-type the same five-line
+//! boilerplate to bring up an [`App`] with [`AstrodynPlugin`]:
+//!
+//! ```ignore
+//! let mut app = App::new();
+//! app.add_plugins(MinimalPlugins);
+//! app.insert_resource(Time::<Fixed>::from_seconds(dt));
+//! app.add_plugins(AstrodynPlugin);
+//! ```
+//!
+//! followed by a four-line block to advance `Time<Fixed>` and run the
+//! `FixedUpdate` schedule. The advance pattern is a footgun: forgetting
+//! `run_schedule(FixedUpdate)` after `advance_by(...)` silently does nothing,
+//! so a test reads stale state and asserts against it.
+//!
+//! [`AstrodynAppExt`] collapses both shapes onto a single canonical surface
+//! that mirrors the proven crate-private helpers in
+//! `astrodyn_verif_parity::tests::common`. The order in which `add_astrodyn`
+//! installs `Time<Fixed>` and the plugin is the same order
+//! [`crate::scenario::SimulationBuilderBevyExt::populate_app`] uses — the
+//! plugin must observe `Time<Fixed>` already in the world.
+
+use std::time::Duration;
+
+use bevy::prelude::*;
+
+use crate::AstrodynPlugin;
+
+/// Ergonomic helpers for setting up and advancing an [`App`] running
+/// [`AstrodynPlugin`] in `FixedUpdate`.
+///
+/// Implemented for [`App`]. The methods chain (each returns `&mut Self`) so
+/// callers can write
+///
+/// ```ignore
+/// App::new()
+///     .add_plugins(MinimalPlugins)
+///     .add_astrodyn(10.0)
+///     .add_systems(Startup, setup);
+/// ```
+///
+/// instead of the four-statement bring-up block.
+pub trait AstrodynAppExt {
+    /// Insert `Time::<Fixed>::from_seconds(dt_seconds)` then add
+    /// [`AstrodynPlugin`].
+    ///
+    /// Insertion order is load-bearing: [`AstrodynPlugin::build`] expects
+    /// `Time<Fixed>` to already be in the world (the schedule's shared `dt`
+    /// drives every JEOD pipeline stage). Mirrors the ordering used by
+    /// `populate_app` in `crate::scenario`. A naive impl that adds the
+    /// plugin first would re-introduce the same precondition footgun the
+    /// trait exists to abolish.
+    ///
+    /// Idempotent on the plugin: a second call is a no-op for the plugin
+    /// half (Bevy panics on duplicate plugin adds, so this method does not
+    /// re-add). The `Time<Fixed>` resource is overwritten on each call —
+    /// the typical usage is a single bring-up, but a test that wants to
+    /// reconfigure `dt` mid-test can re-call this method without standing
+    /// up a new `App`.
+    fn add_astrodyn(&mut self, dt_seconds: f64) -> &mut Self;
+
+    /// Advance `Time<Fixed>` by `dt_seconds` and run the `FixedUpdate`
+    /// schedule, repeated `n` times.
+    ///
+    /// Each iteration corresponds to one JEOD-pipeline tick (one pass
+    /// through the seven `AstrodynSet` stages). The advance and schedule
+    /// run are bonded as a single unit so callers cannot accidentally
+    /// advance the clock without running the pipeline (or vice versa).
+    fn step_fixed_dt(&mut self, n: usize, dt_seconds: f64) -> &mut Self;
+
+    /// Convenience: read `dt` from the existing `Time<Fixed>` resource and
+    /// invoke [`Self::step_fixed_dt`] with it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `Time<Fixed>` is absent from the world. Callers must
+    /// install it first via [`Self::add_astrodyn`] (or a manual
+    /// `insert_resource(Time::<Fixed>::from_seconds(...))` before adding
+    /// [`AstrodynPlugin`]). A missing `Time<Fixed>` means the
+    /// [`AstrodynPlugin`] pipeline never advanced under a known `dt`, so
+    /// silently picking a default would propagate physics under the wrong
+    /// integrator step — exactly the silent-wrong-physics failure mode the
+    /// fail-loud rule forbids.
+    fn step_fixed(&mut self, n: usize) -> &mut Self;
+}
+
+impl AstrodynAppExt for App {
+    fn add_astrodyn(&mut self, dt_seconds: f64) -> &mut Self {
+        // Insert `Time<Fixed>` *before* the plugin so `AstrodynPlugin::build`
+        // sees a populated resource. `populate_app` in `crate::scenario`
+        // documents the same ordering for the same reason.
+        // allowed: `Time::<Fixed>::from_seconds` is Bevy's own constructor
+        // for the `Time<Fixed>` resource, not the banned typed-quantity
+        // `SecondsSince::from_seconds` bypass. The grep pattern catches
+        // `from_seconds` indiscriminately; the argument is a plain `f64`
+        // integrator timestep, not a typed-duration phantom.
+        self.insert_resource(Time::<Fixed>::from_seconds(dt_seconds));
+        if !self.is_plugin_added::<AstrodynPlugin>() {
+            self.add_plugins(AstrodynPlugin);
+        }
+        self
+    }
+
+    fn step_fixed_dt(&mut self, n: usize, dt_seconds: f64) -> &mut Self {
+        let dur = Duration::from_secs_f64(dt_seconds);
+        for _ in 0..n {
+            self.world_mut()
+                .resource_mut::<Time<Fixed>>()
+                .advance_by(dur);
+            self.world_mut().run_schedule(FixedUpdate);
+        }
+        self
+    }
+
+    fn step_fixed(&mut self, n: usize) -> &mut Self {
+        let dt_seconds = self
+            .world()
+            .get_resource::<Time<Fixed>>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "AstrodynAppExt::step_fixed: `Time<Fixed>` resource is missing from \
+                     the world. The convenience overload reads `dt` from the existing \
+                     `Time<Fixed>` to bond the advance to the same step the pipeline \
+                     was configured for. Call `app.add_astrodyn(dt_seconds)` first \
+                     (which installs `Time<Fixed>` then adds `AstrodynPlugin`), or use \
+                     `step_fixed_dt(n, dt_seconds)` to pass the step explicitly."
+                )
+            })
+            .timestep()
+            .as_secs_f64();
+        self.step_fixed_dt(n, dt_seconds)
+    }
+}

--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -10,6 +10,7 @@
 // inside `crate::systems` and friends carries `<P: Planet>` parameters
 // and re-tags into `<SelfRef>`-marked storage at the write site only.
 
+pub mod app_ext;
 pub mod body_action;
 pub mod bundles;
 pub mod components;
@@ -26,6 +27,7 @@ pub mod systems;
 pub mod validation;
 pub mod wrench;
 
+pub use app_ext::AstrodynAppExt;
 pub use body_action::{
     add_body_action_via, body_action_intake_system, body_action_system,
     body_action_unregistered_planet_fence_system, BodyActionCommandsExt, BodyActionEvent,

--- a/crates/astrodyn_bevy/src/prelude.rs
+++ b/crates/astrodyn_bevy/src/prelude.rs
@@ -26,7 +26,7 @@
 //! ```
 
 pub use crate::{
-    Abm4StateC, AerodynamicForceC, AstrodynPlugin, AstrodynSet, AtmosphericStateC,
+    Abm4StateC, AerodynamicForceC, AstrodynAppExt, AstrodynPlugin, AstrodynSet, AtmosphericStateC,
     BodyActionCommandsExt, BodyActionEvent, BodyActionsR, BodyFrameMarker, ClosureJointKinematicsC,
     DetachedSubtreeStateC, DynamicsConfigC, FrameAngVelC, FrameDerivativesC, FrameEntityC,
     FrameRotC, FrameTransC, GaussJacksonStateC, GravityAccelerationC, GravityControlsC,

--- a/crates/astrodyn_bevy/tests/app_ext.rs
+++ b/crates/astrodyn_bevy/tests/app_ext.rs
@@ -1,0 +1,119 @@
+//! End-to-end coverage for [`AstrodynAppExt`].
+//!
+//! Exercises the trait's three methods on a minimal Earth + ISS-style
+//! point-mass scenario:
+//!
+//! 1. [`AstrodynAppExt::add_astrodyn`] brings up an `App` with `Time<Fixed>`
+//!    + `AstrodynPlugin` in one chained call.
+//! 2. [`AstrodynAppExt::step_fixed_dt`] advances the schedule with an
+//!    explicit `dt`.
+//! 3. [`AstrodynAppExt::step_fixed`] reads `dt` from `Time<Fixed>` and
+//!    advances. The body must move under gravity (otherwise the bring-up
+//!    didn't actually wire the pipeline).
+//!
+//! A separate `#[should_panic]` test pins the diagnostic substring used
+//! when a caller invokes `step_fixed` on an `App` that never received a
+//! `Time<Fixed>` resource — the fail-loud guard at the trait surface.
+
+use astrodyn_bevy::prelude::*;
+use astrodyn_bevy::recipes::{earth, orbital_elements, vehicle};
+use bevy::prelude::*;
+
+const DT: f64 = 10.0;
+const N_STEPS: usize = 10;
+
+#[derive(Resource)]
+struct VehicleEntity(Entity);
+
+fn setup_iss(mut commands: Commands) {
+    let earth_recipe = earth::point_mass();
+    let earth_mu = earth_recipe.source.mu;
+    let earth = commands
+        .spawn((
+            Name::new("Earth"),
+            GravitySourceC(earth_recipe.source),
+            SourceInertialPositionC::default(),
+            TranslationalStateC::<Earth>::default(),
+        ))
+        .id();
+
+    let cfg = VehicleBuilder::new()
+        .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
+        .three_dof_point_mass(vehicle::iss_mass())
+        .rk4()
+        .gravity(GravityControl::new_spherical(0_usize, false))
+        .build();
+
+    let vehicle_entity = cfg.spawn_bevy::<astrodyn::Earth>(&mut commands, &[earth]);
+    commands.insert_resource(VehicleEntity(vehicle_entity));
+}
+
+fn read_position_norm(app: &App) -> f64 {
+    let entity = app.world().resource::<VehicleEntity>().0;
+    app.world()
+        .get::<TranslationalStateC<Earth>>(entity)
+        .expect("vehicle entity must carry TranslationalStateC<Earth>")
+        .0
+        .position
+        .raw_si()
+        .length()
+}
+
+/// `add_astrodyn` + `step_fixed_dt` + `step_fixed` chain end-to-end.
+///
+/// After `add_astrodyn(DT)`, the world holds `Time<Fixed>` and the
+/// `AstrodynPlugin` schedule sets are configured. After `N_STEPS` of
+/// `step_fixed_dt` the body has propagated, and another N steps via
+/// `step_fixed` (which must read the same DT back from the resource) keeps
+/// it on a bound orbit. Both halves of the run move the position vector,
+/// confirming the pipeline actually ticks.
+#[test]
+fn app_ext_chain_runs_pipeline() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_astrodyn(DT)
+        .add_systems(Startup, setup_iss);
+    // Flush startup so the vehicle entity exists before any FixedUpdate
+    // schedule run reads its components.
+    app.update();
+
+    let r0 = read_position_norm(&app);
+
+    app.step_fixed_dt(N_STEPS, DT);
+    let r1 = read_position_norm(&app);
+    assert!(
+        (r1 - r0).abs() > 0.0,
+        "step_fixed_dt did not advance the body: r0 = r1 = {r0}",
+    );
+
+    // `step_fixed` reads `dt` from the resource installed by
+    // `add_astrodyn`. The bonded advance + run_schedule pair must move the
+    // body again.
+    app.step_fixed(N_STEPS);
+    let r2 = read_position_norm(&app);
+    assert!(
+        (r2 - r1).abs() > 0.0,
+        "step_fixed did not advance the body: r1 = r2 = {r1}",
+    );
+
+    // Bound orbit sanity: both samples are within a few percent of the
+    // initial radius (ISS altitude). Catches a regression that would tick
+    // the schedule without the gravity stage running.
+    let drift0 = (r1 - r0).abs() / r0;
+    let drift1 = (r2 - r1).abs() / r1;
+    assert!(
+        drift0 < 0.01 && drift1 < 0.01,
+        "implausible position drift over {N_STEPS}*{DT}s: r0={r0} r1={r1} r2={r2}",
+    );
+}
+
+/// `step_fixed` panics with a diagnostic that names `Time<Fixed>` and the
+/// fix (call `add_astrodyn` first / use `step_fixed_dt`).
+#[test]
+#[should_panic(expected = "Time<Fixed>` resource is missing")]
+fn step_fixed_panics_without_time_fixed() {
+    let mut app = App::new();
+    // No `add_astrodyn`, no `insert_resource(Time::<Fixed>::...)` — the
+    // resource is absent, so `step_fixed` must panic at the read site.
+    app.step_fixed(1);
+}


### PR DESCRIPTION
## Summary

- New `AstrodynAppExt` trait (`crates/astrodyn_bevy/src/app_ext.rs`) with `add_astrodyn(dt)`, `step_fixed_dt(n, dt)`, and `step_fixed(n)`. Implemented for `App`, re-exported from `astrodyn_bevy::prelude`. Mirrors the proven crate-private helpers in `astrodyn_verif_parity::tests::common`; gives mission code an ergonomic public surface that doesn't depend on the parity crate.
- `add_astrodyn` installs `Time<Fixed>` **before** `AstrodynPlugin` (the same load-bearing order `populate_app` uses), and `step_fixed_dt` bonds `advance_by` to `run_schedule(FixedUpdate)` so a missing schedule run can no longer silently leave the pipeline idle.
- `step_fixed` panics with a fail-loud diagnostic naming the broken assumption (missing `Time<Fixed>`) and the two fixes (`add_astrodyn` first, or use `step_fixed_dt(n, dt)` explicitly).
- Migrates `examples/typed_mission.rs` and `examples/kepler_orbit.rs` to the new trait; both still propagate the same 560 default ticks. `scenario.rs:635-642` keeps its inline pattern as internal `populate_app` validation. The parity suite's crate-private helpers are intentionally left for #423.

Closes #420.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` (1170 passed)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo test --doc --workspace`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [x] `cargo run -p astrodyn_bevy --example typed_mission` and `--example kepler_orbit` smoke-checked at default 560 ticks
- [x] New `crates/astrodyn_bevy/tests/app_ext.rs` exercises `add_astrodyn` + `step_fixed_dt` + `step_fixed` end-to-end on a point-mass ISS scenario; a `#[should_panic]` sibling pins the missing-`Time<Fixed>` diagnostic substring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)