### PR TITLE
[#423] Return typed siblings from astrodyn_verif_parity common::* helpers

### DIFF
--- a/crates/astrodyn_verif_parity/tests/bevy_parity.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity.rs
@@ -12,8 +12,9 @@
 use std::time::Duration;
 
 use astrodyn::{
-    DynamicsConfig, GravityControl, GravityControls, GravityModel, GravitySource, IntegratorType,
-    JeodQuat, MassProperties, RotationalState, SixDofState, TranslationalState,
+    AngularVelocity, BodyAttitude, BodyFrame, DynamicsConfig, GravityControl, GravityControls,
+    GravityModel, GravitySource, InertiaTensor, IntegratorType, JeodQuat, MassPropertiesTyped,
+    Position, RotationalStateTyped, SelfRef, SixDofState, StructuralFrame, TranslationalState,
 };
 use astrodyn_bevy::{
     AstrodynPlugin, DynamicsConfigC, GravityControlsC, GravitySourceC, IntegratorTypeC,
@@ -21,6 +22,8 @@ use astrodyn_bevy::{
 };
 use bevy::prelude::*;
 use glam::{DMat3, DVec3};
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
 const DT: f64 = 10.0;
@@ -35,19 +38,21 @@ fn initial_trans() -> TranslationalState {
 }
 
 /// Non-trivial initial rotational state with tumble.
-fn initial_rot() -> RotationalState {
-    RotationalState {
-        quaternion: JeodQuat::identity(),
-        ang_vel_body: DVec3::new(0.001, 0.0, 0.001),
-    }
+fn initial_rot() -> RotationalStateTyped<SelfRef> {
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(JeodQuat::identity()),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::new(0.001, 0.0, 0.001)),
+    )
 }
 
 /// ISS-like mass properties with realistic diagonal inertia.
-fn mass_props() -> MassProperties {
-    MassProperties::with_inertia(
-        400_000.0,
-        DMat3::from_diagonal(DVec3::new(1.02e8, 0.91e8, 1.64e8)),
-        DVec3::ZERO,
+fn mass_props() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(400_000.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::new(1.02e8, 0.91e8, 1.64e8),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
@@ -89,12 +94,8 @@ fn build_app() -> (App, Entity, Entity) {
         .spawn((
             Name::new("Vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(mass_props()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(mass_props()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -147,12 +148,8 @@ fn run_simulation_steps() -> SixDofState {
 
     sim.add_body(astrodyn::VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&initial_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(initial_rot()),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(mass_props()),
-        )),
+        rot: Some(initial_rot()),
+        mass: Some(mass_props()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, false)],
         },
@@ -258,12 +255,8 @@ fn bevy_parity_rkf45_matches_simulation_bit_identical() {
         .spawn((
             Name::new("Vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(mass_props()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(mass_props()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -293,12 +286,8 @@ fn bevy_parity_rkf45_matches_simulation_bit_identical() {
 
     sim.add_body(astrodyn::VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&initial_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(initial_rot()),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(mass_props()),
-        )),
+        rot: Some(initial_rot()),
+        mass: Some(mass_props()),
         integrator: IntegratorType::Rkf45,
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, false)],

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
@@ -76,8 +76,12 @@ fn build_two_body_world(
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(parent_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(parent_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -87,8 +91,12 @@ fn build_two_body_world(
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(child_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(child_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -1262,8 +1270,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_runs_combine
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
             IntegSourceC(Some(source_a)),
         ))
@@ -1274,8 +1286,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_runs_combine
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
             IntegSourceC(Some(source_b)),
         ))
@@ -1618,8 +1634,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_rewrites_chi
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
             IntegSourceC(Some(source_a)),
         ))
@@ -1630,8 +1650,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_rewrites_chi
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
             IntegSourceC(Some(source_b)),
         ))
@@ -1853,8 +1877,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_post_frame_switch_same_integ_f
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
             IntegSourceC(Some(source)),
         ))
@@ -1872,8 +1900,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_post_frame_switch_same_integ_f
                 position: child_root_relative_pos,
                 velocity: DVec3::new(0.0, 7600.0, 0.0),
             }),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
             IntegSourceC(None),
         ))
@@ -2042,7 +2074,9 @@ fn bevy_parity_attach_detach_momentum_bevy_detached_body_skips_force_pipeline() 
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans),
             RotationalStateC::default(),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(body_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(body_mass)),
+            ),
             MassBodyIdC(id_body),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
@@ -2426,8 +2460,8 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_attach_detach_momentum(
     );
     let parent_idx = sim.add_body(RunnerVehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&parent_trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(parent_rot))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+        rot: Some(astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(parent_rot))),
+        mass: Some(astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass))),
         integrator: RunnerIntegratorType::Rk4,
         gravity_controls: RunnerGravityControls {
             controls: vec![RunnerGravityControl::new_spherical(inertial, false)],
@@ -2436,8 +2470,8 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_attach_detach_momentum(
     });
     let child_idx = sim.add_body(RunnerVehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&child_trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(child_rot))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+        rot: Some(astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(child_rot))),
+        mass: Some(astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass))),
         integrator: RunnerIntegratorType::Rk4,
         gravity_controls: RunnerGravityControls {
             controls: vec![RunnerGravityControl::new_spherical(inertial, false)],
@@ -2758,8 +2792,12 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(parent_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(parent_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
             IntegSourceC(Some(source_a)),
         ))
@@ -2770,8 +2808,12 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(child_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(child_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
             IntegSourceC(Some(source_b)),
         ))
@@ -2862,8 +2904,8 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
     );
     let parent_idx = sim.add_body(RunnerVehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&parent_trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(parent_rot))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+        rot: Some(astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(parent_rot))),
+        mass: Some(astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass))),
         integrator: RunnerIntegratorType::Rk4,
         gravity_controls: RunnerGravityControls {
             controls: vec![RunnerGravityControl::new_spherical(runner_source_a, false)],
@@ -2873,8 +2915,8 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
     });
     let child_idx = sim.add_body(RunnerVehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&child_trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(child_rot))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+        rot: Some(astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(child_rot))),
+        mass: Some(astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass))),
         integrator: RunnerIntegratorType::Rk4,
         gravity_controls: RunnerGravityControls {
             controls: vec![RunnerGravityControl::new_spherical(runner_source_b, false)],
@@ -3032,8 +3074,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_parents_succee
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
             IntegSourceC(Some(source)),
         ))
@@ -3047,8 +3093,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_parents_succee
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
             IntegSourceC(None),
         ))
@@ -3155,8 +3205,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_malformed_frame_node_panics() 
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3166,8 +3220,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_malformed_frame_node_panics() 
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3256,8 +3314,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_equal_but_illegal_parents_pani
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3267,8 +3329,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_equal_but_illegal_parents_pani
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3383,8 +3449,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_stray_parent_p
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3394,8 +3464,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_stray_parent_p
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3501,7 +3575,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_mass_only_no_frame_entity_succ
         .world_mut()
         .spawn((
             Name::new("Parent"),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3509,7 +3585,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_mass_only_no_frame_entity_succ
         .world_mut()
         .spawn((
             Name::new("Child"),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3609,8 +3687,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_child_of_
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3620,8 +3702,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_child_of_
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3716,8 +3802,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_body_with_no_frame_ent
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3727,8 +3817,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_body_with_no_frame_ent
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3820,7 +3914,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_child_on_mass_only_par
         .world_mut()
         .spawn((
             Name::new("Parent"),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3832,8 +3928,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_child_on_mass_only_par
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -3918,8 +4018,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_translati
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -3929,8 +4033,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_translati
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();
@@ -4026,7 +4134,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_child_on_mass_only_par
         .world_mut()
         .spawn((
             Name::new("Parent"),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -4063,8 +4173,12 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_child_on_mass_only_par
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(initial_rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot)),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
             FrameEntityC(child_frame_entity),
         ))
@@ -4140,7 +4254,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_mass_only_succeeds_without_jeo
         .world_mut()
         .spawn((
             Name::new("Parent"),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass)),
+            ),
             MassBodyIdC(id_a),
         ))
         .id();
@@ -4148,7 +4264,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_mass_only_succeeds_without_jeo
         .world_mut()
         .spawn((
             Name::new("Child"),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_mass))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass)),
