### PR TITLE
[#389] Extract force_torque_response recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -29,6 +29,7 @@
 pub mod sim_attach_detach_trajectory;
 pub mod sim_derived_state;
 pub mod sim_dyncomp;
+pub mod sim_force_torque_response;
 pub mod sim_gj;
 pub mod sim_kinematic_propagation;
 pub mod sim_lvlh_extended;
@@ -148,6 +149,14 @@ impl SimContext for Simulation {
 
     fn mark_kinematic_only(&mut self, child_idx: usize) {
         Simulation::mark_kinematic_only(self, child_idx);
+    }
+
+    fn set_body_external_force(&mut self, body_idx: usize, force: DVec3) {
+        Simulation::set_body_external_force(self, body_idx, force);
+    }
+
+    fn set_body_external_torque(&mut self, body_idx: usize, torque: DVec3) {
+        Simulation::set_body_external_torque(self, body_idx, torque);
     }
 }
 

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
@@ -1,0 +1,446 @@
+// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers (named-method opt-in; the implicit `From<RotationalState>` / `From<MassProperties>` bypass was removed in #397).
+//! `VerificationCase` constructors for the SIM_force_torque analytical
+//! family (`tier3_sim_force_torque_response`).
+//!
+//! JEOD's `models/dynamics/dyn_body/verif/SIM_force_torque/` is an
+//! empty-space test rig that verifies force and torque accumulation,
+//! non-transmitted forces, and the equations of motion. The recipes
+//! here cover the closed-form-checkable cases its `RUN_test/input.py`
+//! schedule exercises: F = m·a translation, τ = I·α rotation, the
+//! decoupling of CoM force from rotation, and the symmetric ±F impulse
+//! that returns a 3-DOF body to rest with a residual displacement.
+//!
+//! These cases have no JEOD reference CSV. Each recipe pairs with
+//! [`CsvReference::SyntheticTimes`] so the parity trait can assert
+//! `runner ↔ bevy` bit-identity at every synthetic record while the
+//! matching tier3 file asserts the closed-form analytical identity on
+//! the runner. The empty-space frame is built the same way the
+//! pre-recipe tier3 file did it: a `central: true` source with `mu=0`
+//! supplies a root frame the body never references (the body's
+//! `GravityControls` is empty), so the body responds only to its
+//! external force/torque inputs.
+//!
+//! The constant-force / constant-torque recipes set
+//! `VehicleConfig.external_force` / `external_torque` at scenario
+//! build time — the runner copies the value onto `SimBody`, the Bevy
+//! adapter inserts `ExternalForceC` / `ExternalTorqueC` on the body
+//! entity, and the load persists across every integration step
+//! without a `pre_step` hook. The symmetric-impulse recipe additionally
+//! installs a `pre_step` closure that flips the inertial-frame force
+//! sign at the midpoint record so the second half of the propagation
+//! decelerates the body back to rest.
+
+use crate::verification::{
+    CsvReference, InitialConditions, PreStepClosure, Tolerances, VerificationCase,
+};
+use astrodyn::{
+    default_leap_second_table, Force, GravityControls, GravityModel, GravitySource,
+    GravitySourceEntry, JeodQuat, MassProperties, RootInertial, RotationModel, RotationalState,
+    SimulationBuilder, SimulationTime, Torque, TranslationalState, VehicleConfig,
+};
+use glam::{DMat3, DVec3};
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Empty-space test mass shared by every recipe (kilograms). Matches the
+/// value the pre-recipe tier3 file used so the analytical assertions
+/// drive identical numerics under the recipe path.
+const MASS_KG: f64 = 100.0;
+
+/// Force-test integrator step (seconds). The pre-recipe tier3 file
+/// drove `tier3_force_constant_acceleration` and the symmetric-impulse
+/// test at `dt = 0.1` (RK4 is exact on the linear ODE so the step does
+/// not affect the analytical bound) — preserve it so the SyntheticTimes
+/// cadence drives identical integration ticks across runner and bevy.
+const DT_FORCE_S: f64 = 0.1;
+
+/// Torque-test integrator step (seconds). The pre-recipe tier3 file
+/// used `dt = 0.01` for the τ = I·α tests; tightening over the force
+/// step keeps the angular-velocity error well below the 1e-10
+/// tolerance.
+const DT_TORQUE_S: f64 = 0.01;
+
+/// Total propagation horizon for the constant-force / impulse cases
+/// (seconds). Pre-recipe `tier3_force_constant_acceleration` and
+/// `tier3_force_symmetric_impulse_returns_to_rest` both ran 10 s.
+const T_TOTAL_FORCE_S: f64 = 10.0;
+
+/// Total propagation horizon for the constant-torque case (seconds).
+const T_TOTAL_TORQUE_S: f64 = 10.0;
+
+/// Total propagation horizon for the decoupling cases (seconds). The
+/// pre-recipe test ran each of the three sub-sims for 5 s.
+const T_TOTAL_DECOUPLE_S: f64 = 5.0;
+
+/// Symmetric-impulse pivot point: the inertial-frame external force
+/// reverses sign exactly at `T_TOTAL_FORCE_S / 2`. Same value the
+/// pre-recipe `tier3_force_symmetric_impulse_returns_to_rest` used.
+const HALF_DURATION_S: f64 = 0.5 * T_TOTAL_FORCE_S;
+
+/// Inertia tensor for the torque-only / decoupling cases when the
+/// principal axes are equal (kg·m²). Matches the pre-recipe
+/// `tier3_force_and_torque_decoupled` body where `I_x = I_y = I_z = 10`.
+fn inertia_uniform() -> DMat3 {
+    DMat3::from_diagonal(DVec3::splat(10.0))
+}
+
+/// Inertia tensor for the constant-torque case. Matches
+/// `tier3_torque_constant_angular_acceleration` where the body has
+/// `diag(10, 20, 20)` so the closed-form rate is
+/// `omega_x = τ_x · t / I_x = 1 rad/s` after 10 s with `τ_x = 1 N·m`.
+fn inertia_torque() -> DMat3 {
+    DMat3::from_cols(
+        DVec3::new(10.0, 0.0, 0.0),
+        DVec3::new(0.0, 20.0, 0.0),
+        DVec3::new(0.0, 0.0, 20.0),
+    )
+}
+
+/// Closed-form synthetic-time cadence: number of `dt`-sized steps that
+/// span `t_total` seconds. The pre-recipe tier3 file used integer
+/// division (e.g. `(10.0 / 0.1) as usize`) — match that exactly so the
+/// recipe's record count is bit-identical to the loop count the
+/// pre-recipe `step_n` calls drove.
+fn num_steps(dt: f64, t_total: f64) -> usize {
+    (t_total / dt) as usize
+}
+
+/// Recipes opt out of every runner-vs-JEOD tolerance group: the
+/// tier3 file asserts closed-form analytical identities directly on
+/// the runner-side result (a = F/m, α = τ/I, decoupling, return-to-
+/// rest), and the parity trait asserts `runner ↔ bevy` bit-identity
+/// at every synthetic record without consulting these tolerances.
+fn analytical_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+/// A negligible gravity source kept in the frame tree but not
+/// referenced by any body. `Simulation` requires a root frame; using
+/// `central: true` with `mu = 0.0` gives us the frame without any
+/// gravitational effect. Mirrors the pre-recipe tier3 file's
+/// `add_dummy_central_source` helper exactly.
+fn add_dummy_central_source(sb: &mut SimulationBuilder) {
+    sb.add_source(
+        "central_point",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+}
+
+/// Shared 3-DOF scenario constructor for the constant-force and
+/// symmetric-impulse recipes. Builds an empty-space simulation with a
+/// single point-mass body at rest, with the given inertial-frame
+/// external force pre-set on `VehicleConfig.external_force` so the
+/// runner-side `SimBody.external_force` and the Bevy-side
+/// `ExternalForceC` start at identical values without a `pre_step`
+/// hook.
+fn build_free_body_3dof(dt: f64, external_force: DVec3) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    add_dummy_central_source(&mut sb);
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+        }),
+        rot: None,
+        mass: Some(super::typed_helpers::mass_typed(&MassProperties::new(
+            MASS_KG,
+        ))),
+        gravity_controls: GravityControls { controls: vec![] },
+        external_force: Force::<RootInertial>::from_raw_si(external_force),
+        ..Default::default()
+    });
+    sb
+}
+
+/// Shared 6-DOF scenario constructor for the constant-torque and
+/// decoupling recipes. Builds an empty-space simulation with a single
+/// rigid body at rest, with the given inertia tensor and any non-zero
+/// external force / body-frame torque pre-set on `VehicleConfig` so
+/// the integrator sees them on the first step.
+fn build_free_body_6dof(
+    dt: f64,
+    inertia: DMat3,
+    external_force: DVec3,
+    external_torque: DVec3,
+) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    add_dummy_central_source(&mut sb);
+    let mass_props = MassProperties::with_inertia(MASS_KG, inertia, DVec3::ZERO);
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+        }),
+        rot: Some(super::typed_helpers::rot_typed(&RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        })),
+        mass: Some(super::typed_helpers::mass_typed(&mass_props)),
+        gravity_controls: GravityControls { controls: vec![] },
+        compute_gravity_gradient: false,
+        external_force: Force::<RootInertial>::from_raw_si(external_force),
+        external_torque: Torque::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
+            external_torque,
+        ),
+        ..Default::default()
+    });
+    sb
+}
+
+// ── Test 1: F = m·a on a free body (constant force) ────────────────
+
+/// Inertial-frame force applied throughout the constant-acceleration
+/// recipe. Pre-recipe `tier3_force_constant_acceleration` used this
+/// arbitrary off-axis vector to exercise all three components.
+fn force_constant_acceleration_force() -> DVec3 {
+    DVec3::new(3.0, -2.0, 1.0)
+}
+
+fn build_force_constant_acceleration(_init: &InitialConditions) -> SimulationBuilder {
+    build_free_body_3dof(DT_FORCE_S, force_constant_acceleration_force())
+}
+
+/// 3-DOF point-mass at rest with a constant inertial-frame force.
+/// After 10 s the analytical sibling asserts `v = F·t/m` and
+/// `x = 0.5·F·t²/m` to RK4-roundoff (`< 1e-12` relative).
+pub fn force_constant_acceleration() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_constant_acceleration",
+        scenario: build_force_constant_acceleration,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_FORCE_S,
+            num_steps: num_steps(DT_FORCE_S, T_TOTAL_FORCE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Test 2: τ = I·α on a free body (constant torque) ───────────────
+
+/// Body-frame torque applied throughout the constant-α recipe. Pre-
+/// recipe `tier3_torque_constant_angular_acceleration` used a pure
+/// x-axis torque so the perpendicular axes stay at zero and the
+/// closed-form `omega_x = τ_x · t / I_x` check is the only nonzero
+/// component.
+fn torque_constant_torque() -> DVec3 {
+    DVec3::new(1.0, 0.0, 0.0)
+}
+
+fn build_torque_constant_angular_acceleration(_init: &InitialConditions) -> SimulationBuilder {
+    build_free_body_6dof(
+        DT_TORQUE_S,
+        inertia_torque(),
+        DVec3::ZERO,
+        torque_constant_torque(),
+    )
+}
+
+/// 6-DOF body at rest with a constant body-frame torque about its
+/// `x` axis (the larger principal axis is along `y` / `z`, so the
+/// inertial coupling is zero by construction). After 10 s the
+/// analytical sibling asserts `omega_x = τ_x · t / I_x = 1 rad/s` to
+/// RK4-roundoff and `omega_y`, `omega_z` stay below 1e-12 rad/s.
+pub fn torque_constant_angular_acceleration() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_torque_constant_angular_acceleration",
+        scenario: build_torque_constant_angular_acceleration,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_TORQUE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Test 3: force-at-CoM decouples translation and rotation ────────
+//
+// The pre-recipe tier3 file ran three sub-sims (force-only, torque-
+// only, both) and asserted decoupling between them. Each sub-sim
+// gets its own recipe factory here so the parity trait can drive
+// each through the bridge independently — the runner-vs-runner
+// algebraic comparisons in the tier3 file then read each recipe's
+// final body state to verify the decoupling identity.
+
+/// Force-only inertial-frame force for the decoupling family. Pre-
+/// recipe used a pure +x vector; preserving it so the closed-form
+/// `v_x = F·t/m` literal matches.
+fn decouple_force() -> DVec3 {
+    DVec3::new(2.0, 0.0, 0.0)
+}
+
+/// Torque-only body-frame torque for the decoupling family. Pre-
+/// recipe used a pure +z vector.
+fn decouple_torque() -> DVec3 {
+    DVec3::new(0.0, 0.0, 1.0)
+}
+
+fn build_force_and_torque_decoupled_force(_init: &InitialConditions) -> SimulationBuilder {
+    build_free_body_6dof(
+        DT_TORQUE_S,
+        inertia_uniform(),
+        decouple_force(),
+        DVec3::ZERO,
+    )
+}
+
+/// Sub-sim A: force-only 6-DOF body. Force at the CoM (no offset on
+/// the mass properties) should produce pure translation with zero
+/// induced angular velocity.
+pub fn force_and_torque_decoupled_force() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_and_torque_decoupled_force",
+        scenario: build_force_and_torque_decoupled_force,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_DECOUPLE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+fn build_force_and_torque_decoupled_torque(_init: &InitialConditions) -> SimulationBuilder {
+    build_free_body_6dof(
+        DT_TORQUE_S,
+        inertia_uniform(),
+        DVec3::ZERO,
+        decouple_torque(),
+    )
+}
+
+/// Sub-sim B: torque-only 6-DOF body. A pure body-frame torque should
+/// produce pure rotation with zero induced translation.
+pub fn force_and_torque_decoupled_torque() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_and_torque_decoupled_torque",
+        scenario: build_force_and_torque_decoupled_torque,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_DECOUPLE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+fn build_force_and_torque_decoupled_both(_init: &InitialConditions) -> SimulationBuilder {
+    build_free_body_6dof(
+        DT_TORQUE_S,
+        inertia_uniform(),
+        decouple_force(),
+        decouple_torque(),
+    )
+}
+
+/// Sub-sim C: both force and torque applied. The tier3 sibling asserts
+/// this run's translational state matches sub-sim A's and its
+/// rotational state matches sub-sim B's — equivalence of independent
+/// applications and joint application.
+pub fn force_and_torque_decoupled_both() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_and_torque_decoupled_both",
+        scenario: build_force_and_torque_decoupled_both,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_DECOUPLE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Test 4: symmetric ±F impulse pair returns body to rest ──────────
+
+/// Inertial-frame force the symmetric-impulse recipe applies in the
+/// first half of the propagation; the `pre_step` closure flips its
+/// sign at `t = HALF_DURATION_S`. Pre-recipe
+/// `tier3_force_symmetric_impulse_returns_to_rest` used a pure +x
+/// vector.
+fn impulse_force() -> DVec3 {
+    DVec3::new(5.0, 0.0, 0.0)
+}
+
+fn build_force_symmetric_impulse(_init: &InitialConditions) -> SimulationBuilder {
+    // Initial force is `+impulse_force()` — the `pre_step` factory
+    // flips it to `-impulse_force()` at the midpoint record.
+    build_free_body_3dof(DT_FORCE_S, impulse_force())
+}
+
+/// `pre_step` factory: flips body 0's inertial-frame external force
+/// from `+F` to `-F` exactly once, at the record that advances the
+/// simulation past the midpoint `t = HALF_DURATION_S`. The
+/// constant-+F initial value is wired through `VehicleConfig.external_force`
+/// in [`build_force_symmetric_impulse`] above, so the closure only
+/// needs to fire the single sign-flip event; the runner side mirrors
+/// the pre-recipe tier3 file's two `set_body_external_force` calls
+/// bracketing the propagation halves, and the Bevy side updates
+/// `ExternalForceC` through the parity trait's `BevySimContext` so
+/// both runtimes integrate identical sub-steps.
+fn impulse_pre_step(_init: &InitialConditions) -> PreStepClosure {
+    Box::new(move |sim, time_s: f64| {
+        let half_dt = 0.5 * DT_FORCE_S;
+        // Fire on the record advancing the sim from `HALF_DURATION_S`
+        // to `HALF_DURATION_S + DT_FORCE_S` — the runner's
+        // `set_body_external_force` call lands before
+        // `step_until(record.time)`, so the +F half integrates
+        // exactly `HALF_DURATION_S / DT_FORCE_S` steps and the -F
+        // half integrates the same count, matching the pre-recipe
+        // file's bracketing call shape.
+        if (time_s - (HALF_DURATION_S + DT_FORCE_S)).abs() < half_dt {
+            sim.set_body_external_force(0, -impulse_force());
+        }
+    })
+}
+
+/// 3-DOF body with a symmetric ±F impulse pair: +F for the first
+/// 5 s, then -F for the next 5 s. The tier3 sibling asserts the
+/// final velocity returns to zero (within roundoff) and the residual
+/// displacement matches the closed-form `2 · 0.5 · (F/m) · (T/2)²`.
+pub fn force_symmetric_impulse() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_symmetric_impulse_returns_to_rest",
+        scenario: build_force_symmetric_impulse,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_FORCE_S,
+            num_steps: num_steps(DT_FORCE_S, T_TOTAL_FORCE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: Some(impulse_pre_step),
+    }
+}

