### PR TITLE
[#389] Extract relative_extended recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -40,6 +40,7 @@ pub mod sim_orbinit_roundtrip;
 pub mod sim_planetary;
 pub mod sim_polar_motion;
 pub mod sim_relative;
+pub mod sim_relative_extended;
 pub mod sim_solar_beta;
 pub mod sim_solar_beta_extended;
 pub mod sim_srp;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_relative_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_relative_extended.rs
@@ -1,0 +1,398 @@
+//! `VerificationCase` constructors for the extended relative-dynamics
+//! analytical family (`tier3_sim_relative_extended`).
+//!
+//! These cases have no JEOD reference CSV — they exercise closed-form
+//! identities of [`astrodyn::compute_relative_state`] and
+//! [`astrodyn::compute_lvlh_relative_state_typed`] by spawning two
+//! orbital bodies around a point-mass Earth and propagating through
+//! `Simulation::step()` for a multi-period scan. Each recipe shares the
+//! same Earth-point-mass + LVLH-derived-state scaffolding; only the
+//! per-case body pair (positions, velocities, and which derived states
+//! are enabled) and the propagation cadence differ, so the per-case
+//! factories all delegate to a shared `build_relative_extended`
+//! constructor and pair the resulting [`SimulationBuilder`] with
+//! [`CsvReference::SyntheticTimes`] for the parity trait's lockstep
+//! `runner ↔ bevy` bit-identity assertion.
+//!
+//! The matching analytical assertions live in
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_relative_extended.rs`;
+//! each tier3 test pulls one or more recipes' scenario factories, builds
+//! the `Simulation`, propagates, and asserts the closed-form relative-
+//! state property. Splitting the scenario into a recipe is what makes
+//! the parity wrapper possible — the bridge needs an adapter-neutral
+//! `SimulationBuilder` to materialize, and a hand-rolled tier3 test
+//! that constructs a `Simulation` directly has no bridge entry point.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::{
+    default_leap_second_table, DerivedStateConfig, GravityControl, GravityControls,
+    GravityGradient, GravityModel, GravitySource, GravitySourceEntry, RotationModel,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
+};
+use glam::DVec3;
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Reference radius for the LEO recipes — 400 km altitude above the
+/// equatorial Earth radius. Matches the constant the pre-recipe tier3
+/// file used so the recipe and the closed-form assertion drive the
+/// identical initial state.
+const R_LEO_M: f64 = 6_778_137.0;
+
+/// Default integrator step size shared by all but the inclination
+/// recipe. Matches the value the pre-recipe tier3 file used so the
+/// SyntheticTimes cadence drives identical integration ticks across
+/// runner and bevy.
+const DT_DEFAULT_S: f64 = 10.0;
+
+/// Tighter step size for the inclined-orbit recipe. The pre-recipe
+/// tier3 file used 5 s here (versus 10 s for the others) so the
+/// cross-track amplitude assertion (`< 1 m` against the analytical
+/// `r * sin(i)`) stays well above the RK4 truncation floor; keep that
+/// value to preserve the same numerical regime under parity.
+const DT_INCLINATION_S: f64 = 5.0;
+
+fn load_mu_earth() -> f64 {
+    // Cache the decoded `mu` for the lifetime of the test process.
+    // The fixture decode parses the entire GGM05C coefficient table
+    // (~12 KiB serialized) just to read a single scalar; without
+    // caching, every `*_num_steps()` and every `build_*` call would
+    // pay that cost again, noticeably inflating the parity/tier3
+    // suite. The decoded `mu` is a pure function of the embedded
+    // bytes, so caching is sound.
+    static MU_EARTH: std::sync::OnceLock<f64> = std::sync::OnceLock::new();
+    *MU_EARTH.get_or_init(|| astrodyn::gravity_fixtures::load_ggm05c().mu)
+}
+
+/// Closed-form circular-orbit period for radius `r` and gravitational
+/// parameter `mu`. Used to size SyntheticTimes cadences for the
+/// multi-period scans.
+fn period_s(mu_earth: f64, r: f64) -> f64 {
+    2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt()
+}
+
+/// Shared scenario builder for every recipe. Parameterised by:
+///   * `mu_earth` — Earth's gravitational parameter (point-mass);
+///   * `dt` — integrator timestep (one of `DT_DEFAULT_S` or
+///     `DT_INCLINATION_S` in this family);
+///   * `trans_chief` / `trans_deputy` — the two bodies' initial
+///     translational states;
+///   * `lvlh` — whether to enable the LVLH derived state on body 0
+///     (only the co-orbiting recipe consumes it; the others read raw
+///     inertial positions for their analytical assertions).
+///
+/// Both bodies are spawned point-mass-only (no rotation, no mass) under
+/// the same Earth source so the integration frame is
+/// `PlanetInertial<Earth>` and parity holds without rotational-state
+/// columns to compare.
+fn build_relative_extended(
+    mu_earth: f64,
+    dt: f64,
+    trans_chief: TranslationalState,
+    trans_deputy: TranslationalState,
+    lvlh: bool,
+) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_earth,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&trans_chief),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        derived: DerivedStateConfig {
+            lvlh,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&trans_deputy),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        derived: DerivedStateConfig {
+            lvlh,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// Analytical recipes opt out of every runner-vs-JEOD tolerance group
+/// because they pair with [`CsvReference::SyntheticTimes`] and assert
+/// in-test against closed-form values rather than logged JEOD columns.
+/// The parity trait still asserts `runner ↔ bevy` bit-identity at every
+/// synthetic record.
+fn analytical_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+// ── Two co-orbiting vehicles (3 periods, LVLH derived state on) ──────
+
+fn two_coorbiting_vehicles_num_steps() -> usize {
+    // `.ceil()` so the cadence actually covers three full orbital
+    // periods — bare `as usize` would truncate and stop a few seconds
+    // short.
+    (3.0 * period_s(load_mu_earth(), R_LEO_M) / DT_DEFAULT_S).ceil() as usize
+}
+
+fn build_two_coorbiting_vehicles(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let r = R_LEO_M;
+    let v = (mu_earth / r).sqrt();
+
+    // Chief at (r, 0, 0), velocity +y.
+    let trans_chief = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    };
+    // Deputy 100 m "ahead" — offset by a tiny true anomaly Δν so that
+    // Δs ≈ r * Δν = 100 m, Δν = 100/r rad.
+    let dnu = 100.0 / r;
+    let trans_deputy = TranslationalState {
+        position: DVec3::new(r * dnu.cos(), r * dnu.sin(), 0.0),
+        velocity: DVec3::new(-v * dnu.sin(), v * dnu.cos(), 0.0),
+    };
+    build_relative_extended(mu_earth, DT_DEFAULT_S, trans_chief, trans_deputy, true)
+}
+
+/// Two vehicles on the same 400 km circular equatorial orbit with a
+/// small along-track Δν offset. In the chief's LVLH frame the deputy
+/// stays at an almost-constant along-track offset over 3 orbits — the
+/// analytical sibling asserts both the inertial separation bound and
+/// the LVLH along-track / out-of-plane components.
+pub fn two_coorbiting_vehicles() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_relative_two_coorbiting_vehicles",
+        scenario: build_two_coorbiting_vehicles,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_DEFAULT_S,
+            num_steps: two_coorbiting_vehicles_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Hohmann-shaped transfer geometry (one deputy period) ─────────────
+
+fn hohmann_transfer_geometry_num_steps() -> usize {
+    let mu_earth = load_mu_earth();
+    let r_chief = R_LEO_M;
+    let r_apo = 1.05 * r_chief;
+    let a_d = 0.5 * (r_chief + r_apo);
+    // Deputy semi-major axis sets the propagation horizon: one full
+    // deputy period brings it back to periapsis. `.ceil()` so the
+    // cadence covers the full period — bare truncation would stop a
+    // few seconds short and miss the apoapsis flyby.
+    (period_s(mu_earth, a_d) / DT_DEFAULT_S).ceil() as usize
+}
+
+fn build_hohmann_transfer_geometry(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let r_chief = R_LEO_M;
+    let v_chief = (mu_earth / r_chief).sqrt();
+
+    // Chief: circular at r_chief.
+    let trans_chief = TranslationalState {
+        position: DVec3::new(r_chief, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v_chief, 0.0),
+    };
+    // Deputy: periapsis at (r_chief, 0, 0), same direction of motion,
+    // apoapsis at r_apo = 1.05 * r_chief.
+    let r_apo = 1.05 * r_chief;
+    let a_d = 0.5 * (r_chief + r_apo);
+    let e_d = (r_apo - r_chief) / (r_apo + r_chief);
+    let v_peri = (mu_earth * (1.0 + e_d) / (a_d * (1.0 - e_d))).sqrt();
+    let trans_deputy = TranslationalState {
+        position: DVec3::new(r_chief, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v_peri, 0.0),
+    };
+    build_relative_extended(mu_earth, DT_DEFAULT_S, trans_chief, trans_deputy, false)
+}
+
+/// Chief in circular orbit at 400 km; deputy in a coplanar ellipse
+/// whose periapsis coincides with the chief's orbit. The analytical
+/// sibling asserts the inertial separation oscillates between the
+/// closed-form geometric bounds over one deputy period.
+pub fn hohmann_transfer_geometry() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_relative_hohmann_transfer_geometry",
+        scenario: build_hohmann_transfer_geometry,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_DEFAULT_S,
+            num_steps: hohmann_transfer_geometry_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Same-orbit 90° phase difference (2 periods) ──────────────────────
+
+fn same_orbit_phase_difference_num_steps() -> usize {
+    // `.ceil()` so the cadence covers two full periods — same
+    // rationale as the co-orbiting recipe.
+    (2.0 * period_s(load_mu_earth(), R_LEO_M) / DT_DEFAULT_S).ceil() as usize
+}
+
+fn build_same_orbit_phase_difference(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let r = R_LEO_M;
+    let v = (mu_earth / r).sqrt();
+
+    // Body A: at (r, 0, 0), velocity (0, v, 0).
+    let trans_a = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    };
+    // Body B: at (0, r, 0) [90° ahead], velocity (-v, 0, 0).
+    let trans_b = TranslationalState {
+        position: DVec3::new(0.0, r, 0.0),
+        velocity: DVec3::new(-v, 0.0, 0.0),
+    };
+    build_relative_extended(mu_earth, DT_DEFAULT_S, trans_a, trans_b, false)
+}
+
+/// Two vehicles in the same circular orbit, 90° apart in true anomaly.
+/// The analytical sibling asserts the chord length stays at
+/// `r * sqrt(2)` over two orbits (RK4 truncation floor is sub-mm at
+/// 10 s).
+pub fn same_orbit_phase_difference() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_relative_same_orbit_phase_difference",
+        scenario: build_same_orbit_phase_difference,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_DEFAULT_S,
+            num_steps: same_orbit_phase_difference_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Different inclinations (2 periods, 5 s cadence) ──────────────────
+
+fn different_inclinations_num_steps() -> usize {
+    // Tighter `DT_INCLINATION_S` keeps the cross-track amplitude
+    // assertion (< 1 m against the analytical `r * sin(i)`) above the
+    // RK4 truncation floor. `.ceil()` so the cadence covers two
+    // periods at the tighter step.
+    (2.0 * period_s(load_mu_earth(), R_LEO_M) / DT_INCLINATION_S).ceil() as usize
+}
+
+fn build_different_inclinations(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let r = R_LEO_M;
+    let v = (mu_earth / r).sqrt();
+    let inc = 1.0_f64.to_radians();
+
+    // Chief: equatorial.
+    let trans_chief = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    };
+    // Deputy: inclined +1° about +X, same initial position; rotation
+    // sends (0, v, 0) → (0, v cos i, v sin i).
+    let trans_deputy = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
+    };
+    build_relative_extended(mu_earth, DT_INCLINATION_S, trans_chief, trans_deputy, false)
+}
+
+/// Chief on equatorial circular orbit; deputy on the same circular
+/// orbit inclined by +1°. The analytical sibling asserts the
+/// cross-track separation amplitude matches `r * sin(i)` within 1 m
+/// over two orbital periods.
+pub fn different_inclinations() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_relative_different_inclinations",
+        scenario: build_different_inclinations,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_INCLINATION_S,
+            num_steps: different_inclinations_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Round-trip frames (one chief period) ─────────────────────────────
+
+fn round_trip_frames_num_steps() -> usize {
+    // `.ceil()` to fully cover one orbital period at the chief radius.
+    (period_s(load_mu_earth(), R_LEO_M) / DT_DEFAULT_S).ceil() as usize
+}
+
+fn build_round_trip_frames(_init: &InitialConditions) -> SimulationBuilder {
+    let mu_earth = load_mu_earth();
+    let r = R_LEO_M;
+    let v = (mu_earth / r).sqrt();
+
+    // Body 0 at (r, 0, 0); Body 1 in a different coplanar circular
+    // orbit 500 km further out.
+    let trans_a = TranslationalState {
+        position: DVec3::new(r, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    };
+    let r2 = r + 500_000.0;
+    let v2 = (mu_earth / r2).sqrt();
+    let trans_b = TranslationalState {
+        position: DVec3::new(r2, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v2, 0.0),
+    };
+    build_relative_extended(mu_earth, DT_DEFAULT_S, trans_a, trans_b, false)
+}
+
+/// Two vehicles on coplanar circular orbits 500 km apart. The
+/// analytical sibling asserts `r_AB = -r_BA` and `v_AB = -v_BA`
+/// (relative-state operator symmetry when neither body carries a
+/// rotational state) at every checkpoint over one orbital period.
+pub fn round_trip_frames() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_relative_round_trip_frames",
+        scenario: build_round_trip_frames,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_DEFAULT_S,
+            num_steps: round_trip_frames_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_relative_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_relative_extended.rs
@@ -77,9 +77,14 @@ fn period_s(mu_earth: f64, r: f64) -> f64 {
 ///     `DT_INCLINATION_S` in this family);
 ///   * `trans_chief` / `trans_deputy` — the two bodies' initial
 ///     translational states;
-///   * `lvlh` — whether to enable the LVLH derived state on body 0
-///     (only the co-orbiting recipe consumes it; the others read raw
-///     inertial positions for their analytical assertions).
+///   * `lvlh_chief` — whether to enable the LVLH derived state on the
+///     chief (body 0). Only the co-orbiting recipe sets this; the
+///     others read raw inertial positions for their analytical
+///     assertions and leave the chief's LVLH unrequested. The deputy
+///     never carries an LVLH request because the LVLH frame in this
+///     family is always the chief's: `compute_lvlh_relative_state_typed`
+///     takes the chief as the reference body, and no test reads the
+///     deputy's own LVLH derived field.
 ///
 /// Both bodies are spawned point-mass-only (no rotation, no mass) under
 /// the same Earth source so the integration frame is
@@ -90,7 +95,7 @@ fn build_relative_extended(
     dt: f64,
     trans_chief: TranslationalState,
     trans_deputy: TranslationalState,
-    lvlh: bool,
+    lvlh_chief: bool,
 ) -> SimulationBuilder {
     let time = SimulationTime::at_j2000(default_leap_second_table());
     let mut sb = SimulationBuilder::new(time, dt);
@@ -118,7 +123,7 @@ fn build_relative_extended(
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         derived: DerivedStateConfig {
-            lvlh,
+            lvlh: lvlh_chief,
             ..Default::default()
         },
         ..Default::default()
@@ -128,10 +133,7 @@ fn build_relative_extended(
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        derived: DerivedStateConfig {
-            lvlh,
-            ..Default::default()
-        },
+        derived: DerivedStateConfig::default(),
         ..Default::default()
     });
     sb

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_relative_extended.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_relative_extended.rs
@@ -20,103 +20,62 @@
 //!   reference frame is inertial (no rotational state), confirming the
 //!   symmetry of the relative-state operator.
 //!
-//! No Docker reference data required. Earth mu is read from JEOD source.
+//! No Docker reference data required. The `Simulation` construction lives
+//! in the `sim_relative_extended` recipe module so the parity wrapper
+//! (`bevy_parity_relative_extended.rs`) can drive the same scenarios
+//! through the Bevy adapter for the `runner ↔ bevy` half of the
+//! transitivity argument.
 
 use astrodyn::{
-    compute_lvlh_relative_state_typed, compute_relative_state, Earth, GravityControl,
-    GravityControls, GravityGradient, GravityModel, GravitySource, PlanetInertial,
-    RelativeTranslation, SelfRef, SimulationTime, TranslationalState, Vec3Ext,
+    compute_lvlh_relative_state_typed, compute_relative_state, Earth, PlanetInertial,
+    RelativeTranslation, SelfRef, Vec3Ext,
 };
-use astrodyn::{DerivedStateConfig, GravitySourceEntry, VehicleConfig};
-use astrodyn_runner::{RotationModel, Simulation};
-use glam::DVec3;
+use astrodyn_runner::builder::SimulationBuilderExt;
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_relative_extended;
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 
-fn load_mu_earth() -> f64 {
-    astrodyn::gravity_fixtures::load_ggm05c().mu
+/// Build the recipe's `Simulation` exactly the way the parity trait does
+/// — call the scenario factory with a default `InitialConditions`, then
+/// `.build()` — so the runner-side propagation here and the Bevy-side
+/// propagation in `bevy_parity_relative_extended.rs` see the same
+/// initial state bit-pattern.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
 }
 
-/// Construct a Simulation with a single point-mass Earth at the origin and
-/// return `(sim, earth_source_idx)` for the caller to populate with bodies.
-fn make_earth_sim(dt: f64, mu_earth: f64) -> (Simulation, usize) {
-    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-    let mut sim = Simulation::new(time, dt);
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_earth,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::default(),
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
-    );
-    (sim, earth)
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_relative_extended` uses this variant
+/// because the family is analytical-only; panicking on any other
+/// variant surfaces a future recipe-shape drift here rather than
+/// producing a silently-truncated propagation. Returning both halves
+/// of the cadence lets callers assert that the `dt` they're stepping
+/// at (typically `sim.dt`) matches the cadence the recipe declared —
+/// catches a future edit that updates the builder dt but forgets the
+/// `SyntheticTimes` dt (or vice versa).
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
+    match &case.reference {
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
 }
 
-fn add_orbital_body(sim: &mut Simulation, earth: usize, trans: TranslationalState) {
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&trans),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        derived: DerivedStateConfig {
-            lvlh: true,
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-}
-
-// non-recipe: bespoke geometry — two vehicles on the same circular orbit
-// with a small along-track Δν offset. No recipe preset captures this pair.
 #[test]
 fn tier3_relative_two_coorbiting_vehicles() {
     // Two vehicles on the same 400 km circular equatorial orbit, separated by
     // a small along-track phase. In the chief's LVLH frame the deputy should
     // remain at an almost-constant along-track offset, up to truncation error
     // from the RK4 integrator at a 10 s step.
-    let mu_earth = load_mu_earth();
-    let dt = 10.0;
-    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
-
-    let r = 6_778_137.0; // ~400 km altitude
-    let v = (mu_earth / r).sqrt();
-
-    // Chief at (r, 0, 0), velocity +y
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v, 0.0),
-        },
+    let case = sim_relative_extended::two_coorbiting_vehicles();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
-
-    // Deputy 100 m "ahead" — i.e., offset by a tiny true anomaly Δν
-    // so that Δs ≈ r * Δν = 100 m, Δν = 100/r rad.
-    let dnu = 100.0 / r;
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r * dnu.cos(), r * dnu.sin(), 0.0),
-            velocity: DVec3::new(-v * dnu.sin(), v * dnu.cos(), 0.0),
-        },
-    );
-
-    sim.validate().unwrap();
-
-    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
-    let end_time = 3.0 * period;
-    let n_steps = (end_time / dt) as usize;
 
     let mut max_sep = 0.0_f64;
     let mut min_sep = f64::INFINITY;