+            ),
             MassBodyIdC(id_b),
         ))
         .id();

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_non_root_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_non_root_integ_source.rs
@@ -46,8 +46,9 @@
 //! seed-time lift at lines 282-307 and writeback lower at 399-407).
 
 use astrodyn::{
-    DynamicsConfig, GravityControls, JeodQuat, MassProperties, MassTree, RotationalState,
-    StageAttachInputs, TranslationalState, EARTH, MOON,
+    AngularVelocity, BodyAttitude, BodyFrame, DynamicsConfig, GravityControls, InertiaTensor,
+    JeodQuat, MassPropertiesTyped, MassTree, Position, RotationalStateTyped, SelfRef,
+    StageAttachInputs, StructuralFrame, TranslationalState, EARTH, MOON,
 };
 use astrodyn_bevy::{
     AstrodynPlugin, AttachEvent, DetachedSubtreeStateC, DynamicsConfigC, FrameDerivativesC,
@@ -56,6 +57,8 @@ use astrodyn_bevy::{
 };
 use bevy::prelude::*;
 use glam::{DMat3, DVec3};
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 const DT: f64 = 60.0;
 const MOON_OFFSET: DVec3 = DVec3::new(3.844e8, 0.0, 0.0);
@@ -67,19 +70,23 @@ const MOON_OFFSET: DVec3 = DVec3::new(3.844e8, 0.0, 0.0);
 /// position. Both are orders of magnitude above tolerances.
 const MOON_VELOCITY: DVec3 = DVec3::new(0.0, 1_000.0, 0.0);
 
-fn parent_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        1_000.0,
-        DMat3::from_diagonal(DVec3::new(100.0, 100.0, 100.0)),
-        DVec3::ZERO,
+fn parent_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(1_000.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::new(100.0, 100.0, 100.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
-fn child_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        500.0,
-        DMat3::from_diagonal(DVec3::new(50.0, 50.0, 50.0)),
-        DVec3::ZERO,
+fn child_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(500.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::new(50.0, 50.0, 50.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
@@ -108,11 +115,11 @@ fn child_initial_trans() -> TranslationalState {
     }
 }
 
-fn initial_rot() -> RotationalState {
-    RotationalState {
-        quaternion: JeodQuat::identity(),
-        ang_vel_body: DVec3::ZERO,
-    }
+fn initial_rot() -> RotationalStateTyped<SelfRef> {
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(JeodQuat::identity()),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::ZERO),
+    )
 }
 
 fn six_dof_config() -> DynamicsConfig {
@@ -145,8 +152,8 @@ fn build_lunar_app() -> (App, Entity, Entity, Entity, astrodyn::MassBodyId) {
         .id();
 
     let mut tree = MassTree::new();
-    let id_parent = tree.add_body("Parent".into(), parent_mass());
-    let id_child = tree.add_body("Child".into(), child_mass());
+    let id_parent = tree.add_body("Parent".into(), parent_mass().to_untyped());
+    let id_child = tree.add_body("Child".into(), child_mass().to_untyped());
     app.insert_resource(MassTreeR(tree));
 
     let parent_entity = app
@@ -154,14 +161,10 @@ fn build_lunar_app() -> (App, Entity, Entity, Entity, astrodyn::MassBodyId) {
         .spawn((
             Name::new("Parent"),
             DynamicsConfigC(six_dof_config()),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(parent_mass()),
-            )),
+            MassPropertiesC::from(parent_mass()),
             MassBodyIdC(id_parent),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
+            RotationalStateC::from(initial_rot()),
             FrameDerivativesC::default(),
             GravityControlsC(GravityControls { controls: vec![] }),
             IntegSourceC(Some(moon)),
@@ -172,14 +175,10 @@ fn build_lunar_app() -> (App, Entity, Entity, Entity, astrodyn::MassBodyId) {
         .spawn((
             Name::new("Child"),
             DynamicsConfigC(six_dof_config()),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(child_mass()),
-            )),
+            MassPropertiesC::from(child_mass()),
             MassBodyIdC(id_child),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
+            RotationalStateC::from(initial_rot()),
             FrameDerivativesC::default(),
             GravityControlsC(GravityControls { controls: vec![] }),
             IntegSourceC(Some(moon)),
@@ -247,7 +246,7 @@ fn bevy_parity_attach_non_root_integ_source_lift_and_lower() {
         .composite_properties;
 
     let q = JeodQuat::identity();
-    let parent_mass_props = parent_mass();
+    let parent_mass_props = parent_mass().to_untyped();
     let expected = astrodyn::stage_attach_combine(StageAttachInputs {
         parent_position: parent_pre_pos_integ + MOON_OFFSET,
         parent_velocity: parent_pre_vel_integ + MOON_VELOCITY,
@@ -260,7 +259,7 @@ fn bevy_parity_attach_non_root_integ_source_lift_and_lower() {
         child_velocity: child_pre_vel_integ + MOON_VELOCITY,
         child_quaternion: q,
         child_ang_vel_body: DVec3::ZERO,
-        child_mass: child_mass(),
+        child_mass: child_mass().to_untyped(),
         combined_mass,
     });
 
@@ -386,7 +385,7 @@ fn bevy_parity_attach_non_root_integ_source_parent_was_detached() {
         .composite_properties;
 
     let q = JeodQuat::identity();
-    let parent_mass_props = parent_mass();
+    let parent_mass_props = parent_mass().to_untyped();
     let expected = astrodyn::stage_attach_combine(StageAttachInputs {
         parent_position: parent_initial_trans().position + MOON_OFFSET,
         parent_velocity: parent_initial_trans().velocity + MOON_VELOCITY,
@@ -399,7 +398,7 @@ fn bevy_parity_attach_non_root_integ_source_parent_was_detached() {
         child_velocity: child_initial_trans().velocity + MOON_VELOCITY,
         child_quaternion: q,
         child_ang_vel_body: DVec3::ZERO,
-        child_mass: child_mass(),
+        child_mass: child_mass().to_untyped(),
         combined_mass,
     });
 

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_init_lvlh_rot.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_init_lvlh_rot.rs
@@ -1,3 +1,4 @@
+// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers.
 //! Bevy parity test for `BodyAction::InitLvlhRot` (port of JEOD's
 //! `DynBodyInitLvlhRotState`).
 //!
@@ -22,9 +23,7 @@ mod common;
 use std::time::Duration;
 
 use astrodyn::{init_rot_from_lvlh, LvlhAngularVelocityFrame as KernelLvlhFrame};
-use astrodyn::{
-    BodyAction, DynamicsConfig, JeodQuat, LvlhAngularVelocityFrame, MassProperties, RotationalState,
-};
+use astrodyn::{BodyAction, DynamicsConfig, JeodQuat, LvlhAngularVelocityFrame, RotationalState};
 use astrodyn_bevy::{
     AstrodynPlugin, BodyActionEvent, GravitySourceC, MassPropertiesC, RotationalStateC,
     SourceInertialPositionC, TranslationalStateC,
@@ -81,11 +80,9 @@ fn build_app() -> (App, Entity) {
             TranslationalStateC::<astrodyn::Earth>::default(),
             // Placeholder rotational state we expect the action to
             // overwrite on `update`.
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(RotationalState::default()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(1_000.0)),
+            RotationalStateC::from(astrodyn::RotationalStateTyped::<astrodyn::SelfRef>::default()),
+            MassPropertiesC::from(astrodyn::MassPropertiesTyped::<astrodyn::SelfRef>::new(
+                uom::si::f64::Mass::new::<uom::si::mass::kilogram>(1_000.0),
             )),
             astrodyn_bevy::DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: false,

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_lifecycle.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_lifecycle.rs
@@ -1,3 +1,4 @@
+// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers.
 //! Tier 3-style cross-validation for the dynamic body-action lifecycle
 //! API (#199). Mirrors JEOD's `SIM_removable_body_action` `RUN_1` and
 //! `mass.py` add → remove → re-add idiom in the Bevy adapter, then
@@ -161,12 +162,16 @@ fn build_app() -> (App, Entity) {
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(RotationalState::default()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(1.0)),
-            )),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
+                    &(RotationalState::default()),
+                ),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(1.0)),
+                ),
+            ),
             astrodyn_bevy::DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -478,12 +483,16 @@ fn bevy_parity_body_action_lifecycle_body_action_init_trans_resets_abm4_history(
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(RotationalState::default()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(400_000.0)),
-            )),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
+                    &(RotationalState::default()),
+                ),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(400_000.0)),
+                ),
+            ),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -638,12 +647,16 @@ fn bevy_parity_body_action_lifecycle_body_action_init_mass_resets_abm4_history()
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(RotationalState::default()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(400_000.0)),
-            )),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
+                    &(RotationalState::default()),
+                ),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(400_000.0)),
+                ),
+            ),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -802,12 +815,16 @@ fn bevy_parity_body_action_lifecycle_body_action_startup_message_applies_exactly
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(RotationalState::default()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(M0)),
-            )),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
+                    &(RotationalState::default()),
+                ),
+            ),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(M0)),
+                ),
+            ),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -854,7 +871,9 @@ fn bevy_parity_body_action_lifecycle_body_action_startup_message_applies_exactly
         .entity_mut(vehicle)
         .get_mut::<MassPropertiesC>()
         .expect("mass props present") = MassPropertiesC::from(
-        astrodyn::typed_bridge::mass_raw_to_self_ref(&(MassProperties::new(SENTINEL))),
+        astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+            &(MassProperties::new(SENTINEL)),
+        ),
     );
 
     // First runs `message_update_system` (the buffer swap). FixedUpdate
