### PR TITLE
[#389] Extract dyncomp_combinations recipe + add bevy_parity wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           cargo nextest run --workspace -E '
             test(bevy_parity) and not (
-              binary(/^bevy_parity_dyncomp_/)
+              binary(/^bevy_parity_dyncomp_run/)
               or binary(/^bevy_parity_solar_beta/)
               or binary(=bevy_parity_torque_simple)
               or binary(=bevy_parity_srp_1st_order)

--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -30,6 +30,7 @@ pub mod sim_attach_detach_trajectory;
 pub mod sim_derived_state;
 pub mod sim_drag_6dof;
 pub mod sim_dyncomp;
+pub mod sim_dyncomp_combinations;
 pub mod sim_force_torque_response;
 pub mod sim_gj;
 pub mod sim_kinematic_propagation;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp_combinations.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp_combinations.rs
@@ -1,0 +1,744 @@
+// JEOD_INV: TS.01 — `<SelfRef>` is used here at the typed↔raw kernel-boundary helpers (named-method opt-in; the implicit `From<RotationalState>` / `From<MassProperties>` bypass was removed in #397).
+//! `VerificationCase` constructors for the analytical SIM_dyncomp
+//! physics-combinations family (`tier3_sim_dyncomp_combinations`).
+//!
+//! The numbered SIM_dyncomp RUN_* scenarios already have Docker-backed
+//! cross-validation tests (`tier3_sim_dyncomp_run2`..`run10`). The
+//! recipes here cover the closed-form / conservation-law checks the
+//! `tier3_sim_dyncomp_combinations.rs` sibling exercises against the
+//! same physics combinations, without needing a JEOD reference CSV:
+//!
+//! - Keplerian energy + angular-momentum conservation (RUN_2 family,
+//!   point-mass gravity);
+//! - Third-body torque on a LEO orbit (RUN_7A/7B analog, Sun + Moon
+//!   point-mass perturbers off the orbital plane);
+//! - Monotonic semi-major-axis decay under drag (RUN_6/RUN_7C/7D analog,
+//!   point-mass Earth + exponential atmosphere with a constant-density
+//!   override);
+//! - Torque-free rigid-body rotation conserving the inertial angular-
+//!   momentum vector (RUN_8A analog);
+//! - F = m·a impulse response on a 3-DOF orbiting body
+//!   (RUN_9C/9D analog, external inertial force applied via
+//!   [`VehicleConfig::external_force`]);
+//! - τ = I·α impulse response on a 6-DOF body (RUN_9A/9B/9C analog,
+//!   external body-frame torque applied via
+//!   [`VehicleConfig::external_torque`]);
+//! - Major-axis spin stability (intermediate-axis theorem, RUN_8B
+//!   neighborhood).
+//!
+//! Each recipe pairs with [`CsvReference::SyntheticTimes`] so the
+//! parity trait can assert `runner ↔ bevy` bit-identity at every
+//! synthetic record while the matching tier3 file asserts the closed-
+//! form analytical identity on the runner. Shared constructors
+//! (`build_kepler_sim`, `build_kepler_6dof_sim`, `build_drag_sim`)
+//! mirror the pre-recipe `make_kepler_sim`-style helpers field-for-
+//! field so the recipe path reproduces the inline tier3 numerics
+//! exactly.
+//!
+//! Every Earth gravity source is configured with
+//! `t_inertial_pfix: Some(DMat3::IDENTITY)` rather than `None`. With
+//! `RotationModel::None` + `planet_omega: 0.0` the runner side is
+//! bit-identical to the previous `None`-based configuration (the
+//! kernel runs `IDENTITY * position` as a no-op before the geodetic
+//! conversion, with no co-rotation wind), while the Bevy adapter gets
+//! the `PlanetFixedRotationC` it requires on the planet entity for
+//! the bridge to lift the scenario across. See `sim_drag_6dof.rs` for
+//! the same rationale on a drag-bearing recipe.
+
+use crate::verification::{CsvReference, InitialConditions, Tolerances, VerificationCase};
+use astrodyn::{
+    default_leap_second_table, AtmosphereConfig, AtmosphereModel, DragConfig,
+    ExponentialAtmosphere, Force, GravityControl, GravityControls, GravityGradient, GravityModel,
+    GravitySource, GravitySourceEntry, JeodQuat, MassProperties, RootInertial, RotationModel,
+    RotationalState, SimulationBuilder, SimulationTime, Torque, TranslationalState, VehicleConfig,
+};
+use glam::{DMat3, DVec3};
+use uom::si::f64::Time;
+use uom::si::time::second;
+
+/// Earth gravitational parameter (m³/s²) — JEOD `earth_GGM05C.cc`.
+/// Inlined from `astrodyn::EARTH.shape` so the recipe-driven
+/// `Simulation` reproduces the pre-recipe inline `make_kepler_sim` /
+/// `make_kepler_6dof_sim` numerics exactly; the inline tier3 file
+/// reads the constant from the same place.
+const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
+
+/// Earth mean equatorial radius (m) — JEOD `earth.cc`. Drives the
+/// 400 km LEO orbit radius shared by every recipe in this file.
+const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
+
+/// Sun gravitational parameter (m³/s²) — JEOD `sun_spherical.cc`.
+/// Used only by the third-body recipe.
+const MU_SUN: f64 = astrodyn::SUN.shape.mu;
+
+/// Moon gravitational parameter (m³/s²) — JEOD `moon_GRAIL150.cc`.
+/// Used only by the third-body recipe.
+const MU_MOON: f64 = astrodyn::MOON.shape.mu;
+
+/// Typical Earth–Sun distance (m, ~1 AU). Matches the value the pre-
+/// recipe inline tier3 file used to place the Sun off the orbital
+/// plane.
+const R_EARTH_SUN: f64 = 1.495_978_707e11;
+
+/// Typical Earth–Moon distance (m). Matches the pre-recipe value.
+const R_EARTH_MOON: f64 = 3.844_0e8;
+
+/// 400 km altitude (ISS-like) shared by every recipe. The orbit radius
+/// `R_EARTH + 400 km` and circular-orbit speed `sqrt(mu / r)` are the
+/// only initial state the recipes share — recipes differ on attitude,
+/// inertia, and external loads.
+const ALT_M: f64 = 400_000.0;
+
+/// Vehicle mass (kg) shared by tests 1, 2, 3, 5, and 7. Tests 4 and 6
+/// override with their own asymmetric inertia geometry; both still use
+/// `mass = 1000.0 kg` so the recipe-wide constant stays meaningful.
+const MASS_KG: f64 = 1000.0;
+
+/// Recipes opt out of every runner-vs-JEOD tolerance group: the tier3
+/// file asserts closed-form analytical identities directly on the
+/// runner-side result, and the parity trait asserts `runner ↔ bevy`
+/// bit-identity at every synthetic record without consulting these
+/// tolerances.
+fn analytical_tolerances() -> Tolerances {
+    Tolerances {
+        position_m: [0.0; 3],
+        velocity_m_s: [0.0; 3],
+        quat_angle_rad: 0.0,
+        ang_vel_rad_s: [0.0; 3],
+        extras: &[],
+    }
+}
+
+/// Initial 400 km circular orbit, body at (r, 0, 0) with velocity
+/// along +Y at the local circular speed. Shared by every recipe.
+fn iss_circular_state() -> (DVec3, DVec3) {
+    let r = R_EARTH + ALT_M;
+    let v = (MU_EARTH / r).sqrt();
+    (DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0))
+}
+
+/// Closed-form circular-orbit period at the recipe's 400 km radius.
+/// Used to size SyntheticTimes cadences for the Kepler and drag scans.
+fn orbital_period_s() -> f64 {
+    2.0 * std::f64::consts::PI * ((R_EARTH + ALT_M).powi(3) / MU_EARTH).sqrt()
+}
+
+/// Number of integration ticks per orbital period at the given `dt`.
+/// Matches the pre-recipe tier3 file's integer-truncated count exactly
+/// so SyntheticTimes cadence reproduces the inline `step_n` loop count.
+fn steps_per_orbit(dt: f64) -> usize {
+    (orbital_period_s() / dt) as usize
+}
+
+/// Add a point-mass Earth gravity source with `t_inertial_pfix:
+/// Some(IDENTITY)`. The identity transform is a no-op on the runner
+/// side (and keeps the Earth-pfix frame present so the Bevy adapter's
+/// atmosphere / planet-fixed lookup succeeds); see the module docstring
+/// for the parity rationale.
+fn add_earth_point_mass(sb: &mut SimulationBuilder) -> usize {
+    sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_EARTH,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    )
+}
+
+/// Shared 3-DOF Kepler scenario constructor. Used by the point-mass
+/// conservation recipe and (with a non-zero `external_force`) by the
+/// F = m·a impulse-response recipe. Mirrors the pre-recipe inline
+/// `make_kepler_sim` helper field-for-field; the additional
+/// `external_force` parameter funnels the impulse case's load through
+/// `VehicleConfig` so the runner-side `SimBody.external_force` and the
+/// Bevy-side `ExternalForceC` start at identical values without a
+/// `pre_step` hook (the impulse window covers the full propagation
+/// horizon, so no mid-run sign change is needed).
+fn build_kepler_sim(
+    pos: DVec3,
+    vel: DVec3,
+    mass: f64,
+    dt: f64,
+    external_force: DVec3,
+) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    let earth = add_earth_point_mass(&mut sb);
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: pos,
+            velocity: vel,
+        }),
+        rot: None,
+        mass: Some(super::typed_helpers::mass_typed(&MassProperties::new(mass))),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        external_force: Force::<RootInertial>::from_raw_si(external_force),
+        ..Default::default()
+    });
+    sb
+}
+
+/// Shared 6-DOF Kepler scenario constructor. Used by tests 4, 6, and 7.
+/// Mirrors the inline 6-DOF setup field-for-field, with
+/// `external_force` and `external_torque` parameters routed through
+/// `VehicleConfig` for the impulse-response cases.
+fn build_kepler_6dof_sim(
+    pos: DVec3,
+    vel: DVec3,
+    mass_props: MassProperties,
+    ang_vel_body: DVec3,
+    dt: f64,
+    external_force: DVec3,
+    external_torque: DVec3,
+) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, dt);
+    let earth = add_earth_point_mass(&mut sb);
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: pos,
+            velocity: vel,
+        }),
+        rot: Some(super::typed_helpers::rot_typed(&RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body,
+        })),
+        mass: Some(super::typed_helpers::mass_typed(&mass_props)),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        compute_gravity_gradient: false,
+        external_force: Force::<RootInertial>::from_raw_si(external_force),
+        external_torque: Torque::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
+            external_torque,
+        ),
+        ..Default::default()
+    });
+    sb
+}
+
+// ─── Test 1: Point-mass Kepler conservation ───
+
+const TEST1_DT_S: f64 = 10.0;
+/// Three full orbits at `TEST1_DT_S = 10 s`. Pre-recipe
+/// `tier3_dyncomp_point_mass_3dof_conservation` used the same integer-
+/// truncated `(3 * period / dt) as usize` count.
+fn test1_num_steps() -> usize {
+    3 * steps_per_orbit(TEST1_DT_S)
+}
+
+fn build_point_mass_3dof_conservation(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    build_kepler_sim(pos, vel, MASS_KG, TEST1_DT_S, DVec3::ZERO)
+}
+
+/// 3-DOF point-mass orbit propagated for 3 orbits. The tier3 sibling
+/// asserts the specific orbital energy and angular momentum stay
+/// conserved (any drift is RK4 truncation error).
+pub fn point_mass_3dof_conservation() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_point_mass_3dof_conservation",
+        scenario: build_point_mass_3dof_conservation,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST1_DT_S,
+            num_steps: test1_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ─── Test 2: Point-mass Earth + third body produces non-conservation of h ───
+
+const TEST2_DT_S: f64 = 10.0;
+/// One full orbital period at `TEST2_DT_S = 10 s`. Pre-recipe
+/// `tier3_dyncomp_point_mass_plus_thirdbody_conservation` used the
+/// same integer-truncated `(period / dt) as usize` count.
+fn test2_num_steps() -> usize {
+    steps_per_orbit(TEST2_DT_S)
+}
+
+/// Sun position ≈ 1 AU at the obliquity-of-the-ecliptic angle (23.4°)
+/// out of the equatorial plane. Pre-recipe placed the Sun here so its
+/// differential acceleration produces a torque on the orbit about an
+/// in-plane axis (nodal regression / inclination wobble); preserving
+/// the same components keeps the third-body torque signature
+/// identical.
+fn sun_inertial_position() -> DVec3 {
+    DVec3::new(R_EARTH_SUN * 0.9175, 0.0, R_EARTH_SUN * 0.3977)
+}
+
+/// Moon position ≈ 384 400 km out of the orbital (X-Y) plane along the
+/// +Y / +Z combination the pre-recipe inline test used (so the +Y
+/// orbital velocity sees a non-zero out-of-plane perturber from the
+/// first step).
+fn moon_inertial_position() -> DVec3 {
+    DVec3::new(0.0, R_EARTH_MOON * 0.9063, R_EARTH_MOON * 0.4226)
+}
+
+fn build_point_mass_plus_thirdbody_conservation(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, TEST2_DT_S);
+    let earth = add_earth_point_mass(&mut sb);
+    let sun = sb.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_SUN,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::from_raw_si(
+                sun_inertial_position(),
+            ),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+            marker_only: false,
+        },
+    );
+    let moon = sb.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: MU_MOON,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::from_raw_si(
+                moon_inertial_position(),
+            ),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+            marker_only: false,
+        },
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: pos,
+            velocity: vel,
+        }),
+        rot: None,
+        mass: Some(super::typed_helpers::mass_typed(&MassProperties::new(
+            MASS_KG,
+        ))),
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_spherical(earth, GravityGradient::Skip),
+                GravityControl::new_third_body(sun),
+                GravityControl::new_third_body(moon),
+            ],
+        },
+        ..Default::default()
+    });
+    sb
+}
+
+/// 3-DOF point-mass orbit with Sun + Moon third bodies. The tier3
+/// sibling asserts orbital energy stays bounded over one orbit and
+/// the angular-momentum vector has measurably tilted (third-body
+/// torque > numerical noise).
+pub fn point_mass_plus_thirdbody_conservation() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_point_mass_plus_thirdbody_conservation",
+        scenario: build_point_mass_plus_thirdbody_conservation,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST2_DT_S,
+            num_steps: test2_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ─── Test 3: drag leads to monotonic decay of SMA ───
+
+const TEST3_DT_S: f64 = 10.0;
+/// Total propagation horizon for the drag-decay scan: 5 orbits at
+/// `TEST3_DT_S = 10 s`. The tier3 sibling samples SMA at each
+/// orbital-period boundary, so the SyntheticTimes cadence must run
+/// long enough to reach the fifth sample.
+fn test3_num_steps() -> usize {
+    5 * steps_per_orbit(TEST3_DT_S)
+}
+
+/// Constant atmospheric density (kg/m³) used for the drag-decay scan.
+/// Boosted well above the realistic 400 km value so SMA decay is
+/// dominant over RK4 truncation error within five orbits. Same value
+/// the pre-recipe inline test used.
+const TEST3_DENSITY: f64 = 1e-11;
+
+fn build_drag_point_mass_monotonic_decay(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, TEST3_DT_S);
+    let earth = add_earth_point_mass(&mut sb);
+    sb = sb.atmosphere(
+        AtmosphereConfig {
+            model: AtmosphereModel::Exponential(ExponentialAtmosphere {
+                rho_0: TEST3_DENSITY,
+                h_0: ALT_M,
+                scale_height: 50_000.0,
+            }),
+            r_eq: R_EARTH,
+            // Match the pre-recipe inline expression
+            // `R_EARTH * (1.0 - 1.0 / 298.257_223_563)` exactly. The
+            // preset `astrodyn::EARTH.shape.r_pol` evaluates to the
+            // same value (the constant in `body_constants.rs` is
+            // `EARTH_R_EQ * (1.0 - EARTH_FLAT_COEFF)` with
+            // `EARTH_FLAT_COEFF = 1.0 / 298.257_223_563`), so the
+            // preset keeps the value bit-identical without hard-coding
+            // the flattening literal here.
+            r_pol: astrodyn::EARTH.shape.r_pol,
+            planet_omega: 0.0,
+        },
+        earth,
+    );
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: pos,
+            velocity: vel,
+        }),
+        rot: Some(super::typed_helpers::rot_typed(&RotationalState {
+            quaternion: JeodQuat::identity(),
+            ang_vel_body: DVec3::ZERO,
+        })),
+        mass: Some(super::typed_helpers::mass_typed(&MassProperties::new(
+            MASS_KG,
+        ))),
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
+        },
+        drag: Some(DragConfig {
+            cd: 2.2,
+            area: 20.0,
+            constant_density: Some(TEST3_DENSITY),
+        }),
+        ..Default::default()
+    });
+    sb
+}
+
+/// 3-DOF (+identity rotation for `DragConfig` requirements) point-
+/// mass orbit with constant-density drag. The tier3 sibling samples
+/// the semi-major axis at each orbital period and asserts strict
+/// monotonic decrease across five orbits.
+pub fn drag_point_mass_monotonic_decay() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_drag_point_mass_monotonic_decay",
+        scenario: build_drag_point_mass_monotonic_decay,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST3_DT_S,
+            num_steps: test3_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ─── Test 4: torque-free rigid-body rotation conserves inertial H ───
+
+const TEST4_DT_S: f64 = 0.5;
+/// 60 s torque-free rotation propagation horizon. Pre-recipe
+/// `tier3_dyncomp_6dof_rigid_body_invariance` used the same integer-
+/// truncated `(60.0 / dt) as usize` step count.
+fn test4_num_steps() -> usize {
+    (60.0 / TEST4_DT_S) as usize
+}
+
+/// Asymmetric diagonal inertia for the torque-free recipe:
+/// `I_x = 1000`, `I_y = I_z = 2500`. Off-axis initial omega exercises
+/// all three Euler equations.
+fn test4_inertia() -> DMat3 {
+    DMat3::from_cols(
+        DVec3::new(1000.0, 0.0, 0.0),
+        DVec3::new(0.0, 2500.0, 0.0),
+        DVec3::new(0.0, 0.0, 2500.0),
+    )
+}
+
+/// Initial body-frame angular velocity for the torque-free recipe
+/// — tipped off the major axis to exercise Euler's coupling.
+fn test4_omega0() -> DVec3 {
+    DVec3::new(0.1, 0.02, 0.0)
+}
+
+fn build_rigid_body_invariance_6dof(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    let mass_props = MassProperties::with_inertia(MASS_KG, test4_inertia(), DVec3::ZERO);
+    build_kepler_6dof_sim(
+        pos,
+        vel,
+        mass_props,
+        test4_omega0(),
+        TEST4_DT_S,
+        DVec3::ZERO,
+        DVec3::ZERO,
+    )
+}
+
+/// 6-DOF asymmetric rigid body in a 400 km LEO orbit, no applied
+/// torque (gravity gradient off). The tier3 sibling asserts the
+/// inertial-frame angular-momentum vector is conserved while the
+/// body-frame omega evolves under Euler's equations.
+pub fn rigid_body_invariance_6dof() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_6dof_rigid_body_invariance",
+        scenario: build_rigid_body_invariance_6dof,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST4_DT_S,
+            num_steps: test4_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ─── Test 5: external force delta-v ───
+
+const TEST5_DT_S: f64 = 1.0;
+/// External-force window duration (s). The force is constant over the
+/// whole propagation horizon, so the SyntheticTimes count covers the
+/// full window. Pre-recipe `tier3_dyncomp_external_force_impulse_response`
+/// computed the count as `(force_duration / dt) as usize`.
+const TEST5_FORCE_DURATION_S: f64 = 10.0;
+fn test5_num_steps() -> usize {
+    (TEST5_FORCE_DURATION_S / TEST5_DT_S) as usize
+}
+
+/// Inertial-frame external force applied throughout the impulse window
+/// — pre-recipe used a pure +X 50 N vector to make the closed-form
+/// `dv = F·t/m` direction check trivial.
+///
+/// Exposed `pub` so the matching tier3 sibling can read it back when
+/// computing the expected `F·t/m` impulse without having to also
+/// duplicate the literal at the call site.
+pub const EXTERNAL_FORCE_IMPULSE_INERTIAL_N: DVec3 = DVec3::new(50.0, 0.0, 0.0);
+
+/// Vehicle mass used by the F = m·a impulse-response recipe. Exposed
+/// so the tier3 sibling can read it back when computing the expected
+/// `F·t/m` impulse magnitude.
+pub const EXTERNAL_FORCE_IMPULSE_MASS_KG: f64 = MASS_KG;
+
+/// Force-window duration used by the F = m·a impulse-response recipe.
+/// Equals the SyntheticTimes `num_steps * dt`. Exposed so the tier3
+/// sibling can compute the closed-form `F·t/m` impulse without
+/// dividing back through the SyntheticTimes variant.
+pub const EXTERNAL_FORCE_IMPULSE_DURATION_S: f64 = TEST5_FORCE_DURATION_S;
+
+fn build_external_force_impulse_response(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    build_kepler_sim(
+        pos,
+        vel,
+        MASS_KG,
+        TEST5_DT_S,
+        EXTERNAL_FORCE_IMPULSE_INERTIAL_N,
+    )
+}
+
+/// Inertial-frame force applied to a 3-DOF orbiting body. The tier3
+/// sibling builds this recipe alongside a no-force reference (the
+/// [`external_force_impulse_kepler_reference`] recipe sized to match),
+/// propagates both for the force window, and asserts the difference
+/// of their velocity vectors matches the closed-form `F·t/m` impulse
+/// (`< 1e-4` relative).
+pub fn external_force_impulse_response() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_external_force_impulse_response",
+        scenario: build_external_force_impulse_response,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST5_DT_S,
+            num_steps: test5_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// No-force reference sibling for [`external_force_impulse_response`].
+/// Same translational state, mass, and integrator timestep — only the
+/// external force is zero. The impulse test subtracts this run's final
+/// velocity from the forced run's final velocity to isolate the force
+/// contribution from the gravity-induced delta-v over the same window.
+pub fn external_force_impulse_kepler_reference() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_external_force_impulse_kepler_reference",
+        scenario: |_init| {
+            let (pos, vel) = iss_circular_state();
+            build_kepler_sim(pos, vel, MASS_KG, TEST5_DT_S, DVec3::ZERO)
+        },
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST5_DT_S,
+            num_steps: test5_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ─── Test 6: external torque delta-omega ───
+
+const TEST6_DT_S: f64 = 1.0;
+/// Torque window duration (s). Same shape as the force-impulse case:
+/// torque is constant over the whole propagation horizon.
+const TEST6_TORQUE_DURATION_S: f64 = 10.0;
+fn test6_num_steps() -> usize {
+    (TEST6_TORQUE_DURATION_S / TEST6_DT_S) as usize
+}
+
+/// Asymmetric diagonal inertia for the torque-impulse recipe:
+/// `I_x = 1000`, `I_y = I_z = 2500`. Torque applied along body +X so
+/// the closed-form `omega_x = τ·t/I_x` is the only non-zero component.
+fn test6_inertia() -> DMat3 {
+    DMat3::from_cols(
+        DVec3::new(EXTERNAL_TORQUE_IMPULSE_INERTIA_X_KGM2, 0.0, 0.0),
+        DVec3::new(0.0, 2500.0, 0.0),
+        DVec3::new(0.0, 0.0, 2500.0),
+    )
+}
+
+/// Body-frame torque vector applied throughout the torque-impulse
+/// window — pre-recipe used a pure +X 10 N·m vector.
+///
+/// Exposed `pub` so the matching tier3 sibling can read it back when
+/// computing the expected `τ·t/I_x` delta-omega without duplicating
+/// the literal.
+pub const EXTERNAL_TORQUE_IMPULSE_BODY_NM: DVec3 = DVec3::new(10.0, 0.0, 0.0);
+
+/// `I_x` principal moment of inertia for the torque-impulse recipe.
+/// Exposed so the tier3 sibling can compute the expected
+/// `omega_x = τ·t/I_x` without re-deriving the inertia from the
+/// typed-bridge accessors.
+pub const EXTERNAL_TORQUE_IMPULSE_INERTIA_X_KGM2: f64 = 1000.0;
+
+/// Torque-window duration used by the τ = I·α impulse-response recipe.
+/// Equals the SyntheticTimes `num_steps * dt`.
+pub const EXTERNAL_TORQUE_IMPULSE_DURATION_S: f64 = TEST6_TORQUE_DURATION_S;
+
+fn build_external_torque_impulse_response(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    let mass_props = MassProperties::with_inertia(MASS_KG, test6_inertia(), DVec3::ZERO);
+    build_kepler_6dof_sim(
+        pos,
+        vel,
+        mass_props,
+        DVec3::ZERO,
+        TEST6_DT_S,
+        DVec3::ZERO,
+        EXTERNAL_TORQUE_IMPULSE_BODY_NM,
+    )
+}
+
+/// Body-frame torque applied to a 6-DOF body initially at rest
+/// (rotationally). The tier3 sibling asserts the final body-frame
+/// angular velocity matches the closed-form `omega_x = τ·t/I_x`
+/// and the perpendicular components stay below numerical noise.
+pub fn external_torque_impulse_response() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_external_torque_impulse_response",
+        scenario: build_external_torque_impulse_response,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST6_DT_S,
+            num_steps: test6_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+// ─── Test 7: major-axis spin stability (intermediate-axis theorem) ───
+
+const TEST7_DT_S: f64 = 0.1;
+/// 60 s spin propagation (`600` ticks at `dt = 0.1 s`).
+fn test7_num_steps() -> usize {
+    (60.0 / TEST7_DT_S) as usize
+}
+
+/// Asymmetric diagonal inertia with the largest moment along +Z.
+/// `I_z = 2500` is the major axis; `I_x = 500`, `I_y = 1000`. Pre-
+/// recipe `tier3_dyncomp_attitude_stability_major_axis` used the same
+/// ordering so the intermediate-axis-theorem prediction (stable spin
+/// about +Z) is the regime the assertion checks.
+fn test7_inertia() -> DMat3 {
+    DMat3::from_cols(
+        DVec3::new(500.0, 0.0, 0.0),
+        DVec3::new(0.0, 1000.0, 0.0),
+        DVec3::new(0.0, 0.0, 2500.0),
+    )
+}
+
+/// Initial body-frame omega: 1 rad/s spin about +Z with 1% perpendicular
+/// perturbations on +X and +Y. The pre-recipe inline test used the same
+/// triple so the bound on `|omega_perp|` stays comparable.
+fn test7_omega0() -> DVec3 {
+    DVec3::new(0.01, 0.01, 1.0)
+}
+
+fn build_attitude_stability_major_axis(_init: &InitialConditions) -> SimulationBuilder {
+    let (pos, vel) = iss_circular_state();
+    let mass_props = MassProperties::with_inertia(MASS_KG, test7_inertia(), DVec3::ZERO);
+    build_kepler_6dof_sim(
+        pos,
+        vel,
+        mass_props,
+        test7_omega0(),
+        TEST7_DT_S,
+        DVec3::ZERO,
+        DVec3::ZERO,
+    )
+}
+
+/// 6-DOF body spinning about its major principal axis (+Z) with a
+/// small perpendicular perturbation. The tier3 sibling asserts the
+/// perpendicular components of body-frame omega stay bounded
+/// (intermediate-axis theorem — stable major-axis rotation).
+pub fn attitude_stability_major_axis() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_dyncomp_attitude_stability_major_axis",
+        scenario: build_attitude_stability_major_axis,
+        reference: CsvReference::SyntheticTimes {
+            dt: TEST7_DT_S,
+            num_steps: test7_num_steps(),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_combinations.rs
@@ -7,6 +7,15 @@
 //! exercised by those RUNs but which admit closed-form / conservation-law
 //! verification without a JEOD reference CSV.
 //!
+//! The `Simulation` construction lives in the `sim_dyncomp_combinations`
+//! recipe module so the parity wrapper
+//! (`bevy_parity_dyncomp_combinations.rs`) can drive the same scenarios
+//! through the Bevy adapter for the `runner ↔ bevy` half of the
+//! transitivity argument. Each test reads recipe-encoded values back
+//! off the built `Simulation` (rather than duplicating literals) so
+//! recipe edits stay locally consistent with their analytical
+//! assertions.
+//!
 //! JEOD scenario mapping:
 //! - tier3_dyncomp_point_mass_3dof_conservation:
 //!   RUN_2 family (point-mass gravity): energy + angular momentum
@@ -32,81 +41,48 @@
 //!   major principal axis is stable (intermediate-axis theorem).
 
 use astrodyn::recipes::helpers::energy_conservation::specific_orbital_energy;
-use astrodyn::{
-    GravityControl, GravityControls, GravityGradient, GravityModel, GravitySource, JeodQuat,
-    MassProperties, RotationalState, SimulationTime, TranslationalState,
-};
-use astrodyn::{GravitySourceEntry, VehicleConfig};
-use astrodyn_runner::{RotationModel, Simulation};
-use glam::{DMat3, DVec3};
+use astrodyn_runner::builder::SimulationBuilderExt;
+use astrodyn_runner::Simulation;
+use astrodyn_verif_jeod::run_verification::sim_dyncomp_combinations;
+use astrodyn_verif_jeod::verification::{CsvReference, InitialConditions, VerificationCase};
 
-/// Earth gravitational parameter (m^3/s^2) — JEOD `earth_GGM05C.cc`.
+/// Earth gravitational parameter (m³/s²) — JEOD `earth_GGM05C.cc`.
 const MU_EARTH: f64 = astrodyn::EARTH.shape.mu;
-/// Earth mean equatorial radius (m) — JEOD `earth.cc`.
-const R_EARTH: f64 = astrodyn::EARTH.shape.r_eq;
-/// Sun gravitational parameter (m^3/s^2) — JEOD `sun_spherical.cc`.
-const MU_SUN: f64 = astrodyn::SUN.shape.mu;
-/// Moon gravitational parameter (m^3/s^2) — JEOD `moon_GRAIL150.cc`.
-const MU_MOON: f64 = astrodyn::MOON.shape.mu;
-/// Typical Earth–Sun distance (m, ~1 AU).
-const R_EARTH_SUN: f64 = 1.495_978_707e11;
-/// Typical Earth–Moon distance (m).
-const R_EARTH_MOON: f64 = 3.844_0e8;
 
-/// Add a central Earth gravity source (point-mass).
-fn add_earth_point_mass(sim: &mut Simulation) -> usize {
-    sim.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: MU_EARTH,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: true,
-            marker_only: false,
-        },
-    )
+/// Build the recipe's `Simulation` by calling the scenario factory with
+/// a default `InitialConditions`, then `.build()`.
+///
+/// `VerificationCaseParityExt::run_and_assert_parity` derives its init
+/// via `initial_conditions_from(&ref_states[0])` rather than
+/// `Default::default()`. Every recipe in this file pairs with
+/// `CsvReference::SyntheticTimes`, for which the loader fills each
+/// generated `StateLog` with `time: t, ..Default::default()`; at
+/// `i = 0` that gives `time = 0.0` and `None`/`DVec3::ZERO` for every
+/// other field, so `initial_conditions_from(ref_states[0])` collapses
+/// to `InitialConditions::default()` bit-for-bit. Passing
+/// `Default::default()` here is therefore equivalent to what the
+/// parity wrapper does *for these cases*, which is why the runner-side
+/// propagation here and the Bevy-side propagation in
+/// `bevy_parity_dyncomp_combinations.rs` see the same initial state.
+/// If a future recipe in this file switches off `SyntheticTimes` or
+/// starts honoring `InitialConditions`, switch this call site to
+/// derive the init the same way `run_and_assert_parity` does.
+fn build_sim(case: &VerificationCase) -> Simulation {
+    (case.scenario)(&InitialConditions::default())
+        .build()
+        .unwrap_or_else(|e| panic!("scenario `{}` build failed: {e:?}", case.name))
 }
 
