### PR TITLE
[#389] Extract orbinit_edge recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -32,6 +32,7 @@ pub mod sim_dyncomp;
 pub mod sim_gj;
 pub mod sim_kinematic_propagation;
 pub mod sim_lvlh_extended;
+pub mod sim_orbinit_edge;
 pub mod sim_planetary;
 pub mod sim_polar_motion;
 pub mod sim_relative;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_edge.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_edge.rs
@@ -1,0 +1,239 @@
+//! `VerificationCase` constructors for the SIM_orbinit edge family
+//! (`tier3_sim_orbinit_edge`).
+//!
+//! These cases exercise the `Simulation` pipeline starting from JEOD's
+//! SIM_orbinit post-initialization output: each RUN's `composite_body`
+//! inertial state (logged at t=0 in `orbinit_0XXX_orbinit.csv`) is fed
+//! to a point-mass-Earth `Simulation` and propagated a single step so
+//! the integrator and frame-propagation stages run end-to-end. The
+//! per-RUN states come from JEOD output (the t=0 row of a JEOD
+//! reference CSV is "JEOD source data" under the workspace's
+//! computational-independence rule).
+//!
+//! Cross-consistency between the STS-114 RUNs (0101, 0301, 0401) and
+//! the cross-vehicle ISS-vs-STS-114 sanity bound stay in the tier3
+//! file — those are properties of the *collection* of recipes, not of
+//! any single one, so they can't live inside a per-recipe factory.
+//!
+//! Each recipe pairs with [`CsvReference::SyntheticTimes`] so the
+//! parity wrapper drives a lockstep `runner ↔ bevy` bit-identity
+//! assertion at the synthetic checkpoint without needing a
+//! multi-record reference CSV (the orbinit CSVs are
+//! initialization-only — they log only the t=0 row, which leaves
+//! `ref_states.iter().skip(1)` empty for `CsvReference::OrbInit`).
+//!
+//! Initial state values originate from the JEOD output rows of
+//! `crates/astrodyn_verif_jeod/test_data/orbinit_0XXX_orbinit.csv`,
+//! committed alongside the rest of the verif fixtures.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::{
+    default_leap_second_table, GravityControl, GravityControls, GravityGradient, GravityModel,
+    GravitySource, GravitySourceEntry, RotationModel, SimulationBuilder, SimulationTime,
+    TranslationalState, VehicleConfig,
+};
+use glam::DVec3;
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Step size shared by every recipe. Matches the value the pre-recipe
+/// tier3 file used so the SyntheticTimes cadence drives identical
+/// integration ticks.
+const DT_S: f64 = 10.0;
+
+/// One propagation step is enough to exercise the integrator and
+/// frame-propagation stages — the original tier3 file called
+/// `sim.step()` exactly once after construction, so a single
+/// synthetic-cadence checkpoint preserves the test's coverage shape.
+const NUM_STEPS: usize = 1;
+
+fn load_mu_earth() -> f64 {
+    // Cache the decoded `mu` for the lifetime of the test process —
+    // every `build_*` call would otherwise re-parse the full GGM05C
+    // coefficient table (≈12 KiB) just to read a single scalar.
+    static MU_EARTH: std::sync::OnceLock<f64> = std::sync::OnceLock::new();
+    *MU_EARTH.get_or_init(|| astrodyn::gravity_fixtures::load_ggm05c().mu)
+}
+
+/// Shared scenario builder for every recipe. Parameterised by:
+///   * `mu_earth` — Earth's gravitational parameter (point-mass);
+///   * `body` — the vehicle's initial translational state in the
+///     RootInertial frame.
+fn build_orbinit_edge(mu_earth: f64, body: TranslationalState) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, DT_S);
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&body),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// Recipes opt out of every runner-vs-JEOD tolerance group because they
+/// pair with [`CsvReference::SyntheticTimes`]; the tier3 sibling
+/// asserts state-range sanity bounds and cross-RUN consistency
+/// directly, and the parity trait drives bit-identity at every
+/// synthetic record.
+fn synthetic_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+// ── Per-RUN initial states ───────────────────────────────────────────
+//
+// Values are copied verbatim from the t=0 row of each
+// `orbinit_0XXX_orbinit.csv` (the JEOD post-initialization output).
+// Distinct RUN labels exercise different SIM_orbinit code paths:
+//
+//   * RUN_0101 — STS-114, orbital elements in the inertial frame;
+//   * RUN_0201 — ISS, orbital elements in the planet-fixed frame;
+//   * RUN_0301 — STS-114, orbital elements in the planet-fixed frame;
+//   * RUN_0401 — STS-114, direct Cartesian state in the inertial
+//                frame (3 decimals less precision than the OE runs —
+//                the CSV truncation is JEOD's, not ours).
+//
+// The pair sharing the same vehicle/configuration trio (0101, 0301,
+// 0401 for STS-114) should land within ≈1 m of each other; that
+// cross-consistency assertion stays in the tier3 sibling.
+
+fn run_0101_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(1_244_471.751921491, 5_655_811.75396678, 3_425_519.023834599),
+        velocity: DVec3::new(-6003.553560448576, -1469.322206986292, 4590.577121215543),
+    }
+}
+
+fn run_0201_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(
+            1_244_540.336462717,
+            5_655_938.802744529,
+            3_425_643.360843232,
+        ),
+        velocity: DVec3::new(-6003.83315183158, -1469.496289202212, 4590.511665610799),
+    }
+}
+
+fn run_0301_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(
+            1_244_471.742508102,
+            5_655_811.758825388,
+            3_425_519.021394584,
+        ),
+        velocity: DVec3::new(-6003.553568336125, -1469.322209110831, 4590.577121539032),
+    }
+}
+
+fn run_0401_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(1_244_471.94, 5_655_811.8, 3_425_518.88),
+        velocity: DVec3::new(-6003.553468, -1469.321965, 4590.57723),
+    }
+}
+
+fn build_run_0101(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbinit_edge(load_mu_earth(), run_0101_state())
+}
+
+fn build_run_0201(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbinit_edge(load_mu_earth(), run_0201_state())
+}
+
+fn build_run_0301(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbinit_edge(load_mu_earth(), run_0301_state())
+}
+
+fn build_run_0401(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbinit_edge(load_mu_earth(), run_0401_state())
+}
+
+/// RUN_0101: STS-114 orbital elements in the inertial frame.
+pub fn run_0101() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_edge_run_0101",
+        scenario: build_run_0101,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// RUN_0201: ISS orbital elements in the planet-fixed frame.
+pub fn run_0201() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_edge_run_0201",
+        scenario: build_run_0201,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// RUN_0301: STS-114 orbital elements in the planet-fixed frame.
+pub fn run_0301() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_edge_run_0301",
+        scenario: build_run_0301,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// RUN_0401: STS-114 direct Cartesian state in the inertial frame.
+pub fn run_0401() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_edge_run_0401",
+        scenario: build_run_0401,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
@@ -116,12 +116,14 @@ fn tier3_simulation_orbinit_cross_consistency() {
         let (init_pos, init_vel) = runner_initial_state(&case);
 
         // Fence: the recipe's baked-in state must reproduce the
-        // JEOD-logged t=0 row exactly, bit-for-bit for the OE RUNs and
-        // within the CSV's printed precision for the Cartesian RUN
-        // (RUN_0401 logs 6 significant digits — JEOD's truncation, not
-        // ours). A future edit that tweaks recipe-side numbers will
-        // trip this check first instead of silently changing what the
-        // parity wrapper integrates.
+        // JEOD-logged t=0 row to within the CSV's printed precision
+        // (≤ 1 m position, ≤ 0.01 m/s velocity). RUN_0401 logs 6
+        // significant digits — JEOD's truncation, not ours; the other
+        // RUNs print closer to f64 precision but the threshold below is
+        // the same for all to keep the diagnostic uniform. A future
+        // edit that tweaks recipe-side numbers will trip this check
+        // first instead of silently changing what the parity wrapper
+        // integrates.
         let pos_drift = (init_pos - csv_init.position).length();
         let vel_drift = (init_vel - csv_init.velocity).length();
         assert!(
@@ -133,11 +135,14 @@ fn tier3_simulation_orbinit_cross_consistency() {
             "{label}: recipe init velocity drifted from CSV by {vel_drift:.6e} m/s"
         );
 
-        // Step once through the full pipeline (TimeUpdate → Environment →
+        // Step through the full pipeline (TimeUpdate → Environment →
         // Integration → DerivedState) at the recipe's synthetic cadence.
-        // Cross-check `dt` against the built `Simulation`'s integrator dt
-        // to catch a future recipe edit that updates one half of the
-        // cadence but not the other.
+        // Drive propagation off the recipe's `n_steps`, not a hardcoded
+        // single step, so any future recipe edit that increases the
+        // cadence rolls through this test on the same `dt`. Cross-check
+        // `dt` against the built `Simulation`'s integrator dt to catch
+        // a recipe edit that updates one half of the cadence but not
+        // the other.
         let mut sim = build_sim(&case);
         let (dt, n_steps) = synthetic_cadence(&case);
         assert_eq!(
@@ -150,7 +155,18 @@ fn tier3_simulation_orbinit_cross_consistency() {
             "`{}`: recipe must propagate at least one step",
             case.name
         );
-        sim.step_until(dt).expect("step_until failed");
+        let t_end = n_steps as f64 * dt;
+        sim.step_until(t_end).expect("step_until failed");
+        // Sanity: propagation actually reached the requested end time.
+        // `step_until` rounds to the next integer step boundary, but for
+        // `n_steps * dt` the boundary IS the request, so equality holds
+        // to within float precision.
+        assert!(
+            (sim.elapsed() - t_end).abs() < 1e-9,
+            "`{}`: sim elapsed {} did not reach requested end {t_end}",
+            case.name,
+            sim.elapsed(),
+        );
 
         // Read back the body state after one step (confirms pipeline ran).
         let body = sim.body(0);

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
@@ -2,8 +2,8 @@
 //!
 //! Validates body initialization from 4 distinct coordinate representations
 //! by building each scenario through its `sim_orbinit_edge` recipe,
-//! propagating one step, and checking range + cross-consistency against
-//! JEOD's logged t=0 state.
+//! propagating for the recipe's declared `SyntheticTimes` cadence, and
+//! checking range + cross-consistency against JEOD's logged t=0 state.
 //!
 //!   RUN_0101: Orbital elements in inertial frame (STS-114)
 //!   RUN_0201: Orbital elements in planet-fixed frame (ISS)
@@ -168,7 +168,7 @@ fn tier3_simulation_orbinit_cross_consistency() {
             sim.elapsed(),
         );
 
-        // Read back the body state after one step (confirms pipeline ran).
+        // Read back the body state after propagation (confirms pipeline ran).
         let body = sim.body(0);
         let r_mag = body.trans.position.raw_si().length();
         let v_mag = body.trans.velocity.raw_si().length();
@@ -185,11 +185,11 @@ fn tier3_simulation_orbinit_cross_consistency() {
         // Sanity: LEO orbit (post-step state should still be LEO).
         assert!(
             (6_000_000.0..=8_000_000.0).contains(&r_mag),
-            "{label}: r={r_mag:.0} m outside LEO range after one step"
+            "{label}: r={r_mag:.0} m outside LEO range after propagation"
         );
         assert!(
             (6_000.0..=8_000.0).contains(&v_mag),
-            "{label}: v={v_mag:.1} m/s outside LEO range after one step"
+            "{label}: v={v_mag:.1} m/s outside LEO range after propagation"
         );
 
         // Use the initial (t=0) state for cross-consistency: it

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
@@ -155,12 +155,12 @@ fn tier3_simulation_orbinit_cross_consistency() {
             "`{}`: recipe must propagate at least one step",
             case.name
         );
+        // `step_n` advances exactly `n_steps` whole steps. (`step_until`
+        // has a 1 ms slop and may stop one step short — see
+        // `Simulation::step_until` doc; sidestep both pitfalls by using
+        // the integer-step entrypoint.)
+        sim.step_n(n_steps).expect("step_n failed");
         let t_end = n_steps as f64 * dt;
-        sim.step_until(t_end).expect("step_until failed");
-        // Sanity: propagation actually reached the requested end time.
-        // `step_until` rounds to the next integer step boundary, but for
-        // `n_steps * dt` the boundary IS the request, so equality holds
-        // to within float precision.
         assert!(
             (sim.elapsed() - t_end).abs() < 1e-9,
             "`{}`: sim elapsed {} did not reach requested end {t_end}",

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_edge.rs
@@ -1,41 +1,101 @@
 //! Tier 3: SIM_orbinit cross-validation via Simulation pipeline
 //!
 //! Validates body initialization from 4 distinct coordinate representations
-//! by creating a `Simulation`, adding each body, validating, and stepping once.
-//! Checks cross-consistency between methods and against JEOD output.
+//! by building each scenario through its `sim_orbinit_edge` recipe,
+//! propagating one step, and checking range + cross-consistency against
+//! JEOD's logged t=0 state.
 //!
 //!   RUN_0101: Orbital elements in inertial frame (STS-114)
 //!   RUN_0201: Orbital elements in planet-fixed frame (ISS)
 //!   RUN_0301: Orbital elements in planet-fixed frame (STS-114)
 //!   RUN_0401: Cartesian state in inertial frame (STS-114)
+//!
+//! The `Simulation` construction lives in the `sim_orbinit_edge` recipe
+//! module so the parity wrapper (`bevy_parity_orbinit_edge.rs`) can drive
+//! the same scenarios through the Bevy adapter for the `runner ↔ bevy`
+//! half of the transitivity argument.
 
+use astrodyn_runner::builder::SimulationBuilderExt;
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_orbinit_edge;
 use astrodyn_verif_jeod::tier3_csv::{load_orbinit_csv, test_data_path};
-
-use astrodyn::{
-    GravityControl, GravityControls, GravityGradient, GravityModel, GravitySource, SimulationTime,
-    TranslationalState,
-};
-use astrodyn::{GravitySourceEntry, VehicleConfig};
-use astrodyn_runner::{RotationModel, Simulation};
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 use glam::DVec3;
+
+/// Build the recipe's `Simulation` exactly the way the parity trait does
+/// — call the scenario factory with a default `InitialConditions` (the
+/// recipes don't read it — initial state is baked in from each RUN's
+/// JEOD output t=0 row), then `.build()` — so the runner-side
+/// propagation here and the Bevy-side propagation in
+/// `bevy_parity_orbinit_edge.rs` see the same initial state bit-pattern.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
+}
+
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_orbinit_edge` uses this variant
+/// because the orbinit CSVs are initialization-only (one row at t=0);
+/// panicking on any other variant surfaces a future recipe-shape drift
+/// here rather than producing a silently-truncated propagation.
+/// Returning both halves of the cadence lets callers assert that the
+/// `dt` they're stepping at (typically `sim.dt`) matches the cadence
+/// the recipe declared.
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
+    match &case.reference {
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
+}
+
+/// Read the post-construction translational state from each RUN's
+/// recipe so the cross-consistency assertions are driven by exactly the
+/// same numbers the parity wrapper integrates. The state is read from
+/// the runner's `body(0)` *before* any propagation step, so each entry
+/// is the t=0 state the recipe bakes in.
+fn runner_initial_state(case: &VerificationCase) -> (DVec3, DVec3) {
+    let sim = build_sim(case);
+    let body = sim.body(0);
+    (body.trans.position.raw_si(), body.trans.velocity.raw_si())
+}
+
+/// Per-RUN row: CSV file name, recipe factory, human-readable label.
+type RunRow = (&'static str, fn() -> VerificationCase, &'static str);
 
 #[test]
 fn tier3_simulation_orbinit_cross_consistency() {
-    let mu_earth = astrodyn::gravity_fixtures::load_ggm05c().mu;
-
-    let runs: Vec<(&str, &str)> = vec![
-        ("orbinit_0101_orbinit.csv", "RUN_0101 (STS-114 inertial OE)"),
-        ("orbinit_0201_orbinit.csv", "RUN_0201 (ISS pfix OE)"),
-        ("orbinit_0301_orbinit.csv", "RUN_0301 (STS-114 pfix OE)"),
+    // The CSV is loaded only to cross-check the recipe's baked-in
+    // initial state against JEOD's logged t=0 row — a regression
+    // fence so a future recipe-side edit can't silently drift away
+    // from the JEOD-source values. The actual propagation uses the
+    // recipe-driven `Simulation`.
+    let runs: [RunRow; 4] = [
+        (
+            "orbinit_0101_orbinit.csv",
+            sim_orbinit_edge::run_0101,
+            "RUN_0101 (STS-114 inertial OE)",
+        ),
+        (
+            "orbinit_0201_orbinit.csv",
+            sim_orbinit_edge::run_0201,
+            "RUN_0201 (ISS pfix OE)",
+        ),
+        (
+            "orbinit_0301_orbinit.csv",
+            sim_orbinit_edge::run_0301,
+            "RUN_0301 (STS-114 pfix OE)",
+        ),
         (
             "orbinit_0401_orbinit.csv",
+            sim_orbinit_edge::run_0401,
             "RUN_0401 (STS-114 inertial cart)",
         ),
     ];
 
     let mut states: Vec<(DVec3, DVec3, &str)> = Vec::new();
 
-    for (filename, label) in &runs {
+    for (filename, recipe, label) in runs {
         let csv_path = test_data_path(filename);
         assert!(
             csv_path.exists(),
@@ -50,49 +110,49 @@ fn tier3_simulation_orbinit_cross_consistency() {
             !records.is_empty(),
             "{label}: no records found in {filename}"
         );
+        let csv_init = &records[0];
 
-        let init = &records[0];
+        let case = recipe();
+        let (init_pos, init_vel) = runner_initial_state(&case);
 
-        // Create a Simulation with Earth point-mass gravity and this body
-        let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-        let mut sim = Simulation::new(time, 10.0);
-
-        let earth = sim.add_source(
-            "Earth",
-            GravitySourceEntry {
-                source: GravitySource {
-                    mu: mu_earth,
-                    model: GravityModel::PointMass,
-                },
-                position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-                velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-                t_inertial_pfix: None,
-                delta_c20: 0.0,
-                rotation_model: RotationModel::default(),
-                tidal_config: None,
-                planet_omega: 0.0,
-                central: true,
-                marker_only: false,
-            },
+        // Fence: the recipe's baked-in state must reproduce the
+        // JEOD-logged t=0 row exactly, bit-for-bit for the OE RUNs and
+        // within the CSV's printed precision for the Cartesian RUN
+        // (RUN_0401 logs 6 significant digits — JEOD's truncation, not
+        // ours). A future edit that tweaks recipe-side numbers will
+        // trip this check first instead of silently changing what the
+        // parity wrapper integrates.
+        let pos_drift = (init_pos - csv_init.position).length();
+        let vel_drift = (init_vel - csv_init.velocity).length();
+        assert!(
+            pos_drift < 1.0,
+            "{label}: recipe init position drifted from CSV by {pos_drift:.6} m"
+        );
+        assert!(
+            vel_drift < 0.01,
+            "{label}: recipe init velocity drifted from CSV by {vel_drift:.6e} m/s"
         );
 
-        sim.add_body(VehicleConfig {
-            trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-                position: init.position,
-                velocity: init.velocity,
-            }),
-            gravity_controls: GravityControls {
-                controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-            },
-            ..Default::default()
-        });
+        // Step once through the full pipeline (TimeUpdate → Environment →
+        // Integration → DerivedState) at the recipe's synthetic cadence.
+        // Cross-check `dt` against the built `Simulation`'s integrator dt
+        // to catch a future recipe edit that updates one half of the
+        // cadence but not the other.
+        let mut sim = build_sim(&case);
+        let (dt, n_steps) = synthetic_cadence(&case);
+        assert_eq!(
+            dt, sim.dt,
+            "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+            case.name, sim.dt
+        );
+        assert!(
+            n_steps >= 1,
+            "`{}`: recipe must propagate at least one step",
+            case.name
+        );
+        sim.step_until(dt).expect("step_until failed");
 
-        sim.validate().unwrap();
-
-        // Step once to exercise the full pipeline
-        sim.step().expect("step failed");
-
-        // Read back the body state after one step (confirms pipeline ran)
+        // Read back the body state after one step (confirms pipeline ran).
         let body = sim.body(0);
         let r_mag = body.trans.position.raw_si().length();
         let v_mag = body.trans.velocity.raw_si().length();
@@ -101,12 +161,12 @@ fn tier3_simulation_orbinit_cross_consistency() {
             "  {label}: r={:.3} km  v={:.6} km/s  pos=[{:.1}, {:.1}, {:.1}] m",
             r_mag / 1000.0,
             v_mag / 1000.0,
-            init.position.x,
-            init.position.y,
-            init.position.z,
+            init_pos.x,
+            init_pos.y,
+            init_pos.z,
         );
 
-        // Sanity: LEO orbit (post-step state should still be LEO)
+        // Sanity: LEO orbit (post-step state should still be LEO).
         assert!(
             (6_000_000.0..=8_000_000.0).contains(&r_mag),
             "{label}: r={r_mag:.0} m outside LEO range after one step"
@@ -116,8 +176,10 @@ fn tier3_simulation_orbinit_cross_consistency() {
             "{label}: v={v_mag:.1} m/s outside LEO range after one step"
         );
 
-        // Use the initial state for cross-consistency (matches JEOD's initialization output)
-        states.push((init.position, init.velocity, label));
+        // Use the initial (t=0) state for cross-consistency: it
+        // mirrors the original test, which compared the JEOD-logged
+        // t=0 vectors across RUNs.
+        states.push((init_pos, init_vel, label));
     }
 
     println!();
@@ -147,7 +209,7 @@ fn tier3_simulation_orbinit_cross_consistency() {
         }
     }
 
-    // ISS vs STS-114: different vehicles at similar epoch
+    // ISS vs STS-114: different vehicles at similar epoch.
     let (pos_iss, _, _) = states[1];
     let (pos_sts, _, _) = states[0];
     let cross_vehicle_err = (pos_iss - pos_sts).length();

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_orbinit_edge.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_orbinit_edge.rs
@@ -1,0 +1,34 @@
+//! Bevy ↔ runner parity for the SIM_orbinit edge scenarios
+//! (`tier3_sim_orbinit_edge`). Wrappers land as part of #389.
+//!
+//! The matching tier3 file builds each scenario through the runner,
+//! propagates a single step, and asserts a range + cross-RUN
+//! consistency property on the JEOD-source initial states. This file
+//! pairs each recipe with the parity trait so the same scenarios also
+//! run through the Bevy adapter and assert `runner ↔ bevy` bit-identity
+//! at the synthetic checkpoint — the second half of the
+//! `runner ↔ JEOD ≈ bevy` transitivity argument the issue's matrix
+//! covers.
+
+use astrodyn_verif_jeod::run_verification::sim_orbinit_edge;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_orbinit_edge_run_0101() {
+    sim_orbinit_edge::run_0101().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_edge_run_0201() {
+    sim_orbinit_edge::run_0201().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_edge_run_0301() {
+    sim_orbinit_edge::run_0301().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_edge_run_0401() {
+    sim_orbinit_edge::run_0401().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -182,11 +182,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          recipe factory not yet defined (#389 follow-up)",
     ),
     (
-        "orbinit_edge",
-        "pre-recipe edge-case sibling — recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "orbinit_families",
         "pre-recipe sibling — sweep across orbit families, recipe factory \
          not yet defined (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Adds `sim_orbinit_edge` recipe module with four per-RUN scenario factories (RUN_0101, 0201, 0301, 0401) covering JEOD's SIM_orbinit edge-case initialization paths (inertial OE, planet-fixed OE, Cartesian inertial). Each pairs with `CsvReference::SyntheticTimes { dt: 10.0, num_steps: 1 }` because the orbinit reference CSVs log only the t=0 row.
- Refactors `tier3_sim_orbinit_edge.rs` to consume the recipes via their factories. The original cross-consistency and LEO-range assertions are preserved, with a new regression fence that the recipe's baked-in initial state still matches each RUN's JEOD-logged t=0 row.
- Adds `bevy_parity_orbinit_edge.rs` with four `runner ↔ bevy` bit-identity wrappers (one per recipe) via `VerificationCaseParityExt::run_and_assert_parity::<astrodyn::Earth>()`.
- Drops the `orbinit_edge` entry from `KNOWN_PARITY_GAPS` in `parity_coverage.rs` now that the wrapper exists.

References #389 (long tail of parity-coverage gaps).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1449 passed
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_orbinit_edge)'` — 4 passed (bit-identity)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — passed (superset invariant holds)
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_orbinit_edge` — passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Generated with [Claude Code](https://claude.com/claude-code).