@@ -204,47 +163,20 @@ fn tier3_relative_two_coorbiting_vehicles() {
     );
 }
 
-// non-recipe: chief circular + deputy ellipse with apoapsis at 1.05·r_chief;
-// hand-crafted Hohmann-shape geometry not in `recipes::orbital_elements`.
 #[test]
 fn tier3_relative_hohmann_transfer_geometry() {
     // Chief in circular orbit at 400 km; deputy in a coplanar ellipse whose
     // periapsis coincides with the chief's orbit (same r, same direction of
     // motion). The separation |r_deputy - r_chief| must oscillate because the
     // deputy climbs to apoapsis and falls back.
-    let mu_earth = load_mu_earth();
-    let dt = 10.0;
-    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
-
-    let r_chief = 6_778_137.0;
-    let v_chief = (mu_earth / r_chief).sqrt();
-
-    // Chief: circular
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r_chief, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v_chief, 0.0),
-        },
+    let case = sim_relative_extended::hohmann_transfer_geometry();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
-
-    // Deputy: periapsis at (r_chief, 0, 0), same direction of motion,
-    // apoapsis at r_apo = 1.05 * r_chief.
-    let r_apo = 1.05 * r_chief;
-    let a_d = 0.5 * (r_chief + r_apo);
-    let e_d = (r_apo - r_chief) / (r_apo + r_chief);
-    let v_peri = (mu_earth * (1.0 + e_d) / (a_d * (1.0 - e_d))).sqrt();
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r_chief, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v_peri, 0.0),
-        },
-    );
-
-    sim.validate().unwrap();
 
     // Initial separation: both bodies at the same point → 0.
     let body0 = sim.body(0);
