### PR TITLE
[#389] Add bevy_parity wrappers for drag_verif and drag_rot_verif

### DIFF
--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag_rot_verif.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag_rot_verif.rs
@@ -1,0 +1,23 @@
+//! Bevy ↔ runner parity for the SIM_dyncomp RUN_6B drag scenario with
+//! a non-identity structural-to-body rotation (1 kg sphere, point-mass
+//! gravity, MET atmosphere, Cd-based drag, 15° eigen rotation about
+//! [1,1,1]) — a topic-alias wrapper.
+//!
+//! The same `sim_dyncomp::run6b_drag_rotated_struct()` recipe is
+//! already exercised under `bevy_parity_dyncomp_run6.rs`, but the
+//! `parity_coverage` superset check matches tier3 topics against
+//! parity wrapper file stems using exact-or-prefix on
+//! `bevy_parity_<topic>`. The owning tier3 file
+//! (`tier3_sim_drag_rot_verif.rs`) canonicalizes to topic
+//! `drag_rot_verif`, which the `dyncomp_run6` group cannot satisfy by
+//! name. This file supplies the matching stem; asserting the same
+//! bit-identity twice is intentional and cheap relative to the cost
+//! of leaving a stale `KNOWN_PARITY_GAPS` entry in place.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_drag_rot_verif() {
+    sim_dyncomp::run6b_drag_rotated_struct().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag_verif.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag_verif.rs
@@ -1,0 +1,22 @@
+//! Bevy ↔ runner parity for the SIM_dyncomp RUN_6B drag aero-trajectory
+//! scenario (1 kg sphere, point-mass gravity, MET atmosphere with mean
+//! solar activity, Cd-based drag) — a topic-alias wrapper.
+//!
+//! The same `sim_dyncomp::run6b_drag_aero_traj()` recipe is already
+//! exercised under `bevy_parity_dyncomp_run6.rs`, but the
+//! `parity_coverage` superset check matches tier3 topics against
+//! parity wrapper file stems using exact-or-prefix on
+//! `bevy_parity_<topic>`. The owning tier3 file
+//! (`tier3_sim_drag_verif.rs`) canonicalizes to topic `drag_verif`,
+//! which the `dyncomp_run6` group cannot satisfy by name. This file
+//! supplies the matching stem; asserting the same bit-identity twice
+//! is intentional and cheap relative to the cost of leaving a stale
+//! `KNOWN_PARITY_GAPS` entry in place.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_drag_verif() {
+    sim_dyncomp::run6b_drag_aero_traj().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -146,17 +146,7 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
         "analytical drag verification — out of trait scope (no propagation)",
     ),
     (
-        "drag_rot_verif",
-        "pre-recipe sibling — drag-rotation recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "drag_ver",
-        "pre-recipe sibling — drag-family recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
-    (
-        "drag_verif",
         "pre-recipe sibling — drag-family recipe factory not yet defined \
          (#389 follow-up)",
     ),


### PR DESCRIPTION
## Summary

- The `drag_verif` and `drag_rot_verif` tier3 topics already drive recipes that are wrapped on the Bevy side: `sim_dyncomp::run6b_drag_aero_traj()` and `sim_dyncomp::run6b_drag_rotated_struct()` are both exercised under `bevy_parity_dyncomp_run6.rs`. The physics parity (`runner ↔ bevy` bit-identity at every reference-CSV checkpoint) is already verified for these scenarios.
- The `parity_coverage` superset check, however, keys off the parity-wrapper file stem using exact-or-prefix on `bevy_parity_<topic>`. The owning tier3 files canonicalize to topics `drag_verif` and `drag_rot_verif`, which the `dyncomp_run6` group cannot satisfy by name. Both entries therefore still sat in `KNOWN_PARITY_GAPS` with stale "recipe factory not yet defined" reasons that no longer apply.
- Add `bevy_parity_drag_verif.rs` and `bevy_parity_drag_rot_verif.rs` as topic-alias wrappers that call the same recipe factories through `VerificationCaseParityExt::run_and_assert_parity::<astrodyn::Earth>()`. Module docstrings explain that the alias exists for the topic matcher's file-name requirement and that asserting the same bit-identity twice is intentional and cheap.
- Drop both stale entries from `KNOWN_PARITY_GAPS`; the meta-test now catches any future regression without an explicit exemption.

References #389 (the meta-issue tracks many more gaps - no closing keyword).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_drag_verif) or test(bevy_parity_drag_rot_verif)'` (2/2 pass)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity_)'` (1198/1198 pass)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Generated with [Claude Code](https://claude.com/claude-code)