### PR TITLE
[#389] Extract solar_beta_extended recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -36,6 +36,7 @@ pub mod sim_planetary;
 pub mod sim_polar_motion;
 pub mod sim_relative;
 pub mod sim_solar_beta;
+pub mod sim_solar_beta_extended;
 pub mod sim_srp;
 pub mod sim_tide_verif;
 pub mod sim_torque_simple;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
@@ -157,7 +157,9 @@ fn period_s(mu_earth: f64, r: f64) -> f64 {
 // ── Equatorial-at-equinox (full-period scan) ─────────────────────────
 
 fn equatorial_at_equinox_num_steps() -> usize {
-    (period_s(load_mu_earth(), R_LEO_M) / DT_S) as usize
+    // `.ceil()` so the cadence actually covers a full orbital period —
+    // bare `as usize` would truncate and stop a few seconds short.
+    (period_s(load_mu_earth(), R_LEO_M) / DT_S).ceil() as usize
 }
 
 fn build_equatorial_at_equinox(_init: &InitialConditions) -> SimulationBuilder {
@@ -299,10 +301,15 @@ pub fn polar_sun_z() -> VerificationCase {
 //   * +Z: ĥ · ẑ = cos i → β = π/2 − i;
 //   * −Y: ĥ · (−ŷ) = sin i → β = i.
 
-/// ISS inclination (51.6°) as a radian constant. Kept private so the
-/// recipes and the tier3 assertions reach the same value through the
-/// same const-fold path.
-const ISS_INCLINATION_RAD: f64 = 51.6 * std::f64::consts::PI / 180.0;
+/// ISS inclination (51.6°) as a radian constant. Mirrors the
+/// expression used by [`f64::to_radians`] (`x * (PI / 180)`) — not
+/// the alternate associativity `(x * PI) / 180` — so the body-state
+/// inclination this constant fixes matches `51.6_f64.to_radians()`
+/// at the last bit. The tier3 closed-form assertion encodes 51.6°
+/// independently via `to_radians`; this convention keeps the two
+/// evaluation paths bit-identical even though they are textually
+/// separate.
+const ISS_INCLINATION_RAD: f64 = 51.6 * (std::f64::consts::PI / 180.0);
 /// Number of cycle steps for the ISS-snapshot recipes — same single-
 /// step rationale as [`POLAR_SNAPSHOT_NUM_STEPS`].
 const ISS_SNAPSHOT_NUM_STEPS: usize = 1;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
@@ -49,10 +49,12 @@ const DT_S: f64 = 10.0;
 /// initial state.
 const R_LEO_M: f64 = 6_778_137.0;
 
-/// Reference radius for the `sun_in_orbital_plane`,
-/// `sun_perpendicular_to_plane`, and `bounded` recipes — slightly above
-/// LEO to keep the orbit-normal computation off the polar singularity
-/// the LEO radius lands on.
+/// Reference radius (7000 km — ~ISS altitude band) for the
+/// `sun_in_orbital_plane`, `sun_perpendicular_to_plane`, and `bounded`
+/// recipes. The β formula is radius-independent, so this is just the
+/// constant the pre-recipe tier3 file used for these specific cases;
+/// holding it fixed here keeps the recipe and the analytical assertion
+/// driving identical initial states.
 const R_MID_M: f64 = 7_000_000.0;
 
 fn load_mu_earth() -> f64 {

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
@@ -58,7 +58,15 @@ const R_LEO_M: f64 = 6_778_137.0;
 const R_MID_M: f64 = 7_000_000.0;
 
 fn load_mu_earth() -> f64 {
-    astrodyn::gravity_fixtures::load_ggm05c().mu
+    // Cache the decoded `mu` for the lifetime of the test process.
+    // The fixture decode parses the entire GGM05C coefficient table
+    // (≈12 KiB serialized) just to read a single scalar; without
+    // caching, every `*_num_steps()` and every `build_*` call would
+    // pay that cost again, noticeably inflating the parity/tier3
+    // suite. The decoded `mu` is a pure function of the embedded
+    // bytes, so caching is sound.
+    static MU_EARTH: std::sync::OnceLock<f64> = std::sync::OnceLock::new();
+    *MU_EARTH.get_or_init(|| astrodyn::gravity_fixtures::load_ggm05c().mu)
 }
 
 /// Shared scenario builder for every recipe. Parameterised by:
@@ -475,9 +483,11 @@ pub fn sun_perpendicular_to_plane() -> VerificationCase {
 
 // ── Bounded scan (multi-period, |β| ≤ π/2 at every record) ───────────
 
-/// Cadence for the bounded scan: three orbital periods at `DT_S`.
+/// Cadence for the bounded scan: at least three orbital periods at
+/// `DT_S` (`.ceil()` so bare-truncation never stops the scan short of
+/// the third period boundary).
 fn bounded_num_steps() -> usize {
-    (3.0 * period_s(load_mu_earth(), R_MID_M) / DT_S) as usize
+    (3.0 * period_s(load_mu_earth(), R_MID_M) / DT_S).ceil() as usize
 }
 
 fn build_bounded(_init: &InitialConditions) -> SimulationBuilder {

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
@@ -1,0 +1,513 @@
+//! `VerificationCase` constructors for the SIM_SolarBeta analytical-extended
+//! family (`tier3_sim_solar_beta_extended`).
+//!
+//! These cases have no JEOD reference CSV — they exercise closed-form
+//! identities of the solar-beta angle (β = asin(ĥ · ŝ)) by parking a
+//! fake Sun source at a chosen position and propagating a vehicle with
+//! `solar_beta: true`. Each recipe shares the same Earth-point-mass +
+//! mu=0 Sun shape; only the per-case initial state, Sun position, and
+//! step count differ, so the per-case factories all delegate to a
+//! shared `build_solar_beta_extended` constructor and pair the
+//! resulting [`SimulationBuilder`] with [`CsvReference::SyntheticTimes`]
+//! for the parity trait's lockstep `runner ↔ bevy` bit-identity
+//! assertion.
+//!
+//! The matching analytical assertions live in
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs`;
+//! each tier3 test pulls one or more recipes' scenario factories, builds
+//! the `Simulation`, propagates, and asserts the closed-form solar-beta
+//! property. Splitting the scenario into a recipe is what makes the
+//! parity wrapper possible — the bridge needs an adapter-neutral
+//! `SimulationBuilder` to materialize, and a hand-rolled tier3 test
+//! that constructs a `Simulation` directly has no bridge entry point.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::Vec3Ext;
+use astrodyn::{
+    default_leap_second_table, DerivedStateConfig, GravityControl, GravityControls,
+    GravityGradient, GravityModel, GravitySource, GravitySourceEntry, RotationModel,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
+};
+use glam::DVec3;
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Sun parked at 1 AU. The body-relative Sun direction stays parallel
+/// to this vector to within `r_orbit / AU` (≈ 5e-5 rad for LEO), which
+/// is well below every test's tolerance.
+const SUN_DISTANCE_M: f64 = 1.495_978_707e11;
+
+/// Step size shared by every recipe. Matches the value the pre-recipe
+/// tier3 file used so the SyntheticTimes cadence drives identical
+/// integration ticks.
+const DT_S: f64 = 10.0;
+
+/// Reference radius for the LEO recipes (`equatorial_at_equinox`,
+/// `polar_*`, `iss_*`) — 400 km altitude above a spherical Earth at
+/// the equatorial radius. Matches the constant the analytical tests
+/// use so the recipe and the closed-form assertion drive the identical
+/// initial state.
+const R_LEO_M: f64 = 6_778_137.0;
+
+/// Reference radius for the `sun_in_orbital_plane`,
+/// `sun_perpendicular_to_plane`, and `bounded` recipes — slightly above
+/// LEO to keep the orbit-normal computation off the polar singularity
+/// the LEO radius lands on.
+const R_MID_M: f64 = 7_000_000.0;
+
+fn load_mu_earth() -> f64 {
+    astrodyn::gravity_fixtures::load_ggm05c().mu
+}
+
+/// Shared scenario builder for every recipe. Parameterised by:
+///   * `mu_earth` — Earth's gravitational parameter (point-mass);
+///   * `dt` — integrator timestep (always `DT_S` for this family);
+///   * `sun_position` — the fake Sun's inertial position (mu=0);
+///   * `body` — the vehicle's initial translational state.
+///
+/// Each recipe wraps this with its case-specific values and pairs the
+/// returned builder with the matching `SyntheticTimes` cadence so the
+/// parity trait can drive `runner ↔ bevy` bit-identity at every step.
+fn build_solar_beta_extended(
+    mu_earth: f64,
+    dt: f64,
+    sun_position: DVec3,
+    body: TranslationalState,
+) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    let sun = sb.add_source(
+        "Sun",
+        GravitySourceEntry {
+            // mu=0 — the Sun's gravity does not perturb the trajectory.
+            // Only the kinematic position feeds the solar-beta direction
+            // computation.
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: sun_position.m_at::<astrodyn::RootInertial>(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+            marker_only: false,
+        },
+    );
+    sb = sb.sun(sun);
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&body),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        derived: DerivedStateConfig {
+            solar_beta: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// Analytical recipes opt out of every runner-vs-JEOD tolerance group
+/// because they pair with [`CsvReference::SyntheticTimes`] and assert
+/// in-test against closed-form values rather than logged JEOD columns.
+/// The parity trait still asserts `runner ↔ bevy` bit-identity at every
+/// synthetic record.
+fn analytical_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+/// Closed-form circular-orbit period for radius `r` and gravitational
+/// parameter `mu`. Used to size SyntheticTimes cadences for the
+/// full-period scans.
+fn period_s(mu_earth: f64, r: f64) -> f64 {
+    2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt()
+}
+
+// ── Equatorial-at-equinox (full-period scan) ─────────────────────────
+
+fn equatorial_at_equinox_num_steps() -> usize {
+    (period_s(load_mu_earth(), R_LEO_M) / DT_S) as usize
+}
+
+fn build_equatorial_at_equinox(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let v = (mu_earth / R_LEO_M).sqrt();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(SUN_DISTANCE_M, 0.0, 0.0),
+        TranslationalState {
+            position: DVec3::new(R_LEO_M, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    )
+}
+
+/// Equatorial circular LEO with Sun in the equatorial plane (+X). The
+/// orbit normal is +Z so ĥ · ŝ = 0 over the entire orbit — β stays
+/// within floating-point noise of 0. Cadence covers one full period so
+/// the analytical test can scan `max |β|`.
+pub fn equatorial_at_equinox() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_equatorial_at_equinox",
+        scenario: build_equatorial_at_equinox,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: equatorial_at_equinox_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Polar-orbit snapshot family (Sun along +X / +Y / +Z) ─────────────
+//
+// All three share the same polar-orbit body state (position +X, velocity
+// +Z → h = +Y) and propagate a single step so the derived state is
+// populated for the closed-form check. Splitting per Sun position keeps
+// each recipe's `scenario` factory deterministic without a runtime
+// switch argument.
+
+const POLAR_SNAPSHOT_NUM_STEPS: usize = 1;
+
+fn polar_body_state(mu_earth: f64) -> TranslationalState {
+    let v = (mu_earth / R_LEO_M).sqrt();
+    TranslationalState {
+        position: DVec3::new(R_LEO_M, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 0.0, v),
+    }
+}
+
+fn build_polar_sun_x(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(SUN_DISTANCE_M, 0.0, 0.0),
+        polar_body_state(mu_earth),
+    )
+}
+
+fn build_polar_sun_y(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(0.0, SUN_DISTANCE_M, 0.0),
+        polar_body_state(mu_earth),
+    )
+}
+
+fn build_polar_sun_z(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(0.0, 0.0, SUN_DISTANCE_M),
+        polar_body_state(mu_earth),
+    )
+}
+
+/// Polar orbit with Sun along +X (equinox-like): ĥ · ŝ = 0 → β = 0.
+pub fn polar_sun_x() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_polar_sun_x",
+        scenario: build_polar_sun_x,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: POLAR_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// Polar orbit (h = +Y) with Sun along +Y → ĥ · ŝ = ±1 → |β| = 90°.
+pub fn polar_sun_y() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_polar_sun_y",
+        scenario: build_polar_sun_y,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: POLAR_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// Polar orbit (h = +Y) with Sun along +Z: Sun lies in the orbital
+/// plane (xz), so ĥ · ŝ = 0 → β = 0.
+pub fn polar_sun_z() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_polar_sun_z",
+        scenario: build_polar_sun_z,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: POLAR_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── ISS-inclination snapshot family (Sun along +X / +Z / −Y) ─────────
+//
+// Position +X, velocity = (0, v cos i, v sin i) at i = 51.6° → orbit
+// normal direction (0, −sin i, cos i). Each recipe pairs with a Sun
+// position chosen to exercise one of the closed-form identities:
+//   * +X: ĥ · x̂ = 0 → β = 0;
+//   * +Z: ĥ · ẑ = cos i → β = π/2 − i;
+//   * −Y: ĥ · (−ŷ) = sin i → β = i.
+
+/// ISS inclination (51.6°) as a radian constant. Kept private so the
+/// recipes and the tier3 assertions reach the same value through the
+/// same const-fold path.
+const ISS_INCLINATION_RAD: f64 = 51.6 * std::f64::consts::PI / 180.0;
+/// Number of cycle steps for the ISS-snapshot recipes — same single-
+/// step rationale as [`POLAR_SNAPSHOT_NUM_STEPS`].
+const ISS_SNAPSHOT_NUM_STEPS: usize = 1;
+
+fn iss_body_state(mu_earth: f64) -> TranslationalState {
+    let v = (mu_earth / R_LEO_M).sqrt();
+    let inc = ISS_INCLINATION_RAD;
+    TranslationalState {
+        position: DVec3::new(R_LEO_M, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    }
+}
+
+fn build_iss_sun_x(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(SUN_DISTANCE_M, 0.0, 0.0),
+        iss_body_state(mu_earth),
+    )
+}
+
+fn build_iss_sun_z(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(0.0, 0.0, SUN_DISTANCE_M),
+        iss_body_state(mu_earth),
+    )
+}
+
+fn build_iss_sun_neg_y(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(0.0, -SUN_DISTANCE_M, 0.0),
+        iss_body_state(mu_earth),
+    )
+}
+
+/// ISS orbit (i = 51.6°), Sun in the equatorial plane (+X). β ≈ 0.
+pub fn iss_sun_x() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_iss_sun_x",
+        scenario: build_iss_sun_x,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: ISS_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// ISS orbit (i = 51.6°), Sun along +Z. β = π/2 − i (peak β for this
+/// inclination).
+pub fn iss_sun_z() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_iss_sun_z",
+        scenario: build_iss_sun_z,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: ISS_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// ISS orbit (i = 51.6°), Sun along −Y. β = i (β reaches the orbit
+/// inclination at this Sun direction).
+pub fn iss_sun_neg_y() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_iss_sun_neg_y",
+        scenario: build_iss_sun_neg_y,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: ISS_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Single-snapshot edge geometries (in-plane Sun, perpendicular Sun) ─
+
+const SINGLE_SNAPSHOT_NUM_STEPS: usize = 1;
+
+fn build_sun_in_orbital_plane(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let v = (mu_earth / R_MID_M).sqrt();
+    let inc = 30.0_f64.to_radians();
+    // Position +X (ascending node), velocity tipped into the plane.
+    // Orbit normal direction is (0, −sin i, cos i); Sun along +X
+    // satisfies +X · (orbit normal) = 0, so Sun lies in the plane.
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(SUN_DISTANCE_M, 0.0, 0.0),
+        TranslationalState {
+            position: DVec3::new(R_MID_M, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+        },
+    )
+}
+
+/// 30°-inclination orbit with Sun at the ascending node (+X). Sun is
+/// in the orbital plane → β = 0.
+pub fn sun_in_orbital_plane() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_sun_in_orbital_plane",
+        scenario: build_sun_in_orbital_plane,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: SINGLE_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+fn build_sun_perpendicular_to_plane(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let v = (mu_earth / R_MID_M).sqrt();
+    // Equatorial orbit: orbit normal = +Z. Sun along +Z → ĥ · ŝ = ±1.
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        DVec3::new(0.0, 0.0, SUN_DISTANCE_M),
+        TranslationalState {
+            position: DVec3::new(R_MID_M, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v, 0.0),
+        },
+    )
+}
+
+/// Equatorial orbit with Sun along the orbit normal (+Z). |β| = π/2.
+pub fn sun_perpendicular_to_plane() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_sun_perpendicular_to_plane",
+        scenario: build_sun_perpendicular_to_plane,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: SINGLE_SNAPSHOT_NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Bounded scan (multi-period, |β| ≤ π/2 at every record) ───────────
+
+/// Cadence for the bounded scan: three orbital periods at `DT_S`.
+fn bounded_num_steps() -> usize {
+    (3.0 * period_s(load_mu_earth(), R_MID_M) / DT_S) as usize
+}
+
+fn build_bounded(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let v = (mu_earth / R_MID_M).sqrt();
+    let inc = 45.0_f64.to_radians();
+    build_solar_beta_extended(
+        mu_earth,
+        DT_S,
+        // Arbitrary Sun direction with components on all three axes
+        // — exercises the generic β formula rather than an axis-aligned
+        // limit.
+        DVec3::new(
+            0.7 * SUN_DISTANCE_M,
+            0.5 * SUN_DISTANCE_M,
+            0.2 * SUN_DISTANCE_M,
+        ),
+        TranslationalState {
+            position: DVec3::new(R_MID_M, 0.0, 0.0),
+            velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+        },
+    )
+}
+
+/// 45°-inclination orbit with an off-axis Sun, propagated for three
+/// periods. The analytical test asserts |β| ≤ π/2 at every record and
+/// also confirms `max |β|` is large enough to actually exercise the
+/// bound (rejects degenerate geometries).
+pub fn bounded() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_solar_beta_bounded",
+        scenario: build_bounded,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: bounded_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
@@ -49,12 +49,14 @@ const DT_S: f64 = 10.0;
 /// initial state.
 const R_LEO_M: f64 = 6_778_137.0;
 
-/// Reference radius (7000 km — ~ISS altitude band) for the
-/// `sun_in_orbital_plane`, `sun_perpendicular_to_plane`, and `bounded`
-/// recipes. The β formula is radius-independent, so this is just the
-/// constant the pre-recipe tier3 file used for these specific cases;
-/// holding it fixed here keeps the recipe and the analytical assertion
-/// driving identical initial states.
+/// Reference radius (7000 km — ~622 km altitude above the equatorial
+/// Earth radius, above the LEO cluster used for the ISS-snapshot
+/// recipes) for the `sun_in_orbital_plane`,
+/// `sun_perpendicular_to_plane`, and `bounded` recipes. The β formula
+/// is radius-independent, so this is just the constant the pre-recipe
+/// tier3 file used for these specific cases; holding it fixed here
+/// keeps the recipe and the analytical assertion driving identical
+/// initial states.
 const R_MID_M: f64 = 7_000_000.0;
 
 fn load_mu_earth() -> f64 {

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
@@ -55,13 +55,14 @@ fn read_beta(sim: &Simulation, case_name: &str) -> f64 {
 /// because the family is analytical-only; panicking on any other variant
 /// makes a future recipe-shape drift surface here rather than producing
 /// a silently-truncated propagation.
-fn synthetic_num_steps(case: &VerificationCase) -> usize {
-    // Match through `&case.reference` so the borrow is explicit — the
-    // pattern only reads a `usize` (Copy), so this avoids any
-    // ambiguity about whether the non-Copy `CsvReference` is being
-    // moved out of the `&VerificationCase` argument.
+/// Pull `(dt, num_steps)` from a recipe's `SyntheticTimes` reference.
+/// Returns both halves of the cadence so tests can assert that the
+/// `dt` they're stepping at (typically `sim.dt`) matches the cadence
+/// the recipe declared — catches a future recipe edit that updates
+/// the builder dt but forgets the `SyntheticTimes` dt (or vice versa).
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
     match &case.reference {
-        CsvReference::SyntheticTimes { num_steps, .. } => *num_steps,
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
         _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
     }
 }
@@ -72,12 +73,19 @@ fn tier3_solar_beta_equatorial_at_equinox() {
     // Sun in the equatorial (x–y) plane → ŝ ⊥ ĥ → β = 0.
     let case = sim_solar_beta_extended::equatorial_at_equinox();
     let mut sim = build_sim(&case);
-    let dt = sim.dt;
 
-    // Scan one full period — same cadence the recipe's SyntheticTimes
-    // generates, so the runner and the parity-wrapped Bevy traversal
-    // step in lockstep.
-    let n_steps = synthetic_num_steps(&case);
+    // Drive the scan from the recipe's `SyntheticTimes` cadence — the
+    // same `(dt, num_steps)` the parity wrapper uses on the Bevy side,
+    // so this loop and the bit-identity assertion step in lockstep.
+    // Cross-check `dt` against the built `Simulation`'s integrator dt
+    // to catch a future recipe edit that updates one half of the
+    // cadence but not the other.
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
+    );
 
     let mut max_beta = 0.0_f64;
     for step in 1..=n_steps {
@@ -223,8 +231,15 @@ fn tier3_solar_beta_bounded() {
     // the mathematical limit |β| ≤ π/2.)
     let case = sim_solar_beta_extended::bounded();
     let mut sim = build_sim(&case);
-    let dt = sim.dt;
-    let n_steps = synthetic_num_steps(&case);
+
+    // Same recipe-cadence + drift-check pattern as the
+    // equatorial-at-equinox scan above.
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
+    );
 
     let pi_2 = std::f64::consts::FRAC_PI_2;
     let mut max_abs_beta = 0.0_f64;

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
@@ -56,8 +56,12 @@ fn read_beta(sim: &Simulation, case_name: &str) -> f64 {
 /// makes a future recipe-shape drift surface here rather than producing
 /// a silently-truncated propagation.
 fn synthetic_num_steps(case: &VerificationCase) -> usize {
-    match case.reference {
-        CsvReference::SyntheticTimes { num_steps, .. } => num_steps,
+    // Match through `&case.reference` so the borrow is explicit — the
+    // pattern only reads a `usize` (Copy), so this avoids any
+    // ambiguity about whether the non-Copy `CsvReference` is being
+    // moved out of the `&VerificationCase` argument.
+    match &case.reference {
+        CsvReference::SyntheticTimes { num_steps, .. } => *num_steps,
         _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
     }
 }

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
@@ -18,123 +18,67 @@
 //! * `tier3_solar_beta_bounded` — for every propagated checkpoint of a mid-
 //!   inclination orbit with a fixed Sun position, |β| ≤ 90°.
 //!
-//! No Docker reference data required.
+//! No Docker reference data required. The `Simulation` construction lives
+//! in the `sim_solar_beta_extended` recipe module so the parity wrapper
+//! (`bevy_parity_solar_beta_extended.rs`) can drive the same scenarios
+//! through the Bevy adapter for the `runner ↔ bevy` half of the
+//! transitivity argument.
 
-use astrodyn::Vec3Ext;
-use astrodyn::{DerivedStateConfig, GravitySourceEntry, VehicleConfig};
-use astrodyn::{
-    GravityControl, GravityControls, GravityGradient, GravityModel, GravitySource, SimulationTime,
-    TranslationalState,
-};
-use astrodyn_runner::{RotationModel, Simulation};
-use glam::DVec3;
+use astrodyn_runner::builder::SimulationBuilderExt;
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_solar_beta_extended;
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 
-fn load_mu_earth() -> f64 {
-    astrodyn::gravity_fixtures::load_ggm05c().mu
+/// Build the recipe's `Simulation` exactly the way the parity trait does
+/// — call the scenario factory with a default `InitialConditions`, then
+/// `.build()` — so the runner-side propagation here and the Bevy-side
+/// propagation in `bevy_parity_solar_beta_extended.rs` see the same
+/// initial state bit-pattern.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
 }
 
-/// Sun at a cartoon distance in the +X direction produces `sun_direction = +X`
-/// for any body near the origin; at this scale the relative-Sun vector from
-/// any LEO body is effectively parallel to the Sun position vector.
-const SUN_DISTANCE_M: f64 = 1.495_978_707e11; // 1 AU
+/// Read the body's `solar_beta` after the most recent propagation step,
+/// panicking with the case name if it's not populated. Shared by every
+/// test in this file so the per-case bodies stay focused on the
+/// closed-form assertion.
+fn read_beta(sim: &Simulation, case_name: &str) -> f64 {
+    sim.body(0)
+        .solar_beta
+        .unwrap_or_else(|| panic!("`{case_name}`: solar_beta not computed"))
+}
 
-/// Build a Simulation with:
-///   * central-body Earth at origin (point-mass gravity),
-///   * a "Sun" source at `sun_position` with mu = 0 (kinematic only),
-///   * a single vehicle configured with `solar_beta: true`.
-///
-/// Returns the simulation ready to be `validate`d and stepped.
-fn build_solar_beta_sim(
-    mu_earth: f64,
-    dt: f64,
-    sun_position: DVec3,
-    body_state: TranslationalState,
-) -> Simulation {
-    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-    let mut sim = Simulation::new(time, dt);
-
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_earth,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
-    );
-
-    let sun = sim.add_source(
-        "Sun",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: 0.0,
-                model: GravityModel::PointMass,
-            },
-            position: sun_position.m_at::<astrodyn::RootInertial>(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-            marker_only: false,
-        },
-    );
-    sim.sun_source = Some(sun);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&body_state),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        derived: DerivedStateConfig {
-            solar_beta: true,
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-
-    sim
+/// Pull the SyntheticTimes step count off a recipe's reference field.
+/// Every recipe in `sim_solar_beta_extended` uses [`CsvReference::SyntheticTimes`]
+/// because the family is analytical-only; panicking on any other variant
+/// makes a future recipe-shape drift surface here rather than producing
+/// a silently-truncated propagation.
+fn synthetic_num_steps(case: &VerificationCase) -> usize {
+    match case.reference {
+        CsvReference::SyntheticTimes { num_steps, .. } => num_steps,
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
 }
 
 #[test]
 fn tier3_solar_beta_equatorial_at_equinox() {
     // Equatorial circular orbit → orbit normal = +Z.
     // Sun in the equatorial (x–y) plane → ŝ ⊥ ĥ → β = 0.
-    let mu_earth = load_mu_earth();
-    let r = 6_778_137.0;
-    let v = (mu_earth / r).sqrt();
+    let case = sim_solar_beta_extended::equatorial_at_equinox();
+    let mut sim = build_sim(&case);
+    let dt = sim.dt;
 
-    let mut sim = build_solar_beta_sim(
-        mu_earth,
-        10.0,
-        DVec3::new(SUN_DISTANCE_M, 0.0, 0.0),
-        TranslationalState {
-            position: DVec3::new(r, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v, 0.0),
-        },
-    );
-    sim.validate().unwrap();
-
-    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
-    let n_steps = (period / 10.0) as usize;
+    // Scan one full period — same cadence the recipe's SyntheticTimes
+    // generates, so the runner and the parity-wrapped Bevy traversal
+    // step in lockstep.
+    let n_steps = synthetic_num_steps(&case);
 
     let mut max_beta = 0.0_f64;
     for step in 1..=n_steps {
-        sim.step_until(step as f64 * 10.0)
-            .expect("step_until failed");
-        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
-        max_beta = max_beta.max(beta.abs());
+        sim.step_until(step as f64 * dt).expect("step_until failed");
+        max_beta = max_beta.max(read_beta(&sim, case.name).abs());
     }
 
     // The Sun-direction deviates slightly from +X as the body orbits (since
@@ -156,31 +100,21 @@ fn tier3_solar_beta_polar_orbit() {
     //   (1) Sun along +X (equinox-like):   ĥ·ŝ = 0 → β = 0
     //   (2) Sun along +Y:                  β = ±90° if orbit normal = ±Y
     //   (3) Sun along +Z:                  Sun is in the orbital plane → β = 0
-    let mu_earth = load_mu_earth();
-    let r = 6_778_137.0;
-    let v = (mu_earth / r).sqrt();
-
-    // Polar orbit: position +X, velocity +Z → h = r × v = r v (+Y)
-    let body = TranslationalState {
-        position: DVec3::new(r, 0.0, 0.0),
-        velocity: DVec3::new(0.0, 0.0, v),
-    };
-
     let cases = [
-        (DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), 0.0_f64), // Sun along +X
-        (DVec3::new(0.0, SUN_DISTANCE_M, 0.0), 90.0_f64), // Sun along +Y
-        (DVec3::new(0.0, 0.0, SUN_DISTANCE_M), 0.0_f64), // Sun along +Z
+        (sim_solar_beta_extended::polar_sun_x(), 0.0_f64),
+        (sim_solar_beta_extended::polar_sun_y(), 90.0_f64),
+        (sim_solar_beta_extended::polar_sun_z(), 0.0_f64),
     ];
 
-    for (sun_pos, expected_deg) in cases {
-        let mut sim = build_solar_beta_sim(mu_earth, 10.0, sun_pos, body);
-        sim.validate().unwrap();
-        sim.step_until(10.0).expect("step_until failed"); // derived state is populated after first step
-        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+    for (case, expected_deg) in cases {
+        let mut sim = build_sim(&case);
+        sim.step_until(sim.dt).expect("step_until failed"); // derived state is populated after first step
+        let beta = read_beta(&sim, case.name);
         let expected = expected_deg.to_radians();
         assert!(
             (beta.abs() - expected).abs() < 1e-4,
-            "polar orbit, Sun at {sun_pos:?}: |beta| = {} rad, expected {}",
+            "`{}`: |beta| = {} rad, expected {}",
+            case.name,
             beta.abs(),
             expected
         );
@@ -199,23 +133,14 @@ fn tier3_solar_beta_iss_orbit() {
     // For Sun along −Y:    ĥ·(−ŷ) = sin i →  β = asin(sin i) = i
     //
     // We verify all three cases.
-    let mu_earth = load_mu_earth();
-    let r = 6_778_137.0;
-    let v = (mu_earth / r).sqrt();
     let inc = 51.6_f64.to_radians();
-
-    let body = TranslationalState {
-        position: DVec3::new(r, 0.0, 0.0),
-        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    };
 
     // Case 1: Sun in the equatorial plane (+X). β ≈ 0.
     {
-        let mut sim =
-            build_solar_beta_sim(mu_earth, 10.0, DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), body);
-        sim.validate().unwrap();
-        sim.step_until(10.0).expect("step_until failed");
-        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        let case = sim_solar_beta_extended::iss_sun_x();
+        let mut sim = build_sim(&case);
+        sim.step_until(sim.dt).expect("step_until failed");
+        let beta = read_beta(&sim, case.name);
         assert!(
             beta.abs() < 1e-4,
             "ISS orbit + Sun in equatorial plane: |beta| = {beta} rad (expected ≈0)"
@@ -224,11 +149,10 @@ fn tier3_solar_beta_iss_orbit() {
 
     // Case 2: Sun along +Z → β = π/2 − i.
     {
-        let mut sim =
-            build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, 0.0, SUN_DISTANCE_M), body);
-        sim.validate().unwrap();
-        sim.step_until(10.0).expect("step_until failed");
-        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        let case = sim_solar_beta_extended::iss_sun_z();
+        let mut sim = build_sim(&case);
+        sim.step_until(sim.dt).expect("step_until failed");
+        let beta = read_beta(&sim, case.name);
         let expected = std::f64::consts::FRAC_PI_2 - inc;
         assert!(
             (beta - expected).abs() < 1e-4,
@@ -239,11 +163,10 @@ fn tier3_solar_beta_iss_orbit() {
     // Case 3: Sun along −Y → β = i. This exercises the bound that β can
     // reach the full inclination angle at a favorable Sun direction.
     {
-        let mut sim =
-            build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, -SUN_DISTANCE_M, 0.0), body);
-        sim.validate().unwrap();
-        sim.step_until(10.0).expect("step_until failed");
-        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        let case = sim_solar_beta_extended::iss_sun_neg_y();
+        let mut sim = build_sim(&case);
+        sim.step_until(sim.dt).expect("step_until failed");
+        let beta = read_beta(&sim, case.name);
         assert!(
             (beta - inc).abs() < 1e-4,
             "ISS orbit + Sun along −Y: beta = {beta} rad (expected {inc} = inclination)"
@@ -256,24 +179,10 @@ fn tier3_solar_beta_sun_in_orbital_plane() {
     // Sun direction exactly in the orbital plane → ĥ · ŝ = 0 → β = 0.
     // Check this for a 30° inclination orbit where the Sun sits exactly at
     // the ascending node direction (in the equatorial plane the node is +X).
-    let mu_earth = load_mu_earth();
-    let r = 7_000_000.0;
-    let v = (mu_earth / r).sqrt();
-    let inc = 30.0_f64.to_radians();
-
-    // Position along +X (ascending node), velocity tipped into the orbit plane.
-    let body = TranslationalState {
-        position: DVec3::new(r, 0.0, 0.0),
-        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    };
-    // Orbit normal: h = r × v = (r, 0, 0) × (0, v cos i, v sin i)
-    //              = (0·v sin i − 0·v cos i, 0·0 − r·v sin i, r·v cos i − 0·0)
-    //              = (0, −r v sin i, r v cos i). Direction = (0, −sin i, cos i).
-    // Sun along +X lies in the plane since +X · (orbit normal) = 0.
-    let mut sim = build_solar_beta_sim(mu_earth, 10.0, DVec3::new(SUN_DISTANCE_M, 0.0, 0.0), body);
-    sim.validate().unwrap();
-    sim.step_until(10.0).expect("step_until failed");
-    let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+    let case = sim_solar_beta_extended::sun_in_orbital_plane();
+    let mut sim = build_sim(&case);
+    sim.step_until(sim.dt).expect("step_until failed");
+    let beta = read_beta(&sim, case.name);
     assert!(
         beta.abs() < 1e-4,
         "Sun in orbital plane: |beta| = {beta} rad exceeds 1e-4"
@@ -284,19 +193,10 @@ fn tier3_solar_beta_sun_in_orbital_plane() {
 fn tier3_solar_beta_sun_perpendicular_to_plane() {
     // Sun along the orbit normal → ĥ · ŝ = ±1 → |β| = π/2.
     // Construct an equatorial orbit (normal = +Z) and place Sun along +Z.
-    let mu_earth = load_mu_earth();
-    let r = 7_000_000.0;
-    let v = (mu_earth / r).sqrt();
-
-    let body = TranslationalState {
-        position: DVec3::new(r, 0.0, 0.0),
-        velocity: DVec3::new(0.0, v, 0.0),
-    };
-
-    let mut sim = build_solar_beta_sim(mu_earth, 10.0, DVec3::new(0.0, 0.0, SUN_DISTANCE_M), body);
-    sim.validate().unwrap();
-    sim.step_until(10.0).expect("step_until failed");
-    let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+    let case = sim_solar_beta_extended::sun_perpendicular_to_plane();
+    let mut sim = build_sim(&case);
+    sim.step_until(sim.dt).expect("step_until failed");
+    let beta = read_beta(&sim, case.name);
 
     let pi_2 = std::f64::consts::FRAC_PI_2;
     // Tolerance accounts for the small LEO offset from the origin vs the Sun
@@ -317,38 +217,16 @@ fn tier3_solar_beta_bounded() {
     // π/2 + inclination — does not apply to β itself, which is always a
     // signed angle in [-π/2, +π/2] by construction; our asserted bound is
     // the mathematical limit |β| ≤ π/2.)
-    let mu_earth = load_mu_earth();
-    let r = 7_000_000.0;
-    let v = (mu_earth / r).sqrt();
-    let inc = 45.0_f64.to_radians();
-
-    let body = TranslationalState {
-        position: DVec3::new(r, 0.0, 0.0),
-        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-    };
-
-    let mut sim = build_solar_beta_sim(
-        mu_earth,
-        10.0,
-        // Arbitrary Sun direction with components in all three axes.
-        DVec3::new(
-            0.7 * SUN_DISTANCE_M,
-            0.5 * SUN_DISTANCE_M,
-            0.2 * SUN_DISTANCE_M,
-        ),
-        body,
-    );
-    sim.validate().unwrap();
-
-    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
-    let n_steps = (3.0 * period / 10.0) as usize;
+    let case = sim_solar_beta_extended::bounded();
+    let mut sim = build_sim(&case);
+    let dt = sim.dt;
+    let n_steps = synthetic_num_steps(&case);
 
     let pi_2 = std::f64::consts::FRAC_PI_2;
     let mut max_abs_beta = 0.0_f64;
     for step in 1..=n_steps {
-        sim.step_until(step as f64 * 10.0)
-            .expect("step_until failed");
-        let beta = sim.body(0).solar_beta.expect("solar beta not computed");
+        sim.step_until(step as f64 * dt).expect("step_until failed");
+        let beta = read_beta(&sim, case.name);
         // Absolute bound from the asin definition.
         assert!(
             beta.abs() <= pi_2 + 1e-12,

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_solar_beta_extended.rs
@@ -50,16 +50,15 @@ fn read_beta(sim: &Simulation, case_name: &str) -> f64 {
         .unwrap_or_else(|| panic!("`{case_name}`: solar_beta not computed"))
 }
 
-/// Pull the SyntheticTimes step count off a recipe's reference field.
-/// Every recipe in `sim_solar_beta_extended` uses [`CsvReference::SyntheticTimes`]
-/// because the family is analytical-only; panicking on any other variant
-/// makes a future recipe-shape drift surface here rather than producing
-/// a silently-truncated propagation.
-/// Pull `(dt, num_steps)` from a recipe's `SyntheticTimes` reference.
-/// Returns both halves of the cadence so tests can assert that the
-/// `dt` they're stepping at (typically `sim.dt`) matches the cadence
-/// the recipe declared — catches a future recipe edit that updates
-/// the builder dt but forgets the `SyntheticTimes` dt (or vice versa).
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_solar_beta_extended` uses this
+/// variant because the family is analytical-only; panicking on any
+/// other variant surfaces a future recipe-shape drift here rather than
+/// producing a silently-truncated propagation. Returning both halves
+/// of the cadence lets callers assert that the `dt` they're stepping
+/// at (typically `sim.dt`) matches the cadence the recipe declared —
+/// catches a future edit that updates the builder dt but forgets the
+/// `SyntheticTimes` dt (or vice versa).
 fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
     match &case.reference {
         CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_solar_beta_extended.rs
@@ -1,0 +1,66 @@
+//! Bevy ↔ runner parity for the analytical SIM_SolarBeta-extended
+//! scenarios (`tier3_sim_solar_beta_extended`). Wrappers land as part of
+//! #389.
+//!
+//! The matching tier3 file drives each scenario through the runner and
+//! asserts a closed-form solar-beta property (β = 0 when ĥ ⊥ ŝ, |β| = π/2
+//! when ĥ ∥ ŝ, β = π/2 − i when Sun is on the polar axis of an inclined
+//! orbit, |β| ≤ π/2 over any propagation window). This file pairs each
+//! recipe with the parity trait so the same scenarios also run through
+//! the Bevy adapter and assert `runner ↔ bevy` bit-identity at every
+//! synthetic record — the second half of the `runner ↔ JEOD ≈ bevy`
+//! transitivity argument the issue's matrix covers.
+
+use astrodyn_verif_jeod::run_verification::sim_solar_beta_extended;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_solar_beta_equatorial_at_equinox() {
+    sim_solar_beta_extended::equatorial_at_equinox().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_polar_sun_x() {
+    sim_solar_beta_extended::polar_sun_x().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_polar_sun_y() {
+    sim_solar_beta_extended::polar_sun_y().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_polar_sun_z() {
+    sim_solar_beta_extended::polar_sun_z().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_iss_sun_x() {
+    sim_solar_beta_extended::iss_sun_x().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_iss_sun_z() {
+    sim_solar_beta_extended::iss_sun_z().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_iss_sun_neg_y() {
+    sim_solar_beta_extended::iss_sun_neg_y().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_sun_in_orbital_plane() {
+    sim_solar_beta_extended::sun_in_orbital_plane().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_sun_perpendicular_to_plane() {
+    sim_solar_beta_extended::sun_perpendicular_to_plane()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_solar_beta_bounded() {
+    sim_solar_beta_extended::bounded().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -207,11 +207,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          CsvReference variant; follow-up to #389",
     ),
     (
-        "solar_beta_extended",
-        "pre-recipe sibling — extended cases recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "time_docker",
         "pre-recipe sibling exercising time-scale conversions — recipe \
          factory not yet defined (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Lift the SIM_SolarBeta analytical-extended scenarios (`tier3_sim_solar_beta_extended`) from inline `Simulation::new`/`add_source`/`add_body` calls into a `VerificationCase` recipe module so the parity trait can drive them through both runtimes.
- Add `bevy_parity_solar_beta_extended.rs` with one wrapper per recipe; every wrapper asserts `runner ↔ bevy` bit-identity at every synthetic record.
- Drop the `solar_beta_extended` entry from `KNOWN_PARITY_GAPS` in `parity_coverage.rs`.

The recipe emits ten factories — one per `Simulation` the pre-recipe tier3 file built inline (equatorial-at-equinox full-period scan, three polar-orbit snapshots, three ISS-inclination snapshots, sun-in-plane, sun-perpendicular, and a bounded multi-period scan). Each pairs with `CsvReference::SyntheticTimes` and all-zero tolerances because the family is analytical-only. The tier3 file's closed-form assertions are unchanged.

References #389.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'`
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_solar_beta_extended` (10/10 pass — bit-identity holds)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_solar_beta_extended` (6/6 pass — analytical semantics unchanged)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)