@@ -258,10 +190,6 @@ fn tier3_relative_hohmann_transfer_geometry() {
         init_sep < 1e-9,
         "Hohmann setup: initial separation {init_sep} m should be 0"
     );
-
-    // Propagate for one deputy period so the deputy returns to its periapsis.
-    let period_d = 2.0 * std::f64::consts::PI * (a_d * a_d * a_d / mu_earth).sqrt();
-    let n_steps = (period_d / dt) as usize;
 
     let mut max_sep = 0.0_f64;
     // Track separation near apoapsis: at T_d/2, deputy is at (-r_apo, ..., 0).
@@ -290,6 +218,11 @@ fn tier3_relative_hohmann_transfer_geometry() {
         max_sep = max_sep.max(sep);
     }
 
+    // The recipe-encoded chief/apoapsis geometry: r_chief = 6_778_137 m,
+    // r_apo = 1.05 * r_chief. Reconstruct the bounds locally so the
+    // assertions match the recipe-driven initial state exactly.
+    let r_chief = 6_778_137.0_f64;
+    let r_apo = 1.05 * r_chief;
     // Upper bound: r_apo + r_chief (deputy-apoapsis, chief-antipode).
     // Lower bound on achievable max separation: r_apo - r_chief when they
     // happen to be co-radial at opposite points.