@@ -878,7 +897,9 @@ fn bevy_parity_body_action_lifecycle_body_action_startup_message_applies_exactly
         .entity_mut(vehicle)
         .get_mut::<MassPropertiesC>()
         .expect("mass props present") = MassPropertiesC::from(
-        astrodyn::typed_bridge::mass_raw_to_self_ref(&(MassProperties::new(SENTINEL2))),
+        astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+            &(MassProperties::new(SENTINEL2)),
+        ),
     );
 
     app.world_mut().run_schedule(First);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
@@ -66,10 +66,10 @@
 //! point.
 
 use astrodyn::IntegratorType;
-use astrodyn::MassProperties;
 use astrodyn::{
-    DynamicsConfig, GravityControls, JeodQuat, MassTree, RotationalState, SimulationTime,
-    TranslationalState, VehicleConfig,
+    AngularVelocity, BodyAttitude, BodyFrame, DynamicsConfig, GravityControls, InertiaTensor,
+    JeodQuat, MassPropertiesTyped, MassTree, Position, RotationalStateTyped, SelfRef,
+    SimulationTime, StructuralFrame, TranslationalState, VehicleConfig,
 };
 use astrodyn_bevy::{
     AstrodynPlugin, AttachEvent, DynamicsConfigC, ExternalForceC, ExternalTorqueC,
@@ -80,6 +80,8 @@ use astrodyn_runner::Simulation;
 use bevy::prelude::*;
 use glam::{DMat3, DVec3};
 use std::time::Duration;
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 const DT: f64 = 0.1;
 /// First attach: v1 → v2 (root subject — bit-equivalent to plain attach).
@@ -91,27 +93,33 @@ const RECHAIN_V1_V3_TIME: f64 = 2.0;
 // ── Initial conditions, all from JEOD Modified_data files (matches
 //    `tier3_sim_complex_attach_detach.rs::veh*_initial_*`). ──
 
-fn veh1_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        1.0,
-        DMat3::from_diagonal(DVec3::splat(10.0)),
-        DVec3::new(5.0, 0.0, 0.0),
+fn veh1_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(1.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::splat(10.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::from_raw_si(DVec3::new(5.0, 0.0, 0.0)),
     )
 }
 
-fn veh2_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        2.0,
-        DMat3::from_diagonal(DVec3::splat(20.0)),
-        DVec3::new(5.0, 0.0, 0.0),
+fn veh2_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(2.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::splat(20.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::from_raw_si(DVec3::new(5.0, 0.0, 0.0)),
     )
 }
 
-fn veh3_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        3.0,
-        DMat3::from_diagonal(DVec3::splat(30.0)),
-        DVec3::new(5.0, 0.0, 0.0),
+fn veh3_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(3.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::splat(30.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::from_raw_si(DVec3::new(5.0, 0.0, 0.0)),
     )
 }
 
@@ -122,11 +130,11 @@ fn veh1_trans() -> TranslationalState {
     }
 }
 
-fn veh1_rot() -> RotationalState {
-    RotationalState {
-        quaternion: JeodQuat::from_array([1.0, 0.0, 0.0, 0.0]),
-        ang_vel_body: DVec3::ZERO,
-    }
+fn veh1_rot() -> RotationalStateTyped<SelfRef> {
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(JeodQuat::from_array([1.0, 0.0, 0.0, 0.0])),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::ZERO),
+    )
 }
 
 fn veh2_trans() -> TranslationalState {
@@ -136,12 +144,12 @@ fn veh2_trans() -> TranslationalState {
     }
 }
 
-fn veh2_rot() -> RotationalState {
+fn veh2_rot() -> RotationalStateTyped<SelfRef> {
     let q = JeodQuat::left_quat_from_eigen_rotation(-2.0, DVec3::Z);
-    RotationalState {
-        quaternion: q,
-        ang_vel_body: DVec3::new(0.0, 0.0, 0.2),
-    }
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(q),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::new(0.0, 0.0, 0.2)),
+    )
 }
 
 fn veh3_trans() -> TranslationalState {
@@ -151,12 +159,12 @@ fn veh3_trans() -> TranslationalState {
     }
 }
 
-fn veh3_rot() -> RotationalState {
+fn veh3_rot() -> RotationalStateTyped<SelfRef> {
     let q = JeodQuat::left_quat_from_eigen_rotation(-15.8, DVec3::Z);
-    RotationalState {
-        quaternion: q,
-        ang_vel_body: DVec3::new(0.0, 0.0, 1.0),
-    }
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(q),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::new(0.0, 0.0, 1.0)),
+    )
 }
 
 /// JEOD `BodyAttachAligned` v1.attach_to_2: composes to identity
@@ -213,24 +221,24 @@ fn build_runner_sim() -> (Simulation, usize, usize, usize) {
     let mut sim = Simulation::new(time, DT);
     let v1 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh1_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(veh1_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh1_mass()))),
+        rot: Some(veh1_rot()),
+        mass: Some(veh1_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
         ..Default::default()
     });
     let v2 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh2_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(veh2_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh2_mass()))),
+        rot: Some(veh2_rot()),
+        mass: Some(veh2_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
         ..Default::default()
     });
     let v3 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh3_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(veh3_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh3_mass()))),
+        rot: Some(veh3_rot()),
+        mass: Some(veh3_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
         ..Default::default()
@@ -256,9 +264,9 @@ fn build_bevy_app() -> (
     app.add_plugins(AstrodynPlugin);
 
     let mut tree = MassTree::new();
-    let id_v1 = tree.add_body("veh1".into(), veh1_mass());
-    let id_v2 = tree.add_body("veh2".into(), veh2_mass());
-    let id_v3 = tree.add_body("veh3".into(), veh3_mass());
+    let id_v1 = tree.add_body("veh1".into(), veh1_mass().to_untyped());
+    let id_v2 = tree.add_body("veh2".into(), veh2_mass().to_untyped());
+    let id_v3 = tree.add_body("veh3".into(), veh3_mass().to_untyped());
     app.insert_resource(MassTreeR(tree));
 
     let v1 = spawn_body(
@@ -293,18 +301,18 @@ fn spawn_body(
     app: &mut App,
     name: &str,
     id: astrodyn::MassBodyId,
-    mass: MassProperties,
+    mass: MassPropertiesTyped<SelfRef>,
     trans: TranslationalState,
-    rot: RotationalState,
+    rot: RotationalStateTyped<SelfRef>,
 ) -> Entity {
     app.world_mut()
         .spawn((
             Name::new(name.to_string()),
             DynamicsConfigC(six_dof_config()),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass))),
+            MassPropertiesC::from(mass),
             MassBodyIdC(id),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(rot))),
+            RotationalStateC::from(rot),
             TotalForceC::default(),
             FrameDerivativesC::default(),
             ExternalForceC::default(),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
@@ -57,9 +57,9 @@ fn bevy_parity_derived_states() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -195,7 +195,7 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -233,7 +233,7 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
     );
 
     let body = VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
+        trans: iss_trans(),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },
@@ -324,8 +324,8 @@ fn bevy_parity_derived_state_eccentric_derived_states() {
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(ecc_trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -383,8 +383,8 @@ fn bevy_parity_derived_state_eccentric_derived_states() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&ecc_trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },
@@ -600,9 +600,9 @@ fn bevy_parity_derived_state_equatorial_solar_beta() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -644,9 +644,9 @@ fn bevy_parity_derived_state_equatorial_solar_beta() {
     sim.sun_source = Some(sun_idx);
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        trans: iss_trans(),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },
@@ -695,8 +695,8 @@ fn run_euler_parity(label: &str, trans: TranslationalState, sequence: EulerSeque
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -716,8 +716,8 @@ fn run_euler_parity(label: &str, trans: TranslationalState, sequence: EulerSeque
     let (mut sim, earth_idx) = new_sim_earth(DT);
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },
@@ -751,7 +751,7 @@ fn run_euler_parity(label: &str, trans: TranslationalState, sequence: EulerSeque
 
 #[test]
 fn bevy_parity_derived_state_euler() {
-    run_euler_parity("euler_inc", iss_trans(), EulerSequence::XYZ);
+    run_euler_parity("euler_inc", iss_trans().to_untyped(), EulerSequence::XYZ);
 }
 
 #[test]
@@ -819,7 +819,7 @@ fn run_lvlh_parity(label: &str, trans: TranslationalState) {
 
 #[test]
 fn bevy_parity_derived_state_lvlh() {
-    run_lvlh_parity("lvlh_inc", iss_trans());
+    run_lvlh_parity("lvlh_inc", iss_trans().to_untyped());
 }
 
 #[test]
@@ -940,7 +940,7 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
 #[test]
 fn bevy_parity_derived_state_ned_sph_inc() {
     let r_sph = astrodyn::EARTH.shape.r_eq;
-    run_ned_parity("ned_sph_inc", iss_trans(), r_sph, r_sph);
+    run_ned_parity("ned_sph_inc", iss_trans().to_untyped(), r_sph, r_sph);
 }
 
 #[test]

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_detach_non_root_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_detach_non_root_integ_source.rs
@@ -158,14 +158,14 @@ fn run_lift_and_lower(moon_velocity: DVec3) {
         .spawn((
             Name::new("Parent"),
             DynamicsConfigC(six_dof_config()),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(parent_mass()),
-            )),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_mass())),
+            ),
             MassBodyIdC(id_parent),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(lunar_initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot())),
+            ),
             FrameDerivativesC::default(),
             GravityControlsC(GravityControls { controls: vec![] }),
             IntegSourceC(Some(moon)),
