### PR TITLE
Add workflow_dispatch recovery path to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,22 @@ name: publish
 on:
   push:
     tags: ["v*"]
+  # Manual recovery path. After a partial publish (e.g. crates.io index
+  # propagation timeout halfway through the sequence), trigger with
+  # `--ref v<X.Y.Z>` so the tag-version verify step still binds to the
+  # release commit, and pass `from_crate` to skip crates the registry
+  # has already accepted.
+  workflow_dispatch:
+    inputs:
+      from_crate:
+        description: "Resume from this crate (leave empty to start at astrodyn_quantities)."
+        required: false
+        type: string
+      no_wait:
+        description: "Skip the post-publish sparse-index poll between crates."
+        required: false
+        type: boolean
+        default: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,9 +59,23 @@ jobs:
       - name: Publish workspace
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          FROM_CRATE: ${{ inputs.from_crate }}
+          NO_WAIT: ${{ inputs.no_wait }}
         # Invoke xtask directly rather than via the `cargo xtask`
         # alias — the alias lives in `.cargo/config.toml.example`,
         # which contributors copy locally but is intentionally not
         # checked in (it also sets JEOD_HOME / TRICK_HOME defaults
         # that don't belong on every machine).
-        run: cargo run --package xtask -- publish
+        #
+        # FROM_CRATE / NO_WAIT are unset for tag pushes (empty
+        # `inputs.*`) and only populated when triggered via
+        # `workflow_dispatch` for recovery.
+        run: |
+          args=()
+          if [ -n "$FROM_CRATE" ]; then
+            args+=("--from" "$FROM_CRATE")
+          fi
+          if [ "$NO_WAIT" = "true" ]; then
+            args+=("--no-wait")
+          fi
+          cargo run --package xtask -- publish "${args[@]}"


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to `.github/workflows/publish.yml` with optional `from_crate` and `no_wait` inputs that pass through to `cargo xtask publish`.
- Lets us resume a partially-completed release without re-publishing crates the registry already accepted.

## Motivation
The v0.1.0 tag push fired the publish workflow ([run 25709594835](https://github.com/simnaut/astrodyn/actions/runs/25709594835)). `astrodyn_quantities v0.1.0` uploaded successfully, but `wait_for_index` then timed out after the 5-minute cap waiting for the crates.io sparse index to serve it. The remaining 12 crates never ran. Re-triggering on the same tag would fail at step 1/13 because `astrodyn_quantities@0.1.0` is now on the registry — but xtask already supports `--from <crate> --no-wait` for exactly this, and the workflow just needed a way to invoke it.

## Recovery procedure (post-merge)
1. Move the `v0.1.0` tag to the merge commit on `main` (so the dispatched run picks up the patched workflow):
   ```bash
   git tag -f v0.1.0 <merge-sha>
   git push origin v0.1.0 --force
   ```
2. Trigger the recovery run:
   ```bash
   gh workflow run publish.yml --ref v0.1.0 \
     -f from_crate=astrodyn_math -f no_wait=true
   ```

## Test plan
- [ ] `actionlint` / GitHub's parser accepts the file (verified by `gh workflow view publish.yml` after merge).
- [ ] On tag push: `inputs.from_crate` is empty, `args` array is empty, `cargo run --package xtask -- publish` runs as before.
- [ ] On `workflow_dispatch` with `from_crate=astrodyn_math no_wait=true`: xtask receives `--from astrodyn_math --no-wait` and publishes crates 2–13.
- [ ] Tag-version verify step still binds correctly when dispatched with `--ref v<X.Y.Z>` (GITHUB_REF_NAME is the tag name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)