@@ -304,44 +237,26 @@ fn tier3_relative_hohmann_transfer_geometry() {
     );
 }
 
-// non-recipe: two-body 90° phase-difference geometry; setup is the assertion.
 #[test]
 fn tier3_relative_same_orbit_phase_difference() {
     // Two vehicles in the same circular orbit, 90° apart in true anomaly.
     // At t=0 their positions are on the same circle of radius r, subtending
     // 90° at Earth, so the chord length is r * sqrt(2). Because they share
     // the orbital period, this separation is preserved forever.
-    let mu_earth = load_mu_earth();
-    let dt = 10.0;
-    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
-
-    let r = 6_778_137.0;
-    let v = (mu_earth / r).sqrt();
-
-    // Body A: at (r, 0, 0), velocity (0, v, 0)
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v, 0.0),
-        },
+    let case = sim_relative_extended::same_orbit_phase_difference();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
 
-    // Body B: at (0, r, 0) [90° ahead], velocity (-v, 0, 0)
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(0.0, r, 0.0),
-            velocity: DVec3::new(-v, 0.0, 0.0),
-        },
-    );
-
-    sim.validate().unwrap();
-
+    // Recipe places both bodies on a 6_778_137 m circle 90° apart, so
+    // the expected chord is r * sqrt(2). Reconstruct locally so the
+    // assertion matches the recipe-encoded initial state exactly.
+    let r = 6_778_137.0_f64;
     let expected_sep = r * std::f64::consts::SQRT_2;