@@ -176,14 +176,14 @@ fn run_lift_and_lower(moon_velocity: DVec3) {
         .spawn((
             Name::new("Child"),
             DynamicsConfigC(six_dof_config()),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(child_mass()),
-            )),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_mass())),
+            ),
             MassBodyIdC(id_child),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(lunar_initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
+            RotationalStateC::from(
+                astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(&(initial_rot())),
+            ),
             FrameDerivativesC::default(),
             GravityControlsC(GravityControls { controls: vec![] }),
             IntegSourceC(Some(moon)),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag.rs
@@ -71,9 +71,9 @@ fn bevy_parity_drag_atmosphere_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -182,9 +182,9 @@ fn bevy_parity_drag_constant_density_drag_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -282,9 +282,9 @@ fn bevy_parity_drag_met_atmosphere_drag_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -381,9 +381,9 @@ fn bevy_parity_drag_met_run5a() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -492,9 +492,9 @@ fn bevy_parity_drag_run6b() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_environment.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_environment.rs
@@ -1,3 +1,4 @@
+// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers.
 //! Schedule-order regression: a frame-attached body's
 //! `AstrodynSet::Environment` consumers (gravity, atmosphere) must observe
 //! the post-`propagate_frame_attached_state_system` body state, not a
@@ -28,14 +29,16 @@
 mod common;
 
 use astrodyn::{
-    DynamicsConfig, GravityControl, GravityControls, MassProperties, RotationalState,
-    TranslationalState,
+    DynamicsConfig, GravityControl, GravityControls, MassPropertiesTyped, RotationalStateTyped,
+    SelfRef, TranslationalState,
 };
 use astrodyn_bevy::{
     DynamicsConfigC, FrameAttachEvent, GravityAccelerationC, GravityControlsC, MassPropertiesC,
     RootFrameEntityR, RotationalStateC, TranslationalStateC,
 };
 use bevy::prelude::*;
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 use common::*;
 
@@ -63,12 +66,10 @@ fn bevy_parity_frame_attach_environment_frame_attach_gravity_sees_propagated_sta
         .spawn((
             Name::new("frame_attached_body"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState::default()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(RotationalState::default()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(1_000.0)),
-            )),
+            RotationalStateC::from(RotationalStateTyped::<SelfRef>::default()),
+            MassPropertiesC::from(MassPropertiesTyped::<SelfRef>::new(Mass::new::<kilogram>(
+                1_000.0,
+            ))),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -88,7 +89,7 @@ fn bevy_parity_frame_attach_environment_frame_attach_gravity_sees_propagated_sta
     // and stationary, so the captured offset *is* the body's
     // root-inertial position after `propagate_frame_attached_state_system`.
     let parent_frame = **app.world().resource::<RootFrameEntityR>();
-    let attach_offset = iss_trans().position;
+    let attach_offset = iss_trans().position.raw_si();
 
     app.world_mut()
         .resource_mut::<bevy::ecs::message::Messages<FrameAttachEvent>>()

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_non_root_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_non_root_integ_source.rs
@@ -1,3 +1,4 @@
+// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers.
 //! Bevy ECS frame-attach parity for bodies whose `IntegSourceC` is a
 //! non-root planet (lunar-orbit integ frame). Pins the
 //! root→integ-frame lower the per-step propagation system applies
@@ -43,8 +44,8 @@
 //! integ_source it is load-bearing.
 
 use astrodyn::{
-    DynamicsConfig, GravityControls, MassProperties, RotationalState, TranslationalState, EARTH,
-    MOON,
+    BodyFrame, DynamicsConfig, GravityControls, InertiaTensor, MassPropertiesTyped, Position,
+    RotationalStateTyped, SelfRef, StructuralFrame, TranslationalState, EARTH, MOON,
 };
 use astrodyn_bevy::{
     AstrodynPlugin, DynamicsConfigC, FrameAttachEvent, FrameAttachedC, FrameDerivativesC,
@@ -54,6 +55,8 @@ use astrodyn_bevy::{
 use bevy::prelude::*;
 use glam::{DMat3, DVec3};
 use std::time::Duration;
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 const DT: f64 = 60.0;
 const MOON_OFFSET: DVec3 = DVec3::new(3.844e8, 0.0, 0.0);
@@ -62,11 +65,13 @@ const MOON_OFFSET: DVec3 = DVec3::new(3.844e8, 0.0, 0.0);
 /// regression is unambiguous in the failure messages.
 const ATTACH_OFFSET: DVec3 = DVec3::new(7.0e6, 0.0, 0.0);
 
-fn body_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        1_000.0,
-        DMat3::from_diagonal(DVec3::new(100.0, 100.0, 100.0)),
-        DVec3::ZERO,
+fn body_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(1_000.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::new(100.0, 100.0, 100.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
@@ -85,8 +90,8 @@ fn initial_trans() -> TranslationalState {
     }
 }
 
-fn initial_rot() -> RotationalState {
-    RotationalState::default()
+fn initial_rot() -> RotationalStateTyped<SelfRef> {
+    RotationalStateTyped::<SelfRef>::default()
 }
 
 /// Frame-attach a body whose `IntegSourceC` points at a non-root
@@ -114,11 +119,9 @@ fn bevy_parity_frame_attach_non_root_integ_source_lowers_to_integ_frame() {
         .spawn((
             Name::new("Lunar"),
             DynamicsConfigC(six_dof_config()),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(body_mass()))),
+            MassPropertiesC::from(body_mass()),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
+            RotationalStateC::from(initial_rot()),
             FrameDerivativesC::default(),
             GravityControlsC(GravityControls { controls: vec![] }),
             IntegSourceC(Some(moon)),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
@@ -17,8 +17,9 @@
 use std::time::Duration;
 
 use astrodyn::{
-    DynamicsConfig, FrameSwitchConfig, GravityControl, GravityControls, GravitySourceEntry,
-    JeodQuat, MassProperties, RotationalState, SwitchSense, TranslationalState, VehicleConfig,
+    AngularVelocity, BodyAttitude, BodyFrame, DynamicsConfig, FrameSwitchConfig, GravityControl,
+    GravityControls, GravitySourceEntry, InertiaTensor, JeodQuat, MassPropertiesTyped, Position,
+    RotationalStateTyped, SelfRef, StructuralFrame, SwitchSense, TranslationalState, VehicleConfig,
     EARTH, MOON,
 };
 use astrodyn_bevy::frame_param::RelativeFrameState;
@@ -30,6 +31,8 @@ use astrodyn_bevy::{
 use astrodyn_runner::Simulation;
 use bevy::prelude::*;
 use glam::DVec3;
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 const DT: f64 = 60.0;
 const NUM_STEPS: usize = 80;
@@ -46,18 +49,20 @@ fn initial_trans() -> TranslationalState {
     }
 }
 
-fn initial_rot() -> RotationalState {
-    RotationalState {
-        quaternion: JeodQuat::identity(),
-        ang_vel_body: DVec3::ZERO,
-    }
+fn initial_rot() -> RotationalStateTyped<SelfRef> {
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(JeodQuat::identity()),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::ZERO),
+    )
 }
 
-fn vehicle_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        1_000.0,
-        glam::DMat3::from_diagonal(DVec3::new(100.0, 100.0, 100.0)),
-        DVec3::ZERO,
+fn vehicle_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(1_000.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(glam::DMat3::from_diagonal(
+            DVec3::new(100.0, 100.0, 100.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
@@ -104,12 +109,8 @@ fn bevy_parity_frame_switch_earth_to_moon_matches_simulation() {
         .spawn((
             Name::new("EarthToMoon"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(vehicle_mass()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(vehicle_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -223,12 +224,8 @@ fn bevy_parity_frame_switch_earth_to_moon_matches_simulation() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&initial_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(initial_rot()),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(vehicle_mass()),
-        )),
+        rot: Some(initial_rot()),
+        mass: Some(vehicle_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(0_usize, false), {
                 let mut c = GravityControl::new_spherical(moon_idx, false);
@@ -327,12 +324,8 @@ fn bevy_parity_frame_switch_on_departure_matches_simulation() {
         .spawn((
             Name::new("EarthDeparture"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(vehicle_mass()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(vehicle_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -395,12 +388,8 @@ fn bevy_parity_frame_switch_on_departure_matches_simulation() {
     );
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&initial_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(initial_rot()),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(vehicle_mass()),
-        )),
+        rot: Some(initial_rot()),
+        mass: Some(vehicle_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(0_usize, false), {
                 let mut c = GravityControl::new_spherical(moon_idx, false);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_gravity_torque.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_gravity_torque.rs
@@ -5,7 +5,7 @@ mod common;
 
 use astrodyn::{
     DynamicsConfig, GravityControl, GravityControls, GravityModel, GravitySource, JeodQuat,
-    MassProperties, RotationalState, SixDofState, TranslationalState,
+    SixDofState, TranslationalState,
 };
 use astrodyn::{GravitySourceEntry, VehicleConfig};
 use astrodyn_bevy::{
@@ -42,9 +42,9 @@ fn bevy_parity_gravity_torque_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -92,15 +92,23 @@ fn bevy_parity_gravity_torque_sixdof() {
 fn bevy_parity_gravity_torque_external_torque_per_body() {
     println!("Scenario G: External torque via per-body functions");
 
-    let mass_props = MassProperties::with_inertia(
-        400_000.0,
-        DMat3::from_cols(
-            DVec3::new(1.02e8, -6.96e6, -5.48e6),
-            DVec3::new(-6.96e6, 0.91e8, 5.90e5),
-            DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+    let mass_props = astrodyn::MassPropertiesTyped::<astrodyn::SelfRef>::with_inertia(
+        uom::si::f64::Mass::new::<uom::si::mass::kilogram>(400_000.0),
+        astrodyn::InertiaTensor::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_dmat3_unchecked(
+            DMat3::from_cols(
+                DVec3::new(1.02e8, -6.96e6, -5.48e6),
+                DVec3::new(-6.96e6, 0.91e8, 5.90e5),
+                DVec3::new(-5.48e6, 5.90e5, 1.64e8),
+            ),
         ),
-        DVec3::new(-3.0, -1.5, 4.0),
+        astrodyn::Position::<astrodyn::StructuralFrame<astrodyn::SelfRef>>::from_raw_si(
+            DVec3::new(-3.0, -1.5, 4.0),
+        ),
     );
+    // Cached untyped form for kernel calls below (`accumulate_gravity`,
+    // `collect_and_resolve_forces`, `integrate_body` all consume raw
+    // `MassProperties`).
+    let mass_props_raw = mass_props.to_untyped();
 
     let config = DynamicsConfig {
         translational_dynamics: true,
@@ -121,8 +129,8 @@ fn bevy_parity_gravity_torque_external_torque_per_body() {
     let num_steps = 100;
 
     // Path A
-    let mut trans_a = iss_trans();
-    let mut rot_a = tumble_rot();
+    let mut trans_a = iss_trans().to_untyped();
+    let mut rot_a = tumble_rot().to_untyped();
     for step in 0..num_steps {
         let torque = if (10..20).contains(&step) {
             external_torque
@@ -144,14 +152,14 @@ fn bevy_parity_gravity_torque_external_torque_per_body() {
             None,
             Some(&rot_a),
             DMat3::IDENTITY,
-            Some(&mass_props),
+            Some(&mass_props_raw),
             grav.grav_accel,
         );
         astrodyn::integrate_body(
             &config,
             &mut trans_a,
             Some(&mut rot_a),
-            Some(&mass_props),
+            Some(&mass_props_raw),
             |pos, _vel, _time_frac| {
                 astrodyn::accumulate_gravity(pos, &controls, DVec3::ZERO, |_| {
                     Some(astrodyn::ResolvedSource {
@@ -185,9 +193,9 @@ fn bevy_parity_gravity_torque_external_torque_per_body() {
     earth_entry.central = true;
     let earth_idx = sim.add_source("Earth", earth_entry);
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
+        trans: iss_trans(),
+        rot: Some(tumble_rot()),
+        mass: Some(mass_props),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },
@@ -223,7 +231,11 @@ fn bevy_parity_gravity_torque_external_torque_per_body() {
 
 // ── Gravity torque parity (elliptical + with rate) ──
 
-fn run_gravity_torque_parity(label: &str, trans: TranslationalState, rot: RotationalState) {
+fn run_gravity_torque_parity(
+    label: &str,
+    trans: TranslationalState,
+    rot: astrodyn::RotationalStateTyped<astrodyn::SelfRef>,
+) {
     // ── Bevy ──
     let mut app = new_bevy_app(DT);
     let planet = spawn_earth_source(&mut app);
@@ -232,8 +244,8 @@ fn run_gravity_torque_parity(label: &str, trans: TranslationalState, rot: Rotati
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            RotationalStateC::from(rot),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -253,8 +265,8 @@ fn run_gravity_torque_parity(label: &str, trans: TranslationalState, rot: Rotati
     let (mut sim, earth_idx) = new_sim_earth(DT);
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(rot))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        rot: Some(rot),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, true)],
         },
@@ -283,10 +295,12 @@ fn bevy_parity_gravity_torque_run10c_gravity_torque_elliptical() {
         // test boundary: typed `RotationalStateC` requires unit-norm.
         let mut q = JeodQuat::new(0.5_f64.sqrt(), 0.5, 0.0, 0.5_f64.sqrt() - 0.5);
         q.normalize();
-        RotationalState {
-            quaternion: q,
-            ang_vel_body: DVec3::ZERO,
-        }
+        astrodyn::RotationalStateTyped::<astrodyn::SelfRef>::new(
+            astrodyn::BodyAttitude::<astrodyn::SelfRef>::from_jeod_quat(q),
+            astrodyn::AngularVelocity::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
+                DVec3::ZERO,
+            ),
+        )
     };
     run_gravity_torque_parity("run10c_grav_torque_ecc", ecc_trans, rot);
 }
@@ -325,18 +339,20 @@ fn run_external_parity(
         // Normalize at boundary; see comment above on tumble quat.
         let mut q = JeodQuat::new(0.5_f64.sqrt(), 0.5, 0.0, 0.5_f64.sqrt() - 0.5);
         q.normalize();
-        RotationalState {
-            quaternion: q,
-            ang_vel_body: init_ang_vel,
-        }
+        astrodyn::RotationalStateTyped::<astrodyn::SelfRef>::new(
+            astrodyn::BodyAttitude::<astrodyn::SelfRef>::from_jeod_quat(q),
+            astrodyn::AngularVelocity::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
+                init_ang_vel,
+            ),
+        )
     };
 
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(rot))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(rot),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -353,9 +369,9 @@ fn run_external_parity(
     // ── Simulation ──
     let (mut sim, earth_idx) = new_sim_earth(dt);
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(rot))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        trans: iss_trans(),
+        rot: Some(rot),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_highfidelity.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_highfidelity.rs
@@ -54,7 +54,7 @@ fn bevy_parity_highfidelity_sh4x4_rnp() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC(astrodyn::DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -89,7 +89,7 @@ fn bevy_parity_highfidelity_sh4x4_rnp() {
     );
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
+        trans: iss_trans(),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_nonspherical(earth_idx, 4, 4, false)],
         },
@@ -161,7 +161,7 @@ fn bevy_parity_highfidelity_tidal_sh4x4() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC(astrodyn::DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: false,
@@ -196,7 +196,7 @@ fn bevy_parity_highfidelity_tidal_sh4x4() {
     );
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
+        trans: iss_trans(),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_nonspherical(earth_idx, 4, 4, false)],
         },
@@ -228,7 +228,7 @@ fn bevy_parity_highfidelity_run2p_polar_motion() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
@@ -251,7 +251,7 @@ fn bevy_parity_highfidelity_run2p_polar_motion() {
     sim.polar_motion = Some((xp, yp));
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
+        trans: iss_trans(),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_integ_source.rs
@@ -13,9 +13,10 @@
 use std::time::Duration;
 
 use astrodyn::{
-    DerivedStateConfig, DynamicsConfig, FlatPlate, FlatPlateParams, FlatPlateState,
-    FlatPlateThermal, GravityControl, GravityControls, GravityModel, GravitySource,
-    GravitySourceEntry, JeodQuat, MassProperties, RotationalState, SixDofState, SrpModel,
+    AngularVelocity, BodyAttitude, BodyFrame, DerivedStateConfig, DynamicsConfig, FlatPlate,
+    FlatPlateParams, FlatPlateState, FlatPlateThermal, GravityControl, GravityControls,
+    GravityModel, GravitySource, GravitySourceEntry, InertiaTensor, JeodQuat, MassPropertiesTyped,
+    Position, RotationalStateTyped, SelfRef, SixDofState, SrpModel, StructuralFrame,
     TranslationalState, Vec3Ext, VehicleConfig, EARTH, MOON,
 };
 use astrodyn_bevy::{
@@ -27,6 +28,8 @@ use astrodyn_bevy::{
 use astrodyn_runner::Simulation;
 use bevy::prelude::*;
 use glam::DVec3;
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 const DT: f64 = 60.0;
 const NUM_STEPS: usize = 30;
@@ -43,18 +46,20 @@ fn lunar_initial_trans() -> TranslationalState {
     }
 }
 
-fn initial_rot() -> RotationalState {
-    RotationalState {
-        quaternion: JeodQuat::identity(),
-        ang_vel_body: DVec3::ZERO,
-    }
+fn initial_rot() -> RotationalStateTyped<SelfRef> {
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(JeodQuat::identity()),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::ZERO),
+    )
 }
 
-fn vehicle_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        1_000.0,
-        glam::DMat3::from_diagonal(DVec3::new(100.0, 100.0, 100.0)),
-        DVec3::ZERO,
+fn vehicle_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(1_000.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(glam::DMat3::from_diagonal(
+            DVec3::new(100.0, 100.0, 100.0),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
@@ -153,12 +158,8 @@ fn bevy_parity_integ_source_lunar_orbit_matches_simulation() {
         .spawn((
             Name::new("Lunar"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(vehicle_mass()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(vehicle_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -226,8 +227,8 @@ fn bevy_parity_integ_source_lunar_orbit_matches_simulation() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&lunar_initial_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&initial_rot())),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&vehicle_mass())),
+        rot: Some(initial_rot()),
+        mass: Some(vehicle_mass()),
         gravity_controls: GravityControls {
             controls: vec![
                 {
@@ -289,12 +290,8 @@ fn bevy_parity_integ_source_moving_moon_matches_simulation() {
         .spawn((
             Name::new("Lunar"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_initial_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(vehicle_mass()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(vehicle_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -358,8 +355,8 @@ fn bevy_parity_integ_source_moving_moon_matches_simulation() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&lunar_initial_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&initial_rot())),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&vehicle_mass())),
+        rot: Some(initial_rot()),
+        mass: Some(vehicle_mass()),
         gravity_controls: GravityControls {
             controls: vec![
                 {
@@ -420,15 +417,13 @@ fn bevy_parity_integ_source_root_matches_legacy_no_op() {
         .spawn((
             Name::new("Vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::with_inertia(
-                    400_000.0,
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(MassPropertiesTyped::<SelfRef>::with_inertia(
+                Mass::new::<kilogram>(400_000.0),
+                InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(
                     glam::DMat3::from_diagonal(DVec3::new(1.02e8, 0.91e8, 1.64e8)),
-                    DVec3::ZERO,
-                )),
+                ),
+                Position::<StructuralFrame<SelfRef>>::from_raw_si(DVec3::ZERO),
             )),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
@@ -468,14 +463,14 @@ fn bevy_parity_integ_source_root_matches_legacy_no_op() {
     sim.add_source("Earth", earth_entry);
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&initial_rot())),
+        rot: Some(initial_rot()),
         // allowed: typed↔raw kernel-boundary lift on scenario mass construction (see #397).
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &MassProperties::with_inertia(
-                400_000.0,
-                glam::DMat3::from_diagonal(DVec3::new(1.02e8, 0.91e8, 1.64e8)),
-                DVec3::ZERO,
-            ),
+        mass: Some(MassPropertiesTyped::<SelfRef>::with_inertia(
+            Mass::new::<kilogram>(400_000.0),
+            InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(glam::DMat3::from_diagonal(
+                DVec3::new(1.02e8, 0.91e8, 1.64e8),
+            )),
+            Position::<StructuralFrame<SelfRef>>::from_raw_si(DVec3::ZERO),
         )),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(0_usize, false)],
@@ -588,12 +583,8 @@ fn bevy_parity_integ_source_solar_beta_in_lunar_integ_frame() {
         .spawn((
             Name::new("Lunar"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_tilted),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(vehicle_mass()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(vehicle_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -657,12 +648,8 @@ fn bevy_parity_integ_source_solar_beta_in_lunar_integ_frame() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&lunar_tilted),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(initial_rot()),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(vehicle_mass()),
-        )),
+        rot: Some(initial_rot()),
+        mass: Some(vehicle_mass()),
         gravity_controls: GravityControls {
             controls: vec![
                 {
@@ -803,12 +790,8 @@ fn bevy_parity_integ_source_flat_plate_srp_in_lunar_integ_frame() {
         .spawn((
             Name::new("Lunar-SRP"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_tilted),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                &(initial_rot()),
-            )),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(vehicle_mass()),
-            )),
+            RotationalStateC::from(initial_rot()),
+            MassPropertiesC::from(vehicle_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -897,12 +880,8 @@ fn bevy_parity_integ_source_flat_plate_srp_in_lunar_integ_frame() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&lunar_tilted),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(initial_rot()),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(vehicle_mass()),
-        )),
+        rot: Some(initial_rot()),
+        mass: Some(vehicle_mass()),
         gravity_controls: GravityControls {
             controls: vec![
                 {

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lighting.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lighting.rs
@@ -297,7 +297,7 @@ fn bevy_parity_lighting_earth_lighting_pipeline() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
@@ -347,7 +347,7 @@ fn bevy_parity_lighting_earth_lighting_pipeline() {
     sim.moon_source = Some(moon_idx);
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
+        trans: iss_trans(),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, false)],
         },

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach.rs
@@ -82,7 +82,7 @@ fn spawn_topology(
     let parent = app
         .world_mut()
         .spawn(MassPropertiesC::from(
-            astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_core)),
+            astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_core)),
         ))
         .id();
     let mut child_entities = Vec::with_capacity(children.len());
@@ -90,7 +90,9 @@ fn spawn_topology(
         let cid = app
             .world_mut()
             .spawn((
-                MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(core)),
+                MassPropertiesC::from(
+                    astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(core),
+                ),
                 MassChildOf::with_rotation(parent, *offset, *t_parent_child),
             ))
             .id();
@@ -446,14 +448,18 @@ fn bevy_parity_mass_attach_detach_bevy_staging_system_does_not_corrupt_composite
     let parent_entity = app
         .world_mut()
         .spawn((
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(parent_core))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(parent_core)),
+            ),
             MassBodyIdC(parent_arena_id),
         ))
         .id();
     let child_entity = app
         .world_mut()
         .spawn((
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(child_core))),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(&(child_core)),
+            ),
             MassBodyIdC(child_arena_id),
         ))
         .id();

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_abm4.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_abm4.rs
@@ -97,9 +97,11 @@ fn build_two_body_app(
             Name::new("VehicleA"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_a),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(1000.0)),
-            )),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(1000.0)),
+                ),
+            ),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
             }),
@@ -114,9 +116,11 @@ fn build_two_body_app(
             Name::new("VehicleB"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_b),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(500.0)),
-            )),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(500.0)),
+                ),
+            ),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
             }),
@@ -256,24 +260,25 @@ fn bevy_parity_mass_attach_detach_with_abm4_mass_attach_resets_full_ancestor_cha
         velocity: DVec3::new(0.0, 8000.0, 0.0),
     };
 
-    let mk_body = |app: &mut App, id: astrodyn::MassBodyId, mass: f64, name: &str| -> Entity {
-        app.world_mut()
-            .spawn((
-                Name::new(name.to_string()),
-                DynamicsConfigC::default(),
-                TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-                MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                    &(MassProperties::new(mass)),
-                )),
-                GravityControlsC(GravityControls {
-                    controls: vec![GravityControl::new_spherical(planet, false)],
-                }),
-                IntegratorTypeC(IntegratorType::Abm4),
-                Abm4StateC(Abm4State::new()),
-                MassBodyIdC(id),
-            ))
-            .id()
-    };
+    let mk_body =
+        |app: &mut App, id: astrodyn::MassBodyId, mass: f64, name: &str| -> Entity {
+            app.world_mut()
+                .spawn((
+                    Name::new(name.to_string()),
+                    DynamicsConfigC::default(),
+                    TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
+                    MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_typed::<
+                        astrodyn::SelfRef,
+                    >(&(MassProperties::new(mass)))),
+                    GravityControlsC(GravityControls {
+                        controls: vec![GravityControl::new_spherical(planet, false)],
+                    }),
+                    IntegratorTypeC(IntegratorType::Abm4),
+                    Abm4StateC(Abm4State::new()),
+                    MassBodyIdC(id),
+                ))
+                .id()
+        };
     let e_top = mk_body(&mut app, id_top, 1000.0, "Top");
     let e_middle = mk_body(&mut app, id_middle, 500.0, "Middle");
     let e_leaf = mk_body(&mut app, id_leaf, 100.0, "Leaf");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_gj.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_gj.rs
@@ -90,9 +90,11 @@ fn build_two_body_app(
             Name::new("VehicleA"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_a),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(1000.0)),
-            )),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(1000.0)),
+                ),
+            ),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
             }),
@@ -107,9 +109,11 @@ fn build_two_body_app(
             Name::new("VehicleB"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_b),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(MassProperties::new(500.0)),
-            )),
+            MassPropertiesC::from(
+                astrodyn::typed_bridge::mass_raw_to_typed::<astrodyn::SelfRef>(
+                    &(MassProperties::new(500.0)),
+                ),
+            ),
             GravityControlsC(GravityControls {
                 controls: vec![GravityControl::new_spherical(planet, false)],
             }),
@@ -241,24 +245,25 @@ fn bevy_parity_mass_attach_detach_with_gj_mass_attach_with_gj_resets_full_ancest
         velocity: DVec3::new(0.0, 8000.0, 0.0),
     };
     let gj_cfg = GaussJacksonConfig::with_order(8);
-    let mk_body = |app: &mut App, id: astrodyn::MassBodyId, mass: f64, name: &str| -> Entity {
-        app.world_mut()
-            .spawn((
-                Name::new(name.to_string()),
-                DynamicsConfigC::default(),
-                TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-                MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                    &(MassProperties::new(mass)),
-                )),
-                GravityControlsC(GravityControls {
-                    controls: vec![GravityControl::new_spherical(planet, false)],
-                }),
-                IntegratorTypeC(IntegratorType::GaussJackson(gj_cfg)),
-                GaussJacksonStateC(GaussJacksonState::new(gj_cfg)),
-                MassBodyIdC(id),
-            ))
-            .id()
-    };
+    let mk_body =
+        |app: &mut App, id: astrodyn::MassBodyId, mass: f64, name: &str| -> Entity {
+            app.world_mut()
+                .spawn((
+                    Name::new(name.to_string()),
+                    DynamicsConfigC::default(),
+                    TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
+                    MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_typed::<
+                        astrodyn::SelfRef,
+                    >(&(MassProperties::new(mass)))),
+                    GravityControlsC(GravityControls {
+                        controls: vec![GravityControl::new_spherical(planet, false)],
+                    }),
+                    IntegratorTypeC(IntegratorType::GaussJackson(gj_cfg)),
+                    GaussJacksonStateC(GaussJacksonState::new(gj_cfg)),
+                    MassBodyIdC(id),
+                ))
+                .id()
+        };
     let e_top = mk_body(&mut app, id_top, 1000.0, "Top");
     let e_middle = mk_body(&mut app, id_middle, 500.0, "Middle");
     let e_leaf = mk_body(&mut app, id_leaf, 100.0, "Leaf");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
@@ -6,7 +6,7 @@ mod common;
 
 use astrodyn::{
     DynamicsConfig, GravityControl, GravityControls, GravityModel, GravitySource, JeodQuat,
-    RotationalState, SixDofState, TranslationalState,
+    SixDofState, TranslationalState,
 };
 use astrodyn::{GravitySourceEntry, VehicleConfig};
 use astrodyn_bevy::{
@@ -43,9 +43,9 @@ fn bevy_parity_point_mass_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -122,7 +122,7 @@ fn run_planetary_parity(label: &str, trans: TranslationalState) {
 
 #[test]
 fn bevy_parity_point_mass_planetary_leo_inc() {
-    run_planetary_parity("planetary_leo_inc", iss_trans());
+    run_planetary_parity("planetary_leo_inc", iss_trans().to_untyped());
 }
 
 #[test]
@@ -172,9 +172,9 @@ fn bevy_parity_point_mass_run2_6dof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_trans()),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -333,9 +333,9 @@ fn bevy_parity_point_mass_time_reversal_round_trip() {
     earth_entry.central = true;
     let earth = sim.add_source("Earth", earth_entry);
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        trans: iss_trans(),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, false)],
         },
@@ -392,26 +392,26 @@ fn bevy_parity_point_mass_relative_state_consistency() {
     let earth = sim.add_source("Earth", earth_entry);
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        trans: iss_trans(),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, false)],
         },
         ..Default::default()
     });
 
-    let mut trans_b = iss_trans();
+    let mut trans_b = iss_trans().to_untyped();
     trans_b.position += DVec3::new(100.0, 0.0, 0.0);
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&trans_b),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: JeodQuat::identity(),
-                ang_vel_body: DVec3::new(0.0, 0.0, 0.001),
-            }),
+        rot: Some(astrodyn::RotationalStateTyped::<astrodyn::SelfRef>::new(
+            astrodyn::BodyAttitude::<astrodyn::SelfRef>::from_jeod_quat(JeodQuat::identity()),
+            astrodyn::AngularVelocity::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
+                DVec3::new(0.0, 0.0, 0.001),
+            ),
         )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, false)],
         },
