### PR TITLE
[#389] Add bevy_parity wrappers for lvlh_edge, ned_edge, solar_beta_edge

### DIFF
--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lvlh_edge.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lvlh_edge.rs
@@ -1,0 +1,24 @@
+//! Bevy ↔ runner parity for SIM_LVLH edge cases (eccentric and
+//! equatorial orbit variants of the LVLH-frame derived state).
+//!
+//! Mirrors `tier3_sim_lvlh_edge.rs` 1-to-1 so the two test files stay
+//! visibly in sync — a new edge-case recipe added there has an obvious
+//! parity sibling slot here. The recipes themselves
+//! (`sim_derived_state::lvlh_ecc`, `lvlh_equ`) are shared with the
+//! base `bevy_parity_lvlh` wrapper; running them again from this file
+//! is intentional: the topic-level coverage check in `parity_coverage`
+//! is per-file, so `lvlh_edge` needs its own wrapper file to satisfy
+//! the `tier3_topics ⊂ bevy_parity_topics` invariant.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_lvlh_edge_ecc() {
+    sim_derived_state::lvlh_ecc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_lvlh_edge_equ() {
+    sim_derived_state::lvlh_equ().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_ned_edge.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_ned_edge.rs
@@ -1,0 +1,30 @@
+//! Bevy ↔ runner parity for SIM_NED edge cases (polar orbit on the
+//! ellipsoidal Earth and inclined/polar orbits on the spherical Earth).
+//!
+//! Mirrors `tier3_sim_ned_edge.rs` 1-to-1 so the two test files stay
+//! visibly in sync — a new edge-case recipe added there has an obvious
+//! parity sibling slot here. The recipes themselves
+//! (`sim_derived_state::ned_ell_polar`, `ned_sph_inc`, `ned_sph_polar`)
+//! are shared with the base `bevy_parity_ned` wrapper; running them
+//! again from this file is intentional: the topic-level coverage check
+//! in `parity_coverage` is per-file, so `ned_edge` needs its own
+//! wrapper file to satisfy the `tier3_topics ⊂ bevy_parity_topics`
+//! invariant.
+
+use astrodyn_verif_jeod::run_verification::sim_derived_state;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_ned_edge_ell_polar() {
+    sim_derived_state::ned_ell_polar().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_ned_edge_sph_inc() {
+    sim_derived_state::ned_sph_inc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_ned_edge_sph_polar() {
+    sim_derived_state::ned_sph_polar().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_solar_beta_edge.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_solar_beta_edge.rs
@@ -1,0 +1,26 @@
+//! Bevy ↔ runner parity for SIM_SolarBeta edge cases (equatorial
+//! orbit with point-mass Earth and Earth-obliquity orbit with 8×8
+//! spherical-harmonics Earth).
+//!
+//! Mirrors `tier3_sim_solar_beta_edge.rs` 1-to-1 so the two test files
+//! stay visibly in sync — a new edge-case recipe added there has an
+//! obvious parity sibling slot here. The recipes themselves
+//! (`sim_solar_beta::solar_beta_equ`, `solar_beta_obliquity`) are
+//! shared with the base `bevy_parity_solar_beta` wrapper; running them
+//! again from this file is intentional: the topic-level coverage check
+//! in `parity_coverage` is per-file, so `solar_beta_edge` needs its
+//! own wrapper file to satisfy the `tier3_topics ⊂ bevy_parity_topics`
+//! invariant.
+
+use astrodyn_verif_jeod::run_verification::sim_solar_beta;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_solar_beta_edge_equ() {
+    sim_solar_beta::solar_beta_equ().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_edge_obliquity() {
+    sim_solar_beta::solar_beta_obliquity().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -171,18 +171,8 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          per-step state component on the Bevy side",
     ),
     (
-        "lvlh_edge",
-        "pre-recipe edge-case sibling — recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "lvlh_extended",
         "pre-recipe sibling — recipe factory not yet defined (#389 follow-up)",
-    ),
-    (
-        "ned_edge",
-        "pre-recipe edge-case sibling — recipe factory not yet defined \
-         (#389 follow-up)",
     ),
     (
         "orbelem_comprehensive",
@@ -218,11 +208,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
         "relative_extended",
         "pre-recipe sibling (same family as `relative`) — needs new \
          CsvReference variant; follow-up to #389",
-    ),
-    (
-        "solar_beta_edge",
-        "pre-recipe edge-case sibling — recipe factory not yet defined \
-         (#389 follow-up)",
     ),
     (
         "solar_beta_extended",


### PR DESCRIPTION
## Summary

Closes three more `KNOWN_PARITY_GAPS` entries in
`crates/astrodyn_verif_parity/tests/parity_coverage.rs` by adding
sibling `bevy_parity_*` wrapper files for each edge-case Tier 3 topic.
Same shape as PR #452 (which closed `euler_edge`).

- New `bevy_parity_lvlh_edge.rs` — drives `sim_derived_state::lvlh_ecc`
  and `lvlh_equ` through `run_and_assert_parity`.
- New `bevy_parity_ned_edge.rs` — drives `sim_derived_state::ned_ell_polar`,
  `ned_sph_inc`, `ned_sph_polar` through `run_and_assert_parity`.
- New `bevy_parity_solar_beta_edge.rs` — drives `sim_solar_beta::solar_beta_equ`
  and `solar_beta_obliquity` through `run_and_assert_parity`.
- Drops the matching `lvlh_edge`, `ned_edge`, `solar_beta_edge`
  entries from `KNOWN_PARITY_GAPS`.

The recipes themselves already exist (used by the base
`bevy_parity_lvlh.rs`, `bevy_parity_ned.rs`, and
`bevy_parity_solar_beta.rs` wrappers). The coverage check in
`parity_coverage.rs` is per-file, so each `_edge` topic needs its own
wrapper file even though the underlying recipe is shared — the
duplication is intentional and matches the precedent established by
`bevy_parity_euler_edge.rs`.

Refs #389 (meta-issue covers many more gaps; not a closing keyword).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` (1190 passed)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` (passes)
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_lvlh_edge) or test(bevy_parity_ned_edge) or test(bevy_parity_solar_beta_edge)'` (7 passed)
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_lvlh_edge --test tier3_sim_ned_edge --test tier3_sim_solar_beta_edge` (7 passed — runner-side siblings unchanged)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Generated with Claude Code.