### PR TITLE
[#389] Extract orbinit_roundtrip recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -32,6 +32,7 @@ pub mod sim_dyncomp;
 pub mod sim_gj;
 pub mod sim_kinematic_propagation;
 pub mod sim_lvlh_extended;
+pub mod sim_orbinit_roundtrip;
 pub mod sim_planetary;
 pub mod sim_polar_motion;
 pub mod sim_relative;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_roundtrip.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_roundtrip.rs
@@ -1,0 +1,420 @@
+//! `VerificationCase` constructors for the orbinit-round-trip analytical
+//! family (`tier3_sim_orbinit_roundtrip`).
+//!
+//! These cases have no JEOD reference CSV — they exercise the closed
+//! identity that Cartesian↔Keplerian conversion plus a full pipeline
+//! propagation under point-mass gravity returns to the same Keplerian
+//! shape/orientation it started from. The recipes share a single
+//! point-mass Earth source + `from_cartesian`-initialised body; only
+//! the per-case initial state and propagation length differ, so the
+//! per-case factories all delegate to a shared scenario constructor
+//! and pair the resulting [`SimulationBuilder`] with
+//! [`CsvReference::SyntheticTimes`] for the parity trait's lockstep
+//! `runner ↔ bevy` bit-identity assertion.
+//!
+//! The matching analytical assertions live in
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_roundtrip.rs`;
+//! each tier3 test pulls one recipe's scenario factory, builds the
+//! `Simulation`, propagates, and asserts the closed-form round-trip
+//! property (shape/orientation elements, or specific energy for the
+//! near-circular case). Splitting the scenario into a recipe is what
+//! makes the parity wrapper possible — the bridge needs an
+//! adapter-neutral `SimulationBuilder` to materialise, and a
+//! hand-rolled tier3 test that constructs a `Simulation` directly has
+//! no bridge entry point.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::recipes::helpers::state_helpers::state_from_elements;
+use astrodyn::{
+    default_leap_second_table, GravityControl, GravityControls, GravityGradient, GravityModel,
+    GravitySource, GravitySourceEntry, RotationModel, SimulationBuilder, SimulationTime,
+    TranslationalState, VehicleConfig,
+};
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Earth gravitational parameter (m³/s²) — JEOD `earth_GGM05C.cc`. The
+/// `astrodyn::EARTH.shape.mu` source is a compile-time literal, so
+/// every recipe and every tier3 closed-form assertion that references
+/// `MU_EARTH` resolves to the same bit-pattern without any fixture
+/// decode.
+const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
+
+/// Earth equatorial radius (m) — JEOD `earth.cc`. Same const-folding
+/// rationale as [`MU_EARTH`].
+const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
+
+/// Integrator step size shared by every full-period recipe. The
+/// hyperbolic case keeps its own short-propagation `dt` because its
+/// trajectory is unbounded, not period-keyed.
+const DT_S: f64 = 10.0;
+
+/// Hyperbolic recipe step size — shorter than [`DT_S`] because the
+/// hyperbolic flyby propagates only 100 s and the round-trip is
+/// asserted at the recovered-element level rather than the full-period
+/// level.
+const DT_HYP_S: f64 = 1.0;
+
+/// Hyperbolic recipe step count — fixed 100-step short flyby. The
+/// round-trip identity is independent of propagation length once the
+/// body has been integrated a non-trivial distance, so the choice is
+/// only a function of how many steps are needed to exercise the
+/// pipeline.
+const HYP_NUM_STEPS: usize = 100;
+
+/// Closed-form circular-orbit period for semi-major axis `a` and
+/// gravitational parameter `mu`. Used to size SyntheticTimes cadences
+/// for the full-period scans.
+fn period_s(mu_earth: f64, a: f64) -> f64 {
+    2.0 * std::f64::consts::PI * (a * a * a / mu_earth).sqrt()
+}
+
+/// Cadence for a full-period propagation at [`DT_S`]. `.ceil()` so the
+/// scan actually covers a full orbital period — bare truncation would
+/// stop a few seconds short of the period boundary.
+fn full_period_num_steps(a: f64) -> usize {
+    (period_s(MU_EARTH, a) / DT_S).ceil() as usize
+}
+
+/// Shared scenario builder for every orbinit round-trip recipe.
+/// Parameterised by:
+///   * `dt` — integrator timestep (`DT_S` for bound orbits, `DT_HYP_S`
+///     for the hyperbolic flyby);
+///   * `body` — the vehicle's initial translational state in
+///     `RootInertial`.
+///
+/// Each recipe wraps this with its case-specific values and pairs the
+/// returned builder with the matching `SyntheticTimes` cadence so the
+/// parity trait can drive `runner ↔ bevy` bit-identity at every step.
+fn build_orbinit_roundtrip(dt: f64, body: TranslationalState) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&body),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// Analytical recipes opt out of every runner-vs-JEOD tolerance group
+/// because they pair with [`CsvReference::SyntheticTimes`] and assert
+/// in-test against closed-form values rather than logged JEOD columns.
+/// The parity trait still asserts `runner ↔ bevy` bit-identity at every
+/// synthetic record.
+fn analytical_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+/// Build a `VerificationCase` from a case name, scenario constructor,
+/// step size, and step count. All orbinit-round-trip cases share the
+/// same Earth-point-mass shape, analytical-tolerance opt-out, and lack
+/// of pre-step hooks, so the per-case factory bodies all collapse to
+/// this single helper.
+fn make_case(
+    name: &'static str,
+    scenario: fn(&InitialConditions) -> SimulationBuilder,
+    dt: f64,
+    num_steps: usize,
+) -> VerificationCase {
+    VerificationCase {
+        name,
+        scenario,
+        reference: CsvReference::SyntheticTimes { dt, num_steps },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Circular LEO ─────────────────────────────────────────────────────
+
+/// Initial orbital elements for the circular recipe. Held as a
+/// function rather than a const so the tier3 closed-form assertion and
+/// the recipe builder share the single source of truth without an
+/// extra public `pub const` widening this module's surface.
+fn circular_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let a = R_EARTH + 400_000.0;
+    let e = 0.0;
+    let i = 51.6_f64.to_radians();
+    let raan = 30.0_f64.to_radians();
+    let argp = 0.0;
+    let nu = 0.0;
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_circular(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = circular_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_S, trans)
+}
+
+/// Circular LEO (a = R_E + 400 km, e = 0, i = 51.6°) propagated for one
+/// full orbital period. The matching tier3 test asserts the
+/// branch-independent specific energy `E = v²/2 − μ/r` returned to its
+/// initial value, plus inclination and RAAN preservation. Eccentricity
+/// recovery is also asserted but kept loose because `from_cartesian`
+/// switches branches near `e ≈ 1e-13`.
+pub fn circular() -> VerificationCase {
+    let (a, ..) = circular_elements();
+    make_case(
+        "tier3_orbinit_roundtrip_circular",
+        build_circular,
+        DT_S,
+        full_period_num_steps(a),
+    )
+}
+
+// ── Eccentric (e = 0.3) ──────────────────────────────────────────────
+
+fn eccentric_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let a = R_EARTH + 2_000_000.0;
+    let e = 0.3;
+    let i = 28.5_f64.to_radians();
+    let raan = 45.0_f64.to_radians();
+    let argp = 90.0_f64.to_radians();
+    let nu = 0.0; // periapsis start — cleanest closed-form round-trip
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_eccentric(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = eccentric_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_S, trans)
+}
+
+/// Eccentric orbit (e = 0.3, i = 28.5°) propagated for one full
+/// orbital period. The tier3 test asserts the shape/orientation
+/// elements (a, e, i, RAAN, argp) recover to their initial values.
+pub fn eccentric() -> VerificationCase {
+    let (a, ..) = eccentric_elements();
+    make_case(
+        "tier3_orbinit_roundtrip_eccentric",
+        build_eccentric,
+        DT_S,
+        full_period_num_steps(a),
+    )
+}
+
+// ── Retrograde ───────────────────────────────────────────────────────
+
+fn retrograde_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let a = R_EARTH + 800_000.0;
+    let e = 0.05;
+    let i = 150.0_f64.to_radians();
+    let raan = 200.0_f64.to_radians();
+    let argp = 30.0_f64.to_radians();
+    let nu = 0.0;
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_retrograde(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = retrograde_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_S, trans)
+}
+
+/// Retrograde orbit (i = 150°). Exercises the inclination > 90° branch
+/// of the Cartesian→Keplerian recovery — the angular-momentum vector
+/// flips sign relative to a prograde orbit but the recovered
+/// inclination still lies in `[0, π]`.
+pub fn retrograde() -> VerificationCase {
+    let (a, ..) = retrograde_elements();
+    make_case(
+        "tier3_orbinit_roundtrip_retrograde",
+        build_retrograde,
+        DT_S,
+        full_period_num_steps(a),
+    )
+}
+
+// ── Equatorial ───────────────────────────────────────────────────────
+
+fn equatorial_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let a = R_EARTH + 600_000.0;
+    let e = 0.1;
+    let i = 0.0;
+    let raan = 0.0;
+    let argp = 45.0_f64.to_radians();
+    let nu = 0.0;
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_equatorial(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = equatorial_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_S, trans)
+}
+
+/// Equatorial orbit (i = 0). The tier3 test skips RAAN because it is
+/// geometrically undefined when the orbit plane coincides with the
+/// equator (the line of nodes vanishes); shape elements still recover
+/// cleanly.
+pub fn equatorial() -> VerificationCase {
+    let (a, ..) = equatorial_elements();
+    make_case(
+        "tier3_orbinit_roundtrip_equatorial",
+        build_equatorial,
+        DT_S,
+        full_period_num_steps(a),
+    )
+}
+
+// ── Polar ────────────────────────────────────────────────────────────
+
+fn polar_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let a = R_EARTH + 500_000.0;
+    let e = 0.02;
+    let i = 90.0_f64.to_radians();
+    let raan = 60.0_f64.to_radians();
+    let argp = 0.0;
+    let nu = 0.0;
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_polar(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = polar_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_S, trans)
+}
+
+/// Polar orbit (i = 90°). Exercises the boundary where the angular-
+/// momentum z-component is zero; shape and orientation elements still
+/// recover to their initial values.
+pub fn polar() -> VerificationCase {
+    let (a, ..) = polar_elements();
+    make_case(
+        "tier3_orbinit_roundtrip_polar",
+        build_polar,
+        DT_S,
+        full_period_num_steps(a),
+    )
+}
+
+// ── Molniya (high-eccentricity) ──────────────────────────────────────
+
+fn molniya_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let a = R_EARTH + 10_000_000.0;
+    let e = 0.7;
+    let i = 63.4_f64.to_radians();
+    let raan = 120.0_f64.to_radians();
+    let argp = 270.0_f64.to_radians();
+    let nu = 0.0;
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_molniya(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = molniya_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_S, trans)
+}
+
+/// Highly eccentric Molniya-like orbit (e = 0.7, i = 63.4°). The
+/// tier3 test relaxes the per-element tolerances slightly to cover the
+/// integrator error budget over a single long-period orbit.
+pub fn molniya() -> VerificationCase {
+    let (a, ..) = molniya_elements();
+    make_case(
+        "tier3_orbinit_roundtrip_molniya",
+        build_molniya,
+        DT_S,
+        full_period_num_steps(a),
+    )
+}
+
+// ── Hyperbolic (short flyby) ─────────────────────────────────────────
+
+fn hyperbolic_elements() -> (f64, f64, f64, f64, f64, f64) {
+    let e = 1.5;
+    let r_peri = R_EARTH + 300_000.0;
+    let a = -(r_peri / (e - 1.0));
+    let i = 30.0_f64.to_radians();
+    let raan = 0.0;
+    let argp = 0.0;
+    let nu = 0.1;
+    (a, e, i, raan, argp, nu)
+}
+
+fn build_hyperbolic(_init: &InitialConditions) -> SimulationBuilder {
+    let (a, e, i, raan, argp, nu) = hyperbolic_elements();
+    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+    build_orbinit_roundtrip(DT_HYP_S, trans)
+}
+
+/// Hyperbolic flyby (e = 1.5) over a 100 s short propagation. With
+/// `e > 1` there is no bounded period, so the recipe uses a fixed
+/// 100-step horizon at the hyperbolic step size. The tier3 test
+/// asserts the recovered elements still match the initial Keplerian
+/// shape — for a hyperbola `a < 0` and the parabolic / elliptic
+/// branch boundaries don't apply.
+pub fn hyperbolic() -> VerificationCase {
+    make_case(
+        "tier3_orbinit_roundtrip_hyperbolic",
+        build_hyperbolic,
+        DT_HYP_S,
+        HYP_NUM_STEPS,
+    )
+}
+
+/// Initial orbital-element tuples exposed for the tier3 closed-form
+/// assertions. Returning the same `(a, e, i, raan, argp, nu)` shape
+/// that drives [`state_from_elements`] inside each builder keeps the
+/// tier3 file's expected-value vector and the recipe's built initial
+/// state on the same single source of truth.
+pub mod elements {
+    /// Initial orbital elements for the [`super::circular`] recipe.
+    pub fn circular() -> (f64, f64, f64, f64, f64, f64) {
+        super::circular_elements()
+    }
+    /// Initial orbital elements for the [`super::eccentric`] recipe.
+    pub fn eccentric() -> (f64, f64, f64, f64, f64, f64) {
+        super::eccentric_elements()
+    }
+    /// Initial orbital elements for the [`super::retrograde`] recipe.
+    pub fn retrograde() -> (f64, f64, f64, f64, f64, f64) {
+        super::retrograde_elements()
+    }
+    /// Initial orbital elements for the [`super::equatorial`] recipe.
+    pub fn equatorial() -> (f64, f64, f64, f64, f64, f64) {
+        super::equatorial_elements()
+    }
+    /// Initial orbital elements for the [`super::polar`] recipe.
+    pub fn polar() -> (f64, f64, f64, f64, f64, f64) {
+        super::polar_elements()
+    }
+    /// Initial orbital elements for the [`super::molniya`] recipe.
+    pub fn molniya() -> (f64, f64, f64, f64, f64, f64) {
+        super::molniya_elements()
+    }
+    /// Initial orbital elements for the [`super::hyperbolic`] recipe.
+    pub fn hyperbolic() -> (f64, f64, f64, f64, f64, f64) {
+        super::hyperbolic_elements()
+    }
+}

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_roundtrip.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_roundtrip.rs
@@ -8,87 +8,70 @@
 //! initialization, RK4 integration with point-mass gravity, and
 //! Cartesian-to-element recovery -- ensuring no information is lost
 //! or corrupted through the pipeline.
+//!
+//! The `Simulation` construction lives in the
+//! [`sim_orbinit_roundtrip`] recipe module so the parity wrapper
+//! (`bevy_parity_orbinit_roundtrip.rs`) can drive the same scenarios
+//! through the Bevy adapter for the `runner ↔ bevy` half of the
+//! transitivity argument.
 
-use astrodyn::recipes::helpers::state_helpers::state_from_elements;
+use astrodyn::recipes::helpers::state_helpers::angle_diff;
 use astrodyn::OrbitalElements;
-use astrodyn::{
-    GravityControl, GravityControls, GravityGradient, GravityModel, GravitySource, SimulationTime,
-};
-use astrodyn::{GravitySourceEntry, VehicleConfig};
-use astrodyn_runner::{RotationModel, Simulation};
+use astrodyn_runner::builder::SimulationBuilderExt;
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_orbinit_roundtrip;
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 
-/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+/// Earth gravitational parameter (m³/s²) — same const-folded literal
+/// the recipe uses, so the expected-vs-recovered comparison resolves
+/// against the same bit-pattern that drove the initial state.
 const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
 
-/// Earth equatorial radius (m) — JEOD `earth.cc`.
-const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
+/// Build the recipe's `Simulation` exactly the way the parity trait
+/// does — call the scenario factory with a default `InitialConditions`,
+/// then `.build()` — so the runner-side propagation here and the
+/// Bevy-side propagation in `bevy_parity_orbinit_roundtrip.rs` see the
+/// same initial state bit-pattern.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
+}
 
-/// Build a Simulation, propagate for approximately one full orbit (for bound
-/// orbits), recover orbital elements, and verify shape/orientation elements
-/// match the originals.
-///
-/// Asserts: semi-major axis (a), eccentricity (e), inclination (i), and
-/// conditionally RAAN (non-equatorial) and argument of periapsis
-/// (non-circular). Anomalies (true, mean, eccentric) are excluded because
-/// they evolve with time and do not return to their initial values unless
-/// the propagation time matches the period exactly.
-///
-/// For point-mass gravity, after approximately one orbit these
-/// shape/orientation elements should remain preserved within the test
-/// tolerances (the orbit is a fixed Keplerian ellipse).
-#[allow(clippy::too_many_arguments)]
-fn roundtrip_via_simulation(
-    a: f64,
-    e: f64,
-    i: f64,
-    raan: f64,
-    argp: f64,
-    nu: f64,
-    dt: f64,
-    n_steps: usize,
-    label: &str,
-    a_tol: f64,
-    e_tol: f64,
-    angle_tol: f64,
-) {
-    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_orbinit_roundtrip` uses this variant
+/// because the family is analytical-only; panicking on any other
+/// variant surfaces a future recipe-shape drift here rather than
+/// producing a silently-truncated propagation. Returning both halves
+/// of the cadence lets callers assert that the `dt` they're stepping
+/// at (`sim.dt`) matches the cadence the recipe declared — catches a
+/// future edit that updates the builder dt but forgets the
+/// `SyntheticTimes` dt (or vice versa).
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
+    match &case.reference {
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
+}
 
-    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-    let mut sim = Simulation::new(time, dt);
-
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
+/// Propagate `sim` for the recipe's full SyntheticTimes cadence, then
+/// recover `OrbitalElements` from the final body state.
+fn propagate_and_recover(
+    case: &VerificationCase,
+    sim: &mut Simulation,
+) -> OrbitalElements<astrodyn::Earth> {
+    let (dt, n_steps) = synthetic_cadence(case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
 
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
     sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
     use astrodyn::{F64Ext, PlanetInertial, Vec3Ext};
-    let oe_recovered = OrbitalElements::<astrodyn::Earth>::from_cartesian_typed(
+    OrbitalElements::<astrodyn::Earth>::from_cartesian_typed(
         F64Ext::m3_per_s2(MU_EARTH),
         body.trans
             .position
@@ -99,61 +82,83 @@ fn roundtrip_via_simulation(
             .raw_si()
             .m_per_s_at::<PlanetInertial<astrodyn::Earth>>(),
     )
-    .expect("from_cartesian_typed failed after propagation");
+    .expect("from_cartesian_typed failed after propagation")
+}
 
-    println!("  {label}: recovered elements after {n_steps} steps");
+/// Shape/orientation closed-form check shared by every round-trip
+/// test except the near-circular one (which compares specific energy
+/// instead, see [`tier3_orbinit_roundtrip_circular`]).
+///
+/// Asserts: semi-major axis (a), eccentricity (e), inclination (i), and
+/// conditionally RAAN (non-equatorial) and argument of periapsis
+/// (non-circular). Anomalies are excluded because they evolve with time
+/// and do not return to their initial values unless the propagation
+/// time matches the period exactly.
+#[allow(clippy::too_many_arguments)]
+fn assert_roundtrip_elements(
+    label: &str,
+    recovered: &OrbitalElements<astrodyn::Earth>,
+    a: f64,
+    e: f64,
+    i: f64,
+    raan: f64,
+    argp: f64,
+    a_tol: f64,
+    e_tol: f64,
+    angle_tol: f64,
+) {
+    println!("  {label}: recovered elements");
     println!(
         "    a: {:.6e} (expected {:.6e}, err {:.3e})",
-        oe_recovered.semi_major_axis,
+        recovered.semi_major_axis,
         a,
-        (oe_recovered.semi_major_axis - a).abs()
+        (recovered.semi_major_axis - a).abs()
     );
     println!(
         "    e: {:.10} (expected {:.10}, err {:.3e})",
-        oe_recovered.e_mag,
+        recovered.e_mag,
         e,
-        (oe_recovered.e_mag - e).abs()
+        (recovered.e_mag - e).abs()
     );
     println!(
         "    i: {:.8} rad (expected {:.8}, err {:.3e})",
-        oe_recovered.inclination,
+        recovered.inclination,
         i,
-        (oe_recovered.inclination - i).abs()
+        (recovered.inclination - i).abs()
     );
 
-    // Semi-major axis (relative error)
-    let a_err = (oe_recovered.semi_major_axis - a).abs() / a.abs();
+    let a_err = (recovered.semi_major_axis - a).abs() / a.abs();
     assert!(
         a_err < a_tol,
         "{label}: semi_major_axis relative error {a_err:.6e} exceeds tolerance {a_tol:.1e}"
     );
 
-    // Eccentricity (absolute error -- e can be small or zero)
-    let e_err = (oe_recovered.e_mag - e).abs();
+    let e_err = (recovered.e_mag - e).abs();
     assert!(
         e_err < e_tol,
         "{label}: eccentricity error {e_err:.6e} exceeds tolerance {e_tol:.1e}"
     );
 
-    // Inclination (absolute error in radians)
-    let i_err = (oe_recovered.inclination - i).abs();
+    let i_err = (recovered.inclination - i).abs();
     assert!(
         i_err < angle_tol,
         "{label}: inclination error {i_err:.6e} rad exceeds tolerance {angle_tol:.1e}"
     );
 
-    // RAAN -- only check for non-equatorial orbits (singular when i~0)
+    // RAAN — undefined at the equatorial singularity (line of nodes
+    // vanishes when `i ≈ 0` or `i ≈ π`).
     if i > 1e-6 && (std::f64::consts::PI - i) > 1e-6 {
-        let raan_err = angle_diff(oe_recovered.long_asc_node, raan);
+        let raan_err = angle_diff(recovered.long_asc_node, raan);
         assert!(
             raan_err < angle_tol,
             "{label}: RAAN error {raan_err:.6e} rad exceeds tolerance {angle_tol:.1e}"
         );
     }
 
-    // Argument of periapsis -- only check for non-circular orbits
+    // Argument of periapsis — undefined for circular orbits (periapsis
+    // direction is unconstrained when `e ≈ 0`).
     if e > 1e-6 {
-        let argp_err = angle_diff(oe_recovered.arg_periapsis, argp);
+        let argp_err = angle_diff(recovered.arg_periapsis, argp);
         assert!(
             argp_err < angle_tol,
             "{label}: arg_periapsis error {argp_err:.6e} rad exceeds tolerance {angle_tol:.1e}"
@@ -161,70 +166,33 @@ fn roundtrip_via_simulation(
     }
 }
 
-use astrodyn::recipes::helpers::state_helpers::angle_diff;
-
 // ======================================================================
 // Circular LEO round-trip
 // ======================================================================
 
 #[test]
 fn tier3_orbinit_roundtrip_circular() {
-    let a = R_EARTH + 400_000.0;
-    let e = 0.0;
-    let i = 51.6_f64.to_radians();
-    let raan = 30.0_f64.to_radians();
-    let argp = 0.0;
-    let nu = 0.0;
+    let case = sim_orbinit_roundtrip::circular();
+    let (_, _e_init, i, raan, _argp, _nu) = sim_orbinit_roundtrip::elements::circular();
 
-    let period = 2.0 * std::f64::consts::PI * (a * a * a / MU_EARTH).sqrt();
-    let dt = 10.0;
-    let n_steps = (period / dt).round() as usize;
+    let mut sim = build_sim(&case);
 
-    println!("Tier 3 round-trip: Circular LEO (period={period:.1} s, {n_steps} steps)");
-
-    // For circular orbits, from_cartesian switches branches at e_mag < 1e-13
-    // (setting a = r_mag in the circular branch). Tiny numerical eccentricity
-    // after integration can cross this threshold, changing how semi_major_axis
-    // is computed. Instead, compare specific energy E = -mu/(2a), which is
-    // branch-independent and stable for near-circular orbits.
-    let trans = state_from_elements(a, e, i, raan, argp, nu, MU_EARTH);
-
-    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-    let mut sim = Simulation::new(time, dt);
-
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
-    );
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-
-    // Compute initial specific energy
+    // For circular orbits, `from_cartesian` switches branches at
+    // `e_mag < 1e-13` (setting `a = r_mag` in the circular branch).
+    // Tiny numerical eccentricity after integration can cross this
+    // threshold, changing how `semi_major_axis` is computed. Instead,
+    // compare specific energy `E = v²/2 − μ/r`, which is branch-
+    // independent and stable for near-circular orbits.
     let body0 = sim.body(0);
     let energy_0 = body0.trans.velocity.raw_si().length_squared() / 2.0
         - MU_EARTH / body0.trans.position.raw_si().length();
+
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
+    );
 
     sim.step_n(n_steps).expect("step_n failed");
 
@@ -243,7 +211,6 @@ fn tier3_orbinit_roundtrip_circular() {
     )
     .expect("from_cartesian_typed failed after propagation");
 
-    // Specific energy: E = v^2/2 - mu/r = -mu/(2a), branch-independent
     let energy_now = body.trans.velocity.raw_si().length_squared() / 2.0
         - MU_EARTH / body.trans.position.raw_si().length();
     let energy_err = (energy_now - energy_0).abs() / energy_0.abs();
@@ -282,29 +249,18 @@ fn tier3_orbinit_roundtrip_circular() {
 
 #[test]
 fn tier3_orbinit_roundtrip_eccentric() {
-    let a = R_EARTH + 2_000_000.0;
-    let e = 0.3;
-    let i = 28.5_f64.to_radians();
-    let raan = 45.0_f64.to_radians();
-    let argp = 90.0_f64.to_radians();
-    let nu = 0.0; // start at periapsis for clean round-trip
-
-    let period = 2.0 * std::f64::consts::PI * (a * a * a / MU_EARTH).sqrt();
-    let dt = 10.0;
-    let n_steps = (period / dt).round() as usize;
-
-    println!("Tier 3 round-trip: Eccentric e=0.3 (period={period:.1} s, {n_steps} steps)");
-
-    roundtrip_via_simulation(
+    let case = sim_orbinit_roundtrip::eccentric();
+    let (a, e, i, raan, argp, _nu) = sim_orbinit_roundtrip::elements::eccentric();
+    let mut sim = build_sim(&case);
+    let oe = propagate_and_recover(&case, &mut sim);
+    assert_roundtrip_elements(
+        "eccentric_e03",
+        &oe,
         a,
         e,
         i,
         raan,
         argp,
-        nu,
-        dt,
-        n_steps,
-        "eccentric_e03",
         1e-10,
         1e-10,
         1e-8,
@@ -317,33 +273,11 @@ fn tier3_orbinit_roundtrip_eccentric() {
 
 #[test]
 fn tier3_orbinit_roundtrip_retrograde() {
-    let a = R_EARTH + 800_000.0;
-    let e = 0.05;
-    let i = 150.0_f64.to_radians();
-    let raan = 200.0_f64.to_radians();
-    let argp = 30.0_f64.to_radians();
-    let nu = 0.0;
-
-    let period = 2.0 * std::f64::consts::PI * (a * a * a / MU_EARTH).sqrt();
-    let dt = 10.0;
-    let n_steps = (period / dt).round() as usize;
-
-    println!("Tier 3 round-trip: Retrograde (period={period:.1} s, {n_steps} steps)");
-
-    roundtrip_via_simulation(
-        a,
-        e,
-        i,
-        raan,
-        argp,
-        nu,
-        dt,
-        n_steps,
-        "retrograde",
-        1e-10,
-        1e-10,
-        1e-8,
-    );
+    let case = sim_orbinit_roundtrip::retrograde();
+    let (a, e, i, raan, argp, _nu) = sim_orbinit_roundtrip::elements::retrograde();
+    let mut sim = build_sim(&case);
+    let oe = propagate_and_recover(&case, &mut sim);
+    assert_roundtrip_elements("retrograde", &oe, a, e, i, raan, argp, 1e-10, 1e-10, 1e-8);
 }
 
 // ======================================================================
@@ -352,33 +286,11 @@ fn tier3_orbinit_roundtrip_retrograde() {
 
 #[test]
 fn tier3_orbinit_roundtrip_equatorial() {
-    let a = R_EARTH + 600_000.0;
-    let e = 0.1;
-    let i = 0.0;
-    let raan = 0.0;
-    let argp = 45.0_f64.to_radians();
-    let nu = 0.0;
-
-    let period = 2.0 * std::f64::consts::PI * (a * a * a / MU_EARTH).sqrt();
-    let dt = 10.0;
-    let n_steps = (period / dt).round() as usize;
-
-    println!("Tier 3 round-trip: Equatorial (period={period:.1} s, {n_steps} steps)");
-
-    roundtrip_via_simulation(
-        a,
-        e,
-        i,
-        raan,
-        argp,
-        nu,
-        dt,
-        n_steps,
-        "equatorial",
-        1e-10,
-        1e-10,
-        1e-8,
-    );
+    let case = sim_orbinit_roundtrip::equatorial();
+    let (a, e, i, raan, argp, _nu) = sim_orbinit_roundtrip::elements::equatorial();
+    let mut sim = build_sim(&case);
+    let oe = propagate_and_recover(&case, &mut sim);
+    assert_roundtrip_elements("equatorial", &oe, a, e, i, raan, argp, 1e-10, 1e-10, 1e-8);
 }
 
 // ======================================================================
@@ -387,22 +299,11 @@ fn tier3_orbinit_roundtrip_equatorial() {
 
 #[test]
 fn tier3_orbinit_roundtrip_polar() {
-    let a = R_EARTH + 500_000.0;
-    let e = 0.02;
-    let i = 90.0_f64.to_radians();
-    let raan = 60.0_f64.to_radians();
-    let argp = 0.0;
-    let nu = 0.0;
-
-    let period = 2.0 * std::f64::consts::PI * (a * a * a / MU_EARTH).sqrt();
-    let dt = 10.0;
-    let n_steps = (period / dt).round() as usize;
-
-    println!("Tier 3 round-trip: Polar (period={period:.1} s, {n_steps} steps)");
-
-    roundtrip_via_simulation(
-        a, e, i, raan, argp, nu, dt, n_steps, "polar", 1e-10, 1e-10, 1e-8,
-    );
+    let case = sim_orbinit_roundtrip::polar();
+    let (a, e, i, raan, argp, _nu) = sim_orbinit_roundtrip::elements::polar();
+    let mut sim = build_sim(&case);
+    let oe = propagate_and_recover(&case, &mut sim);
+    assert_roundtrip_elements("polar", &oe, a, e, i, raan, argp, 1e-10, 1e-10, 1e-8);
 }
 
 // ======================================================================
@@ -411,23 +312,15 @@ fn tier3_orbinit_roundtrip_polar() {
 
 #[test]
 fn tier3_orbinit_roundtrip_molniya() {
-    let a = R_EARTH + 10_000_000.0;
-    let e = 0.7;
-    let i = 63.4_f64.to_radians();
-    let raan = 120.0_f64.to_radians();
-    let argp = 270.0_f64.to_radians();
-    let nu = 0.0;
-
-    let period = 2.0 * std::f64::consts::PI * (a * a * a / MU_EARTH).sqrt();
-    let dt = 10.0;
-    let n_steps = (period / dt).round() as usize;
-
-    println!("Tier 3 round-trip: Molniya (period={period:.1} s, {n_steps} steps)");
-
-    roundtrip_via_simulation(
-        a, e, i, raan, argp, nu, dt, n_steps, "molniya",
-        1e-9, // relaxed for high eccentricity
-        1e-9, 1e-7,
+    let case = sim_orbinit_roundtrip::molniya();
+    let (a, e, i, raan, argp, _nu) = sim_orbinit_roundtrip::elements::molniya();
+    let mut sim = build_sim(&case);
+    let oe = propagate_and_recover(&case, &mut sim);
+    assert_roundtrip_elements(
+        "molniya", &oe, a, e, i, raan, argp,
+        // Per-element tolerances relaxed slightly for the long-period
+        // high-eccentricity case (integrator budget over ~24-hour orbit).
+        1e-9, 1e-9, 1e-7,
     );
 }
 
@@ -437,32 +330,9 @@ fn tier3_orbinit_roundtrip_molniya() {
 
 #[test]
 fn tier3_orbinit_roundtrip_hyperbolic() {
-    let e = 1.5;
-    let r_peri = R_EARTH + 300_000.0;
-    let a = -(r_peri / (e - 1.0));
-    let i = 30.0_f64.to_radians();
-    let raan = 0.0;
-    let argp = 0.0;
-    let nu = 0.1;
-
-    // Short propagation: 100 steps of 1 second
-    let dt = 1.0;
-    let n_steps = 100;
-
-    println!("Tier 3 round-trip: Hyperbolic (a={a:.0} m, e={e})");
-
-    roundtrip_via_simulation(
-        a,
-        e,
-        i,
-        raan,
-        argp,
-        nu,
-        dt,
-        n_steps,
-        "hyperbolic",
-        1e-10,
-        1e-10,
-        1e-10,
-    );
+    let case = sim_orbinit_roundtrip::hyperbolic();
+    let (a, e, i, raan, argp, _nu) = sim_orbinit_roundtrip::elements::hyperbolic();
+    let mut sim = build_sim(&case);
+    let oe = propagate_and_recover(&case, &mut sim);
+    assert_roundtrip_elements("hyperbolic", &oe, a, e, i, raan, argp, 1e-10, 1e-10, 1e-10);
 }

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_orbinit_roundtrip.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_orbinit_roundtrip.rs
@@ -1,0 +1,51 @@
+//! Bevy ↔ runner parity for the analytical orbinit-round-trip
+//! scenarios (`tier3_sim_orbinit_roundtrip`). Wrappers land as part of
+//! #389.
+//!
+//! The matching tier3 file drives each scenario through the runner and
+//! asserts a closed-form round-trip property (shape and orientation
+//! orbital elements recover to the initial values after propagation
+//! under point-mass gravity, or specific energy for the near-circular
+//! case). This file pairs each recipe with the parity trait so the
+//! same scenarios also run through the Bevy adapter and assert
+//! `runner ↔ bevy` bit-identity at every synthetic record — the second
+//! half of the `runner ↔ JEOD ≈ bevy` transitivity argument the
+//! issue's matrix covers.
+
+use astrodyn_verif_jeod::run_verification::sim_orbinit_roundtrip;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_circular() {
+    sim_orbinit_roundtrip::circular().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_eccentric() {
+    sim_orbinit_roundtrip::eccentric().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_retrograde() {
+    sim_orbinit_roundtrip::retrograde().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_equatorial() {
+    sim_orbinit_roundtrip::equatorial().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_polar() {
+    sim_orbinit_roundtrip::polar().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_molniya() {
+    sim_orbinit_roundtrip::molniya().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_roundtrip_hyperbolic() {
+    sim_orbinit_roundtrip::hyperbolic().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -192,11 +192,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          not yet defined (#389 follow-up)",
     ),
     (
-        "orbinit_roundtrip",
-        "pre-recipe sibling — Cartesian↔Keplerian round-trip, recipe not yet \
-         defined (#389 follow-up)",
-    ),
-    (
         "ref_attach",
         "pre-recipe sibling exercising attach_to_frame — recipe factory \
          not yet defined (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Closes the `orbinit_roundtrip` parity gap (#389) by extracting the inline `Simulation` construction in `tier3_sim_orbinit_roundtrip.rs` into a `sim_orbinit_roundtrip` recipe module with 7 per-case factories sharing a common `build_orbinit_roundtrip` scenario constructor, paired with `CsvReference::SyntheticTimes` (analytical family — no JEOD reference CSV).
- Adds `bevy_parity_orbinit_roundtrip.rs` — 7 wrappers (`circular`, `eccentric`, `retrograde`, `equatorial`, `polar`, `molniya`, `hyperbolic`) that drive each scenario through the Bevy adapter and assert `runner ↔ bevy` bit-identity at every synthetic record.
- The tier3 file now delegates to the recipe factories, calls a `synthetic_cadence(&case)` helper to read `(dt, num_steps)` off the recipe and assert `dt == sim.dt`, and keeps the existing closed-form assertions intact (branch-independent specific energy for the near-circular case; recovered shape/orientation orbital elements for the rest).
- Drops the `orbinit_roundtrip` entry from `KNOWN_PARITY_GAPS` in `parity_coverage.rs` and registers the new recipe module in `run_verification/mod.rs`.

Refs #389 (do not auto-close — meta-issue).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1198/1198 pass
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_orbinit_roundtrip)'` — 7/7 pass
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — superset invariant holds
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_orbinit_roundtrip` — 7/7 pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)