-/// Circular orbit at 400 km altitude (ISS-like) in the equatorial plane.
-fn iss_circular_state() -> (DVec3, DVec3) {
-    let r = R_EARTH + 400_000.0;
-    let v = (MU_EARTH / r).sqrt();
-    (DVec3::new(r, 0.0, 0.0), DVec3::new(0.0, v, 0.0))
-}
-
-/// Build a 3-DOF point-mass orbit simulation (pure Kepler).
-fn make_kepler_sim(pos: DVec3, vel: DVec3, mass: f64, dt: f64) -> Simulation {
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
-    let earth = add_earth_point_mass(&mut sim);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel,
-        }),
-        rot: None,
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(MassProperties::new(mass)),
-        )),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-    sim
+/// Pull `(dt, num_steps)` off a recipe's [`CsvReference::SyntheticTimes`]
+/// reference. Every recipe in `sim_dyncomp_combinations` uses this
+/// variant because the family is analytical-only; panicking on any
+/// other variant surfaces a future recipe-shape drift here rather than
+/// producing a silently-truncated propagation.
+fn synthetic_cadence(case: &VerificationCase) -> (f64, usize) {
+    match &case.reference {
+        CsvReference::SyntheticTimes { dt, num_steps } => (*dt, *num_steps),
+        _ => panic!("`{}`: expected SyntheticTimes reference", case.name),
+    }
 }
 
 // ─── Test 1: Point-mass Kepler conservation ───