@@ -482,8 +482,8 @@ fn bevy_parity_point_mass_lvlh_relative_consistency() {
     use astrodyn::{compute_body_lvlh_frame, compute_lvlh_relative_state};
     println!("Scenario R: LVLH-relative state consistency");
 
-    let ref_pos = iss_trans().position;
-    let ref_vel = iss_trans().velocity;
+    let ref_pos = iss_trans().position.raw_si();
+    let ref_vel = iss_trans().velocity.raw_si();
     let subj_pos = ref_pos + DVec3::new(100.0, 50.0, -30.0);
     let subj_vel = ref_vel + DVec3::new(0.01, -0.02, 0.005);
 
@@ -614,7 +614,7 @@ fn bevy_parity_point_mass_multi_source_rotation() {
     );
 
     sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
+        trans: iss_trans(),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, false)],
         },
@@ -690,8 +690,8 @@ fn run_atmosphere_parity(label: &str, trans: TranslationalState) {
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-            RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-            MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+            RotationalStateC::from(tumble_rot()),
+            MassPropertiesC::from(iss_mass()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
                 rotational_dynamics: true,
@@ -710,8 +710,8 @@ fn run_atmosphere_parity(label: &str, trans: TranslationalState) {
     let (mut sim, earth_idx) = new_sim_earth(DT);
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, true)],
         },

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_third_body.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_third_body.rs
@@ -7,7 +7,7 @@ mod common;
 use astrodyn::{DerivedStateConfig, GravitySourceEntry, SrpModel, VehicleConfig};
 use astrodyn::{
     DynamicsConfig, Ephemeris, EphemerisBody, GravityControl, GravityControls, GravityModel,
-    GravitySource, MassProperties, SixDofState, TranslationalState,
+    GravitySource, SixDofState, TranslationalState,
 };
 use astrodyn_bevy::{
     CannonballSrpC, DynamicsConfigC, EphemerisBodyC, GravityControlsC, GravitySourceC,
@@ -291,10 +291,8 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
         app.world_mut()
             .spawn((
                 TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
-                RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
-                    &(tumble_rot()),
-                )),
-                MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+                RotationalStateC::from(tumble_rot()),
+                MassPropertiesC::from(iss_mass()),
                 DynamicsConfigC(config),
                 GravityControlsC(GravityControls { controls }),
             ))
