### PR TITLE
[perf] Cache Epoch per step in update_ephemeris (closes #464)

### DIFF
--- a/crates/astrodyn_bevy/src/systems/ephemeris_update.rs
+++ b/crates/astrodyn_bevy/src/systems/ephemeris_update.rs
@@ -50,6 +50,12 @@ pub fn planet_fixed_rotation_system<P: Planet>(
     type PlanetRot<P> = astrodyn::FrameTransform<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>;
     let mut earth_rotation: Option<PlanetRot<P>> = Option::None;
     let mut earth_rotation_raw: Option<glam::DMat3> = Option::None;
+    // Lazy-build the ANISE `Epoch` for the current TDB instant once.
+    // The MoonDE421 branch below is the only consumer; hoisting the
+    // `Epoch::from_tdb_seconds` + `hifitime::Epoch::to_time_scale` cost
+    // out of the per-entity match keeps multi-Moon scenarios honest and
+    // mirrors the runner's `update_ephemeris` epoch-cache pattern.
+    let mut tdb_epoch: Option<astrodyn::Epoch> = Option::None;
     for (entity, mut rot, model, omega, ang_vel, pfix_frame_entity) in &mut query {
         let default_model = astrodyn::RotationModel::EarthRNP;
         let rotation_model = model.map_or(&default_model, |m| &m.0);
@@ -106,8 +112,10 @@ pub fn planet_fixed_rotation_system<P: Planet>(
                      body to RotationModel::MoonIAU.",
                 );
                 let tdb_jd = sim_time.tdb_julian_date();
+                let epoch =
+                    *tdb_epoch.get_or_insert_with(|| astrodyn::Ephemeris::tdb_jd_to_epoch(tdb_jd));
                 let mat = eph
-                    .get_body_rotation(astrodyn::EphemerisBody::Moon, tdb_jd)
+                    .get_body_rotation_epoch(astrodyn::EphemerisBody::Moon, epoch)
                     .unwrap_or_else(|err| {
                         panic!(
                             "Moon DE421 BPC rotation query failed at TDB JD {tdb_jd}: {err:?}. \
@@ -335,13 +343,19 @@ pub fn ephemeris_update_system<P: Planet>(
         return;
     };
     let tdb_jd = sim_time.tdb_julian_date();
+    // Build the ANISE `Epoch` once per system run and reuse across all
+    // matched entities — every query in the loop evaluates at the same
+    // instant, so the `Epoch::from_tdb_seconds` +
+    // `hifitime::Epoch::to_time_scale` work only needs to happen once.
+    // Mirrors the runner's `update_ephemeris` per-step epoch cache.
+    let epoch = astrodyn::Ephemeris::tdb_jd_to_epoch(tdb_jd);
     for (ephem_body, mut source_pos, source_vel, trans_state) in &mut query {
         // Typed sibling: returns `(Position<RootInertial>, Velocity<RootInertial>)`
         // directly, matching the typed component storage. Bit-identical to
         // the deprecated f64 path — the kernel itself extracts SI base
         // values from ANISE and re-wraps them.
         let (pos_typed, vel_typed) = eph
-            .get_state_typed(ephem_body.target, ephem_body.observer, tdb_jd)
+            .get_state_typed_epoch(ephem_body.target, ephem_body.observer, epoch)
             .unwrap_or_else(|e| {
                 panic!(
                     "Ephemeris lookup failed for {:?} wrt {:?} at TDB JD {tdb_jd}: {e}",

--- a/crates/astrodyn_ephemeris/src/ephemeris.rs
+++ b/crates/astrodyn_ephemeris/src/ephemeris.rs
@@ -87,6 +87,23 @@ impl Ephemeris {
             .describe(Some(true), Some(true), None, None, None, None, None, None);
     }
 
+    /// Build the ANISE [`Epoch`] for a TDB Julian Date.
+    ///
+    /// Hoisting this construction out of the per-query path lets callers
+    /// that issue multiple queries at the same instant (e.g. the per-step
+    /// ephemeris update which fetches Earth, Sun, and Moon-libration in
+    /// one go) pay the `Epoch::from_tdb_seconds` +
+    /// `hifitime::Epoch::to_time_scale` cost once instead of once per
+    /// query. The byte-identity guarantee follows from `Epoch` being a
+    /// plain value with no internal allocations: constructing once vs.
+    /// three times yields the same bits.
+    #[inline]
+    pub fn tdb_jd_to_epoch(tdb_jd: f64) -> Epoch {
+        // Convert JD to seconds since J2000.0 TDB: (jd - 2451545.0) * 86400.0
+        let tdb_s_since_j2000 = (tdb_jd - 2_451_545.0) * 86_400.0;
+        Epoch::from_tdb_seconds(tdb_s_since_j2000)
+    }
+
     /// Get state of `target` relative to `observer` at a given TDB Julian Date,
     /// returning frame-tagged, dimensioned quantities in the J2000 (ICRF-aligned)
     /// inertial frame.
@@ -95,15 +112,32 @@ impl Ephemeris {
     /// entry point wraps as `Position<RootInertial>` / `Velocity<RootInertial>`. The
     /// pre-Phase-10 bare-`f64` `get_state` was removed; use `.raw_si()` on
     /// the returned values when an unwrapped `DVec3` is needed.
+    ///
+    /// When issuing multiple queries at the same instant, prefer
+    /// [`Self::get_state_typed_epoch`] paired with [`Self::tdb_jd_to_epoch`]
+    /// to avoid rebuilding the [`Epoch`] (which internally calls
+    /// `hifitime::Epoch::to_time_scale`) on every call.
     pub fn get_state_typed(
         &self,
         target: EphemerisBody,
         observer: EphemerisBody,
         tdb_jd: f64,
     ) -> Result<(Position<RootInertial>, Velocity<RootInertial>), EphemerisError> {
-        // Convert JD to seconds since J2000.0 TDB: (jd - 2451545.0) * 86400.0
-        let tdb_s_since_j2000 = (tdb_jd - 2_451_545.0) * 86_400.0;
-        let epoch = Epoch::from_tdb_seconds(tdb_s_since_j2000);
+        self.get_state_typed_epoch(target, observer, Self::tdb_jd_to_epoch(tdb_jd))
+    }
+
+    /// [`Self::get_state_typed`] variant that takes a pre-built [`Epoch`].
+    ///
+    /// Use this when a single step issues multiple ephemeris queries at
+    /// the same instant: build the [`Epoch`] once with
+    /// [`Self::tdb_jd_to_epoch`] and pass it to each query, amortising
+    /// the `hifitime::Epoch::to_time_scale` cost across all queries.
+    pub fn get_state_typed_epoch(
+        &self,
+        target: EphemerisBody,
+        observer: EphemerisBody,
+        epoch: Epoch,
+    ) -> Result<(Position<RootInertial>, Velocity<RootInertial>), EphemerisError> {
         let target_frame = body_to_frame(target);
         let observer_frame = body_to_frame(observer);
 
@@ -150,14 +184,28 @@ impl Ephemeris {
     /// For Moon: uses the DE421 Principal Axes (PA) frame from a BPC kernel,
     /// which must already be loaded via `load_bpc()`.
     /// For Mars: uses IAU_MARS built-in constants.
+    ///
+    /// When issuing multiple queries at the same instant, prefer
+    /// [`Self::get_body_rotation_epoch`] paired with
+    /// [`Self::tdb_jd_to_epoch`] to avoid rebuilding the [`Epoch`].
     pub fn get_body_rotation(
         &self,
         body: EphemerisBody,
         tdb_jd: f64,
     ) -> Result<glam::DMat3, EphemerisError> {
-        let tdb_s_since_j2000 = (tdb_jd - 2_451_545.0) * 86_400.0;
-        let epoch = Epoch::from_tdb_seconds(tdb_s_since_j2000);
+        self.get_body_rotation_epoch(body, Self::tdb_jd_to_epoch(tdb_jd))
+    }
 
+    /// [`Self::get_body_rotation`] variant that takes a pre-built [`Epoch`].
+    ///
+    /// Use this when a single step issues multiple ephemeris queries at
+    /// the same instant (see [`Self::get_state_typed_epoch`] for the
+    /// amortisation rationale).
+    pub fn get_body_rotation_epoch(
+        &self,
+        body: EphemerisBody,
+        epoch: Epoch,
+    ) -> Result<glam::DMat3, EphemerisError> {
         // Use DE421 PA frame for Moon (high fidelity libration from BPC),
         // IAU built-in for other bodies.
         let orient = match body {

--- a/crates/astrodyn_ephemeris/src/lib.rs
+++ b/crates/astrodyn_ephemeris/src/lib.rs
@@ -60,3 +60,10 @@ pub mod ephemeris;
 
 pub use bodies::EphemerisBody;
 pub use ephemeris::{Ephemeris, EphemerisError};
+
+// Re-export ANISE's `Epoch` so callers that hoist epoch construction out
+// of per-query paths (`Ephemeris::get_state_typed_epoch`,
+// `Ephemeris::get_body_rotation_epoch`) can name the type without
+// reaching into `anise` directly. ANISE's `Epoch` is `hifitime::Epoch`
+// re-exported through `anise::prelude`.
+pub use anise::prelude::Epoch;

--- a/crates/astrodyn_runner/src/simulation/step/ephemeris.rs
+++ b/crates/astrodyn_runner/src/simulation/step/ephemeris.rs
@@ -47,6 +47,18 @@ impl Simulation {
         } else {
             None
         };
+
+        // Build the ANISE `Epoch` for the current TDB instant once. The
+        // BPC libration query (MoonDE421 branch below) and the DE4xx
+        // source-position queries in the 2b loop all evaluate at the
+        // same instant, so hoisting `Epoch::from_tdb_seconds` (and the
+        // internal `hifitime::Epoch::to_time_scale` it forces inside
+        // anise) out of each query is a strict reduction in work with
+        // no effect on the f64 outputs. The lazy initialisation keeps
+        // configurations without any ephemeris source from paying for
+        // an unused conversion.
+        let tdb_jd = self.time.tdb_julian_date();
+        let mut tdb_epoch: Option<astrodyn::Epoch> = None;
         for (i, grav) in self.gravity_data.iter_mut().enumerate() {
             match grav.rotation_model {
                 RotationModel::None => {}
@@ -78,7 +90,6 @@ impl Simulation {
                     }
                 }
                 RotationModel::MoonIAU => {
-                    let tdb_jd = self.time.tdb_julian_date();
                     let tdb_s_since_j2000 =
                         (tdb_jd - astrodyn::J2000_TT_JD) * astrodyn::SECONDS_PER_DAY;
                     let rotation =
@@ -97,9 +108,10 @@ impl Simulation {
                         "MoonDE421 rotation requires ephemeris with BPC. \
                          Set sim.ephemeris = Some(eph) after calling eph.load_bpc().",
                     );
-                    let tdb_jd = self.time.tdb_julian_date();
+                    let epoch = *tdb_epoch
+                        .get_or_insert_with(|| astrodyn::Ephemeris::tdb_jd_to_epoch(tdb_jd));
                     let rotation = eph
-                        .get_body_rotation(astrodyn::EphemerisBody::Moon, tdb_jd)
+                        .get_body_rotation_epoch(astrodyn::EphemerisBody::Moon, epoch)
                         .expect("Moon DE421 BPC rotation query failed");
                     if let Some(pfix_id) = self.source_frame_ids[i].pfix {
                         sync_pfix_rotation(
@@ -126,11 +138,15 @@ impl Simulation {
         // ── 2b. Ephemeris update — source positions from DE4xx ──
         // Update source positions from ephemeris each step and sync to frame tree.
         if let Some(ref eph) = self.ephemeris {
-            let tdb_jd = self.time.tdb_julian_date();
+            // Reuse the epoch built lazily above (or build it now if no
+            // rotation branch needed it) so all 2b source queries share
+            // a single `Epoch` value with the MoonDE421 query above.
+            let epoch =
+                *tdb_epoch.get_or_insert_with(|| astrodyn::Ephemeris::tdb_jd_to_epoch(tdb_jd));
             for i in 0..self.source_ephem_bodies.len() {
                 if let Some(Some((target, observer))) = self.source_ephem_bodies.get(i) {
                     let (pos_typed, vel_typed) = eph
-                        .get_state_typed(*target, *observer, tdb_jd)
+                        .get_state_typed_epoch(*target, *observer, epoch)
                         .map_err(|e| StepError::EphemerisLookup {
                             source_idx: i,
                             target: *target,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ pub use astrodyn_frames::{
 
 // astrodyn_ephemeris: ephemeris data
 pub use astrodyn_ephemeris::{
-    assets as ephemeris_assets, Ephemeris, EphemerisBody, EphemerisError,
+    assets as ephemeris_assets, Ephemeris, EphemerisBody, EphemerisError, Epoch,
 };
 
 // astrodyn_gravity: relativistic-correction submodule consumed by mission


### PR DESCRIPTION
## Summary

- Hoist `Epoch::from_tdb_seconds` + `hifitime::Epoch::to_time_scale` out of the per-query path in both `astrodyn_runner::Simulation::update_ephemeris` and the matching `astrodyn_bevy` systems (`planet_fixed_rotation_system`, `ephemeris_update_system`). All queries at the same TDB instant now share a single cached `Epoch`.
- Add `Ephemeris::tdb_jd_to_epoch(tdb_jd)`, `Ephemeris::get_state_typed_epoch(target, observer, epoch)`, and `Ephemeris::get_body_rotation_epoch(body, epoch)` overloads in `astrodyn_ephemeris`. The existing `tdb_jd: f64` entry points become thin wrappers that delegate to the `_epoch` siblings, so existing callers keep working at unchanged bit-identity.
- Re-export `anise::prelude::Epoch` from `astrodyn_ephemeris` and the `astrodyn` gateway so callers can name the cached type without reaching around the gateway.

Closes #464.

## Bit-identity rationale

The f64-JD `Ephemeris::get_state_typed` / `get_body_rotation` entry points are now thin wrappers around the `_epoch` siblings: `get_state_typed(.., tdb_jd) ⇒ get_state_typed_epoch(.., tdb_jd_to_epoch(tdb_jd))`. So a single epoch construction vs. three constructions produces the **same `Epoch` value** (a plain `hifitime::Epoch` with no internal allocations), and anise's `translate` / `rotate` accept that value by value without mutation. The downstream `state.radius_km` / `state.velocity_km_s` extraction is therefore byte-identical, and every subsequent f64 op in the integration loop reads the same bits.

## Local checks (all green)

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` → 1198/1198 passed
- [x] `cargo nextest run -p astrodyn_verif_parity` (bit-identity gate) → **303/303 passed** including `bevy_parity_solar_beta_*`, `bevy_parity_tide_verif_run01`, `bevy_parity_srp_1st_order_trajectory`, and the heavy `bevy_parity_dyncomp_*` / `bevy_parity_third_body` suites
- [x] `cargo doc --workspace --no-deps` (no warnings)
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_bypass_deps.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

## Deferred to CI

- `cargo nextest run -E 'test(tier3_simulation_earth_moon_clem)'` (~17 min) — deferred to `test-tier3-full` on main push. The bit-identity rationale above plus the 303/303 parity suite already cover the transitivity argument: if `runner ↔ bevy` is bit-identical (✓ via parity) and `runner ↔ JEOD` was within tolerance pre-change (✓ on main), then `runner ↔ JEOD` post-change is bit-identical to the pre-change result, hence still within tolerance.
- `diff target/tier3_crossval/tier3_earth_moon_clem.json{,.pre-change}` — same rationale; would require running the heavy earth_moon test twice. CI's `tier3_baseline_diff` job catches any drift on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)