--- a/crates/astrodyn_verif_jeod/src/verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/verification/mod.rs
@@ -144,6 +144,45 @@ pub trait SimContext {
              (e.g. inserts KinematicChildC on the Bevy entity)"
         );
     }
+
+    /// Set body `body_idx`'s root-inertial external force, replacing
+    /// any previous value. Mirrors the runner's
+    /// `Simulation::set_body_external_force` — invoked from a
+    /// `pre_step` closure to schedule time-stamped external load
+    /// changes (impulse pairs, on/off pulses) without dropping out of
+    /// the recipe path.
+    ///
+    /// The default implementation panics with an explicit
+    /// "set_body_external_force not supported" message so existing
+    /// `SimContext` implementors stay source-compatible. Adapters
+    /// that own a body-force injection surface (runner's `SimBody`,
+    /// the Bevy adapter's `ExternalForceC` component) override this.
+    fn set_body_external_force(&mut self, body_idx: usize, force: DVec3) {
+        let _ = (body_idx, force);
+        panic!(
+            "set_body_external_force not supported by this SimContext implementation; \
+             provide a SimContext impl that mutates the adapter's external-load \
+             surface (e.g. ExternalForceC on the Bevy body entity)"
+        );
+    }
+
+    /// Set body `body_idx`'s body-frame external torque, replacing any
+    /// previous value. Mirrors the runner's
+    /// `Simulation::set_body_external_torque` — invoked from a
+    /// `pre_step` closure to schedule time-stamped torque changes.
+    ///
+    /// The default implementation panics with an explicit
+    /// "set_body_external_torque not supported" message so existing
+    /// `SimContext` implementors stay source-compatible. Adapters
+    /// that own a body-torque injection surface override this.
+    fn set_body_external_torque(&mut self, body_idx: usize, torque: DVec3) {
+        let _ = (body_idx, torque);
+        panic!(
+            "set_body_external_torque not supported by this SimContext implementation; \
+             provide a SimContext impl that mutates the adapter's external-load \
+             surface (e.g. ExternalTorqueC on the Bevy body entity)"
+        );
+    }
 }
 
 /// Closure type produced by a [`PreStepBuilder`]. Invoked once per

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_force_torque_response.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_force_torque_response.rs
@@ -1,134 +1,102 @@
-// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers (named-method opt-in; the implicit `From<RotationalState>` / `From<MassProperties>` bypass was removed in #397).
 //! Tier 3: Analytical verification of SIM_force_torque physics.
 //!