@@ -116,16 +92,21 @@ fn make_kepler_sim(pos: DVec3, vel: DVec3, mass: f64, dt: f64) -> Simulation {
 /// dynamics. Any drift is numerical integrator error.
 #[test]
 fn tier3_dyncomp_point_mass_3dof_conservation() {
-    let (pos, vel) = iss_circular_state();
-    let dt = 10.0;
-    let mut sim = make_kepler_sim(pos, vel, 1000.0, dt);
+    let case = sim_dyncomp_combinations::point_mass_3dof_conservation();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    assert_eq!(
+        dt, sim.dt,
+        "`{}`: recipe SyntheticTimes dt ({dt}) and Simulation dt ({}) drifted apart",
+        case.name, sim.dt
+    );
 
-    let e0 = specific_orbital_energy(pos, vel, MU_EARTH);
-    let h0 = pos.cross(vel);
+    let body0 = sim.body(0);
+    let pos0 = body0.trans.position.raw_si();
+    let vel0 = body0.trans.velocity.raw_si();
+    let e0 = specific_orbital_energy(pos0, vel0, MU_EARTH);
+    let h0 = pos0.cross(vel0);
 
-    // Propagate for 3 orbits.
-    let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
-    let n_steps = (3.0 * period / dt) as usize;
     sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
@@ -165,93 +146,16 @@ fn tier3_dyncomp_point_mass_3dof_conservation() {
 /// required to demonstrate the third-body torque effect checked here.
 #[test]
 fn tier3_dyncomp_point_mass_plus_thirdbody_conservation() {
-    let (pos, vel) = iss_circular_state();
-    let dt = 10.0;
+    let case = sim_dyncomp_combinations::point_mass_plus_thirdbody_conservation();
+    let mut sim = build_sim(&case);
+    let (_dt, n_steps) = synthetic_cadence(&case);
 
-    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
-    let mut sim = Simulation::new(time, dt);
+    let body0 = sim.body(0);
+    let pos0 = body0.trans.position.raw_si();
+    let vel0 = body0.trans.velocity.raw_si();
+    let e0 = specific_orbital_energy(pos0, vel0, MU_EARTH);
+    let h0 = pos0.cross(vel0);
 
-    let earth = add_earth_point_mass(&mut sim);
-
-    // Sun/Moon placed off the orbital (X-Y) plane so their differential
-    // accelerations produce a torque on the orbit about axes in the plane
-    // (nodal regression / inclination wobble).  A purely in-plane third body
-    // only perturbs the energy and periapsis — it does not tilt the orbital
-    // plane.
-    let sun = sim.add_source(
-        "Sun",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: MU_SUN,
-                model: GravityModel::PointMass,
-            },
-            // Sun ~23.4° out of the equator (ecliptic obliquity).
-            position: astrodyn::Position::<astrodyn::RootInertial>::from_raw_si(DVec3::new(
-                R_EARTH_SUN * 0.9175,
-                0.0,
-                R_EARTH_SUN * 0.3977,
-            )),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-            marker_only: false,
-        },
-    );
-    let moon = sim.add_source(
-        "Moon",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: MU_MOON,
-                model: GravityModel::PointMass,
-            },
-            // Moon ~5° off the ecliptic — put it off the XY plane too.
-            position: astrodyn::Position::<astrodyn::RootInertial>::from_raw_si(DVec3::new(
-                0.0,
-                R_EARTH_MOON * 0.9063,
-                R_EARTH_MOON * 0.4226,
-            )),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-            marker_only: false,
-        },
-    );
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel,
-        }),
-        rot: None,
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(MassProperties::new(1000.0)),
-        )),
-        gravity_controls: GravityControls {
-            controls: vec![
-                GravityControl::new_spherical(earth, GravityGradient::Skip),
-                GravityControl::new_third_body(sun),
-                GravityControl::new_third_body(moon),
-            ],
-        },
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-
-    let e0 = specific_orbital_energy(pos, vel, MU_EARTH);
-    let h0 = pos.cross(vel);
-
-    // Integrate for one orbit.
-    let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
-    let n_steps = (period / dt) as usize;
     sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
