### PR TITLE
[#389] Extract orbelem_comprehensive recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -32,6 +32,7 @@ pub mod sim_dyncomp;
 pub mod sim_gj;
 pub mod sim_kinematic_propagation;
 pub mod sim_lvlh_extended;
+pub mod sim_orbelem_comprehensive;
 pub mod sim_orbinit_edge;
 pub mod sim_orbinit_families;
 pub mod sim_orbinit_roundtrip;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
@@ -3,13 +3,23 @@
 //!
 //! These cases exercise the `Simulation` pipeline from the t=0 row of
 //! each `orbelem_verif_tXX_orbelem.csv` (JEOD's verification output for
-//! the orbital-elements derived state across seven orbit families:
-//! circular, eccentric, hyperbolic, near-parabolic, retrograde,
-//! equatorial, polar). The per-RUN initial inertial position/velocity
-//! is fed to a point-mass-Earth `Simulation` configured with the
-//! `OrbitalElementsConfigC`-equivalent `DerivedStateConfig`, propagated
-//! a single step at a tiny `dt`, and the resulting orbital elements
-//! are compared against the JEOD-logged columns by the tier3 sibling.
+//! the orbital-elements derived state). The per-RUN initial inertial
+//! position/velocity is fed to a point-mass-Earth `Simulation`
+//! configured with the `OrbitalElementsConfigC`-equivalent
+//! `DerivedStateConfig`, propagated a single step at a tiny `dt`, and
+//! the resulting orbital elements are compared against the JEOD-logged
+//! columns by the tier3 sibling.
+//!
+//! The seven RUN labels (T01, T10, T20, T30, T40, T50, T55) come from
+//! JEOD's SIM_orbital_elements regression suite; the original design
+//! intent (circular / eccentric / hyperbolic / near-parabolic /
+//! retrograde / equatorial / polar) does *not* match what the
+//! committed fixture CSVs actually contain — see the per-case notes
+//! near `t01_state` etc. for the elements each fixture truly carries
+//! (e.g. T20 is e=0.2 elliptic, T55 is ISS-like LEO, T30/T40 are
+//! degenerate `sma=0` extraction edge cases). The fixture is the
+//! ground truth; the labels are kept as JEOD RUN identifiers, not
+//! orbit-family descriptors.
 //!
 //! The integrator step size is intentionally tiny (`DT_S = 1e-9`):
 //! one step barely moves the state, but it does drive the full pipeline

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
@@ -19,9 +19,12 @@
 //!
 //! Each recipe pairs with [`CsvReference::SyntheticTimes`] so the
 //! parity wrapper drives a lockstep `runner ↔ bevy` bit-identity
-//! assertion at the synthetic checkpoint without needing a multi-record
-//! reference CSV (the orbelem CSVs are initialization-only — they log
-//! only the t=0 row).
+//! assertion at the synthetic checkpoint without consulting the
+//! reference CSV at all. (The orbelem fixture CSVs *do* contain
+//! multiple rows — most are just t=0..2, but t50 spans t=0..5000 —
+//! but the per-case tier3 assertions only need the JEOD-logged
+//! initial state, which is baked into each recipe directly rather
+//! than parsed at runtime.)
 //!
 //! Initial state values originate from the JEOD output rows of
 //! `crates/astrodyn_verif_jeod/test_data/orbelem_verif_tXX_orbelem.csv`,

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
@@ -1,0 +1,341 @@
+//! `VerificationCase` constructors for the SIM_OrbElem comprehensive
+//! sweep (`tier3_sim_orbelem_comprehensive`).
+//!
+//! These cases exercise the `Simulation` pipeline from the t=0 row of
+//! each `orbelem_verif_tXX_orbelem.csv` (JEOD's verification output for
+//! the orbital-elements derived state across seven orbit families:
+//! circular, eccentric, hyperbolic, near-parabolic, retrograde,
+//! equatorial, polar). The per-RUN initial inertial position/velocity
+//! is fed to a point-mass-Earth `Simulation` configured with the
+//! `OrbitalElementsConfigC`-equivalent `DerivedStateConfig`, propagated
+//! a single step at a tiny `dt`, and the resulting orbital elements
+//! are compared against the JEOD-logged columns by the tier3 sibling.
+//!
+//! The integrator step size is intentionally tiny (`DT_S = 1e-9`):
+//! one step barely moves the state, but it does drive the full pipeline
+//! through to the stage-9 derived-state computation. With a normal
+//! step the orbital elements drift away from the JEOD-logged t=0 row
+//! by enough that the tight per-element tolerances would fail.
+//!
+//! Each recipe pairs with [`CsvReference::SyntheticTimes`] so the
+//! parity wrapper drives a lockstep `runner ↔ bevy` bit-identity
+//! assertion at the synthetic checkpoint without needing a multi-record
+//! reference CSV (the orbelem CSVs are initialization-only — they log
+//! only the t=0 row).
+//!
+//! Initial state values originate from the JEOD output rows of
+//! `crates/astrodyn_verif_jeod/test_data/orbelem_verif_tXX_orbelem.csv`,
+//! committed alongside the rest of the verif fixtures.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::{
+    default_leap_second_table, DerivedStateConfig, GravityControl, GravityControls,
+    GravityGradient, GravityModel, GravitySource, GravitySourceEntry, RotationModel,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
+};
+use glam::DVec3;
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Integrator step size. Matches the value the pre-recipe tier3 file
+/// used (`Simulation::new(time, 1e-9)`) — one tiny step exercises the
+/// pipeline through stage-9 derived-state computation while keeping
+/// the state drift below ≈1e-5 m so the JEOD-logged orbital elements
+/// stay within the per-element tolerances.
+const DT_S: f64 = 1e-9;
+
+/// One propagation step is enough to trigger derived-state computation
+/// — the original tier3 file called `sim.step()` exactly once after
+/// construction, so a single synthetic-cadence checkpoint preserves
+/// the test's coverage shape.
+const NUM_STEPS: usize = 1;
+
+fn load_mu_earth() -> f64 {
+    // Cache the decoded `mu` for the lifetime of the test process —
+    // every `build_*` call would otherwise re-parse the full GGM05C
+    // coefficient table (≈12 KiB) just to read a single scalar.
+    static MU_EARTH: std::sync::OnceLock<f64> = std::sync::OnceLock::new();
+    *MU_EARTH.get_or_init(|| astrodyn::gravity_fixtures::load_ggm05c().mu)
+}
+
+/// Shared scenario builder for every recipe. Parameterised by:
+///   * `mu_earth` — Earth's gravitational parameter (point-mass);
+///   * `body` — the vehicle's initial translational state in the
+///     RootInertial frame.
+///
+/// The body is configured with `orbital_elements_source` so stage 9
+/// produces the per-step `OrbitalElements` the tier3 sibling reads.
+fn build_orbelem_comprehensive(mu_earth: f64, body: TranslationalState) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, DT_S);
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&body),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        derived: DerivedStateConfig {
+            orbital_elements_source: Some(earth),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// Recipes opt out of every runner-vs-JEOD tolerance group because they
+/// pair with [`CsvReference::SyntheticTimes`]; the tier3 sibling asserts
+/// per-orbital-element bounds against the JEOD-logged CSV columns
+/// directly, and the parity trait drives bit-identity at every
+/// synthetic record.
+fn synthetic_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+// ── Per-RUN initial states ───────────────────────────────────────────
+//
+// Values are copied verbatim from the t=0 row of each
+// `orbelem_verif_tXX_orbelem.csv` (the JEOD verification output).
+// Distinct case labels exercise different orbital-element extraction
+// branches:
+//
+//   * T01 — circular orbit (e ≈ 0);
+//   * T10 — eccentric orbit (0 < e < 1);
+//   * T20 — hyperbolic orbit (e > 1);
+//   * T30 — near-parabolic orbit (e ≈ 1, separate branch in JEOD's
+//           orbital-element extraction);
+//   * T40 — retrograde orbit (i > 90°);
+//   * T50 — equatorial orbit (i ≈ 0, RAAN degenerate);
+//   * T55 — polar orbit (i ≈ 90°).
+
+fn t01_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(7_378_145.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7_350.141_635_341_643, 0.0),
+    }
+}
+
+fn t10_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(-4_518_172.624_566_75, 4_518_172.624_566_75, 3_689_072.5),
+        velocity: DVec3::new(-5_197.334_993_031_66, -5_197.334_993_031_66, 0.0),
+    }
+}
+
+fn t20_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(5_217_136.362_077_619, -5_217_136.362_077_62, 0.0),
+        velocity: DVec3::new(
+            4_025.838_374_534_529,
+            4_025.838_374_534_528,
+            -5_693.395_229_188_787,
+        ),
+    }
+}
+
+fn t30_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(
+            -4_518_172.624_566_758,
+            4_518_172.624_566_755,
+            3_689_072.500_000_006,
+        ),
+        velocity: DVec3::new(
+            -5_197.334_993_031_658,
+            -5_197.334_993_031_644,
+            4.964_758_611_634_907e-12,
+        ),
+    }
+}
+
+fn t40_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(
+            5_217_136.362_077_619,
+            -5_217_136.362_077_619,
+            -3.102_474_751_043_898e-11,
+        ),
+        velocity: DVec3::new(
+            4_025.838_374_534_53,
+            4_025.838_374_534_528,
+            -5_693.395_229_188_788,
+        ),
+    }
+}
+
+fn t50_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(7_378_145.0, 0.0, 0.0),
+        velocity: DVec3::new(0.0, 7_350.141_635_341_643, 0.0),
+    }
+}
+
+fn t55_state() -> TranslationalState {
+    TranslationalState {
+        position: DVec3::new(5_657_077.34, 3_080_301.15, 1_918_782.98),
+        velocity: DVec3::new(-3_868.050_682, 3_564.535_653, 5_633.830_366),
+    }
+}
+
+fn build_t01(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t01_state())
+}
+
+fn build_t10(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t10_state())
+}
+
+fn build_t20(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t20_state())
+}
+
+fn build_t30(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t30_state())
+}
+
+fn build_t40(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t40_state())
+}
+
+fn build_t50(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t50_state())
+}
+
+fn build_t55(_init: &InitialConditions) -> SimulationBuilder {
+    build_orbelem_comprehensive(load_mu_earth(), t55_state())
+}
+
+/// T01 — circular orbit (e ≈ 0).
+pub fn t01() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t01",
+        scenario: build_t01,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// T10 — eccentric orbit (0 < e < 1).
+pub fn t10() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t10",
+        scenario: build_t10,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// T20 — hyperbolic orbit (e > 1).
+pub fn t20() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t20",
+        scenario: build_t20,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// T30 — near-parabolic orbit (e ≈ 1).
+pub fn t30() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t30",
+        scenario: build_t30,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// T40 — retrograde orbit (i > 90°).
+pub fn t40() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t40",
+        scenario: build_t40,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// T50 — equatorial orbit (i ≈ 0, RAAN degenerate).
+pub fn t50() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t50",
+        scenario: build_t50,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// T55 — polar orbit (i ≈ 90°).
+pub fn t55() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbelem_comprehensive_t55",
+        scenario: build_t55,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
@@ -122,17 +122,23 @@ fn synthetic_tolerances() -> Tolerances {
 //
 // Values are copied verbatim from the t=0 row of each
 // `orbelem_verif_tXX_orbelem.csv` (the JEOD verification output).
-// Distinct case labels exercise different orbital-element extraction
-// branches:
+// The case IDs (T01, T10, ...) are JEOD's RUN labels; the
+// per-case descriptors below summarise the actual orbital elements
+// JEOD wrote for that row (rather than the family the RUN was
+// originally designed for, which sometimes diverges from the
+// committed fixture — see #389 thread).
 //
-//   * T01 — circular orbit (e ≈ 0);
-//   * T10 — eccentric orbit (0 < e < 1);
-//   * T20 — hyperbolic orbit (e > 1);
-//   * T30 — near-parabolic orbit (e ≈ 1, separate branch in JEOD's
-//           orbital-element extraction);
-//   * T40 — retrograde orbit (i > 90°);
-//   * T50 — equatorial orbit (i ≈ 0, RAAN degenerate);
-//   * T55 — polar orbit (i ≈ 90°).
+//   * T01 — equatorial circular (e=0, i=0, sma≈7378 km);
+//   * T10 — inclined near-circular (i≈30°, e≈0, sma≈7378 km);
+//   * T20 — eccentric inclined (e=0.2, i≈45°, sma≈9223 km);
+//   * T30 — orb_elem edge case (sma=0 in JEOD output despite a
+//           valid 7.2 Mm Cartesian state; exercises a degenerate
+//           branch of the orbital-element extraction);
+//   * T40 — orb_elem edge case with eccentricity (sma=0 in
+//           JEOD output, e=0.2, i≈45°);
+//   * T50 — equatorial circular with extended log (matches T01
+//           initial state, but the fixture spans t=0..5000s);
+//   * T55 — ISS-like LEO (i≈51.7°, e≈0.0025, sma≈6733 km).
 
 fn t01_state() -> TranslationalState {
     TranslationalState {
@@ -231,7 +237,7 @@ fn build_t55(_init: &InitialConditions) -> SimulationBuilder {
     build_orbelem_comprehensive(load_mu_earth(), t55_state())
 }
 
-/// T01 — circular orbit (e ≈ 0).
+/// T01 — equatorial circular (e=0, i=0, sma≈7378 km).
 pub fn t01() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t01",
@@ -247,7 +253,7 @@ pub fn t01() -> VerificationCase {
     }
 }
 
-/// T10 — eccentric orbit (0 < e < 1).
+/// T10 — inclined near-circular (i≈30°, e≈0, sma≈7378 km).
 pub fn t10() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t10",
@@ -263,7 +269,7 @@ pub fn t10() -> VerificationCase {
     }
 }
 
-/// T20 — hyperbolic orbit (e > 1).
+/// T20 — eccentric inclined (e=0.2, i≈45°, sma≈9223 km).
 pub fn t20() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t20",
@@ -279,7 +285,9 @@ pub fn t20() -> VerificationCase {
     }
 }
 