-//! JEOD's `dyn_body/verif/SIM_force_torque/` is an empty-space test rig that
-//! verifies force and torque accumulation, non-transmitted forces, and the
-//! equations of motion by scheduling time-stamped force/torque changes and
-//! checking that the body traces out a predictable trajectory.
+//! JEOD's `models/dynamics/dyn_body/verif/SIM_force_torque/` is an
+//! empty-space test rig that verifies force and torque accumulation,
+//! non-transmitted forces, and the equations of motion by scheduling
+//! time-stamped force/torque changes and checking that the body
+//! traces out a predictable trajectory.
 //!
-//! Our rig has no "empty space" ephemeris mode — instead we build a central
-//! gravity source that the body does not reference (empty `GravityControls`).
-//! With no gravity control applied, the body responds only to external
-//! force/torque, giving the same behavior as JEOD's EmptySpace mode for the
-//! purposes of these analytical checks.
+//! The scenario factories live in
+//! [`astrodyn_verif_jeod::run_verification::sim_force_torque_response`];
+//! each tier3 function below materializes one of those recipes
+//! through [`VerificationCaseExt::run_and_assert`] semantics by
+//! re-using the runner-side builder + propagation path, then reads
+//! body 0's final state and asserts the closed-form analytical
+//! identity that recipe targets. The matching `bevy_parity_*`
+//! wrapper drives the same recipes through the Bevy adapter and
+//! asserts `runner ↔ bevy` bit-identity at every synthetic record.
 //!
