### PR TITLE
[#412] Document per-stage temperature-derivative dispatch in coupled SRP path

### DIFF
--- a/crates/astrodyn_bevy/src/systems/integration.rs
+++ b/crates/astrodyn_bevy/src/systems/integration.rs
@@ -623,9 +623,39 @@ pub fn integration_system<P: Planet>(
                     let srp_force_inertial = t_inertial_struct.transpose() * srp_result.force;
                     final_srp_inertial_force = srp_force_inertial;
                     final_srp_torque = srp_result.torque;
+                    // Per-stage SRP force is always recomputed (the
+                    // `compute_flat_plate_srp_thermal` call above runs at
+                    // every RK4 stage with the intermediate orbital +
+                    // attitude state); only the temperature-derivative
+                    // feed differs by `thermal_order`. Energy
+                    // conservation in the thermal coupling requires that
+                    // the per-stage `temp_dots` consumed by
+                    // `integrate_body_coupled` reflect a flux state
+                    // consistent with the integrator's intended thermal
+                    // integration order, not just the most recently
+                    // computed flux. The runner side carries the
+                    // matching dispatch in
+                    // `crates/astrodyn_runner/src/simulation/step/integrate.rs`.
                     let temp_dots = match thermal_order {
-                        astrodyn::ThermalIntegrationOrder::DerivativeRk4 => srp_result.temp_dots,
+                        astrodyn::ThermalIntegrationOrder::DerivativeRk4 => {
+                            // True RK4 thermal: use this stage's freshly
+                            // computed `temp_dots` so the kernel's
+                            // `finalize_rk4_temperatures` averages four
+                            // distinct k-values (matches JEOD's
+                            // `ThermalIntegrationOrder::DerivativeRk4`).
+                            srp_result.temp_dots
+                        }
                         astrodyn::ThermalIntegrationOrder::DerivativeFirstOrder => {
+                            // Capture k1 at stage 1 (`time_frac == 0.0`)
+                            // and feed it back at stages 2-4 so the RK4
+                            // combine collapses to a forward-Euler step
+                            // over k1 — JEOD's ER7_Utils first-order
+                            // integrator behavior, while still
+                            // evaluating the orbital-state RK4 at full
+                            // 4th-order accuracy. Returning a stage-2-4
+                            // `srp_result.temp_dots` here would silently
+                            // upgrade the thermal integration order
+                            // (and break parity with `astrodyn_runner`).
                             if time_frac == 0.0 {
                                 k1_temp_dots = Some(srp_result.temp_dots.clone());
                                 srp_result.temp_dots


### PR DESCRIPTION
## Summary

Issue #412 reports that the bevy ↔ runner parity wrapper for `srp_1st_order`
(`ThermalIntegrationOrder::DerivativeFirstOrder`) fails bit-identity by ~0.23 m
on `position[0]` at t=3000s. The hypothesis is that the bevy 1st-order thermal
SRP path computes the temperature derivative once per tick where the runner
re-evaluates per stage.

After investigation, **the divergence is no longer reproducible on `main`**:

```
$ cargo nextest run -p astrodyn_verif_parity --test bevy_parity_srp_1st_order
        PASS [ 842.303s] (1/1) astrodyn_verif_parity::bevy_parity_srp_1st_order \
            bevy_parity_srp_1st_order_trajectory
     Summary [ 842.303s] 1 test run: 1 passed, 0 skipped
```

The parity test is the bit-identity comparison (per-component `f64::to_bits()`
across 2000 reference-CSV records over the GEO 23-day window), so a single
diverging position component anywhere along the trajectory would surface as
a `bits=…` mismatch. It does not.

The bug-shape from the issue's likely-cause analysis is also not present
in the code:

- The bevy adapter's `integration_system`
  (`crates/astrodyn_bevy/src/systems/integration.rs`) already recomputes
  the SRP force per RK4 stage — the closure passed to
  `integrate_body_coupled` calls `compute_flat_plate_srp_thermal` at every
  stage with the intermediate orbital + attitude state.
- The `DerivativeFirstOrder` arm of the `temp_dots` match captures k1 at
  stage 1 (`time_frac == 0.0`) and re-feeds it at stages 2-4, so the
  kernel's `finalize_rk4_temperatures` averages four equal k-values and
  collapses to a forward-Euler step — JEOD's ER7_Utils first-order
  integrator behavior.
- The runner side
  (`crates/astrodyn_runner/src/simulation/step/integrate.rs`) carries
  the matching dispatch.

The most likely explanation is that the divergence originated on the
issue's source branch (`claude/review-issue-389-stk3t`) and was resolved
before the parity wrapper landed on `main` (which it did via #406 / #415,
without an `#[ignore]`). Sibling parity tests for the same code path
(`bevy_parity_srp_rk4_thermal_srp_derivative_first_order`,
`bevy_parity_srp_rk4_thermal_srp_derivative_rk4`,
`bevy_parity_srp_rk4_thermal_srp_derivative_rk4_with_rotated_struct_frame`)
also pass.

## Change

The bevy `temp_dots` match arm previously had the inline mechanics
(`if time_frac == 0.0 { … }`) without the rationale that makes the
asymmetry between the two derivative orders intentional. This PR adds:

- A header comment above the match block explaining that per-stage SRP
  force is always recomputed and only the temperature-derivative feed
  varies by `thermal_order` for energy conservation in the thermal
  coupling.
- An arm-level comment for `DerivativeRk4` pointing at JEOD's matching
  mode and noting that all four k-values are distinct.
- An arm-level comment for `DerivativeFirstOrder` explaining the
  ER7_Utils first-order behavior, why returning the stage-2-4
  `srp_result.temp_dots` would silently upgrade the integration order,
  and why that would break parity with `astrodyn_runner`.

No behavior change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_srp_1st_order` (PASS, 842.303s)
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_srp` (PASS, both wrappers)
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_srp_basic --test bevy_parity_srp_rk4_thermal` (5/5 PASS)
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` (1175/1175 PASS)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo test --doc --workspace`
- [x] `cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Closes #412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)