-    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
 
     let mut max_dev = 0.0_f64;
 
@@ -364,8 +279,6 @@ fn tier3_relative_same_orbit_phase_difference() {
         max_dev = max_dev.max((sep - expected_sep).abs());
     }
 
-    // Check every dt seconds over 2 orbits
-    let n_steps = (2.0 * period / dt) as usize;
     for step in 1..=n_steps {
         let t = step as f64 * dt;
         sim.step_until(t).expect("step_until failed");
@@ -393,47 +306,27 @@ fn tier3_relative_same_orbit_phase_difference() {
     );
 }
 
-// non-recipe: chief equatorial vs deputy at +1° inclination — bespoke
-// cross-track geometry test.
 #[test]
 fn tier3_relative_different_inclinations() {
     // Chief on equatorial circular orbit; deputy on the same circular orbit
     // inclined by +1° about the +X axis (i.e., node on the +X axis, AOL 0).
     // Both start at (r, 0, 0). Cross-track excursion (out-of-plane in chief's
     // frame) oscillates at the orbital period with amplitude r * sin(1°).
-    let mu_earth = load_mu_earth();
-    let dt = 5.0;
-    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
+    let case = sim_relative_extended::different_inclinations();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
+    );
 
-    let r = 6_778_137.0;
-    let v = (mu_earth / r).sqrt();
+    // Recipe places both bodies at (r, 0, 0) with the deputy's velocity
+    // tipped by +1° about +X. The expected cross-track amplitude is
+    // r * sin(i). Reconstruct locally so the assertion matches the
+    // recipe-encoded initial state exactly.
+    let r = 6_778_137.0_f64;
     let inc = 1.0_f64.to_radians();