-//! JEOD scenario mapping (SIM_force_torque/SET_test/RUN_test/input.py):
+//! JEOD scenario mapping (`SIM_force_torque/SET_test/RUN_test/input.py`):
 //! - The scheduled `trick.add_read` blocks successively apply a z-axis
-//!   force that yields 1 m/s^2, 2 m/s^2, 3 m/s^2 on the composite body,
+//!   force that yields 1 m/s², 2 m/s², 3 m/s² on the composite body,
 //!   then play with non-transmitted forces, yaw/roll maneuvers, etc.
-//! - Our tests below pick out the three primary physics verifications in
-//!   that sim: uniform F/m translation, tau/I rotation, and independence
-//!   of the two when the force is applied at the center of mass.
+//! - The tests below pick out the four primary physics verifications
+//!   in that sim: uniform F/m translation, τ/I rotation, independence
+//!   of the two when the force is applied at the center of mass, and
+//!   the symmetric ±F impulse that returns the body to rest.
 
-use astrodyn::{
-    GravityControls, GravityModel, GravitySource, JeodQuat, MassProperties, RotationalState,
-    SimulationTime, TranslationalState,
-};
-use astrodyn::{GravitySourceEntry, VehicleConfig};
-use astrodyn_runner::{RotationModel, Simulation};
-use glam::{DMat3, DVec3};
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_force_torque_response;
+use astrodyn_verif_jeod::verification::{InitialConditions, VerificationCase};
 