-/// T30 — near-parabolic orbit (e ≈ 1).
+/// T30 — orb_elem edge case (JEOD logs sma=0 with a valid 7.2 Mm
+/// Cartesian state; exercises a degenerate branch of the
+/// orbital-element extraction).
 pub fn t30() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t30",
@@ -295,7 +303,8 @@ pub fn t30() -> VerificationCase {
     }
 }
 
-/// T40 — retrograde orbit (i > 90°).
+/// T40 — orb_elem edge case with eccentricity (JEOD logs sma=0,
+/// e=0.2, i≈45°).
 pub fn t40() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t40",
@@ -311,7 +320,8 @@ pub fn t40() -> VerificationCase {
     }
 }
 
-/// T50 — equatorial orbit (i ≈ 0, RAAN degenerate).
+/// T50 — equatorial circular, extended log (same initial state as
+/// T01; fixture spans t=0..5000s).
 pub fn t50() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t50",
@@ -327,7 +337,7 @@ pub fn t50() -> VerificationCase {
     }
 }
 
-/// T55 — polar orbit (i ≈ 90°).
+/// T55 — ISS-like LEO (i≈51.7°, e≈0.0025, sma≈6733 km).
 pub fn t55() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbelem_comprehensive_t55",

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
@@ -85,13 +85,21 @@ fn load_verif_record(csv_name: &str) -> VerifRecord {
     }
 }
 