-
-    // Chief: equatorial
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v, 0.0),
-        },
-    );
-
-    // Deputy: inclined, same initial position, velocity tipped into +Z
-    // by inc. Rotation about +X by +inc sends (0, v, 0) → (0, v cos i, v sin i).
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v * inc.cos(), v * inc.sin()),
-        },
-    );
-
-    sim.validate().unwrap();
-
-    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
-    let n_steps = (2.0 * period / dt) as usize;
     let expected_amplitude = r * inc.sin();
 
     let mut max_abs_z = 0.0_f64; // inertial Z separation (cross-track)
@@ -458,44 +351,19 @@ fn tier3_relative_different_inclinations() {
     );
 }
 
-// non-recipe: two orbits at different radii to verify r_AB = -r_BA symmetry;
-// the geometry is the test.
 #[test]
 fn tier3_relative_round_trip_frames() {
     // When neither body has a rotational state, the relative-state operator
     // has a clean symmetry: r_AB = -r_BA and v_AB = -v_BA. We verify this on
     // the propagated trajectory at several checkpoints.
-    let mu_earth = load_mu_earth();
-    let dt = 10.0;
-    let (mut sim, earth) = make_earth_sim(dt, mu_earth);
-
-    let r = 6_778_137.0;
-    let v = (mu_earth / r).sqrt();
-
-    // Body 0 at (r, 0, 0); Body 1 in a different coplanar circular orbit.
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v, 0.0),
-        },
+    let case = sim_relative_extended::round_trip_frames();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
-    let r2 = r + 500_000.0;
-    let v2 = (mu_earth / r2).sqrt();
-    add_orbital_body(
-        &mut sim,
-        earth,
-        TranslationalState {
-            position: DVec3::new(r2, 0.0, 0.0),
-            velocity: DVec3::new(0.0, v2, 0.0),
-        },
-    );
-
-    sim.validate().unwrap();
-
-    let period = 2.0 * std::f64::consts::PI * (r * r * r / mu_earth).sqrt();
-    let n_steps = (period / dt) as usize;
 
     let mut max_sum_pos = 0.0_f64;
     let mut max_sum_vel = 0.0_f64;

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_relative_extended.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_relative_extended.rs
@@ -1,0 +1,41 @@
+//! Bevy ↔ runner parity for the analytical extended relative-dynamics
+//! scenarios (`tier3_sim_relative_extended`). Wrappers land as part of
+//! #389.
+//!
+//! The matching tier3 file drives each scenario through the runner and
+//! asserts a closed-form relative-state property (co-orbiting LVLH
+//! separation bound, Hohmann-geometry separation oscillation, same-orbit
+//! 90° chord length, cross-track amplitude r·sin(i),
+//! r_AB = -r_BA symmetry). This file pairs each recipe with the parity
+//! trait so the same scenarios also run through the Bevy adapter and
+//! assert `runner ↔ bevy` bit-identity at every synthetic record — the
+//! second half of the `runner ↔ JEOD ≈ bevy` transitivity argument the
+//! issue's matrix covers.
+
+use astrodyn_verif_jeod::run_verification::sim_relative_extended;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_relative_extended_two_coorbiting_vehicles() {
+    sim_relative_extended::two_coorbiting_vehicles().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_relative_extended_hohmann_transfer_geometry() {
+    sim_relative_extended::hohmann_transfer_geometry().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_relative_extended_same_orbit_phase_difference() {
+    sim_relative_extended::same_orbit_phase_difference().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_relative_extended_different_inclinations() {
+    sim_relative_extended::different_inclinations().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_relative_extended_round_trip_frames() {
+    sim_relative_extended::round_trip_frames().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -177,11 +177,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          not yet defined (#389 follow-up)",
     ),
     (
-        "relative_extended",
-        "pre-recipe sibling (same family as `relative`) — needs new \
-         CsvReference variant; follow-up to #389",
-    ),
-    (
         "time_docker",
         "pre-recipe sibling exercising time-scale conversions — recipe \
          factory not yet defined (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Extract `tier3_sim_relative_extended`'s inline `Simulation` construction into a new `sim_relative_extended` recipe module with 5 factories (`two_coorbiting_vehicles`, `hohmann_transfer_geometry`, `same_orbit_phase_difference`, `different_inclinations`, `round_trip_frames`). Each factory spawns a point-mass Earth and two orbital bodies through a shared `build_relative_extended` constructor, then pairs the resulting `SimulationBuilder` with `CsvReference::SyntheticTimes` sized to the case's analytical horizon (1-3 orbital periods at the recipe's `dt`).
- Add `bevy_parity_relative_extended.rs` with one wrapper per recipe. All 5 wrappers pass `f64::to_bits` parity at every synthetic record, so the `runner ↔ bevy` half of the `runner ↔ JEOD ≈ bevy` transitivity argument now covers this family.
- Drop the `relative_extended` entry from `KNOWN_PARITY_GAPS` (the comment claimed "needs new CsvReference variant" but `CsvReference::SyntheticTimes` already exists and the new wrapper satisfies the superset invariant).
- The refactored tier3 test builds each scenario through the recipe factory, asserts the recipe's `SyntheticTimes` `dt` matches the built `Simulation`'s integrator dt, and keeps every closed-form analytical assertion (inertial/LVLH separation bounds, Hohmann-geometry oscillation, same-orbit 90° chord length, cross-track amplitude `r·sin(i)`, `r_AB = -r_BA` symmetry) with the original tolerances unchanged.

References #389 (the meta-issue tracks many more gaps - no closing keyword).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_relative_extended)'` (5/5 pass)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_relative_extended` (5/5 pass)
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (1481/1481 pass)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Generated with [Claude Code](https://claude.com/claude-code)