### PR TITLE
[#389] Extract drag_6dof recipe + add bevy_parity wrapper

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod sim_attach_detach_trajectory;
 pub mod sim_derived_state;
+pub mod sim_drag_6dof;
 pub mod sim_dyncomp;
 pub mod sim_force_torque_response;
 pub mod sim_gj;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
@@ -72,10 +72,12 @@ const AREA_M2: f64 = 10.0;
 /// exponential atmosphere model and drives the assertion content.
 const DENSITY: f64 = 1e-12;
 
-/// Number of integration steps to cover one circular-orbit period at
-/// `R_ORBIT_M`. The pre-recipe tier3 file computed this with bare
-/// `as usize` truncation, so reproduce that convention here for
-/// bit-identical step counts.
+/// Number of integration steps to cover approximately one
+/// circular-orbit period at `R_ORBIT_M`, truncated to an integer number
+/// of `DT_S` ticks so the simulated duration is
+/// `floor(period / DT_S) * DT_S` (always ≤ one period). The pre-recipe
+/// tier3 file computed this with bare `as usize` truncation; reproduce
+/// that convention here for bit-identical step counts.
 fn num_steps_one_period() -> usize {
     let period = 2.0 * std::f64::consts::PI * (R_ORBIT_M.powi(3) / MU_EARTH).sqrt();
     (period / DT_S) as usize
@@ -105,17 +107,20 @@ fn build_drag_6dof(
             },
             position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
             velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            // Identity `t_inertial_pfix` + `RotationModel::None` +
-            // `planet_omega: 0.0` reproduces the previous
-            // `t_inertial_pfix: None` spherical-fallback semantics on
-            // the runner side bit-for-bit (the atmosphere kernel
-            // computes `IDENTITY * position == position` before the
-            // geodetic conversion, and no co-rotation wind is added);
-            // see the matching `PlanetFixedRotationC` spawn the bridge
-            // performs on the Bevy side. The Bevy atmosphere stage
-            // requires *some* `PlanetFixedRotationC` on the planet
-            // entity, so the runner has to publish the identity matrix
-            // for the bridge to lift across.
+            // The atmosphere kernel treats `t_inertial_pfix: None` as
+            // "position is already in planet-fixed coordinates" (it
+            // skips the inertial→pfix rotation and feeds the position
+            // straight into the geodetic conversion). For an
+            // Earth-inertial body that semantics is wrong — but with
+            // `RotationModel::None` + `planet_omega: 0.0` the only
+            // numerical effect of supplying `Some(IDENTITY)` instead
+            // of `None` is to make the kernel run `IDENTITY * position`
+            // (a no-op) before the geodetic conversion, with no
+            // co-rotation wind added either way. The runner therefore
+            // stays bit-identical to the previous `None`-based
+            // configuration on this scenario, while the Bevy atmosphere
+            // stage gets the `PlanetFixedRotationC` it requires on the
+            // planet entity for the bridge to lift across.
             t_inertial_pfix: Some(DMat3::IDENTITY),
             delta_c20: 0.0,
             rotation_model: RotationModel::None,

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
@@ -1,0 +1,303 @@
+//! `VerificationCase` constructors for the 6-DOF drag analytical family
+//! (`tier3_sim_drag_6dof`).
+//!
+//! These cases have no JEOD reference CSV — they exercise closed-form
+//! identities of the ballistic-drag model (constant `Cd·A` with a
+//! constant-density override) by propagating a spinning body in a
+//! 400 km circular orbit through `Simulation::step()` for one orbital
+//! period. Each recipe shares the same Earth-point-mass +
+//! exponential-atmosphere + constant-density scaffolding; only the
+//! initial attitude and angular velocity differ, so the per-case
+//! factories all delegate to a shared `build_drag_6dof` constructor and
+//! pair the resulting [`SimulationBuilder`] with
+//! [`CsvReference::SyntheticTimes`] for the parity trait's lockstep
+//! `runner ↔ bevy` bit-identity assertion.
+//!
+//! The matching analytical assertions live in
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs`; each tier3
+//! test pulls one or more recipes' scenario factories, builds the
+//! `Simulation`, propagates, and asserts the closed-form drag property
+//! (monotonic specific-orbital-energy loss; ballistic-drag attitude
+//! invariance). Splitting the scenario into a recipe is what makes the
+//! parity wrapper possible — the bridge needs an adapter-neutral
+//! `SimulationBuilder` to materialize, and a hand-rolled tier3 test
+//! that constructs a `Simulation` directly has no bridge entry point.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::{
+    default_leap_second_table, AtmosphereConfig, AtmosphereModel, DragConfig,
+    ExponentialAtmosphere, GravityControl, GravityControls, GravityGradient, GravityModel,
+    GravitySource, GravitySourceEntry, JeodQuat, MassProperties, RotationModel, RotationalState,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig,
+};
+use glam::{DMat3, DVec3};
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Earth gravitational parameter (m³/s²) — JEOD `earth_GGM05C.cc`.
+/// Inlined from `astrodyn::EARTH.shape` (rather than reaching into the
+/// gravity-fixture decode the way `sim_relative_extended` does) so that
+/// the recipe-driven `Simulation` reproduces the bit-pattern of the
+/// pre-recipe inline `make_6dof_drag_sim` constructor exactly. The two
+/// `mu` sources agree numerically today, but pinning the recipe to the
+/// same constant the test always used keeps the analytical assertions
+/// driving from a single value.
+const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
+
+/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
+const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
+
+/// Orbit radius for every recipe — 400 km altitude above the equatorial
+/// Earth radius. Matches the constant the pre-recipe tier3 file used so
+/// the recipe and the closed-form assertion drive the identical initial
+/// state.
+const R_ORBIT_M: f64 = R_EARTH + 400_000.0;
+
+/// Integrator step size shared by every recipe. Matches the value the
+/// pre-recipe tier3 file used so the SyntheticTimes cadence drives
+/// identical integration ticks across runner and bevy.
+const DT_S: f64 = 10.0;
+
+/// Vehicle mass (kg) — bespoke 1 t test geometry.
+const MASS_KG: f64 = 1000.0;
+
+/// Drag coefficient — bespoke ballistic-drag geometry shared across
+/// every recipe.
+const CD: f64 = 2.2;
+
+/// Drag reference area (m²) — bespoke geometry.
+const AREA_M2: f64 = 10.0;
+
+/// Constant atmospheric density override (kg/m³) — bypasses the
+/// exponential atmosphere model and drives the assertion content.
+const DENSITY: f64 = 1e-12;
+
+/// Number of integration steps to cover one circular-orbit period at
+/// `R_ORBIT_M`. The pre-recipe tier3 file computed this with bare
+/// `as usize` truncation, so reproduce that convention here for
+/// bit-identical step counts.
+fn num_steps_one_period() -> usize {
+    let period = 2.0 * std::f64::consts::PI * (R_ORBIT_M.powi(3) / MU_EARTH).sqrt();
+    (period / DT_S) as usize
+}
+
+/// Shared scenario builder for every recipe. Parameterised by the body's
+/// initial translational state, rotational state, and mass properties.
+/// All other knobs (Earth source, atmosphere config, drag config,
+/// integrator dt) are recipe-wide constants.
+///
+/// Mirrors `make_6dof_drag_sim` in the pre-recipe tier3 file
+/// field-for-field. The atmosphere config is required by validation
+/// even when `constant_density` overrides the atmospheric density.
+fn build_drag_6dof(
+    trans: TranslationalState,
+    rot: RotationalState,
+    mass_props: MassProperties,
+) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, DT_S);
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            // Identity `t_inertial_pfix` + `RotationModel::None` +
+            // `planet_omega: 0.0` reproduces the previous
+            // `t_inertial_pfix: None` spherical-fallback semantics on
+            // the runner side bit-for-bit (the atmosphere kernel
+            // computes `IDENTITY * position == position` before the
+            // geodetic conversion, and no co-rotation wind is added);
+            // see the matching `PlanetFixedRotationC` spawn the bridge
+            // performs on the Bevy side. The Bevy atmosphere stage
+            // requires *some* `PlanetFixedRotationC` on the planet
+            // entity, so the runner has to publish the identity matrix
+            // for the bridge to lift across.
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    sb = sb.atmosphere(
+        AtmosphereConfig {
+            model: AtmosphereModel::Exponential(ExponentialAtmosphere {
+                rho_0: 1e-12,
+                h_0: 400_000.0,
+                scale_height: 50_000.0,
+            }),
+            r_eq: R_EARTH,
+            // Match the pre-recipe inline expression for `r_pol`
+            // exactly: `R_EARTH * (1.0 - 1.0 / 298.257_223_563)`. This
+            // is also what `astrodyn::EARTH.shape.r_pol` evaluates to
+            // (the `EARTH_R_POL` constant in `body_constants.rs` is
+            // `EARTH_R_EQ * (1.0 - EARTH_FLAT_COEFF)` with
+            // `EARTH_FLAT_COEFF = 1.0 / 298.257_223_563`), so using the
+            // preset keeps the value bit-identical and avoids
+            // hard-coding the flattening literal here.
+            r_pol: astrodyn::EARTH.shape.r_pol,
+            planet_omega: 0.0,
+        },
+        earth,
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&trans),
+        rot: Some(super::typed_helpers::rot_typed(&rot)),
+        mass: Some(super::typed_helpers::mass_typed(&mass_props)),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        drag: Some(DragConfig {
+            cd: CD,
+            area: AREA_M2,
+            constant_density: Some(DENSITY),
+        }),
+        ..Default::default()
+    });
+    sb
+}
+
+/// Analytical recipes opt out of every runner-vs-JEOD tolerance group
+/// because they pair with [`CsvReference::SyntheticTimes`] and assert
+/// in-test against closed-form values rather than logged JEOD columns.
+/// The parity trait still asserts `runner ↔ bevy` bit-identity at every
+/// synthetic record.
+fn analytical_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+/// Initial circular-orbit translational state at `R_ORBIT_M` with the
+/// body at (r, 0, 0) and velocity along +Y at the local circular speed.
+/// Shared across every recipe in the family.
+fn circular_orbit_trans() -> TranslationalState {
+    let v = (MU_EARTH / R_ORBIT_M).sqrt();
+    TranslationalState {
+        position: DVec3::new(R_ORBIT_M, 0.0, 0.0),
+        velocity: DVec3::new(0.0, v, 0.0),
+    }
+}
+
+/// Uniform-sphere mass properties for the bespoke 1 t / 1 m-radius body:
+/// `I = (2/5) m r² = 0.4 * MASS_KG * 1.0` on each diagonal, CoM at the
+/// origin.
+fn uniform_sphere_mass_props() -> MassProperties {
+    let i_val = 0.4 * MASS_KG * 1.0;
+    let inertia = DMat3::from_diagonal(DVec3::splat(i_val));
+    MassProperties::with_inertia(MASS_KG, inertia, DVec3::ZERO)
+}
+
+// ── Drag with rotation: energy-loss assertion ─────────────────────────
+
+fn build_drag_with_rotation_energy_loss(_init: &InitialConditions) -> SimulationBuilder {
+    let eigen_angle = 30.0_f64.to_radians();
+    let eigen_axis = DVec3::new(1.0, 1.0, 1.0).normalize();
+    let quat = JeodQuat::left_quat_from_eigen_rotation(eigen_angle, eigen_axis);
+    let ang_vel = DVec3::new(0.01, -0.005, 0.003);
+    build_drag_6dof(
+        circular_orbit_trans(),
+        RotationalState {
+            quaternion: quat,
+            ang_vel_body: ang_vel,
+        },
+        uniform_sphere_mass_props(),
+    )
+}
+
+/// 6-DOF body on a 400 km equatorial circular orbit with a non-trivial
+/// initial attitude (30° about the (1,1,1) axis) and small spin. The
+/// analytical sibling asserts the specific orbital energy decreases
+/// monotonically (ballistic drag removes energy) and that the angular
+/// velocity magnitude is conserved (ballistic drag produces no torque,
+/// and the gravity gradient is disabled).
+pub fn drag_with_rotation_energy_loss() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_drag_with_rotation_energy_loss",
+        scenario: build_drag_with_rotation_energy_loss,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: num_steps_one_period(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Ballistic-drag attitude invariance: identity-attitude leg ─────────
+
+fn build_drag_attitude_invariance_identity(_init: &InitialConditions) -> SimulationBuilder {
+    build_drag_6dof(
+        circular_orbit_trans(),
+        RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        },
+        uniform_sphere_mass_props(),
+    )
+}
+
+/// Identity-attitude leg of the ballistic-drag attitude-invariance
+/// pair. Same translational state, mass, and drag config as the
+/// rotated leg; the analytical sibling propagates both for one orbital
+/// period and asserts their translational trajectories agree to within
+/// numerical precision.
+pub fn drag_attitude_invariance_identity() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_drag_attitude_invariance_identity",
+        scenario: build_drag_attitude_invariance_identity,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: num_steps_one_period(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ── Ballistic-drag attitude invariance: rotated-attitude leg ──────────
+
+fn build_drag_attitude_invariance_rotated(_init: &InitialConditions) -> SimulationBuilder {
+    let quat =
+        JeodQuat::left_quat_from_eigen_rotation(45.0_f64.to_radians(), DVec3::new(0.0, 0.0, 1.0));
+    build_drag_6dof(
+        circular_orbit_trans(),
+        RotationalState {
+            quaternion: quat,
+            ang_vel_body: DVec3::new(0.0, 0.0, 0.05),
+        },
+        uniform_sphere_mass_props(),
+    )
+}
+
+/// Rotated-attitude leg of the ballistic-drag attitude-invariance pair
+/// (45° about +Z, spinning about +Z at 0.05 rad/s). Same translational
+/// state, mass, and drag config as the identity-attitude leg.
+pub fn drag_attitude_invariance_rotated() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_drag_attitude_invariance_rotated",
+        scenario: build_drag_attitude_invariance_rotated,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: num_steps_one_period(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs
@@ -4,104 +4,47 @@
 //! These tests exercise aerodynamic drag with rotational dynamics through
 //! `Simulation::step()`, verifying that drag interacts correctly with the
 //! attitude state. All tests use analytical verification.
+//!
+//! No Docker reference data required. The `Simulation` construction lives
+//! in the `sim_drag_6dof` recipe module so the parity wrapper
+//! (`bevy_parity_drag_6dof.rs`) can drive the same scenarios through the
+//! Bevy adapter for the `runner ↔ bevy` half of the transitivity argument.
 
 use astrodyn::recipes::helpers::energy_conservation::specific_orbital_energy;
-use astrodyn::{
-    AtmosphereConfig, AtmosphereModel, DragConfig, ExponentialAtmosphere, GravityControl,
-    GravityControls, GravityGradient, GravityModel, GravitySource, JeodQuat, MassProperties,
-    RotationalState, SimulationTime, TranslationalState,
-};
-use astrodyn::{GravitySourceEntry, VehicleConfig};
+use astrodyn_runner::builder::SimulationBuilderExt;
 use astrodyn_runner::Simulation;
-use glam::{DMat3, DVec3};
+use astrodyn_verif_jeod::run_verification::sim_drag_6dof;
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 
-/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+/// Earth gravitational parameter (m³/s²) — JEOD `earth_GGM05C.cc`.
+/// Matches the value the `sim_drag_6dof` recipe uses so the analytical
+/// assertions reconstruct the recipe-encoded initial state exactly.
 const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
 
 /// Earth mean equatorial radius (m) — JEOD `earth.cc`.
 const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
 
-/// Create a 6-DOF simulation with point-mass gravity and constant-density drag.
-#[allow(clippy::too_many_arguments)]
-fn make_6dof_drag_sim(
-    pos: DVec3,
-    vel: DVec3,
-    mass: f64,
-    inertia: DMat3,
-    quat: JeodQuat,
-    ang_vel: DVec3,
-    cd: f64,
-    area: f64,
-    density: f64,
-    dt: f64,
-) -> Simulation {
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
+/// Build the recipe's `Simulation` exactly the way the parity trait does
+/// — call the scenario factory with a default `InitialConditions`, then
+/// `.build()` — so the runner-side propagation here and the Bevy-side
+/// propagation in `bevy_parity_drag_6dof.rs` see the same initial state
+/// bit-pattern.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
+}
 
-    let earth = sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: astrodyn_runner::RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
-    );
-
-    // Atmosphere config is required by validation even when constant_density
-    // overrides the atmospheric density.
-    sim.atmosphere = Some(AtmosphereConfig {
-        model: AtmosphereModel::Exponential(ExponentialAtmosphere {
-            rho_0: 1e-12,
-            h_0: 400_000.0,
-            scale_height: 50_000.0,
-        }),
-        r_eq: R_EARTH,
-        r_pol: R_EARTH * (1.0 - 1.0 / 298.257_223_563),
-        planet_omega: 0.0,
-    });
-    sim.atmosphere_planet_source = Some(earth);
-
-    let drag_config = DragConfig {
-        cd,
-        area,
-        constant_density: Some(density),
-    };
-
-    let mass_props = MassProperties::with_inertia(mass, inertia, DVec3::ZERO);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: quat,
-                ang_vel_body: ang_vel,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        drag: Some(drag_config),
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-    sim
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_drag_6dof` uses this variant because
+/// the family is analytical-only; panicking on any other variant
+/// surfaces a future recipe-shape drift here rather than producing a
+/// silently-truncated propagation.
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
+    match &case.reference {
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
 }
 
 /// 6-DOF with rotation: drag should still remove orbital energy.
@@ -110,41 +53,28 @@ fn make_6dof_drag_sim(
 /// the drag magnitude. The force always opposes the relative velocity
 /// regardless of body orientation. This test verifies that a spinning body
 /// still experiences proper orbital energy dissipation.
-// non-recipe: 1 t mass + ballistic Cd·A on a 400 km equatorial circular
-// orbit; the geometry is bespoke and the drag config (Cd=2.2, area=10,
-// constant density 1e-12) drives the assertion content.
 #[test]
 fn tier3_drag_with_rotation_energy_loss() {
-    let r = R_EARTH + 400_000.0;
-    let v = (MU_EARTH / r).sqrt();
-    let pos = DVec3::new(r, 0.0, 0.0);
-    let vel = DVec3::new(0.0, v, 0.0);
-
-    let mass = 1000.0;
-    let cd = 2.2;
-    let area = 10.0;
-    let density = 1e-12;
-    let dt = 10.0;
-
-    // Uniform sphere inertia: I = 2/5 * m * r^2 (1m radius)
-    let i_val = 0.4 * mass * 1.0;
-    let inertia = DMat3::from_diagonal(DVec3::splat(i_val));
-
-    // Non-trivial initial attitude and spin
-    let eigen_angle = 30.0_f64.to_radians();
-    let eigen_axis = DVec3::new(1.0, 1.0, 1.0).normalize();
-    let quat = JeodQuat::left_quat_from_eigen_rotation(eigen_angle, eigen_axis);
-    let ang_vel = DVec3::new(0.01, -0.005, 0.003); // rad/s
-
-    let mut sim = make_6dof_drag_sim(
-        pos, vel, mass, inertia, quat, ang_vel, cd, area, density, dt,
+    let case = sim_drag_6dof::drag_with_rotation_energy_loss();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
     );
 
+    // Reconstruct the recipe-encoded initial position/velocity locally
+    // so the closed-form initial energy matches the recipe's t=0 state
+    // exactly (the recipe places the body at (R_ORBIT, 0, 0) with the
+    // local circular speed along +Y).
+    let r = R_EARTH + 400_000.0;
+    let v = (MU_EARTH / r).sqrt();
+    let pos = glam::DVec3::new(r, 0.0, 0.0);
+    let vel = glam::DVec3::new(0.0, v, 0.0);
     let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
+    let initial_ang_vel_mag = glam::DVec3::new(0.01, -0.005, 0.003).length();
 
-    // Propagate for 1 orbit
-    let period = 2.0 * std::f64::consts::PI * (r.powi(3) / MU_EARTH).sqrt();
-    let n_steps = (period / dt) as usize;
     sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
@@ -172,7 +102,6 @@ fn tier3_drag_with_rotation_energy_loss() {
         .as_ref()
         .expect("6-DOF body should have rotational state");
     let final_ang_vel_mag = rot.ang_vel_body.raw_si().length();
-    let initial_ang_vel_mag = ang_vel.length();
 
     println!("  Initial |omega|: {initial_ang_vel_mag:.6e} rad/s");
     println!("  Final   |omega|: {final_ang_vel_mag:.6e} rad/s");
@@ -195,46 +124,38 @@ fn tier3_drag_with_rotation_energy_loss() {
 /// attitudes but same translational state should experience the same
 /// translational trajectory. The force direction changes in the body frame,
 /// but in the inertial frame it is always anti-velocity.
-// non-recipe: same drag setup as `tier3_drag_with_rotation_energy_loss`,
-// run twice with different attitudes to verify ballistic-drag invariance.
 #[test]
 fn tier3_drag_attitude_invariance_ballistic() {
-    let r = R_EARTH + 400_000.0;
-    let v = (MU_EARTH / r).sqrt();
-    let pos = DVec3::new(r, 0.0, 0.0);
-    let vel = DVec3::new(0.0, v, 0.0);
+    let case_identity = sim_drag_6dof::drag_attitude_invariance_identity();
+    let case_rotated = sim_drag_6dof::drag_attitude_invariance_rotated();
 
-    let mass = 1000.0;
-    let cd = 2.2;
-    let area = 10.0;
-    let density = 1e-12;
-    let dt = 10.0;
-
-    // Uniform sphere inertia
-    let i_val = 0.4 * mass * 1.0;
-    let inertia = DMat3::from_diagonal(DVec3::splat(i_val));
-
-    // Case 1: identity attitude, no spin
-    let quat1 = JeodQuat::identity();
-    let ang_vel1 = DVec3::ZERO;
-
-    // Case 2: 45-degree rotation about Z, spinning
-    let quat2 =
-        JeodQuat::left_quat_from_eigen_rotation(45.0_f64.to_radians(), DVec3::new(0.0, 0.0, 1.0));
-    let ang_vel2 = DVec3::new(0.0, 0.0, 0.05);
-
-    let mut sim1 = make_6dof_drag_sim(
-        pos, vel, mass, inertia, quat1, ang_vel1, cd, area, density, dt,
+    let mut sim1 = build_sim(&case_identity);
+    let mut sim2 = build_sim(&case_rotated);
+    let (dt1, n_steps1) = synthetic_cadence(&case_identity);
+    let (dt2, n_steps2) = synthetic_cadence(&case_rotated);
+    assert_eq!(
+        dt1, sim1.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt1}) and Simulation dt ({}) drifted apart",
+        case_identity.name, sim1.dt
     );
-    let mut sim2 = make_6dof_drag_sim(
-        pos, vel, mass, inertia, quat2, ang_vel2, cd, area, density, dt,
+    assert_eq!(
+        dt2, sim2.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt2}) and Simulation dt ({}) drifted apart",
+        case_rotated.name, sim2.dt
+    );
+    // Both legs must propagate for the same number of integration ticks
+    // — the attitude-invariance assertion compares their final
+    // translational states, which is only meaningful when the two
+    // trajectories were stepped through the same cadence.
+    assert_eq!(
+        (dt1, n_steps1),
+        (dt2, n_steps2),
+        "attitude-invariance legs disagree on cadence: \
+         identity=({dt1}, {n_steps1}), rotated=({dt2}, {n_steps2})"
     );
 
-    // Propagate for 1 orbit
-    let period = 2.0 * std::f64::consts::PI * (r.powi(3) / MU_EARTH).sqrt();
-    let n_steps = (period / dt) as usize;
-    sim1.step_n(n_steps).expect("step_n failed");
-    sim2.step_n(n_steps).expect("step_n failed");
+    sim1.step_n(n_steps1).expect("step_n failed");
+    sim2.step_n(n_steps2).expect("step_n failed");
 
     let body1 = sim1.body(0);
     let body2 = sim2.body(0);

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs
@@ -17,12 +17,11 @@ use astrodyn_verif_jeod::run_verification::sim_drag_6dof;
 use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 
 /// Earth gravitational parameter (m³/s²) — JEOD `earth_GGM05C.cc`.
-/// Matches the value the `sim_drag_6dof` recipe uses so the analytical
-/// assertions reconstruct the recipe-encoded initial state exactly.
+/// The recipe encodes the initial position and velocity; the analytical
+/// assertion below pulls those values back off the built `Simulation`
+/// and uses this `mu` only to evaluate the closed-form specific orbital
+/// energy `E = v²/2 - μ/r`.
 const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
-
-/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
-const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
 
 /// Build the recipe's `Simulation` exactly the way the parity trait does
 /// — call the scenario factory with a default `InitialConditions`, then
@@ -64,16 +63,24 @@ fn tier3_drag_with_rotation_energy_loss() {
         case.name, sim.dt
     );
 
-    // Reconstruct the recipe-encoded initial position/velocity locally
-    // so the closed-form initial energy matches the recipe's t=0 state
-    // exactly (the recipe places the body at (R_ORBIT, 0, 0) with the
-    // local circular speed along +Y).
-    let r = R_EARTH + 400_000.0;
-    let v = (MU_EARTH / r).sqrt();
-    let pos = glam::DVec3::new(r, 0.0, 0.0);
-    let vel = glam::DVec3::new(0.0, v, 0.0);
-    let e_initial = specific_orbital_energy(pos, vel, MU_EARTH);
-    let initial_ang_vel_mag = glam::DVec3::new(0.01, -0.005, 0.003).length();
+    // Read the recipe-encoded initial state directly off the built
+    // `Simulation` so the closed-form initial energy and angular-velocity
+    // magnitude track whatever the recipe sets at t=0. Duplicating the
+    // recipe's literals here would let the assertion silently drift if
+    // the recipe edits the altitude or omega without the test noticing.
+    let initial = sim.body(0);
+    let e_initial = specific_orbital_energy(
+        initial.trans.position.raw_si(),
+        initial.trans.velocity.raw_si(),
+        MU_EARTH,
+    );
+    let initial_ang_vel_mag = initial
+        .rot
+        .as_ref()
+        .expect("6-DOF body should have rotational state")
+        .ang_vel_body
+        .raw_si()
+        .length();
 
     sim.step_n(n_steps).expect("step_n failed");
 

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_6dof.rs
@@ -23,11 +23,24 @@ use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, Verific
 /// energy `E = v²/2 - μ/r`.
 const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
 
-/// Build the recipe's `Simulation` exactly the way the parity trait does
-/// — call the scenario factory with a default `InitialConditions`, then
-/// `.build()` — so the runner-side propagation here and the Bevy-side
-/// propagation in `bevy_parity_drag_6dof.rs` see the same initial state
-/// bit-pattern.
+/// Build the recipe's `Simulation` by calling the scenario factory with
+/// a default `InitialConditions`, then `.build()`.
+///
+/// `VerificationCaseParityExt::run_and_assert_parity` derives its init
+/// via `initial_conditions_from(&ref_states[0])` rather than
+/// `Default::default()`. Every recipe in this file pairs with
+/// `CsvReference::SyntheticTimes`, for which the loader fills each
+/// generated `StateLog` with `time: t, ..Default::default()`; at
+/// `i = 0` that gives `time = 0.0` and `None`/`DVec3::ZERO` for every
+/// other field, so `initial_conditions_from(ref_states[0])` collapses
+/// to `InitialConditions::default()` bit-for-bit. Passing
+/// `Default::default()` here is therefore equivalent to what the parity
+/// wrapper does *for these cases*, which is why the runner-side
+/// propagation here and the Bevy-side propagation in
+/// `bevy_parity_drag_6dof.rs` see the same initial state. If a future
+/// recipe in this file switches off `SyntheticTimes` or starts honoring
+/// `InitialConditions`, switch this call site to derive the init the
+/// same way `run_and_assert_parity` does.
 fn build_sim(case: &VerificationCase) -> Simulation {
     (case.scenario)(&InitialConditions::default())
         .build()

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag_6dof.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag_6dof.rs
@@ -1,5 +1,5 @@
 //! Bevy ↔ runner parity for the 6-DOF drag analytical scenarios
-//! (`tier3_sim_drag_6dof`). Wrappers land as part of #389.
+//! (`tier3_sim_drag_6dof`).
 //!
 //! The matching tier3 file drives each scenario through the runner and
 //! asserts a closed-form drag property (monotonic specific-orbital-energy
@@ -7,9 +7,12 @@
 //! ballistic-drag translational trajectory). This file pairs each recipe
 //! with the parity trait so the same scenarios also run through the
 //! Bevy adapter and assert `runner ↔ bevy` bit-identity at every
-//! synthetic record — the second half of the
-//! `runner ↔ JEOD ≈ bevy` transitivity argument the issue's matrix
-//! covers.
+//! synthetic record. Bit-identity here plus the analytical assertions in
+//! the sibling tier3 file together imply the Bevy adapter satisfies the
+//! same closed-form drag properties — the analytical analog of the
+//! `runner ↔ bevy` (this file) + `runner ↔ JEOD` (sibling tier3
+//! assertions) ⇒ `bevy ↔ JEOD` transitivity argument the issue's matrix
+//! covers for CSV-backed scenarios, within the runner's tolerance.
 
 use astrodyn_verif_jeod::run_verification::sim_drag_6dof;
 use astrodyn_verif_parity::VerificationCaseParityExt;

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag_6dof.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag_6dof.rs
@@ -1,0 +1,30 @@
+//! Bevy ↔ runner parity for the 6-DOF drag analytical scenarios
+//! (`tier3_sim_drag_6dof`). Wrappers land as part of #389.
+//!
+//! The matching tier3 file drives each scenario through the runner and
+//! asserts a closed-form drag property (monotonic specific-orbital-energy
+//! loss under ballistic drag with rotation; attitude-invariance of the
+//! ballistic-drag translational trajectory). This file pairs each recipe
+//! with the parity trait so the same scenarios also run through the
+//! Bevy adapter and assert `runner ↔ bevy` bit-identity at every
+//! synthetic record — the second half of the
+//! `runner ↔ JEOD ≈ bevy` transitivity argument the issue's matrix
+//! covers.
+
+use astrodyn_verif_jeod::run_verification::sim_drag_6dof;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_drag_6dof_drag_with_rotation_energy_loss() {
+    sim_drag_6dof::drag_with_rotation_energy_loss().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_drag_6dof_drag_attitude_invariance_identity() {
+    sim_drag_6dof::drag_attitude_invariance_identity().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_drag_6dof_drag_attitude_invariance_rotated() {
+    sim_drag_6dof::drag_attitude_invariance_rotated().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -137,11 +137,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
          not yet defined; needs `pre_step` Bevy support too (#389 follow-up)",
     ),
     (
-        "drag_6dof",
-        "pre-recipe sibling — drag-family recipe factories not yet defined \
-         (#389 follow-up)",
-    ),
-    (
         "drag_analytical",
         "analytical drag verification — out of trait scope (no propagation)",
     ),


### PR DESCRIPTION
## Summary
- Adds `sim_drag_6dof` recipe with three analytical `VerificationCase` factories (`drag_with_rotation_energy_loss`, `drag_attitude_invariance_identity`, `drag_attitude_invariance_rotated`) sharing a `build_drag_6dof` constructor that mirrors the pre-recipe `make_6dof_drag_sim` field-for-field (point-mass Earth, exponential atmosphere, constant-density ballistic drag, RK4 at 10 s). Each recipe pairs the resulting `SimulationBuilder` with `CsvReference::SyntheticTimes` sized to one orbital period.
- Refactors `tier3_sim_drag_6dof.rs` to drive its `Simulation` from each recipe via `SimulationBuilder::build()`; every closed-form analytical assertion (monotonic energy loss, angular-velocity conservation under ballistic drag, attitude-invariance of the translational trajectory) is preserved with the original tolerances.
- Adds `bevy_parity_drag_6dof.rs` with one `#[test]` per recipe, each calling `.run_and_assert_parity::<astrodyn::Earth>()`. Drops the `drag_6dof` entry from `KNOWN_PARITY_GAPS` in `parity_coverage.rs`.
- Publishes an identity `t_inertial_pfix` on the Earth source (`RotationModel::None`, `planet_omega: 0.0`) so the Bevy adapter can spawn `PlanetFixedRotationC` for the atmosphere stage. The atmosphere kernel multiplies position by IDENTITY before the geodetic conversion, so this is bit-identical to the previous `t_inertial_pfix: None` spherical-fallback path on the runner side.

References #389.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity_)'`
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_)'` (294 tests, all pass)
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_drag_6dof`
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

The `drag_6dof` topic has no entries in `test_data/baselines.json` (analytical-only, no JEOD CSV), so the `tier3_baseline_diff` invariance check has no surface to fail on for this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)