@@ -303,61 +207,20 @@ fn tier3_dyncomp_point_mass_plus_thirdbody_conservation() {
 /// not required to demonstrate monotonic SMA decay under drag.
 #[test]
 fn tier3_dyncomp_drag_point_mass_monotonic_decay() {
-    use astrodyn::{AtmosphereConfig, AtmosphereModel, DragConfig, ExponentialAtmosphere};
+    let case = sim_dyncomp_combinations::drag_point_mass_monotonic_decay();
+    let mut sim = build_sim(&case);
+    let (_dt, n_total_steps) = synthetic_cadence(&case);
 
-    let (pos, vel) = iss_circular_state();
-    let dt = 10.0;
-    let mass = 1000.0;
-
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
+    // The recipe's `num_steps` covers five orbital periods. Recover
+    // the per-orbit tick count by dividing — both sides are integer-
+    // truncated identically, so this matches the recipe's
+    // `steps_per_orbit(dt)` helper without re-importing it.
+    let steps_per_orbit = n_total_steps / 5;
+    assert!(
+        steps_per_orbit > 0 && steps_per_orbit * 5 == n_total_steps,
+        "`{}`: SyntheticTimes count {n_total_steps} not a clean 5×steps_per_orbit",
+        case.name,
     );
-    let earth = add_earth_point_mass(&mut sim);
-
-    // Constant-density drag atmosphere so we have repeatable per-orbit decay.
-    sim.atmosphere = Some(AtmosphereConfig {
-        model: AtmosphereModel::Exponential(ExponentialAtmosphere {
-            rho_0: 1e-11,
-            h_0: 400_000.0,
-            scale_height: 50_000.0,
-        }),
-        r_eq: R_EARTH,
-        r_pol: R_EARTH * (1.0 - 1.0 / 298.257_223_563),
-        planet_omega: 0.0,
-    });
-    sim.atmosphere_planet_source = Some(earth);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: JeodQuat::identity(),
-                ang_vel_body: DVec3::ZERO,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(MassProperties::new(mass)),
-        )),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        drag: Some(DragConfig {
-            cd: 2.2,
-            area: 20.0,
-            constant_density: Some(1e-11), // boosted density for clear decay
-        }),
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-
-    // Sample SMA at orbital-period intervals for several orbits.
-    let period = 2.0 * std::f64::consts::PI * ((R_EARTH + 400_000.0).powi(3) / MU_EARTH).sqrt();
-    let steps_per_orbit = (period / dt) as usize;
 
     let mut sma_samples = Vec::new();
     for _ in 0..5 {
@@ -400,63 +263,41 @@ fn tier3_dyncomp_drag_point_mass_monotonic_decay() {
 /// momentum vector is rigorously conserved.
 #[test]
 fn tier3_dyncomp_6dof_rigid_body_invariance() {
-    let (pos, vel) = iss_circular_state();
-    let dt = 0.5;
+    let case = sim_dyncomp_combinations::rigid_body_invariance_6dof();
+    let mut sim = build_sim(&case);
+    let (_dt, n_steps) = synthetic_cadence(&case);
 
-    // Asymmetric diagonal inertia (principal axes aligned with body frame).
-    let i_x = 1000.0;
-    let i_y = 2500.0;
-    let i_z = 2500.0;
-    let inertia = DMat3::from_cols(
-        DVec3::new(i_x, 0.0, 0.0),
-        DVec3::new(0.0, i_y, 0.0),
-        DVec3::new(0.0, 0.0, i_z),
-    );
-    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::ZERO);
-
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
-    let earth = add_earth_point_mass(&mut sim);
-
-    // Initial omega tipped off the major axis to exercise all three Euler eqs.
-    let omega0_body = DVec3::new(0.1, 0.02, 0.0); // rad/s
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: JeodQuat::identity(),
-                ang_vel_body: omega0_body,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        // Gravity gradient torque OFF (RUN_8 has it off).
-        compute_gravity_gradient: false,
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-
-    // H_inertial(0) = T^T * I * omega_body
-    let body = sim.body(0);
-    let q0 = body.rot.as_ref().unwrap().q_inertial_body.to_jeod_quat();
+    // Recover the recipe's inertia + initial omega from the built body
+    // so the closed-form initial angular momentum tracks whatever the
+    // recipe sets at t=0. Duplicating the recipe literals here would
+    // let the assertion silently drift if the recipe edits the inertia
+    // without the test noticing. `Simulation::body_mass` returns the
+    // typed `MassPropertiesTyped<SelfRef>`; demote through the kernel-
+    // boundary helper because `VehicleOutput` doesn't carry mass.
+    let mass0_typed = sim
+        .body_mass(0)
+        .expect("6-DOF body must have mass properties");
+    let inertia = astrodyn::typed_bridge::mass_typed_to_raw(mass0_typed).inertia;
+    let body0 = sim.body(0);
+    let rot0 = body0
+        .rot
+        .as_ref()
+        .expect("6-DOF body must have rotational state");
+    let omega0_body = rot0.ang_vel_body.raw_si();
+    let q0 = rot0.q_inertial_body.to_jeod_quat();
     let t0 = q0.left_quat_to_transformation(); // inertial→body
     let h_body0 = inertia * omega0_body;
     let h_inertial_0 = t0.transpose() * h_body0;
 
-    // Propagate for 60 seconds.
-    sim.step_n((60.0 / dt) as usize).expect("step_n failed");
+    sim.step_n(n_steps).expect("step_n failed");
 
     let body = sim.body(0);
-    let q1 = body.rot.as_ref().unwrap().q_inertial_body.to_jeod_quat();
-    let omega1_body = body.rot.as_ref().unwrap().ang_vel_body.raw_si();
+    let rot = body
+        .rot
+        .as_ref()
+        .expect("6-DOF body must have rotational state");
+    let q1 = rot.q_inertial_body.to_jeod_quat();
+    let omega1_body = rot.ang_vel_body.raw_si();
     let t1 = q1.left_quat_to_transformation();
     let h_body1 = inertia * omega1_body;
     let h_inertial_1 = t1.transpose() * h_body1;
@@ -492,39 +333,44 @@ fn tier3_dyncomp_6dof_rigid_body_invariance() {
 /// the body's velocity increment equals F*dt/m along the force direction.
 #[test]
 fn tier3_dyncomp_external_force_impulse_response() {
-    let (pos, vel0) = iss_circular_state();
-    let dt = 1.0;
-    let mass = 1000.0;
-    let mut sim = make_kepler_sim(pos, vel0, mass, dt);
+    use sim_dyncomp_combinations::{
+        EXTERNAL_FORCE_IMPULSE_DURATION_S, EXTERNAL_FORCE_IMPULSE_INERTIAL_N,
+        EXTERNAL_FORCE_IMPULSE_MASS_KG,
+    };
+    let case = sim_dyncomp_combinations::external_force_impulse_response();
+    let case_ref = sim_dyncomp_combinations::external_force_impulse_kepler_reference();
+    let mut sim = build_sim(&case);
+    let mut ref_sim = build_sim(&case_ref);
+    let (dt, n_steps) = synthetic_cadence(&case);
+    let (dt_ref, n_steps_ref) = synthetic_cadence(&case_ref);
+    assert_eq!(
+        (dt, n_steps),
+        (dt_ref, n_steps_ref),
+        "force-impulse and reference cadences must agree: \
+         forced=({dt}, {n_steps}), reference=({dt_ref}, {n_steps_ref})"
+    );
+    // Cross-check that the SyntheticTimes horizon exactly covers the
+    // exposed force-window duration. Catches silent drift if a future
+    // recipe edit changes one but not the other.
+    let computed_duration = (n_steps as f64) * dt;
+    assert!(
+        (computed_duration - EXTERNAL_FORCE_IMPULSE_DURATION_S).abs() < 1e-12,
+        "force-impulse SyntheticTimes horizon ({computed_duration} s) drifted from \
+         exposed EXTERNAL_FORCE_IMPULSE_DURATION_S ({EXTERNAL_FORCE_IMPULSE_DURATION_S} s)"
+    );
 
-    let force_inertial = DVec3::new(50.0, 0.0, 0.0); // 50 N along +X inertial
-    let force_duration = 10.0;
-
-    // Record velocity immediately before force window.
     let v_before = sim.body(0).trans.velocity.raw_si();
 
-    // Apply force for force_duration seconds.
-    sim.set_body_external_force(0, force_inertial);
-    sim.step_n((force_duration / dt) as usize)
-        .expect("step_n failed");
-    sim.set_body_external_force(0, DVec3::ZERO);
+    // Propagate both sims through the force window.
+    sim.step_n(n_steps).expect("step_n failed");
+    ref_sim.step_n(n_steps_ref).expect("step_n failed");
 
     let v_after = sim.body(0).trans.velocity.raw_si();
-    let delta_v = v_after - v_before;
-
-    // Expected delta-v components from impulse: F*dt/m
-    // The orbital motion contributes extra delta-v from gravity during the
-    // window, so we subtract the no-force reference to isolate the force.
-    let mut ref_sim = make_kepler_sim(pos, vel0, mass, dt);
-    // Advance the reference simulation by the same elapsed time as the force
-    // window started at t=0 and lasted `force_duration`.
-    ref_sim
-        .step_n((force_duration / dt) as usize)
-        .expect("step_n failed");
     let v_reference = ref_sim.body(0).trans.velocity.raw_si();
 
     let force_delta_v = v_after - v_reference;
-    let expected_dv = force_inertial * force_duration / mass;
+    let expected_dv = EXTERNAL_FORCE_IMPULSE_INERTIAL_N * EXTERNAL_FORCE_IMPULSE_DURATION_S
+        / EXTERNAL_FORCE_IMPULSE_MASS_KG;
 
     let err = (force_delta_v - expected_dv).length();
     let rel_err = err / expected_dv.length();
@@ -542,14 +388,20 @@ fn tier3_dyncomp_external_force_impulse_response() {
     );
 
     // Delta-v direction should match force direction.
-    let cos_align = force_delta_v.normalize().dot(force_inertial.normalize());
+    let cos_align = force_delta_v
+        .normalize()
+        .dot(EXTERNAL_FORCE_IMPULSE_INERTIAL_N.normalize());
     assert!(
         cos_align > 0.9999,
-        "delta-v direction {force_delta_v:?} not aligned with force {force_inertial:?}: cos={cos_align}"
+        "delta-v direction {force_delta_v:?} not aligned with force {EXTERNAL_FORCE_IMPULSE_INERTIAL_N:?}: cos={cos_align}"
     );
 
-    // Use delta_v to suppress unused-variable warning (it's informational).
-    let _ = delta_v;
+    // Sanity that the forced sim did pick up the force in the first place.
+    let total_delta_v = v_after - v_before;
+    assert!(
+        (total_delta_v - force_delta_v).length() > 0.0,
+        "forced sim must include gravity contribution; total dv = {total_delta_v:?}"
+    );
 }
 
 // ─── Test 6: external torque delta-omega ───
@@ -559,59 +411,30 @@ fn tier3_dyncomp_external_force_impulse_response() {
 /// equals tau*dt/I.
 #[test]
 fn tier3_dyncomp_external_torque_impulse_response() {
-    let (pos, vel0) = iss_circular_state();
-    let dt = 1.0;
-    let mass = 1000.0;
+    use sim_dyncomp_combinations::{
+        EXTERNAL_TORQUE_IMPULSE_BODY_NM, EXTERNAL_TORQUE_IMPULSE_DURATION_S,
+        EXTERNAL_TORQUE_IMPULSE_INERTIA_X_KGM2,
+    };
+    let case = sim_dyncomp_combinations::external_torque_impulse_response();
+    let mut sim = build_sim(&case);
+    let (dt, n_steps) = synthetic_cadence(&case);
 
-    // Diagonal inertia — apply torque along the body x-axis (principal axis).
-    let i_x = 1000.0;
-    let i_y = 2500.0;
-    let i_z = 2500.0;
-    let inertia = DMat3::from_cols(
-        DVec3::new(i_x, 0.0, 0.0),
-        DVec3::new(0.0, i_y, 0.0),
-        DVec3::new(0.0, 0.0, i_z),
+    // Cross-check the SyntheticTimes horizon against the exposed
+    // torque-window duration. Catches silent drift if a future recipe
+    // edit changes one but not the other.
+    let computed_duration = (n_steps as f64) * dt;
+    assert!(
+        (computed_duration - EXTERNAL_TORQUE_IMPULSE_DURATION_S).abs() < 1e-12,
+        "torque-impulse SyntheticTimes horizon ({computed_duration} s) drifted from \
+         exposed EXTERNAL_TORQUE_IMPULSE_DURATION_S ({EXTERNAL_TORQUE_IMPULSE_DURATION_S} s)"
     );
-    let mass_props = MassProperties::with_inertia(mass, inertia, DVec3::ZERO);
 
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
-    let earth = add_earth_point_mass(&mut sim);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel0,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: JeodQuat::identity(),
-                ang_vel_body: DVec3::ZERO,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        compute_gravity_gradient: false,
-        ..Default::default()
-    });
-    sim.validate().unwrap();
-
-    let torque_body = DVec3::new(10.0, 0.0, 0.0); // 10 N·m about x
-    let torque_duration = 10.0;
-
-    // Apply torque window.
-    sim.set_body_external_torque(0, torque_body);
-    sim.step_n((torque_duration / dt) as usize)
-        .expect("step_n failed");
-    sim.set_body_external_torque(0, DVec3::ZERO);
+    sim.step_n(n_steps).expect("step_n failed");
 
     let omega_after = sim.body(0).rot.as_ref().unwrap().ang_vel_body.raw_si();
     // Expected: omega_x = tau_x * dt / I_xx (y, z remain ~zero).
-    let expected_omega_x = torque_body.x * torque_duration / i_x;
+    let expected_omega_x = EXTERNAL_TORQUE_IMPULSE_BODY_NM.x * EXTERNAL_TORQUE_IMPULSE_DURATION_S
+        / EXTERNAL_TORQUE_IMPULSE_INERTIA_X_KGM2;
 
     let err_x = (omega_after.x - expected_omega_x).abs();
     let rel_err = err_x / expected_omega_x.abs();
@@ -647,53 +470,13 @@ fn tier3_dyncomp_external_torque_impulse_response() {
 /// nearly all its angular momentum along that axis.
 #[test]
 fn tier3_dyncomp_attitude_stability_major_axis() {
-    let (pos, vel) = iss_circular_state();
-    let dt = 0.1;
+    let case = sim_dyncomp_combinations::attitude_stability_major_axis();
+    let mut sim = build_sim(&case);
+    let (_dt, n_steps) = synthetic_cadence(&case);
 
-    // I_z is the largest principal moment (major axis).
-    let i_x = 500.0;
-    let i_y = 1000.0;
-    let i_z = 2500.0; // major axis
-    let inertia = DMat3::from_cols(
-        DVec3::new(i_x, 0.0, 0.0),
-        DVec3::new(0.0, i_y, 0.0),
-        DVec3::new(0.0, 0.0, i_z),
-    );
-    let mass_props = MassProperties::with_inertia(1000.0, inertia, DVec3::ZERO);
-
-    // Spin about z with 1% perturbation on x and y.
-    let omega0 = DVec3::new(0.01, 0.01, 1.0); // rad/s
-
-    let mut sim = Simulation::new(
-        SimulationTime::at_j2000(astrodyn::default_leap_second_table()),
-        dt,
-    );
-    let earth = add_earth_point_mass(&mut sim);
-
-    sim.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: pos,
-            velocity: vel,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: JeodQuat::identity(),
-                ang_vel_body: omega0,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
-        gravity_controls: GravityControls {
-            controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
-        },
-        compute_gravity_gradient: false,
-        ..Default::default()
-    });
-
-    sim.validate().unwrap();
-
-    // Propagate 60 s and sample omega regularly.
+    // Propagate one step at a time and track the maximum |omega_perp|.
     let mut max_perp = 0.0_f64;
-    for _ in 0..600 {
+    for _ in 0..n_steps {
         sim.step_n(1).expect("step_n failed");
         let omega = sim.body(0).rot.as_ref().unwrap().ang_vel_body.raw_si();
         let perp = (omega.x.powi(2) + omega.y.powi(2)).sqrt();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_combinations.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_combinations.rs
@@ -431,7 +431,13 @@ fn tier3_dyncomp_external_torque_impulse_response() {
 
     sim.step_n(n_steps).expect("step_n failed");
 
-    let omega_after = sim.body(0).rot.as_ref().unwrap().ang_vel_body.raw_si();
+    let omega_after = sim
+        .body(0)
+        .rot
+        .as_ref()
+        .expect("6-DOF body should carry rotational state after torque-impulse propagation")
+        .ang_vel_body
+        .raw_si();
     // Expected: omega_x = tau_x * dt / I_xx (y, z remain ~zero).
     let expected_omega_x = EXTERNAL_TORQUE_IMPULSE_BODY_NM.x * EXTERNAL_TORQUE_IMPULSE_DURATION_S
         / EXTERNAL_TORQUE_IMPULSE_INERTIA_X_KGM2;

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_combinations.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_dyncomp_combinations.rs
@@ -1,0 +1,77 @@
+//! Bevy ↔ runner parity for the analytical SIM_dyncomp physics-
+//! combinations family (`tier3_sim_dyncomp_combinations`).
+//!
+//! The matching tier3 file drives each scenario through the runner and
+//! asserts a closed-form / conservation-law property (Keplerian energy
+//! plus angular-momentum conservation, third-body torque, monotonic SMA
+//! decay under drag, torque-free rigid-body inertial angular-momentum
+//! conservation, constant-force impulse response, constant-torque
+//! impulse response, major-axis spin stability). This file pairs each
+//! recipe with the parity trait so the same scenarios also run through
+//! the Bevy adapter and assert `runner ↔ bevy` bit-identity at every
+//! synthetic record. Bit-identity here plus the analytical assertions
+//! in the sibling tier3 file together imply the Bevy adapter satisfies
+//! the same closed-form properties — the analytical analog of the
+//! `runner ↔ bevy` (this file) plus `runner ↔ JEOD` (sibling tier3
+//! assertions) ⇒ `bevy ↔ JEOD` transitivity argument the issue's
+//! matrix covers for CSV-backed scenarios, within the runner's
+//! tolerance.
+//!
+//! The force-impulse case ships *two* parity wrappers — one for the
+//! forced sim and one for its no-force Kepler sibling. The tier3
+//! assertion subtracts the no-force final velocity from the forced
+//! final velocity to isolate the impulse contribution from gravity's
+//! delta-v; both legs must therefore agree bit-for-bit between runner
+//! and Bevy for the analytical-analog transitivity argument to carry
+//! through to the Bevy adapter.
+
+use astrodyn_verif_jeod::run_verification::sim_dyncomp_combinations;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_dyncomp_combinations_point_mass_3dof_conservation() {
+    sim_dyncomp_combinations::point_mass_3dof_conservation()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_point_mass_plus_thirdbody_conservation() {
+    sim_dyncomp_combinations::point_mass_plus_thirdbody_conservation()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_drag_point_mass_monotonic_decay() {
+    sim_dyncomp_combinations::drag_point_mass_monotonic_decay()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_rigid_body_invariance_6dof() {
+    sim_dyncomp_combinations::rigid_body_invariance_6dof()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_external_force_impulse_response() {
+    sim_dyncomp_combinations::external_force_impulse_response()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_external_force_impulse_kepler_reference() {
+    sim_dyncomp_combinations::external_force_impulse_kepler_reference()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_external_torque_impulse_response() {
+    sim_dyncomp_combinations::external_torque_impulse_response()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_dyncomp_combinations_attitude_stability_major_axis() {
+    sim_dyncomp_combinations::attitude_stability_major_axis()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -122,11 +122,6 @@ const KNOWN_PARITY_GAPS: &[(&str, &str)] = &[
     //    recipe lands", and the matching follow-up can drop the entry
     //    when the wrapper file is created.
     (
-        "dyncomp_combinations",
-        "pre-recipe family aggregator — multiple sub-cases need recipe \
-         factories before parity can drive them (#389 follow-up)",
-    ),
-    (
         "dyncomp_run9",
         "pre-recipe sibling — recipe factory for run9 not yet defined \
          (#389 follow-up)",


### PR DESCRIPTION
## Summary

- Extract `tier3_sim_dyncomp_combinations`'s 7 analytical tests' inline `Simulation` construction into a new `sim_dyncomp_combinations` recipe module with 8 factories (`point_mass_3dof_conservation`, `point_mass_plus_thirdbody_conservation`, `drag_point_mass_monotonic_decay`, `rigid_body_invariance_6dof`, `external_force_impulse_response`, `external_force_impulse_kepler_reference`, `external_torque_impulse_response`, `attitude_stability_major_axis`). Each pairs its `SimulationBuilder` with `CsvReference::SyntheticTimes { dt, num_steps }` sized to the analytical horizon.
- Tests 5 and 6 (external force/torque impulse) route the impulse load through `VehicleConfig::{external_force, external_torque}` directly (`pre_step: None`) — the analytical assertion checks the integrated impulse `Δv = F·dt/m` / `Δω = τ·dt/I` over the *full* propagation window, so a constant force value is bit-equivalent to a windowed `pre_step` setter for these closed-form tests and keeps the runner ↔ Bevy comparison straightforward.
- Add `bevy_parity_dyncomp_combinations.rs` with 8 wrappers calling `.run_and_assert_parity::<astrodyn::Earth>()`. All 8 pass `f64::to_bits` parity at every synthetic record.
- Refactor the tier3 test from ~700 lines to ~180 lines by replacing the inline construction with recipe-driven `build()`. Every closed-form analytical assertion (energy / angular-momentum conservation, monotonic SMA decay under drag, `F = m·a` / `τ = I·α` impulse response, major-axis spin stability) is preserved at the original tolerances. `tier3_baseline_diff` reports OK (76 matched; 0 drift).
- Tighten the CI `parity-trajectory-fast` exclusion regex from `^bevy_parity_dyncomp_` → `^bevy_parity_dyncomp_run`, so the new analytical `bevy_parity_dyncomp_combinations` binary runs in the PR-fast lane rather than being deferred to the full lane.
- Drop `dyncomp_combinations` from `KNOWN_PARITY_GAPS`.

References #389.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_dyncomp_combinations` (7/7 pass)
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_dyncomp_combinations` (8/8 bit-identity pass)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [x] `cargo run -p astrodyn_verif_jeod --bin tier3_baseline_diff -- --allow-missing-from .github/tier3-allow-missing.txt` → `OK (76 matched; 1 allowed-missing; 11 new)` — no drift on dyncomp_combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)