-/// Build the recipe's `Simulation` exactly the way the parity trait does
-/// — call the scenario factory with a default `InitialConditions` (the
-/// recipes don't read it — initial state is baked in from each case's
-/// JEOD-output t=0 row), then `.build()` — so the runner-side
+/// Build the recipe's `Simulation`.
+///
+/// Calls the scenario factory with a default `InitialConditions` and
+/// then `.build()`. Note: `VerificationCaseParityExt::run_and_assert_parity`
+/// derives `init` from `ref_states[0]` via `initial_conditions_from`
+/// (for `CsvReference::SyntheticTimes` that resolves to all-defaults
+/// anyway, so the two paths coincide today). Every recipe in this
+/// module ignores the passed `InitialConditions` — initial state is
+/// baked in from each case's JEOD-output t=0 row — so the runner-side
 /// propagation here and the Bevy-side propagation in
 /// `bevy_parity_orbelem_comprehensive.rs` see the same initial state
-/// bit-pattern.
+/// bit-pattern regardless of which `InitialConditions` is threaded in.
+/// If a future recipe in this module starts reading `init`, this
+/// helper would need to match what the parity trait does to keep the
+/// two sides in lockstep.
 fn build_sim(case: &VerificationCase) -> Simulation {
     (case.scenario)(&InitialConditions::default())
         .build()

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
@@ -351,7 +351,7 @@ fn tier3_simulation_orbelem_t01() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t01(),
         "orbelem_verif_t01_orbelem.csv",
-        "T01 circular (e~0)",
+        "T01 equatorial circular (e=0, i=0)",
         false,
     );
 }
