### PR TITLE
Fix clementine_1994 epoch recipe (closes #458)

### DIFF
--- a/crates/astrodyn_verif_jeod/src/setups/earth_moon_clem.rs
+++ b/crates/astrodyn_verif_jeod/src/setups/earth_moon_clem.rs
@@ -87,8 +87,9 @@ pub fn earth_moon_clem(dt: f64, initial_state: Option<(DVec3, DVec3)>) -> Simula
     // JEOD `SIM_Earth_Moon RUN_clem` epoch: 1994-03-01 00:00:00 UTC.
     //   JD = 2449412.5; MJD = 49412.0; TJT = MJD - 40000 = 9412.0
     //   TAI-UTC = 28 s at 1994-03-01 (29th leap second added 1994-07-01)
-    // NOT `epoch::clementine_1994()` — that recipe is 1994-02-19 and its
-    // doc comment incorrectly claims to anchor this Tier 3 case. See #458.
+    // Kept as an explicit literal so this setup module is self-documenting
+    // for future JEOD-reference regens — it matches
+    // [`astrodyn::recipes::epoch::clementine_1994`] bit-for-bit.
     let clem_tai_tjt = 9412.0 + 28.0 / 86400.0;
     let time = SimulationTime::new(clem_tai_tjt, astrodyn::default_leap_second_table());
     let epoch_tdb_jd = time.tdb_julian_date();
@@ -168,4 +169,20 @@ pub fn earth_moon_clem(dt: f64, initial_state: Option<(DVec3, DVec3)>) -> Simula
         ..Default::default()
     });
     sb
+}
+
+#[cfg(test)]
+mod tests {
+    use astrodyn::recipes::epoch;
+
+    /// The explicit `SimulationTime::new(9412.0 + 28.0/86400.0, …)`
+    /// literal in [`earth_moon_clem`] must agree bit-for-bit with the
+    /// recipe-layer entry [`epoch::clementine_1994`]. If a future edit
+    /// drifts one of them, this guard fails before any Tier 3 run.
+    #[test]
+    fn epoch_literal_matches_recipe_clementine_1994() {
+        let literal_tai_tjt = 9412.0 + 28.0 / 86400.0;
+        let recipe_tai_tjt = epoch::clementine_1994().tai_tjt_at_epoch;
+        assert_eq!(literal_tai_tjt, recipe_tai_tjt);
+    }
 }

--- a/src/recipes/epoch.rs
+++ b/src/recipes/epoch.rs
@@ -26,13 +26,14 @@ pub fn at_tai_tjt(tai_tjt: f64) -> SimulationTime {
     SimulationTime::new(tai_tjt, default_leap_second_table())
 }
 
-/// Clementine lunar mission epoch: 1994-02-19 00:00:00 UTC.
+/// Clementine lunar mission epoch: 1994-03-01 00:00:00 UTC.
 ///
-/// Anchors `crates/astrodyn_runner/examples/earth_moon.rs` and the
-/// `tier3_sim_earth_moon` Tier 3 case.
+/// Matches the JEOD `SIM_Earth_Moon RUN_clem` reference scenario
+/// (`JD = 2449412.5`, `MJD = 49412`, `TJT = MJD - 40000 = 9412`).
+/// TAI-UTC at this instant is 28 s (the 29th leap second was added
+/// 1994-07-01), so TAI TJT = 9412 + 28/86400.
 pub fn clementine_1994() -> SimulationTime {
-    // TAI-UTC = 28s in 1994. tai_tjt encodes the offset internally.
-    at_tai_tjt(8_815.000_324_074_073)
+    at_tai_tjt(9_412.0 + 28.0 / 86_400.0)
 }
 
 /// Dawn-at-Mars epoch: 2009-02-17 23:00:00 UTC (TAI-UTC = 34s).
@@ -209,5 +210,26 @@ mod tests {
             "at_utc(CC8) tai_tjt = {}, expected {expected_tai_tjt}, err = {err}",
             t.tai_tjt_at_epoch
         );
+    }
+
+    /// [`clementine_1994`] must anchor at the JEOD `SIM_Earth_Moon RUN_clem`
+    /// epoch (1994-03-01 00:00:00 UTC, TAI-UTC = 28 s). The recipe and the
+    /// hand-rolled `SimulationTime::new(9412.0 + 28.0/86400.0, …)` in
+    /// `astrodyn_verif_jeod::setups::earth_moon_clem` must yield identical
+    /// TAI TJTs so the recipe can serve as the canonical entry point.
+    #[test]
+    fn clementine_1994_matches_run_clem_epoch() {
+        let from_recipe = clementine_1994();
+        let expected_tai_tjt = 9_412.0 + 28.0 / 86_400.0;
+        let err = (from_recipe.tai_tjt_at_epoch - expected_tai_tjt).abs();
+        assert!(
+            err < 1e-12,
+            "clementine_1994 tai_tjt = {}, expected {expected_tai_tjt}, err = {err}",
+            from_recipe.tai_tjt_at_epoch
+        );
+        // Cross-check against the calendar form. UTC -> TAI adds 28 s,
+        // which `at_utc` looks up from the default leap-second table.
+        let from_utc = at_utc(1994, 3, 1, 0, 0, 0.0);
+        assert_eq!(from_recipe.tai_tjt_at_epoch, from_utc.tai_tjt_at_epoch);
     }
 }


### PR DESCRIPTION
## Summary

`recipes::epoch::clementine_1994()` previously returned TAI TJT `8_815.000_324_074_073` (MJD 48815, ≈ 1992-07-12) with a docstring that claimed 1994-02-19 UTC and that it anchored `tier3_sim_earth_moon`. Neither was true: the JEOD `SIM_Earth_Moon RUN_clem` reference scenario uses TAI TJT `9412.0 + 28.0/86400.0` (MJD 49412 = 1994-03-01 UTC, TAI-UTC = 28 s). The tier3 setup module from #447 already pinned itself with that explicit literal and flagged this discrepancy in a code comment referencing #458.

- Repoint the recipe at the JEOD anchor: `at_tai_tjt(9_412.0 + 28.0 / 86_400.0)`.
- Rewrite the docstring to state 1994-03-01 UTC and cite the `SIM_Earth_Moon RUN_clem` derivation.
- Add a `clementine_1994_matches_run_clem_epoch` unit test in `src/recipes/epoch.rs` that pins the value and cross-checks it against `at_utc(1994, 3, 1, 0, 0, 0.0)`.
- Add a paired `epoch_literal_matches_recipe_clementine_1994` test in `astrodyn_verif_jeod::setups::earth_moon_clem` that asserts the hand-rolled tier3 literal still agrees bit-for-bit with the recipe, so future edits cannot drift one without the other.
- Update the in-source comment in the tier3 setup to remove the (now-stale) `#458`/wrong-recipe note and describe its present role.

Other `recipes::epoch::*` entries audited and confirmed correct:
- `dawn_mars_2009` → `14_879.958_727` matches 2009-02-17 23:00:00 UTC + 34 s (delta < 1.5e-7 days).
- `j2000` / `at_utc` / `at_iso` are already covered by existing tests.

Closes #458.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (1502 passed)
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_)'` (302 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [ ] CI `test-tier3-full` exercises the unchanged Tier 3 earth_moon literal on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)