### PR TITLE
[#389] Add bevy_parity_euler_edge wrapper

### DIFF
--- a/crates/astrodyn_verif_parity/tests/bevy_parity_euler_edge.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_euler_edge.rs
@@ -1,0 +1,24 @@
+//! Bevy ↔ runner parity for SIM_Euler edge cases (eccentric and
+//! equatorial orbit variants of the Euler-angle derived state).
+//!
+//! Mirrors `tier3_sim_euler_edge.rs` 1-to-1 so the two test files stay
+//! visibly in sync — a new edge-case recipe added there has an obvious
+//! parity sibling slot here. The recipes themselves
+//! (`sim_derived_state::euler_ecc`, `euler_equ`) are shared with the
+//! base `bevy_parity_euler` wrapper; running them again from this file
+//! is intentional: the topic-level coverage check in `parity_coverage`
+//! is per-file, so `euler_edge` needs its own wrapper file to satisfy
+//! the `tier3_topics ⊂ bevy_parity_topics` invariant.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_euler_edge_ecc() {
+    sim_derived_state::euler_ecc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_euler_edge_equ() {
+    sim_derived_state::euler_equ().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -160,11 +160,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          (#389 follow-up)",
     ),
     (
-        "euler_edge",
-        "pre-recipe edge-case sibling — recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "force_torque_response",
         "pre-recipe sibling exercising external forces/torques — \
          recipe factory not yet defined (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Adds `crates/astrodyn_verif_parity/tests/bevy_parity_euler_edge.rs` mirroring `tier3_sim_euler_edge.rs` 1-to-1 (`euler_ecc`, `euler_equ`). Both reuse the existing `sim_derived_state` recipe factories; only the per-file topic-coverage stub was missing.
- Drops the `euler_edge` entry from `KNOWN_PARITY_GAPS` in `parity_coverage.rs`. The redundancy check on that exemption list would have flagged the stale entry once the wrapper landed; this removes it preemptively.

The wrapper drives both `astrodyn_runner` and `astrodyn_bevy` through `VerificationCaseParityExt::run_and_assert_parity::<astrodyn::Earth>()` and asserts bit-identical translational + rotational state at every reference-CSV checkpoint, carrying the `runner ≡ bevy` half of the `bevy ↔ JEOD` transitivity argument for this topic.

Closes #389 → no, this is one step toward closing #389 (which tracks the full superset invariant). This PR closes the `euler_edge` gap entry; remaining deferred gaps continue to be tracked in `KNOWN_PARITY_GAPS`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — still passes after dropping the gap entry; coverage invariant holds.
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_euler_edge` — both `_ecc` and `_equ` cases reach bit-identity over 24h.
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_euler_edge` — runner-vs-JEOD sibling unchanged.
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1190 passed, 445 skipped.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Generated with [Claude Code](https://claude.com/claude-code)