@@ -368,13 +366,13 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
         trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
         rot: if sixdof {
             // allowed: typed↔raw kernel-boundary lift (see #397).
-            Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&tumble_rot()))
+            Some(tumble_rot())
         } else {
             None
         },
         mass: if sixdof {
             // allowed: typed↔raw kernel-boundary lift (see #397).
-            Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&iss_mass()))
+            Some(iss_mass())
         } else {
             None
         },
@@ -403,25 +401,25 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
 #[test]
 fn bevy_parity_third_body_run3b_3rd_body_sun() {
     println!("Dyncomp run3b: ISS + Sun 3rd body, 3-DOF");
-    run_3rd_body_parity("run3b", iss_trans(), false, false);
+    run_3rd_body_parity("run3b", iss_trans().to_untyped(), false, false);
 }
 
 #[test]
 fn bevy_parity_third_body_run4_3rd_body_sun_moon() {
     println!("Dyncomp run4: ISS + Sun + Moon 3rd body, 3-DOF");
-    run_3rd_body_parity("run4", iss_trans(), true, false);
+    run_3rd_body_parity("run4", iss_trans().to_untyped(), true, false);
 }
 
 #[test]
 fn bevy_parity_third_body_run7a_3rd_body_sixdof() {
     println!("Dyncomp run7a: ISS + Sun 3rd body, 6-DOF");
-    run_3rd_body_parity("run7a", iss_trans(), false, true);
+    run_3rd_body_parity("run7a", iss_trans().to_untyped(), false, true);
 }
 
 #[test]
 fn bevy_parity_third_body_run7b_3rd_body_sun_moon_sixdof() {
     println!("Dyncomp run7b: ISS + Sun + Moon 3rd body, 6-DOF");
-    run_3rd_body_parity("run7b", iss_trans(), true, true);
+    run_3rd_body_parity("run7b", iss_trans().to_untyped(), true, true);
 }
 
 #[test]
