### PR TITLE
Bump publish-index-poll timeout from 5 to 15 minutes

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -628,13 +628,18 @@ fn publish(argv: Vec<String>) {
 // version (not just the name) is critical: on every publish after the
 // first, the crate name is already on the registry from a prior
 // version, so a name-only check would short-circuit while the index
-// is still serving stale metadata. Cap at 5 minutes — anything
-// longer is almost certainly a registry incident worth a human eye.
+// is still serving stale metadata. Cap at 15 minutes — both the
+// v0.1.0 and v0.1.1 releases hit the previous 5-min cap on the
+// first-crate poll, so the longer window covers the observed
+// sparse-index propagation tail. Anything beyond that is a registry
+// incident worth a human eye.
+const WAIT_FOR_INDEX_SECS: u64 = 900;
+
 fn wait_for_index(crate_name: &str, expected_version: &str) {
     use std::thread::sleep;
     use std::time::{Duration, Instant};
 
-    let deadline = Instant::now() + Duration::from_secs(300);
+    let deadline = Instant::now() + Duration::from_secs(WAIT_FOR_INDEX_SECS);
     let mut attempt = 0u32;
     eprintln!("publish: waiting for crates.io index to serve {crate_name} {expected_version}...");
     // `cargo search foo --limit 1` prints `foo = "x.y.z" # ...` for
@@ -654,8 +659,9 @@ fn wait_for_index(crate_name: &str, expected_version: &str) {
             }
         }
         if Instant::now() >= deadline {
+            let mins = WAIT_FOR_INDEX_SECS / 60;
             eprintln!(
-                "publish: timed out after 5 min waiting for {crate_name} {expected_version} \
+                "publish: timed out after {mins} min waiting for {crate_name} {expected_version} \
                  on the index. If `cargo publish` succeeded, you can resume with:\n\
                  \n    cargo xtask publish --from <next crate> --no-wait\n"
             );


### PR DESCRIPTION
## Summary
Widen the sparse-index propagation cap in `xtask::wait_for_index` from 5 minutes to 15. Both the v0.1.0 and v0.1.1 publish runs tripped the 5-min cap on the *first* crate of the release and had to be finished by a manual `workflow_dispatch` resume.

## Diff
`xtask/src/main.rs`:
- Extract the cap to a `WAIT_FOR_INDEX_SECS` constant (kept the error message in sync via `WAIT_FOR_INDEX_SECS / 60`).
- 300 → 900.

The backoff schedule (10s/10s/15s/20s/30s) is unchanged; only the deadline.

## Test plan
- [x] `cargo build -p xtask`
- [x] `cargo clippy -p xtask -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Real signal arrives on the next release — if a future tag push completes without a manual `workflow_dispatch` resume, the cap is doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)