@@ -361,7 +361,7 @@ fn tier3_simulation_orbelem_t10() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t10(),
         "orbelem_verif_t10_orbelem.csv",
-        "T10 eccentric (0<e<1)",
+        "T10 inclined near-circular (i=30deg, e~0)",
         false,
     );
 }
@@ -371,7 +371,7 @@ fn tier3_simulation_orbelem_t20() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t20(),
         "orbelem_verif_t20_orbelem.csv",
-        "T20 hyperbolic (e>1)",
+        "T20 eccentric inclined (e=0.2, i=45deg)",
         false,
     );
 }
@@ -381,7 +381,7 @@ fn tier3_simulation_orbelem_t30() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t30(),
         "orbelem_verif_t30_orbelem.csv",
-        "T30 near-parabolic (e~1)",
+        "T30 orb_elem edge case (sma=0 output, i=30deg)",
         true,
     );
 }
@@ -391,7 +391,7 @@ fn tier3_simulation_orbelem_t40() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t40(),
         "orbelem_verif_t40_orbelem.csv",
-        "T40 retrograde (i>90deg)",
+        "T40 orb_elem edge case (sma=0 output, e=0.2, i=45deg)",
         true,
     );
 }
@@ -401,7 +401,7 @@ fn tier3_simulation_orbelem_t50() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t50(),
         "orbelem_verif_t50_orbelem.csv",