@@ -788,10 +786,12 @@ fn bevy_parity_third_body_earth_moon_clem() {
     let albedo = 0.3;
     let diffuse = 0.5;
     let mass = 500.0;
-    let mass_props = MassProperties::with_inertia(
-        mass,
-        DMat3::from_diagonal(DVec3::new(200.0, 200.0, 200.0)),
-        DVec3::ZERO,
+    let mass_props = astrodyn::MassPropertiesTyped::<astrodyn::SelfRef>::with_inertia(
+        uom::si::f64::Mass::new::<uom::si::mass::kilogram>(mass),
+        astrodyn::InertiaTensor::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_dmat3_unchecked(
+            DMat3::from_diagonal(DVec3::new(200.0, 200.0, 200.0)),
+        ),
+        astrodyn::Position::<astrodyn::StructuralFrame<astrodyn::SelfRef>>::zero(),
     );
 
     let eph_bevy = Ephemeris::from_bsp(&bsp_path()).expect("load DE421");
@@ -854,9 +854,7 @@ fn bevy_parity_third_body_earth_moon_clem() {
         .world_mut()
         .spawn((
             TranslationalStateC::<astrodyn::Earth>::from_untyped(clem_trans),
-            astrodyn_bevy::MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
-                &(mass_props),
-            )),
+            astrodyn_bevy::MassPropertiesC::from(mass_props),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
                 controls: vec![
@@ -914,7 +912,7 @@ fn bevy_parity_third_body_earth_moon_clem() {
 
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&clem_trans),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
+        mass: Some(mass_props),
         gravity_controls: GravityControls {
             controls: vec![
                 GravityControl::new_spherical(earth_idx, false),

--- a/crates/astrodyn_verif_parity/tests/common/mod.rs
+++ b/crates/astrodyn_verif_parity/tests/common/mod.rs
@@ -18,8 +18,10 @@
 use std::time::Duration;
 
 use astrodyn::{
-    Ephemeris, EphemerisBody, GravityControl, GravityControls, GravityModel, GravitySource,
-    MassProperties, RotationalState, SixDofState, TranslationalState,
+    AngularVelocity, BodyAttitude, BodyFrame, Ephemeris, EphemerisBody, GravityControl,
+    GravityControls, GravityModel, GravitySource, InertiaTensor, MassPropertiesTyped, Position,
+    RootInertial, RotationalStateTyped, SelfRef, SixDofState, StructuralFrame, TranslationalState,
+    TranslationalStateTyped, Velocity,
 };
 use astrodyn::{GravitySourceEntry, VehicleConfig};
 use astrodyn_bevy::{
@@ -28,6 +30,8 @@ use astrodyn_bevy::{
 use astrodyn_runner::Simulation;
 use bevy::prelude::*;
 use glam::{DMat3, DVec3};
+use uom::si::f64::Mass;
+use uom::si::mass::kilogram;
 
 /// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc` via presets.
 pub const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
@@ -38,35 +42,36 @@ pub const NUM_STEPS: usize = 100;
 
 // ── Shared initial conditions ──
 
-pub fn iss_trans() -> TranslationalState {
-    TranslationalState {
-        position: DVec3::new(6_778_137.0, 0.0, 0.0),
-        velocity: DVec3::new(0.0, 7668.56, 0.0),
+pub fn iss_trans() -> TranslationalStateTyped<RootInertial> {
+    TranslationalStateTyped::<RootInertial> {
+        position: Position::<RootInertial>::from_raw_si(DVec3::new(6_778_137.0, 0.0, 0.0)),
+        velocity: Velocity::<RootInertial>::from_raw_si(DVec3::new(0.0, 7668.56, 0.0)),
     }
 }
 
-pub fn tumble_rot() -> RotationalState {
+pub fn tumble_rot() -> RotationalStateTyped<SelfRef> {
     // Deliberately non-trivial tumble (axis ≠ basis, ω with mixed
     // signs) so attitude propagation exercises off-diagonal RNP terms.
-    // Pre-#172 H1 the quaternion was deliberately *not* unit-norm to
-    // exercise the integrator's renormalize-after-step path; the
-    // migration to typed `RotationalStateC` (which carries a
-    // `NormalizedQuat` witness) requires a normalized input at the
-    // ECS surface. The integrator's renormalize behavior is still
-    // tested by `rotational::tests::*` in astrodyn_dynamics.
+    // The quaternion is normalized at construction because
+    // `RotationalStateC` (and its `BodyAttitude` witness) require a
+    // unit-norm quaternion at the ECS surface. The integrator's own
+    // renormalize-after-step path is still exercised by the
+    // `rotational::tests::*` in astrodyn_dynamics.
     let mut q = astrodyn::JeodQuat::new(0.5_f64.sqrt(), 0.5, 0.0, 0.5_f64.sqrt() - 0.5);
     q.normalize();
-    RotationalState {
-        quaternion: q,
-        ang_vel_body: DVec3::new(0.001, -0.0005, 0.001),
-    }
+    RotationalStateTyped::<SelfRef>::new(
+        BodyAttitude::<SelfRef>::from_jeod_quat(q),
+        AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(DVec3::new(0.001, -0.0005, 0.001)),
+    )
 }
 
-pub fn iss_mass() -> MassProperties {
-    MassProperties::with_inertia(
-        400_000.0,
-        DMat3::from_diagonal(DVec3::new(1.02e8, 0.91e8, 1.64e8)),
-        DVec3::ZERO,
+pub fn iss_mass() -> MassPropertiesTyped<SelfRef> {
+    MassPropertiesTyped::<SelfRef>::with_inertia(
+        Mass::new::<kilogram>(400_000.0),
+        InertiaTensor::<BodyFrame<SelfRef>>::from_dmat3_unchecked(DMat3::from_diagonal(
+            DVec3::new(1.02e8, 0.91e8, 1.64e8),
+        )),
+        Position::<StructuralFrame<SelfRef>>::zero(),
     )
 }
 
@@ -218,9 +223,9 @@ pub fn assert_geodetic_eq(label: &str, a: &astrodyn::GeodeticState, b: &astrodyn
 
 pub fn new_sim_body_sixdof(earth_idx: usize, gradient: bool) -> VehicleConfig {
     VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&iss_trans()),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(&(tumble_rot()))),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(iss_mass()))),
+        trans: iss_trans(),
+        rot: Some(tumble_rot()),
+        mass: Some(iss_mass()),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth_idx, gradient)],
         },


### PR DESCRIPTION
## Summary

Helpers in `crates/astrodyn_verif_parity/tests/common/mod.rs` now return
typed siblings — `TranslationalStateTyped<RootInertial>`,
`RotationalStateTyped<SelfRef>`, `MassPropertiesTyped<SelfRef>` — instead of
raw `TranslationalState` / `RotationalState` / `MassProperties`. Callsites
across the `bevy_parity_*` test suite drop their `astrodyn::typed_bridge::*`
wrappers; the existing `From` impls on `TranslationalStateC<P>` /
`RotationalStateC` / `MassPropertiesC` (in `astrodyn_bevy/src/components/state.rs`)
already accept the typed input directly.

This eliminates ~30 of the ~352 `typed_bridge` import sites in the parity
suite — the audit for the sibling `#[doc(hidden)]` annotation on
`typed_bridge` now has a much smaller residual surface.

Bit-identity holds: the change is purely at the type boundary; semantics
are unchanged. Mechanical migration only.

## Verification

```
$ grep -rn 'rot_raw_to_self_ref\|mass_raw_to_self_ref' \
    crates/astrodyn_verif_parity/tests
# (no output — zero hits)
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1190/1190 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage` — 6/6 passed
- [ ] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_)'` — relying on CI (lockstep parity wrappers, ~50 min total)

Closes #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)