### PR TITLE
CI: split parity-trajectory into fast (PR) and full (main) lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         run: cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'
 
   test-parity-trajectory:
-    name: Test (parity trajectory)
+    name: Test (parity trajectory fast)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,13 +132,59 @@ jobs:
             echo "FATAL: JEOD_HOME / JEOD_PATH must be unset for the standalone-repo CI fence" >&2
             exit 1
           fi
-      # All `bevy_parity_*` tests run here. The runner-vs-bevy
-      # lockstep harness (see `crates/astrodyn_verif_parity/src/lib.rs`)
-      # propagates each scenario twice for bit-identity, so the cost
-      # profile matches Tier 3 trajectory runs. The file-stem naming
-      # convention (every `#[test] fn` shares its file's stem) is
-      # enforced by `crates/astrodyn_verif_parity/tests/parity_coverage.rs`.
-      - name: Run bevy_parity_* tests
+      # All `bevy_parity_*` tests run here, MINUS a slow subset that
+      # is deferred to the main-branch `test-parity-trajectory-full`
+      # job below. The runner-vs-bevy lockstep harness (see
+      # `crates/astrodyn_verif_parity/src/lib.rs`) propagates each
+      # scenario twice for bit-identity, so the cost profile matches
+      # Tier 3 trajectory runs.
+      #
+      # The exclusion list below mirrors the `not test(earth_moon)`
+      # filter on `test-tier3`: drop the few heaviest binaries on PRs
+      # to keep this lane fast, then re-run everything on main. The
+      # excluded binaries account for ~80% of release-build CPU time
+      # measured on commit 97231b3 (see PR introducing this split for
+      # the per-binary timing table). Dropping them takes a ~45-60 min
+      # PR job to ~10-12 min; full coverage still gates merges to main
+      # through `test-parity-trajectory-full`.
+      #
+      # When adding a new heavy parity binary that bloats this lane,
+      # extend both this exclusion and the
+      # `test-parity-trajectory-full` job's matching comment so the
+      # full-coverage invariant stays explicit.
+      - name: Run fast bevy_parity_* tests (exclude heavy binaries)
+        run: |
+          cargo nextest run --workspace -E '
+            test(bevy_parity) and not (
+              binary(/^bevy_parity_dyncomp_/)
+              or binary(/^bevy_parity_solar_beta/)
+              or binary(=bevy_parity_torque_simple)
+              or binary(=bevy_parity_srp_1st_order)
+            )
+          '
+
+  test-parity-trajectory-full:
+    name: Test (parity trajectory full)
+    if: github.ref == 'refs/heads/main'
+    needs: test-parity-trajectory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Verify JEOD env vars are unset (regression fence)
+        run: |
+          if [ -n "${JEOD_HOME:-}" ] || [ -n "${JEOD_PATH:-}" ]; then
+            echo "FATAL: JEOD_HOME / JEOD_PATH must be unset for the standalone-repo CI fence" >&2
+            exit 1
+          fi
+      # Full bevy_parity_* coverage, including the slow binaries that
+      # `test-parity-trajectory` excludes on PRs (dyncomp_run*,
+      # solar_beta + solar_beta_edge, torque_simple, srp_1st_order).
+      # This lane only runs on push to main, mirroring the
+      # `test-tier3-full` job's role for the `earth_moon` Tier 3 test.
+      - name: Run all bevy_parity_* tests
         run: cargo nextest run --workspace -E 'test(bevy_parity)'
 
   test-tier3:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,9 +484,10 @@ All Tier 3 test functions use the `tier3_` prefix, enabling cargo's name-based
 filtering. CI (`.github/workflows/ci.yml`) uses this:
 
 - **PRs**: `check` (fmt + clippy), `test` (unit + tier 2),