-        "T50 equatorial (i~0)",
+        "T50 equatorial circular extended log (same as T01, fixture spans 5000s)",
         false,
     );
 }
@@ -411,7 +411,7 @@ fn tier3_simulation_orbelem_t55() {
     verify_orbit_family(
         sim_orbelem_comprehensive::t55(),
         "orbelem_verif_t55_orbelem.csv",
-        "T55 polar (i~90deg)",
+        "T55 ISS-like LEO (i=51.7deg, e=0.0025)",
         false,
     );
 }

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
@@ -1,23 +1,23 @@
 //! Tier 3: SIM_orb_elem comprehensive -- 7 orbit families via Simulation pipeline
 //!
-//! Creates a `Simulation` for each orbit family, adds a body with
-//! `orbital_elements_source` configured, steps once to trigger derived-state
-//! computation, and compares orbital elements against JEOD reference.
+//! Builds each scenario through its `sim_orbelem_comprehensive` recipe,
+//! propagates for the recipe's declared `SyntheticTimes` cadence (one
+//! tiny-dt step), and compares the resulting orbital elements against
+//! the JEOD-logged columns at t=0.
+//!
+//! The `Simulation` construction lives in the
+//! `sim_orbelem_comprehensive` recipe module so the parity wrapper
+//! (`bevy_parity_orbelem_comprehensive.rs`) can drive the same scenarios
+//! through the Bevy adapter for the `runner ↔ bevy` half of the
+//! transitivity argument.
 
 use astrodyn::recipes::helpers::state_helpers::angle_diff;