-/// A negligible gravity source kept in the frame tree but not referenced by
-/// any body.  Simulation requires a root frame; using `central: true` with
-/// `mu=0` gives us the frame without any gravitational effect.
-fn add_dummy_central_source(sim: &mut Simulation) {
-    sim.add_source(
-        "central_point",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: 0.0,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
+use astrodyn::SimulationBuilder;
+use astrodyn_runner::builder::SimulationBuilderExt;
+use glam::DVec3;
+
+/// Materialize one of the recipes into a runtime `Simulation` and
+/// propagate it through every synthetic record (driving any `pre_step`
+/// closure in the process). Returns the post-propagation simulation so
+/// the test can read body 0's final state for its closed-form
+/// assertion. Mirrors the runner-side shape of
+/// [`astrodyn_verif_jeod::run_verification::VerificationCaseExt::run_and_assert`],
+/// minus the JEOD CSV comparison (none of these recipes pair with a
+/// real reference) and minus the tolerance asserts (each test asserts
+/// directly on the closed-form identity below).
+fn run_recipe(case: &VerificationCase) -> Simulation {
+    // Empty-space scenarios derive their initial conditions from the
+    // recipe constants, not from a JEOD CSV. Pass a default
+    // `InitialConditions` so the factory signature is satisfied
+    // without re-parsing anything; the recipe ignores the parameter.
+    let init = InitialConditions::default();
+    let sb: SimulationBuilder = (case.scenario)(&init);
+    let dt = sb.dt;
+    let mut sim = sb
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` failed validation: {e:?}", case.name));
+    let mut pre_step = case.pre_step.map(|builder| builder(&init));
+
+    let (sync_dt, num_steps) = match case.reference {
+        astrodyn_verif_jeod::verification::CsvReference::SyntheticTimes { dt, num_steps } => {
+            (dt, num_steps)
+        }
+        ref other => panic!(
+            "tier3_sim_force_torque_response: recipe `{}` reference must be \
+             SyntheticTimes; got {other:?}",
+            case.name
+        ),
+    };
+    assert_eq!(
+        sync_dt, dt,
+        "recipe `{}`: SyntheticTimes.dt ({sync_dt}) must match \
+         SimulationBuilder.dt ({dt}) so the closed-form analytical \
+         constants line up with the integration cadence",
+        case.name,
     );
-}
 
-/// Build an empty-space 3-DOF simulation with a single mass-only body.
-fn make_free_body_3dof(mass: f64, dt: f64) -> Simulation {
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
-    add_dummy_central_source(&mut sim);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: DVec3::ZERO,
-            velocity: DVec3::ZERO,
-        }),
-        rot: None,
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(MassProperties::new(mass)),
-        )),
-        gravity_controls: GravityControls { controls: vec![] },
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
+    for step in 1..=num_steps {
+        let t = (step as f64) * dt;
+        if let Some(hook) = pre_step.as_mut() {
+            hook(&mut sim, t);
+        }
+        sim.step()
+            .unwrap_or_else(|e| panic!("`{}`: step at t={t} failed: {e}", case.name));
+    }
     sim
 }
 
-/// Build an empty-space 6-DOF simulation with a single rigid body.
-fn make_free_body_6dof(mass: f64, inertia: DMat3, dt: f64) -> Simulation {
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
-    add_dummy_central_source(&mut sim);
+// ── Test 1: F = m·a on a free body ───────────────────────────────
 
-    let mass_props = MassProperties::with_inertia(mass, inertia, DVec3::ZERO);
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: DVec3::ZERO,
-            velocity: DVec3::ZERO,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: JeodQuat::identity(),
-                ang_vel_body: DVec3::ZERO,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
-        gravity_controls: GravityControls { controls: vec![] },
-        compute_gravity_gradient: false,
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-    sim
-}
-
-// ─── Test 1: F = m*a on a free body ───
-
-/// Constant force on a free body produces uniform acceleration a = F/m.
-/// After applying F for T seconds starting from rest:
-///   v(T) = F*T/m
-///   x(T) = 0.5 * F*T^2/m
-// non-recipe: SIM_force_torque uses 100 kg test masses and diag(10,20,20)
-// inertia for closed-form verification of F=m·a and τ=I·α. Analytical
-// constants don't match any recipe vehicle preset, and the constant-input
-// pattern is shorter than `force_torque_profiles::step_input` because
-// the on/off times here are step-count expressions, not test parameters.
+/// Constant force on a free body produces uniform acceleration
+/// `a = F/m`. After applying F for T seconds starting from rest:
+///   v(T) = F·T/m
+///   x(T) = 0.5 · F·T² / m
 #[test]
 fn tier3_force_constant_acceleration() {
-    let mass = 100.0; // kg
-    let dt = 0.1; // s
-    let t_total = 10.0; // s
-    let force = DVec3::new(3.0, -2.0, 1.0); // N (arbitrary direction)
+    let mass = 100.0;
+    let t_total = 10.0;
+    let force = DVec3::new(3.0, -2.0, 1.0);
 
-    let mut sim = make_free_body_3dof(mass, dt);
-    sim.set_body_external_force(0, force);
-    sim.step_n((t_total / dt) as usize).expect("step_n failed");
-
+    let sim = run_recipe(&sim_force_torque_response::force_constant_acceleration());
     let body = sim.body(0);
 
     let expected_v = force * t_total / mass;
@@ -156,33 +124,22 @@ fn tier3_force_constant_acceleration() {
     assert!(rel_x < 1.0e-12, "position rel err {rel_x:.3e}");
 }
 
-// ─── Test 2: tau = I*alpha on a symmetric body (constant torque) ───
+// ── Test 2: τ = I·α on a symmetric body (constant torque) ─────────
 
-/// Constant torque about a principal axis of a body with diagonal inertia:
-///   omega(T) = tau*T/I (on that axis; zero on others)
-///   theta(T) = 0.5 * tau*T^2/I
-/// For an initially aligned body, after 10 s with tau_x=1 N·m and I_x=10:
+/// Constant torque about a principal axis of a body with diagonal
+/// inertia:
+///   omega(T) = τ·T / I (on that axis; zero on others)
+///   theta(T) = 0.5 · τ·T² / I
+/// For an initially aligned body, after 10 s with `τ_x = 1 N·m` and
+/// `I_x = 10`:
 ///   omega_x = 1 rad/s, theta_x = 5 rad.
-// non-recipe: same analytical-mass setup as `tier3_force_constant_acceleration`.
 #[test]
 fn tier3_torque_constant_angular_acceleration() {
-    let mass = 100.0;
     let i_x = 10.0;
-    let i_y = 20.0;
-    let i_z = 20.0;
-    let inertia = DMat3::from_cols(
-        DVec3::new(i_x, 0.0, 0.0),
-        DVec3::new(0.0, i_y, 0.0),
-        DVec3::new(0.0, 0.0, i_z),
-    );
-    let dt = 0.01;
     let t_total = 10.0;
-    let tau = DVec3::new(1.0, 0.0, 0.0); // N·m about body x-axis
+    let tau = DVec3::new(1.0, 0.0, 0.0);
 
-    let mut sim = make_free_body_6dof(mass, inertia, dt);
-    sim.set_body_external_torque(0, tau);
-    sim.step_n((t_total / dt) as usize).expect("step_n failed");
-
+    let sim = run_recipe(&sim_force_torque_response::torque_constant_angular_acceleration());
     let body = sim.body(0);
     let omega = body.rot.as_ref().unwrap().ang_vel_body.raw_si();
 
@@ -195,8 +152,8 @@ fn tier3_torque_constant_angular_acceleration() {
 
     assert!(rel_err < 1.0e-10, "omega_x rel err {rel_err:.3e}");
 
-    // Perpendicular components stay zero (diagonal inertia, torque on principal
-    // axis, no initial rate).
+    // Perpendicular components stay zero (diagonal inertia, torque on
+    // principal axis, no initial rate).
     assert!(
         omega.y.abs() < 1.0e-12,
         "omega_y should be zero, got {}",
@@ -209,54 +166,33 @@ fn tier3_torque_constant_angular_acceleration() {
     );
 }
 
-// ─── Test 3: force at CoM decouples translation and rotation ───
+// ── Test 3: force at CoM decouples translation and rotation ────────
 
-/// When a force is applied through the center of mass and an independent
-/// torque is applied on the body, translation and rotation are decoupled:
-///   linear motion follows v = F*t/m regardless of torque
-///   angular motion follows omega = tau*t/I regardless of force
-// non-recipe: same analytical-mass setup as `tier3_force_constant_acceleration`.
+/// When a force is applied through the center of mass and an
+/// independent torque is applied on the body, translation and
+/// rotation are decoupled:
+///   linear motion follows v = F·t/m regardless of torque
+///   angular motion follows omega = τ·t/I regardless of force
 #[test]
 fn tier3_force_and_torque_decoupled() {
     let mass = 100.0;
-    let i_x = 10.0;
-    let i_y = 10.0;
     let i_z = 10.0;
-    let inertia = DMat3::from_cols(
-        DVec3::new(i_x, 0.0, 0.0),
-        DVec3::new(0.0, i_y, 0.0),
-        DVec3::new(0.0, 0.0, i_z),
-    );
-    let dt = 0.01;
     let t_total = 5.0;
-    let force = DVec3::new(2.0, 0.0, 0.0); // N along inertial x
-    let tau = DVec3::new(0.0, 0.0, 1.0); // N·m about body z
+    let force = DVec3::new(2.0, 0.0, 0.0);
+    let tau = DVec3::new(0.0, 0.0, 1.0);
 
     // Case A: only force.
-    let mut sim_a = make_free_body_6dof(mass, inertia, dt);
-    sim_a.set_body_external_force(0, force);
-    sim_a
-        .step_n((t_total / dt) as usize)
-        .expect("step_n failed");
+    let sim_a = run_recipe(&sim_force_torque_response::force_and_torque_decoupled_force());
     let v_a = sim_a.body(0).trans.velocity.raw_si();
     let omega_a = sim_a.body(0).rot.as_ref().unwrap().ang_vel_body.raw_si();
 
     // Case B: only torque.
-    let mut sim_b = make_free_body_6dof(mass, inertia, dt);
-    sim_b.set_body_external_torque(0, tau);
-    sim_b
-        .step_n((t_total / dt) as usize)
-        .expect("step_n failed");
+    let sim_b = run_recipe(&sim_force_torque_response::force_and_torque_decoupled_torque());
     let v_b = sim_b.body(0).trans.velocity.raw_si();
     let omega_b = sim_b.body(0).rot.as_ref().unwrap().ang_vel_body.raw_si();
 
     // Case C: both.
-    let mut sim_c = make_free_body_6dof(mass, inertia, dt);
-    sim_c.set_body_external_force(0, force);
-    sim_c.set_body_external_torque(0, tau);
-    sim_c
-        .step_n((t_total / dt) as usize)
-        .expect("step_n failed");
+    let sim_c = run_recipe(&sim_force_torque_response::force_and_torque_decoupled_both());
     let v_c = sim_c.body(0).trans.velocity.raw_si();
     let omega_c = sim_c.body(0).rot.as_ref().unwrap().ang_vel_body.raw_si();
 
@@ -290,48 +226,37 @@ fn tier3_force_and_torque_decoupled() {
         omega_a.length()
     );
 
-    // Absolute magnitudes match F=ma and tau=I*alpha analytical predictions.
+    // Absolute magnitudes match F=ma and τ=I·α analytical predictions.
     let expected_v_x = force.x * t_total / mass;
     let expected_omega_z = tau.z * t_total / i_z;
     assert!((v_a.x - expected_v_x).abs() < 1.0e-12);
     assert!((omega_b.z - expected_omega_z).abs() < 1.0e-12);
 }
 
-// ─── Test 4: symmetric +F/-F forcing returns body to rest with residual displacement ───
+// ── Test 4: symmetric +F/-F impulse pair returns body to rest ──────
 
-/// Mirrors JEOD's SIM_force_torque scheduling:
-///   From t=7 to t=9 apply force that reverses from +F to -F so that the
-///   net velocity change is zero after the symmetric impulse pair.
+/// Mirrors JEOD's SIM_force_torque scheduling: from `t=7` to `t=9`
+/// the input.py applies a force that reverses from +F to -F so the
+/// net velocity change is zero after the symmetric impulse pair.
 ///
-/// Here: 5 seconds at +F, then 5 seconds at -F. Velocity returns to zero,
-/// but position remains positive because the body continues to drift while
-/// decelerating; analytically, the final displacement is twice the position
-/// reached at `t = half_duration`. A symmetric triangle of acceleration is
-/// enough to assert that the body behaves linearly.
-// non-recipe: symmetric ±F impulse sequence verifies linearity; the
-// schedule is two `set_body_external_force` calls bracketing a
-// `step_n` count, simpler than instantiating a profile struct.
+/// Here: 5 seconds at +F, then 5 seconds at -F. Velocity returns to
+/// zero, but position remains positive because the body continues to
+/// drift while decelerating; analytically the final displacement is
+/// twice the position reached at `t = HALF_DURATION_S`. A symmetric
+/// triangle of acceleration is enough to assert the body behaves
+/// linearly.
 #[test]
 fn tier3_force_symmetric_impulse_returns_to_rest() {
     let mass = 100.0;
-    let dt = 0.1;
     let force = DVec3::new(5.0, 0.0, 0.0);
     let half_duration = 5.0;
 
-    let mut sim = make_free_body_3dof(mass, dt);
-    sim.set_body_external_force(0, force);
-    sim.step_n((half_duration / dt) as usize)
-        .expect("step_n failed");
-    let v_mid = sim.body(0).trans.velocity.raw_si();
-
-    sim.set_body_external_force(0, -force);
-    sim.step_n((half_duration / dt) as usize)
-        .expect("step_n failed");
-    let v_end = sim.body(0).trans.velocity.raw_si();
-    let x_end = sim.body(0).trans.position.raw_si();
+    let sim = run_recipe(&sim_force_torque_response::force_symmetric_impulse());
+    let body = sim.body(0);
+    let v_end = body.trans.velocity.raw_si();
+    let x_end = body.trans.position.raw_si();
 
     // Velocity should be back to zero within roundoff.
-    println!("  v_mid = {v_mid:?}");
     println!("  v_end = {v_end:?}");
     println!("  x_end = {x_end:?}");
     assert!(
@@ -341,10 +266,10 @@ fn tier3_force_symmetric_impulse_returns_to_rest() {
     );
 
     // Position must be nonzero (body has drifted).  Analytical:
-    //   v during [0,5]:  (F/m)*t peaks at v_mid = 0.25 m/s
-    //   x at t=5:        0.5 * a * 5^2 = 0.625 m
-    //   v during [5,10]: v_mid - (F/m)*(t-5), zero at t=10
-    //   x at t=10:       x(5) + v_mid*5 - 0.5*a*5^2 = 1.25 m
+    //   v during [0,5]:  (F/m)·t peaks at v_mid = 0.25 m/s
+    //   x at t=5:        0.5 · a · 5² = 0.625 m
+    //   v during [5,10]: v_mid - (F/m)·(t-5), zero at t=10
+    //   x at t=10:       x(5) + v_mid·5 - 0.5·a·5² = 1.25 m
     let expected_x = 2.0 * 0.5 * force.x / mass * half_duration * half_duration;
     let rel = (x_end.x - expected_x).abs() / expected_x;
     println!(

--- a/crates/astrodyn_verif_parity/src/bevy_context.rs
+++ b/crates/astrodyn_verif_parity/src/bevy_context.rs
@@ -46,12 +46,13 @@
 //! mid-step reentrant attach is structurally impossible.
 
 use astrodyn::{
-    FrameTransform, Planet, PlanetInertial, Position, RootInertial, SelfRef, StructuralFrame,
-    Vec3Ext,
+    BodyFrame, Force, FrameTransform, Planet, PlanetInertial, Position, RootInertial, SelfRef,
+    StructuralFrame, Torque, Vec3Ext,
 };
 use astrodyn_bevy::{
-    AttachEvent, DetachEvent, FrameEntityC, FrameTransC, KinematicChildC, MassChildOf,
-    SourceInertialPositionC, SourceInertialVelocityC, TidalConfigC, TranslationalStateC,
+    AttachEvent, DetachEvent, ExternalForceC, ExternalTorqueC, FrameEntityC, FrameTransC,
+    KinematicChildC, MassChildOf, SourceInertialPositionC, SourceInertialVelocityC, TidalConfigC,
+    TranslationalStateC,
 };
 use astrodyn_verif_jeod::verification::SimContext;
 use bevy::ecs::message::Messages;
@@ -395,6 +396,44 @@ impl<P: Planet> SimContext for BevySimContext<'_, P> {
             },
             KinematicChildC,
         ));
+    }
+
+    fn set_body_external_force(&mut self, body_idx: usize, force: DVec3) {
+        // Match the runner's `Simulation::set_body_external_force`
+        // bit-for-bit: overwrite the body's external-force component
+        // with the new value. The runner's storage frame is
+        // `RootInertial` (the recipe wires `external_force` typed
+        // against root-inertial on `VehicleConfig`), and the Bevy
+        // `ExternalForceC` carries the same phantom — so this is a
+        // direct typed write with no relabel.
+        let entity = self.body_entity(body_idx);
+        let typed = Force::<RootInertial>::from_raw_si(force);
+        // Auto-insert when missing: `populate_app` only inserts
+        // `ExternalForceC` when `VehicleConfig.external_force` is
+        // non-zero, so a scenario that starts with zero force but
+        // schedules a non-zero pulse needs the component installed
+        // here (mirrors the `SourceInertialVelocityC` auto-insert in
+        // `set_source_state` above).
+        if let Some(mut fc) = self.world.get_mut::<ExternalForceC>(entity) {
+            fc.0 = typed;
+        } else {
+            self.world.entity_mut(entity).insert(ExternalForceC(typed));
+        }
+    }
+
+    fn set_body_external_torque(&mut self, body_idx: usize, torque: DVec3) {
+        // Match the runner: overwrite the body's external-torque
+        // component with the new value. The torque carries the
+        // body-frame phantom against the runtime-resolved
+        // `SelfRef` vehicle wildcard (JEOD_INV: TS.01), same as
+        // `VehicleConfig.external_torque` and `ExternalTorqueC`.
+        let entity = self.body_entity(body_idx);
+        let typed = Torque::<BodyFrame<SelfRef>>::from_raw_si(torque);
+        if let Some(mut tc) = self.world.get_mut::<ExternalTorqueC>(entity) {
+            tc.0 = typed;
+        } else {
+            self.world.entity_mut(entity).insert(ExternalTorqueC(typed));
+        }
     }
 }
 

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_force_torque_response.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_force_torque_response.rs
@@ -1,0 +1,57 @@
+//! Bevy ↔ runner parity for the analytical SIM_force_torque scenarios
+//! (`tier3_sim_force_torque_response`).
+//!
+//! The matching tier3 file drives each scenario through the runner and
+//! asserts a closed-form analytical identity (F = m·a translation,
+//! τ = I·α rotation, the decoupling of CoM force from rotation, and
+//! the symmetric ±F impulse returning the body to rest). This file
+//! pairs each recipe with the parity trait so the same scenarios also
+//! run through the Bevy adapter and assert `runner ↔ bevy` bit-
+//! identity at every synthetic record — the second half of the
+//! `runner ↔ JEOD ≈ bevy` transitivity argument the issue's matrix
+//! covers.
+//!
+//! The symmetric-impulse wrapper exercises the new
+//! `SimContext::set_body_external_force` surface on both runtimes: the
+//! recipe's `pre_step` closure flips the inertial-frame force sign at
+//! the midpoint record, and the `BevySimContext` mirror writes the
+//! same value into `ExternalForceC` so both runtimes integrate
+//! bit-identical sub-steps through the rest of the propagation.
+
+use astrodyn_verif_jeod::run_verification::sim_force_torque_response;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_force_torque_response_force_constant_acceleration() {
+    sim_force_torque_response::force_constant_acceleration()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_force_torque_response_torque_constant_angular_acceleration() {
+    sim_force_torque_response::torque_constant_angular_acceleration()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_force_torque_response_force_and_torque_decoupled_force() {
+    sim_force_torque_response::force_and_torque_decoupled_force()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_force_torque_response_force_and_torque_decoupled_torque() {
+    sim_force_torque_response::force_and_torque_decoupled_torque()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_force_torque_response_force_and_torque_decoupled_both() {
+    sim_force_torque_response::force_and_torque_decoupled_both()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_force_torque_response_force_symmetric_impulse() {
+    sim_force_torque_response::force_symmetric_impulse().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -151,11 +151,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          (#389 follow-up)",
     ),
     (
-        "force_torque_response",
-        "pre-recipe sibling exercising external forces/torques — \
-         recipe factory not yet defined (#389 follow-up)",
-    ),
-    (
         "lsode",
         "pre-recipe sibling for LSODE integrator — recipe factory not yet \
          defined (#389 follow-up); LSODE integrator may need its own \


### PR DESCRIPTION
## Summary

- Extract `tier3_sim_force_torque_response`'s inline `Simulation` construction into a new `sim_force_torque_response` recipe module with six factories (`force_constant_acceleration`, `torque_constant_angular_acceleration`, `force_and_torque_decoupled_force`, `force_and_torque_decoupled_torque`, `force_and_torque_decoupled_both`, `force_symmetric_impulse`). Each factory pairs a `SimulationBuilder` (built around a `mu=0` central source so the body responds only to its external loads) with `CsvReference::SyntheticTimes` sized to the case's analytical horizon. Constant-force / constant-torque recipes wire the load through `VehicleConfig.external_force` / `external_torque` at scenario build time; the symmetric-impulse recipe additionally installs a `pre_step` closure that flips the inertial-frame force sign at the midpoint record.
- Extend `SimContext` with `set_body_external_force` / `set_body_external_torque` (default-panic bodies, source-compatible with existing implementors). The runner-side impl forwards to `Simulation::set_body_external_*`; the new Bevy-side impl on `BevySimContext` writes `ExternalForceC` / `ExternalTorqueC` on the body entity (auto-inserting when the recipe starts from zero, mirroring the `SourceInertialVelocityC` auto-insert pattern). The impulse recipe drives both runtimes through this surface in lockstep.
- Add `bevy_parity_force_torque_response.rs` with one wrapper per recipe (6 wrappers). All pass `f64::to_bits` parity at every synthetic record, so the `runner ↔ bevy` half of the `runner ↔ JEOD ≈ bevy` transitivity argument now covers this family.
- Drop `force_torque_response` from `KNOWN_PARITY_GAPS` in `parity_coverage.rs`.
- The refactored tier3 test materializes each recipe via a small local helper that mirrors the runner-side propagation shape (no JEOD CSV, no tolerance asserts — the closed-form analytical identities stay in the test source), reads body 0's final state, and asserts the F = m·a, τ = I·α, decoupling, and return-to-rest identities with the original tolerances unchanged.

References #389.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --tests --examples -- -D warnings -D deprecated\`
- [x] \`cargo nextest run -p astrodyn_verif_parity --test bevy_parity_force_torque_response\` (6/6 pass)
- [x] \`cargo nextest run -p astrodyn_verif_parity --test parity_coverage\`
- [x] \`cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_force_torque_response\` (4/4 pass)
- [x] \`cargo nextest run --workspace -E 'not test(tier3_)'\` (1489/1489 pass)
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps\`
- [x] \`scripts/check_no_escape_hatches.sh\`
- [x] \`cargo test -p astrodyn --test invariant_coverage\`

Generated with [Claude Code](https://claude.com/claude-code)