-  `test-parity-trajectory` (the fast `bevy_parity_*` subset — see
-  exclusion list below), and `test-tier3` (tier 3 excluding
-  `earth_moon`) run in parallel for fast feedback.
+  `test-parity-trajectory` (the fast `bevy_parity_*` subset — the
+  exclusion list lives inline in `.github/workflows/ci.yml`), and
+  `test-tier3` (tier 3 excluding `earth_moon`) run in parallel for
+  fast feedback.
 - **Main push**: same jobs, plus `test-tier3-full` (includes the
   `earth_moon` test, ~17 min, generates the cross-validation report)
   and `test-parity-trajectory-full` (the heavy parity binaries excluded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,18 +484,23 @@ All Tier 3 test functions use the `tier3_` prefix, enabling cargo's name-based
 filtering. CI (`.github/workflows/ci.yml`) uses this:
 
 - **PRs**: `check` (fmt + clippy), `test` (unit + tier 2),
-  `test-parity-trajectory` (every `bevy_parity_*` lockstep wrapper),
-  and `test-tier3` (tier 3 excluding `earth_moon`) run in parallel for
-  fast feedback.
-- **Main push**: same jobs, plus `test-tier3-full` which includes the
-  `earth_moon` test (~17 min) and generates the cross-validation report.
+  `test-parity-trajectory` (the fast `bevy_parity_*` subset — see
+  exclusion list below), and `test-tier3` (tier 3 excluding
+  `earth_moon`) run in parallel for fast feedback.
+- **Main push**: same jobs, plus `test-tier3-full` (includes the
+  `earth_moon` test, ~17 min, generates the cross-validation report)
+  and `test-parity-trajectory-full` (the heavy parity binaries excluded
+  from PR CI; full bit-identity coverage on `main`).
 - **Push to non-main branches**: no CI (only PRs and main trigger workflows).
 
 When adding new Tier 3 tests, always prefix the function name with `tier3_` so
 CI filtering picks it up automatically. When adding a new parity wrapper,
 the `bevy_parity_` file-stem prefix (enforced by `parity_coverage.rs`)
-routes it through `test-parity-trajectory` automatically; no regex
-maintenance is required.
+routes it through `test-parity-trajectory` automatically. If the new
+wrapper joins the heavy bucket (e.g. multi-hour SH+drag trajectory),
+extend the exclusion filter in `.github/workflows/ci.yml` so the PR
+lane stays under ~12 min — see the comment above the filter for the
+binaries currently deferred to `test-parity-trajectory-full`.
 
 See `crates/astrodyn_bevy/tests/README.md` for tier conventions and the tolerance/baseline workflow.
 


### PR DESCRIPTION
## Summary

The `test-parity-trajectory` job runs every `bevy_parity_*` wrapper twice (runner + bevy lockstep), and at 233 wrappers it has crept to **~45-60 min on PR CI** (e.g. 48m 43s on PR #451). Mirror the existing `test-tier3` / `test-tier3-full` split: keep PRs on a fast subset and re-run everything on push to `main`.

- New `test-parity-trajectory` (renamed display: *Test (parity trajectory fast)*) runs 203 of 233 `bevy_parity_*` wrappers — the 80%-of-CPU exclusion list is inline in the workflow filter.
- New `test-parity-trajectory-full` runs every `bevy_parity_*` wrapper, gated on `if: github.ref == 'refs/heads/main'` and `needs: test-parity-trajectory`. Mirrors `test-tier3-full`.

## Picking the exclusion set

Measured per-test timings by running the full parity suite locally in `--release` (`cargo nextest run --release -p astrodyn_verif_parity -E 'test(bevy_parity)'` → 4636s CPU / 1266s wall-clock across 233 tests on commit 97231b3). Top time-consumers by binary:

| Binary | CPU s | Tests |
|---|---|---|
| `bevy_parity_dyncomp_run*` (run2_3dof, run2_6dof, run3, run4, run5, run6, run7, run10) | ~2240 | 18 |
| `bevy_parity_solar_beta(+_edge)` | 666 | 5 |
| `bevy_parity_torque_simple` | 407 | 6 |
| `bevy_parity_srp_1st_order` | 390 | 1 |
| **excluded total** | **~3705 (80% of parity CPU)** | **30** |

The remaining 203 tests cover every other physics topic — third-body, drag, SRP basic / shadow / flat-plate, gravity-torque (via dyncomp_run10 is excluded; gravity-gradient torque coverage stays via highfidelity and gravity_torque), tides (`tide_verif` kept, see below), MET atmosphere, polar motion, lighting, RNP, NESC CC8, point-mass parity, all attach/detach/momentum structural tests, derived states, frame switches, integ source, ned, lvlh, euler, orbital elements, kinematic propagation, source mutation, body-action lifecycle, etc. Topic coverage is preserved; only the *heaviest scenarios per topic* defer to `main`.

## Measured impact

Smoke-ran the fast filter on debug build (matches CI):

```
Summary [ 689.093s] 203 tests run: 203 passed (5 slow), 1418 skipped
```

- **Before**: 45-60 min on PRs
- **After**: ~11.5 min on PRs (4-5× faster)
- **Full coverage**: still gates `main`, same total cost moved off the per-PR critical path

The wall-clock long-pole in the fast subset is now `bevy_parity_tide_verif_run01` at 523s (8.7 min); everything else finishes well before. If a follow-up wants to push the fast lane below ~5 min, dropping `tide_verif` would cleave the long pole — but the current set hits a clean physics-topic boundary (exclude only the 4 heaviest *categories*, keep at least one ~2-min representative of every other topic).

## Maintenance

The exclusion filter lives **inline in `.github/workflows/ci.yml`**, matching the `not test(earth_moon)` precedent on `test-tier3`. New parity wrappers route into the fast lane automatically (via the `bevy_parity_` prefix that `parity_coverage.rs` already enforces); only a brand-new *heavy* binary needs an exclusion-list addition. The workflow comment + `CLAUDE.md`'s "Test tiers and CI" section both spell out the contract for future contributors.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses
- [x] `cargo nextest list --workspace -E '<fast filter>'` — 203 tests selected (filter expression syntax valid)
- [x] `cargo nextest list --workspace -E '<slow filter>'` — 30 tests selected (mutually exclusive partition of the 233 wrappers)
- [x] `cargo nextest run --workspace -E '<fast filter>'` — **203/203 pass in 689s debug wall-clock**
- [ ] CI run on this PR confirms the `test-parity-trajectory` job is fast (~10-12 min) and `test-parity-trajectory-full` is skipped (PR ref, not `main`)
- [ ] Post-merge CI run on `main` confirms `test-parity-trajectory-full` runs and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHjoA6Ppgs9d5uqAxbmzro)_