+use astrodyn_runner::builder::SimulationBuilderExt;
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_orbelem_comprehensive;
 use astrodyn_verif_jeod::tier3_csv::test_data_path;
-
-use astrodyn::{DerivedStateConfig, GravitySourceEntry, VehicleConfig};
-use astrodyn::{
-    GravityControl, GravityControls, GravityGradient, GravityModel, GravitySource, SimulationTime,
-    TranslationalState,
-};
-use astrodyn_runner::{RotationModel, Simulation};
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 use glam::DVec3;
-
-fn load_mu_earth() -> f64 {
-    astrodyn::gravity_fixtures::load_ggm05c().mu
-}
 
 /// Full record parsed from the verification CSV (all 21 columns).
 struct VerifRecord {
@@ -85,6 +85,34 @@ fn load_verif_record(csv_name: &str) -> VerifRecord {
     }
 }
 
+/// Build the recipe's `Simulation` exactly the way the parity trait does
+/// — call the scenario factory with a default `InitialConditions` (the
+/// recipes don't read it — initial state is baked in from each case's
+/// JEOD-output t=0 row), then `.build()` — so the runner-side
+/// propagation here and the Bevy-side propagation in
+/// `bevy_parity_orbelem_comprehensive.rs` see the same initial state
+/// bit-pattern.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
+}
+
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_orbelem_comprehensive` uses this
+/// variant because the orbelem verification CSVs are initialization-only
+/// (one row at t=0); panicking on any other variant surfaces a future
+/// recipe-shape drift here rather than producing a silently-truncated
+/// propagation. Returning both halves of the cadence lets callers
+/// assert that the `dt` they're stepping at (`sim.dt`) matches the
+/// cadence the recipe declared.
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
+    match &case.reference {
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
+}
+
 fn assert_close(name: &str, computed: f64, reference: f64, rel_tol: f64, abs_tol: f64) {
     let diff = (computed - reference).abs();
     let tol = if reference.abs() > abs_tol {
@@ -108,62 +136,55 @@ fn assert_angle_close(name: &str, computed: f64, reference: f64, abs_tol: f64) {
     );
 }
 
-/// Create a Simulation, add body with orbital_elements derived state, step once,
-/// and compare orbital elements against JEOD reference.
-fn verify_orbit_family(csv_name: &str, label: &str, skip_degenerate_scalars: bool) {
-    let mu_earth = load_mu_earth();
+/// Build a Simulation from the recipe, propagate for the declared
+/// SyntheticTimes cadence, and compare orbital elements against the
+/// JEOD-logged t=0 row from `csv_name`. The recipe's baked-in initial
+/// state is cross-checked against the CSV's position/velocity so a
+/// future recipe-side edit can't silently drift away from the
+/// JEOD-source values.
+fn verify_orbit_family(
+    case: VerificationCase,
+    csv_name: &str,
+    label: &str,
+    skip_degenerate_scalars: bool,
+) {
     let rec = load_verif_record(csv_name);
 
-    // Create Simulation with Earth point-mass gravity
-    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-    // Use tiny dt so one step barely changes the state.
-    // dt=1e-9 keeps position drift below 1e-5 m.
-    let mut sim = Simulation::new(time, 1e-9);
-
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_earth,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
 
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: rec.position,
-            velocity: rec.velocity,
-        }),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        derived: DerivedStateConfig {
-            orbital_elements_source: Some(earth),
-            ..Default::default()
-        },
-        ..Default::default()
-    });
+    // Fence: the recipe's baked-in state must reproduce the JEOD-logged
+    // t=0 row to f64 precision. A future edit that tweaks recipe-side
+    // numbers will trip this check first instead of silently changing
+    // what the parity wrapper integrates.
+    let body0 = sim.body(0);
+    let init_pos = body0.trans.position.raw_si();
+    let init_vel = body0.trans.velocity.raw_si();
+    let pos_drift = (init_pos - rec.position).length();
+    let vel_drift = (init_vel - rec.velocity).length();
+    assert!(
+        pos_drift < 1e-6,
+        "{label}: recipe init position drifted from CSV by {pos_drift:.6e} m"
+    );
+    assert!(
+        vel_drift < 1e-9,
+        "{label}: recipe init velocity drifted from CSV by {vel_drift:.6e} m/s"
+    );
 
-    sim.validate().unwrap();
-
-    // Step once to trigger derived-state computation (stage 9)
-    sim.step().expect("step failed");
+    // `step_n` advances exactly `n_steps` whole steps. (`step_until`
+    // has a 1 ms slop and may stop one step short.)
+    sim.step_n(n_steps).expect("step_n failed");
 
     let output = sim.body(0);
     let oe = output
         .orbital_elements
         .as_ref()
-        .unwrap_or_else(|| panic!("{label}: orbital_elements not computed after step()"));
+        .unwrap_or_else(|| panic!("{label}: orbital_elements not computed after propagation"));
 
     println!("Tier 3 (Simulation): {label}");
     println!(
@@ -317,12 +338,18 @@ fn verify_orbit_family(csv_name: &str, label: &str, skip_degenerate_scalars: boo
 
 #[test]
 fn tier3_simulation_orbelem_t01() {
-    verify_orbit_family("orbelem_verif_t01_orbelem.csv", "T01 circular (e~0)", false);
+    verify_orbit_family(
+        sim_orbelem_comprehensive::t01(),
+        "orbelem_verif_t01_orbelem.csv",
+        "T01 circular (e~0)",
+        false,
+    );
 }
 
 #[test]
 fn tier3_simulation_orbelem_t10() {
     verify_orbit_family(
+        sim_orbelem_comprehensive::t10(),
         "orbelem_verif_t10_orbelem.csv",
         "T10 eccentric (0<e<1)",
         false,
@@ -332,6 +359,7 @@ fn tier3_simulation_orbelem_t10() {
 #[test]
 fn tier3_simulation_orbelem_t20() {
     verify_orbit_family(
+        sim_orbelem_comprehensive::t20(),
         "orbelem_verif_t20_orbelem.csv",
         "T20 hyperbolic (e>1)",
         false,
@@ -341,6 +369,7 @@ fn tier3_simulation_orbelem_t20() {
 #[test]
 fn tier3_simulation_orbelem_t30() {
     verify_orbit_family(
+        sim_orbelem_comprehensive::t30(),
         "orbelem_verif_t30_orbelem.csv",
         "T30 near-parabolic (e~1)",
         true,
@@ -350,6 +379,7 @@ fn tier3_simulation_orbelem_t30() {
 #[test]
 fn tier3_simulation_orbelem_t40() {
     verify_orbit_family(
+        sim_orbelem_comprehensive::t40(),
         "orbelem_verif_t40_orbelem.csv",
         "T40 retrograde (i>90deg)",
         true,
@@ -359,6 +389,7 @@ fn tier3_simulation_orbelem_t40() {
 #[test]
 fn tier3_simulation_orbelem_t50() {
     verify_orbit_family(
+        sim_orbelem_comprehensive::t50(),
         "orbelem_verif_t50_orbelem.csv",
         "T50 equatorial (i~0)",
         false,
@@ -368,6 +399,7 @@ fn tier3_simulation_orbelem_t50() {
 #[test]
 fn tier3_simulation_orbelem_t55() {
     verify_orbit_family(
+        sim_orbelem_comprehensive::t55(),
         "orbelem_verif_t55_orbelem.csv",
         "T55 polar (i~90deg)",
         false,

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbelem_comprehensive.rs
@@ -100,12 +100,14 @@ fn build_sim(case: &VerificationCase) -> Simulation {
 
 /// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
 /// reference. Every recipe in `sim_orbelem_comprehensive` uses this
-/// variant because the orbelem verification CSVs are initialization-only
-/// (one row at t=0); panicking on any other variant surfaces a future
-/// recipe-shape drift here rather than producing a silently-truncated
-/// propagation. Returning both halves of the cadence lets callers
-/// assert that the `dt` they're stepping at (`sim.dt`) matches the
-/// cadence the recipe declared.
+/// variant because the per-case assertions only need the JEOD-logged
+/// initial state (baked into the recipe directly), not the full
+/// fixture CSV — even though most CSVs do contain a handful of
+/// downstream rows (and t50 spans t=0..5000). Panicking on any other
+/// variant surfaces a future recipe-shape drift here rather than
+/// producing a silently-truncated propagation. Returning both halves
+/// of the cadence lets callers assert that the `dt` they're stepping
+/// at (`sim.dt`) matches the cadence the recipe declared.
 fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
     match &case.reference {
         CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_orbelem_comprehensive.rs
@@ -1,0 +1,49 @@
+//! Bevy ↔ runner parity for the SIM_OrbElem comprehensive sweep
+//! (`tier3_sim_orbelem_comprehensive`). Wrappers land as part of #389.
+//!
+//! The matching tier3 file builds each scenario through the runner,
+//! propagates a single tiny-dt step, and asserts per-orbital-element
+//! bounds on the resulting state against the JEOD-logged t=0 row. This
+//! file pairs each recipe with the parity trait so the same scenarios
+//! also run through the Bevy adapter and assert `runner ↔ bevy`
+//! bit-identity at the synthetic checkpoint — the second half of the
+//! `runner ↔ JEOD ≈ bevy` transitivity argument the issue's matrix
+//! covers.
+
+use astrodyn_verif_jeod::run_verification::sim_orbelem_comprehensive;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t01() {
+    sim_orbelem_comprehensive::t01().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t10() {
+    sim_orbelem_comprehensive::t10().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t20() {
+    sim_orbelem_comprehensive::t20().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t30() {
+    sim_orbelem_comprehensive::t30().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t40() {
+    sim_orbelem_comprehensive::t40().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t50() {
+    sim_orbelem_comprehensive::t50().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbelem_comprehensive_t55() {
+    sim_orbelem_comprehensive::t55().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -172,11 +172,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          per-step state component on the Bevy side",
     ),
     (
-        "orbelem_comprehensive",
-        "pre-recipe sibling — comprehensive sweep recipe not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "orbinit_docker",
         "pre-recipe sibling exercising orbital-element initialization — \
          recipe factory not yet defined (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Extract the inline `Simulation` construction in `tier3_sim_orbelem_comprehensive` into a new `sim_orbelem_comprehensive` recipe module (7 factories: `t01`, `t10`, `t20`, `t30`, `t40`, `t50`, `t55`). Each factory pairs the builder with `CsvReference::SyntheticTimes`.
- Add `bevy_parity_orbelem_comprehensive.rs` with one wrapper per recipe. All 7 wrappers pass `f64::to_bits` parity at every record.
- Drop the `orbelem_comprehensive` entry from `KNOWN_PARITY_GAPS`.

References #389 (the meta-issue tracks many more gaps — no closing keyword).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_orbelem_comprehensive` (7/7 pass bit-identically)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` (meta-test green)
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_orbelem_comprehensive` (7/7 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)