### PR TITLE
Type compute_left_quat_deriv to AngularVelocity<BodyFrame<V>> (closes #455)

### DIFF
--- a/crates/astrodyn_dynamics/src/integration.rs
+++ b/crates/astrodyn_dynamics/src/integration.rs
@@ -1,3 +1,9 @@
+// JEOD_INV: TS.01 — the integrator stage kernels operate on the raw
+// `SixDofState` storage shape (one anonymous vehicle per call), so the
+// typed-seam lifts to `BodyAttitude<SelfRef>` /
+// `AngularVelocity<BodyFrame<SelfRef>>` here use the per-entity
+// storage-boundary wildcard; see `docs/JEOD_invariants.md` row TS.01
+// and the lint at `tests/self_ref_self_planet_discipline.rs`.
 //! Integration-method dispatch and the per-method translational /
 //! rotational step kernels.
 //!
@@ -12,6 +18,8 @@ use crate::mass::MassProperties;
 use crate::rotational::*;
 use crate::state::TranslationalState;
 use astrodyn_math::JeodQuat;
+use astrodyn_quantities::aliases::AngularVelocity;
+use astrodyn_quantities::frame::{BodyFrame, SelfRef};
 use glam::DVec3;
 
 /// Integration method selection.
@@ -173,11 +181,19 @@ pub fn rk4_sixdof_step(
     let eval_derivs = |s: &SixDofState, time_frac: f64| -> (DVec3, DVec3, [f64; 4], DVec3) {
         let k_v = s.trans.velocity;
         let k_a = accel_fn(s, time_frac);
-        let k_qdot = compute_left_quat_deriv(&s.rot.quaternion, s.rot.ang_vel_body);
-        let k_alpha = compute_rotational_acceleration(
+        // Lift the body-rate into the typed seam so
+        // `compute_left_quat_deriv_typed` /
+        // `compute_rotational_acceleration_typed` reject an
+        // inertial-frame ω at compile time. The quaternion stays raw —
+        // intermediate RK4 stages are not unit-norm by design.
+        // allowed: typed-integrator seam — lifts the per-stage `DVec3` body rate into the
+        // typed kernel so `compute_left_quat_deriv_typed` rejects an inertial ω at compile time.
+        let typed_omega = AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(s.rot.ang_vel_body);
+        let k_qdot = compute_left_quat_deriv_typed::<SelfRef>(&s.rot.quaternion, typed_omega);
+        let k_alpha = compute_rotational_acceleration_typed::<SelfRef>(
             &mass_props.inertia,
             &mass_props.inverse_inertia,
-            s.rot.ang_vel_body,
+            typed_omega,
             torque_fn(s),
         );
         (k_v, k_a, k_qdot, k_alpha)

--- a/crates/astrodyn_dynamics/src/integration.rs
+++ b/crates/astrodyn_dynamics/src/integration.rs
@@ -1,9 +1,14 @@
 // JEOD_INV: TS.01 — the integrator stage kernels operate on the raw
 // `SixDofState` storage shape (one anonymous vehicle per call), so the
-// typed-seam lifts to `BodyAttitude<SelfRef>` /
-// `AngularVelocity<BodyFrame<SelfRef>>` here use the per-entity
-// storage-boundary wildcard; see `docs/JEOD_invariants.md` row TS.01
-// and the lint at `tests/self_ref_self_planet_discipline.rs`.
+// typed-seam lift to `AngularVelocity<BodyFrame<SelfRef>>` here uses
+// the per-entity storage-boundary wildcard. The quaternion stays a
+// raw `JeodQuat` by design: RK4/RKF45 substages produce intermediate
+// quaternion accumulator values that are *not* unit-norm, so the
+// witness-gated `BodyAttitude<V>` constructor would panic on
+// legitimate mid-stage state — only ω is the kind-distinct frame
+// invariant that benefits from compile-time checking here. See
+// `docs/JEOD_invariants.md` row TS.01 and the lint at
+// `tests/self_ref_self_planet_discipline.rs`.
 //! Integration-method dispatch and the per-method translational /
 //! rotational step kernels.
 //!

--- a/crates/astrodyn_dynamics/src/lib.rs
+++ b/crates/astrodyn_dynamics/src/lib.rs
@@ -121,8 +121,9 @@ pub use rkf45::{
     rkf45_translational_step, AdaptiveConfig, AdaptiveResult,
 };
 pub use rotational::{
-    compute_left_quat_deriv, compute_rotational_acceleration, normalize_integ, RotationalState,
-    RotationalStateTyped, SixDofState, SixDofStateTyped,
+    compute_left_quat_deriv, compute_left_quat_deriv_typed, compute_rotational_acceleration,
+    compute_rotational_acceleration_typed, normalize_integ, RotationalState, RotationalStateTyped,
+    SixDofState, SixDofStateTyped,
 };
 pub use state::TranslationalState;
 pub use subtree::DetachedSubtreeState;

--- a/crates/astrodyn_dynamics/src/rkf45.rs
+++ b/crates/astrodyn_dynamics/src/rkf45.rs
@@ -1,9 +1,14 @@
 // JEOD_INV: TS.01 — the integrator stage kernels operate on the raw
 // `SixDofState` storage shape (one anonymous vehicle per call), so the
-// typed-seam lifts to `BodyAttitude<SelfRef>` /
-// `AngularVelocity<BodyFrame<SelfRef>>` here use the per-entity
-// storage-boundary wildcard; see `docs/JEOD_invariants.md` row TS.01
-// and the lint at `tests/self_ref_self_planet_discipline.rs`.
+// typed-seam lift to `AngularVelocity<BodyFrame<SelfRef>>` here uses
+// the per-entity storage-boundary wildcard. The quaternion stays a
+// raw `JeodQuat` by design: RK4/RKF45 substages produce intermediate
+// quaternion accumulator values that are *not* unit-norm, so the
+// witness-gated `BodyAttitude<V>` constructor would panic on
+// legitimate mid-stage state — only ω is the kind-distinct frame
+// invariant that benefits from compile-time checking here. See
+// `docs/JEOD_invariants.md` row TS.01 and the lint at
+// `tests/self_ref_self_planet_discipline.rs`.
 //! Runge-Kutta-Fehlberg 4(5) integrator.
 //!
 //! Port of JEOD/Trick ER7 `rkf45_butcher_tableau.cc` coefficients and

--- a/crates/astrodyn_dynamics/src/rkf45.rs
+++ b/crates/astrodyn_dynamics/src/rkf45.rs
@@ -1,3 +1,9 @@
+// JEOD_INV: TS.01 — the integrator stage kernels operate on the raw
+// `SixDofState` storage shape (one anonymous vehicle per call), so the
+// typed-seam lifts to `BodyAttitude<SelfRef>` /
+// `AngularVelocity<BodyFrame<SelfRef>>` here use the per-entity
+// storage-boundary wildcard; see `docs/JEOD_invariants.md` row TS.01
+// and the lint at `tests/self_ref_self_planet_discipline.rs`.
 //! Runge-Kutta-Fehlberg 4(5) integrator.
 //!
 //! Port of JEOD/Trick ER7 `rkf45_butcher_tableau.cc` coefficients and
@@ -17,6 +23,8 @@ use crate::mass::MassProperties;
 use crate::rotational::*;
 use crate::state::TranslationalState;
 use astrodyn_math::JeodQuat;
+use astrodyn_quantities::aliases::AngularVelocity;
+use astrodyn_quantities::frame::{BodyFrame, SelfRef};
 use glam::DVec3;
 
 // ── Butcher tableau coefficients ──
@@ -172,11 +180,19 @@ pub fn rkf45_sixdof_step(
     let eval_derivs = |s: &SixDofState, time_frac: f64| -> (DVec3, DVec3, [f64; 4], DVec3) {
         let k_v = s.trans.velocity;
         let k_a = accel_fn(s, time_frac);
-        let k_qdot = compute_left_quat_deriv(&s.rot.quaternion, s.rot.ang_vel_body);
-        let k_alpha = compute_rotational_acceleration(
+        // Typed seam — see `integration.rs::rk4_sixdof_step` for the
+        // matching pattern. The body-frame discipline on ω is
+        // structural through the `_typed` siblings; the intermediate
+        // quaternion stays raw because RK4/RKF45 stages do not
+        // renormalize between evaluations.
+        // allowed: typed-integrator seam — lifts the per-stage `DVec3` body rate into the
+        // typed kernel so `compute_left_quat_deriv_typed` rejects an inertial ω at compile time.
+        let typed_omega = AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(s.rot.ang_vel_body);
+        let k_qdot = compute_left_quat_deriv_typed::<SelfRef>(&s.rot.quaternion, typed_omega);
+        let k_alpha = compute_rotational_acceleration_typed::<SelfRef>(
             &mass_props.inertia,
             &mass_props.inverse_inertia,
-            s.rot.ang_vel_body,
+            typed_omega,
             torque_fn(s),
         );
         (k_v, k_a, k_qdot, k_alpha)
@@ -617,11 +633,20 @@ pub fn rkf45_adaptive_sixdof_step(
         let eval_derivs = |s: &SixDofState, time_frac: f64| -> (DVec3, DVec3, [f64; 4], DVec3) {
             let k_v = s.trans.velocity;
             let k_a = accel_fn(s, time_frac);
-            let k_qdot = compute_left_quat_deriv(&s.rot.quaternion, s.rot.ang_vel_body);
-            let k_alpha = compute_rotational_acceleration(
+            // Typed seam — same lift pattern as `rkf45_sixdof_step`
+            // above. The body-frame discipline on ω is structural
+            // through the `_typed` siblings; the intermediate
+            // quaternion stays raw because RK4/RKF45 stages do not
+            // renormalize between evaluations.
+            // allowed: typed-integrator seam — lifts the per-stage `DVec3` body rate into the
+            // typed kernel so `compute_left_quat_deriv_typed` rejects an inertial ω at compile time.
+            let typed_omega =
+                AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(s.rot.ang_vel_body);
+            let k_qdot = compute_left_quat_deriv_typed::<SelfRef>(&s.rot.quaternion, typed_omega);
+            let k_alpha = compute_rotational_acceleration_typed::<SelfRef>(
                 &mass_props.inertia,
                 &mass_props.inverse_inertia,
-                s.rot.ang_vel_body,
+                typed_omega,
                 torque_fn(s),
             );
             (k_v, k_a, k_qdot, k_alpha)

--- a/crates/astrodyn_dynamics/src/rotational.rs
+++ b/crates/astrodyn_dynamics/src/rotational.rs
@@ -194,6 +194,17 @@ impl<V: Vehicle> RotationalStateTyped<V> {
 /// rot_accel = inverse_inertia * torque_body
 /// ```
 /// Components with magnitude below 1e-20 are zeroed (JEOD `zero_small`).
+///
+/// This is the raw kernel — `ang_vel` is a bare `DVec3` and the caller
+/// asserts it lives in the rigid body's body frame (Euler's equation is
+/// frame-relative). Public callers in the integration call graph should
+/// prefer the typed sibling
+/// [`compute_rotational_acceleration_typed`], which makes the body-frame
+/// constraint structural via `AngularVelocity<BodyFrame<V>>`. The raw
+/// kernel remains public so the typed sibling can forward to it and so
+/// out-of-band consumers (`compute_frame_derivatives` in
+/// [`crate::forces`], integrator tests) can continue to call it
+/// directly.
 // JEOD_INV: FD.02 — rot_accel = I^-1 * (tau - omega x I*omega)
 // JEOD_INV: DB.19 — inverse_inertia used for Euler equation
 pub fn compute_rotational_acceleration(
@@ -218,6 +229,29 @@ pub fn compute_rotational_acceleration(
     zero_small(rot_accel)
 }
 
+/// Typed sibling of [`compute_rotational_acceleration`].
+///
+/// Accepts a body-frame [`AngularVelocity<BodyFrame<V>>`] in place of a
+/// bare `DVec3`, making the body-frame requirement structural: passing
+/// an inertial-frame angular velocity is a compile error at the seam
+/// (the diagnostic fires via `AngularVelocity<RootInertial>` vs
+/// `AngularVelocity<BodyFrame<V>>` mismatch on the `Qty3` frame
+/// phantom). Internally drops to `.raw_si()` and forwards to the raw
+/// kernel — arithmetic is byte-identical.
+///
+/// The external torque is still a bare `DVec3`; tightening it to a
+/// `Torque<BodyFrame<V>>` is a larger boundary refactor and out of
+/// scope here.
+#[inline]
+pub fn compute_rotational_acceleration_typed<V: Vehicle>(
+    inertia: &DMat3,
+    inverse_inertia: &DMat3,
+    ang_vel: AngularVelocity<BodyFrame<V>>,
+    extern_torq_body: DVec3,
+) -> DVec3 {
+    compute_rotational_acceleration(inertia, inverse_inertia, ang_vel.raw_si(), extern_torq_body)
+}
+
 /// Zero components with magnitude below 1e-20, matching JEOD `Vector3::zero_small`.
 fn zero_small(v: DVec3) -> DVec3 {
     const THRESHOLD: f64 = 1e-20;
@@ -238,6 +272,14 @@ fn zero_small(v: DVec3) -> DVec3 {
 /// ```
 ///
 /// Returns `[qdot_scalar, qdot_vx, qdot_vy, qdot_vz]` in JEOD scalar-first order.
+///
+/// This is the raw kernel — `ang_vel` is a bare `DVec3` and the caller
+/// asserts it lives in the body frame of the rigid body whose attitude
+/// is `q`. Mixing an inertial-frame ω with a body-frame quaternion
+/// here silently produces the conjugate trajectory (matching ω, π-off
+/// quaternion drift); it is exactly the bypass class that the typed
+/// sibling [`compute_left_quat_deriv_typed`] closes. New callers in
+/// the integration call graph should prefer the typed sibling.
 pub fn compute_left_quat_deriv(q: &JeodQuat, ang_vel: DVec3) -> [f64; 4] {
     let mhang_vel = -0.5 * ang_vel;
     let qv = q.vector();
@@ -250,6 +292,41 @@ pub fn compute_left_quat_deriv(q: &JeodQuat, ang_vel: DVec3) -> [f64; 4] {
     let qdot_v = qs * mhang_vel + mhang_vel.cross(qv);
 
     [qdot_s, qdot_v.x, qdot_v.y, qdot_v.z]
+}
+
+/// Typed sibling of [`compute_left_quat_deriv`].
+///
+/// The body-frame requirement on ω is structural — `ang_vel` is an
+/// [`AngularVelocity<BodyFrame<V>>`], so the compiler refuses any call
+/// that hands in an inertial-frame ω (or another vehicle's body-frame
+/// ω) at the kinematic ODE. That is the bypass class that hid the CC8
+/// attitude-integrator divergence: every legacy caller passed a field
+/// literally named `ang_vel_body` to a function that accepted any
+/// `DVec3`, so a future caller could silently feed an inertial-frame
+/// ω with no compiler complaint.
+///
+/// The quaternion stays a raw `&JeodQuat` rather than a
+/// `BodyAttitude<V>` because the integrator deliberately runs without
+/// renormalizing between RK4 / RKF45 stages — only the final combined
+/// quaternion is renormalized. `BodyAttitude` is a witnessed unit-norm
+/// type and would panic on those intermediate non-unit values; the
+/// kinematic ODE itself does not care about unit-norm-ness and the
+/// renormalization happens downstream of this kernel. The ω side is
+/// where the bypass actually lives, so typing it alone is sufficient
+/// to close the gap.
+///
+/// Internally drops `ang_vel` to `.raw_si()` and forwards to the raw
+/// kernel — arithmetic is byte-identical.
+///
+/// Returns `[qdot_scalar, qdot_vx, qdot_vy, qdot_vz]` in JEOD
+/// scalar-first order, matching the raw kernel exactly so callers can
+/// continue to step a `[f64; 4]` accumulator across stages.
+#[inline]
+pub fn compute_left_quat_deriv_typed<V: Vehicle>(
+    q: &JeodQuat,
+    ang_vel: AngularVelocity<BodyFrame<V>>,
+) -> [f64; 4] {
+    compute_left_quat_deriv(q, ang_vel.raw_si())
 }
 
 /// Normalize a quaternion without forcing scalar non-negative.
@@ -561,6 +638,71 @@ mod tests {
         let s = RotationalStateTyped::<TestVehicle>::default();
         assert_eq!(s.q_inertial_body.to_jeod_quat(), JeodQuat::identity());
         assert_eq!(s.ang_vel_body.raw_si(), DVec3::ZERO);
+    }
+
+    /// The typed sibling [`compute_left_quat_deriv_typed`] must forward
+    /// to the raw kernel with byte-identical arithmetic — the only
+    /// difference is structural type-checking at the seam.
+    #[test]
+    fn typed_left_quat_deriv_matches_raw() {
+        use astrodyn_quantities::aliases::AngularVelocity;
+        use astrodyn_quantities::frame::TestVehicle;
+
+        let q = JeodQuat::left_quat_from_eigen_rotation(0.7, DVec3::new(1.0, 2.0, 3.0).normalize());
+        let omega_vec = DVec3::new(0.001, -0.002, 0.0035);
+
+        let typed_omega = AngularVelocity::<BodyFrame<TestVehicle>>::from_raw_si(omega_vec);
+
+        let raw = compute_left_quat_deriv(&q, omega_vec);
+        let typed = compute_left_quat_deriv_typed::<TestVehicle>(&q, typed_omega);
+        assert_eq!(raw, typed);
+    }
+
+    /// The typed sibling tolerates non-unit intermediate quaternions —
+    /// RK4/RKF45 stages accumulate `q + qdot*h` without normalizing
+    /// between stages, so passing a slightly-off-unit JeodQuat through
+    /// the typed seam must not panic and must produce the same `qdot`
+    /// the raw kernel would.
+    #[test]
+    fn typed_left_quat_deriv_accepts_non_unit_intermediate_quat() {
+        use astrodyn_quantities::aliases::AngularVelocity;
+        use astrodyn_quantities::frame::TestVehicle;
+
+        // Synthesize a non-unit intermediate quaternion matching what a
+        // mid-stage RK4 accumulator looks like.
+        let q = JeodQuat::new(1.0 + 1e-4, 1e-3, -2e-3, 3e-3);
+        assert!((q.norm_sq() - 1.0).abs() > 1e-12);
+        let omega_vec = DVec3::new(0.001, -0.002, 0.0035);
+
+        let typed_omega = AngularVelocity::<BodyFrame<TestVehicle>>::from_raw_si(omega_vec);
+
+        let raw = compute_left_quat_deriv(&q, omega_vec);
+        let typed = compute_left_quat_deriv_typed::<TestVehicle>(&q, typed_omega);
+        assert_eq!(raw, typed);
+    }
+
+    /// The typed sibling [`compute_rotational_acceleration_typed`]
+    /// must forward to the raw kernel with byte-identical arithmetic.
+    #[test]
+    fn typed_rot_accel_matches_raw() {
+        use astrodyn_quantities::aliases::AngularVelocity;
+        use astrodyn_quantities::frame::TestVehicle;
+
+        let inertia = DMat3::from_diagonal(DVec3::new(10.0, 20.0, 30.0));
+        let inv_inertia = DMat3::from_diagonal(DVec3::new(0.1, 0.05, 1.0 / 30.0));
+        let omega_vec = DVec3::new(1.0, 2.0, 3.0);
+        let torque = DVec3::new(0.1, 0.2, -0.3);
+
+        let typed_omega = AngularVelocity::<BodyFrame<TestVehicle>>::from_raw_si(omega_vec);
+
+        let raw = compute_rotational_acceleration(&inertia, &inv_inertia, omega_vec, torque);
+        let typed = compute_rotational_acceleration_typed::<TestVehicle>(
+            &inertia,
+            &inv_inertia,
+            typed_omega,
+            torque,
+        );
+        assert_eq!(raw, typed);
     }
 
     // The constant-ω attitude advance helper that used to live here

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -12,8 +12,10 @@ use glam::DVec3;
 
 use crate::integrator::IntegratorType;
 use astrodyn_math::JeodQuat;
-use astrodyn_quantities::aliases::{Acceleration, Force, Position, Torque, Velocity};
-use astrodyn_quantities::frame::{BodyFrame, Frame, Vehicle};
+use astrodyn_quantities::aliases::{
+    Acceleration, AngularVelocity, Force, Position, Torque, Velocity,
+};
+use astrodyn_quantities::frame::{BodyFrame, Frame, SelfRef, Vehicle};
 use uom::si::f64::Time;
 
 use crate::integrable::IntegrableObject;
@@ -537,13 +539,20 @@ fn eval_stage(
         // qdot is computed from the *raw* stage quaternion (not the
         // normalized copy in `stage_rot_buf`) to match the rest of the
         // RK4 integration paths: intermediate stages are not
-        // renormalized — only the final combined quaternion is.
+        // renormalized — only the final combined quaternion is. The ω
+        // is lifted into the typed seam so the body-frame discipline
+        // is structural — `compute_left_quat_deriv_typed` rejects an
+        // inertial-frame ω at compile time.
         let raw_quat = JeodQuat::new(stage_q[i][0], stage_q[i][1], stage_q[i][2], stage_q[i][3]);
-        let qdot = astrodyn_dynamics::compute_left_quat_deriv(&raw_quat, stage_omega[i]);
-        let alpha = astrodyn_dynamics::compute_rotational_acceleration(
+        // allowed: typed-integrator seam — lifts the per-stage `DVec3` body rate into the
+        // typed kernel so `compute_left_quat_deriv_typed` rejects an inertial ω at compile time.
+        let typed_omega = AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(stage_omega[i]);
+        let qdot =
+            astrodyn_dynamics::compute_left_quat_deriv_typed::<SelfRef>(&raw_quat, typed_omega);
+        let alpha = astrodyn_dynamics::compute_rotational_acceleration_typed::<SelfRef>(
             &body.mass.inertia,
             &body.mass.inverse_inertia,
-            stage_omega[i],
+            typed_omega,
             total_torque,
         );
         k_v[i] = stage_vel[i];
@@ -1075,19 +1084,32 @@ fn integrate_coupled_sixdof<V: astrodyn_quantities::frame::Vehicle>(
     };
 
     // Helper: compute orbital + rotational derivatives from eval
-    let eval_rot_derivs =
-        |eval: &CoupledStageEval, rot_s: &RotationalState| -> (DVec3, [f64; 4], DVec3) {
-            let accel = compute_total_accel(eval, Some(mass_props));
-            let k_qdot =
-                astrodyn_dynamics::compute_left_quat_deriv(&rot_s.quaternion, rot_s.ang_vel_body);
-            let k_alpha = astrodyn_dynamics::compute_rotational_acceleration(
-                &mass_props.inertia,
-                &mass_props.inverse_inertia,
-                rot_s.ang_vel_body,
-                eval.torque,
-            );
-            (accel, k_qdot, k_alpha)
-        };
+    let eval_rot_derivs = |eval: &CoupledStageEval,
+                           rot_s: &RotationalState|
+     -> (DVec3, [f64; 4], DVec3) {
+        let accel = compute_total_accel(eval, Some(mass_props));
+        // Typed seam — same lift pattern as the
+        // `integrate_bodies_contact_coupled` stage above. The
+        // body-frame discipline on ω is structural through
+        // `compute_left_quat_deriv_typed` /
+        // `compute_rotational_acceleration_typed`; the intermediate
+        // quaternion stays raw because RK4 stages do not renormalize
+        // between evaluations.
+        // allowed: typed-integrator seam — lifts the per-stage `DVec3` body rate into the
+        // typed kernel so `compute_left_quat_deriv_typed` rejects an inertial ω at compile time.
+        let typed_omega = AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(rot_s.ang_vel_body);
+        let k_qdot = astrodyn_dynamics::compute_left_quat_deriv_typed::<SelfRef>(
+            &rot_s.quaternion,
+            typed_omega,
+        );
+        let k_alpha = astrodyn_dynamics::compute_rotational_acceleration_typed::<SelfRef>(
+            &mass_props.inertia,
+            &mass_props.inverse_inertia,
+            typed_omega,
+            eval.torque,
+        );
+        (accel, k_qdot, k_alpha)
+    };
 
     // Stage 1 (time_frac = 0.0)
     let eval1 = stage_fn(trans, Some(rot), thermal, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,12 +202,14 @@ pub use wrench::{aggregate_wrenches_via_storage, edge_geometry_from_composites, 
 // astrodyn_dynamics: state types, force types, mass, config, frame utilities
 pub use astrodyn_dynamics::{
     abm4_translational_step, combine_states_at_attach, compute_frame_derivatives,
-    compute_kinematic_child_state, compute_t_inertial_struct, compute_translational_derivatives,
-    derive_frame_attached_state, propagate_forward, recompute_composites_via_storage,
-    shift_wrench_to_parent, AttachCombineInputs, DetachedSubtreeState, DynamicsConfig,
-    FrameAttachInputs, FrameDerivatives, GravityAcceleration, MassBodyId, MassNodeOutputs,
-    MassNodeView, MassPointState, MassProperties, MassStorage, MassTree, RotationalState,
-    SixDofState, SixDofStateTyped, TotalForce, TranslationalState, Wrench,
+    compute_kinematic_child_state, compute_left_quat_deriv_typed,
+    compute_rotational_acceleration_typed, compute_t_inertial_struct,
+    compute_translational_derivatives, derive_frame_attached_state, propagate_forward,
+    recompute_composites_via_storage, shift_wrench_to_parent, AttachCombineInputs,
+    DetachedSubtreeState, DynamicsConfig, FrameAttachInputs, FrameDerivatives, GravityAcceleration,
+    MassBodyId, MassNodeOutputs, MassNodeView, MassPointState, MassProperties, MassStorage,
+    MassTree, RotationalState, SixDofState, SixDofStateTyped, TotalForce, TranslationalState,
+    Wrench,
 };
 
 // astrodyn_dynamics::body_init: typed orbital-element initializer


### PR DESCRIPTION
Closes #455.

## Summary

The CC8 attitude-integrator divergence (#454) escaped the type system at
the seam between the attitude integrator and `compute_left_quat_deriv` —
the typed quantity `AngularVelocity<BodyFrame<V>>` already existed, but
the RK4 / RKF45 callsites bypassed it and passed a bare `DVec3` named
`ang_vel_body`, with no compiler enforcement that the value actually
lives in the body frame. This PR closes that seam.

## Phase A — typed siblings (`crates/astrodyn_dynamics/src/rotational.rs`)

Two new public functions next to the existing raw kernels:

```rust
pub fn compute_left_quat_deriv_typed<V: Vehicle>(
    q: &JeodQuat,
    ang_vel: AngularVelocity<BodyFrame<V>>,
) -> [f64; 4];

pub fn compute_rotational_acceleration_typed<V: Vehicle>(
    inertia: &DMat3,
    inverse_inertia: &DMat3,
    ang_vel: AngularVelocity<BodyFrame<V>>,
    extern_torq_body: DVec3,
) -> DVec3;
```

Both call `.raw_si()` at the boundary and forward into the existing raw
kernels — arithmetic is byte-identical. The `<V: Vehicle>` parameter
threads the vehicle phantom through the body-frame ω, so the compiler
refuses an inertial-frame ω (or another vehicle's body-frame ω) at the
kinematic ODE entry point. The existing `Qty3` frame-mismatch
diagnostic (`CompatibleFrames` in `crates/astrodyn_quantities/src/diagnostics.rs`)
fires with the standard "expected `AngularVelocity<BodyFrame<V>>`,
found `AngularVelocity<...>`" message.

The quaternion stays a raw `&JeodQuat` rather than a `BodyAttitude<V>`:
RK4 / RKF45 stages deliberately do not renormalize between
evaluations, so wrapping mid-stage values in `BodyAttitude` (which
witnesses unit-norm to 1e-12) would panic on legitimate intermediate
quaternions. The ω side is where the diagnosed bypass actually lives
(#454's "matching ω with π-off quaternion drift" signature is the
fingerprint of an ω frame-mix), so typing ω alone closes the gap
without adding a new "unchecked" attitude constructor.

## Phase B — out of scope for this PR

Re-typing `RotationalState.ang_vel_body` to the typed quantity itself
(rather than at the integrator seam) is a larger refactor that
crosses the boundary with `forces::compute_frame_derivatives` and
several runner / Bevy consumers. The typed sibling
`RotationalStateTyped<V>` already exists and already wraps the typed ω;
folding the untyped `RotationalState` out of the integrator's stage
helpers is a follow-up that depends on routing every consumer through
the typed shape. Tracked as #455 Phase B.

## Phase C — five callsite migrations

The five attitude-integration callsites identified in #455 now lift
the raw `DVec3` body rate to `AngularVelocity<BodyFrame<SelfRef>>` at
the seam and call the typed siblings:

- `crates/astrodyn_dynamics/src/integration.rs:176` — `rk4_sixdof_step`
- `crates/astrodyn_dynamics/src/rkf45.rs:175` — `rkf45_sixdof_step`
- `crates/astrodyn_dynamics/src/rkf45.rs:620` — `rkf45_adaptive_sixdof_step`
- `src/integration.rs:542` — `integrate_bodies_contact_coupled` (contact-coupled RK4)
- `src/integration.rs:1082` — coupled 6-DOF stage helper

Each seam is a single `AngularVelocity::<BodyFrame<SelfRef>>::from_raw_si(...)`
call annotated `// allowed: typed-integrator seam …` so the bypass is
grep-able and is the only place a raw `DVec3` ω reaches the kinematic
ODE. The `SelfRef` phantom is the standard per-entity
storage-boundary wildcard (TS.01 in `docs/JEOD_invariants.md`); the
two `crates/astrodyn_dynamics/src/` files that newly mint `SelfRef`
carry the file-level TS.01 marker required by
`tests/self_ref_self_planet_discipline.rs`.

## Phase D — `compute_rotational_acceleration`

Audited per the issue's Phase D and typed in the same PR. The raw
kernel stays `pub` because `forces::compute_frame_derivatives` (a
non-integration consumer with its own external callers across crates)
still calls it directly; widening that further would touch
`astrodyn_interactions`, `astrodyn_bevy`, and `astrodyn_runner` and is
out of scope for a signature refactor.

## Gateway re-exports

`astrodyn::lib` re-exports both typed siblings so production-path
consumers (mission crates, `astrodyn_bevy`, the verif crates) reach
them through the single API surface required by CLAUDE.md.

## Bit-identity rationale

Arithmetic does not change. The typed wrappers are one-line
forwarders that `.raw_si()` the typed ω and call the existing raw
kernels. A unit test (`typed_left_quat_deriv_matches_raw`,
`typed_rot_accel_matches_raw`) asserts byte-equality against the raw
kernel on a non-trivial input, and a second unit test
(`typed_left_quat_deriv_accepts_non_unit_intermediate_quat`) exercises
the documented mid-stage non-unit quaternion case so the typed seam
cannot be retrofitted with a `BodyAttitude`-wrapping that would panic
on legitimate integrator state.

## Verification

Locally passing:

- `cargo fmt --check`
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1203/1203
- `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_)'` — **302/302 pass** (lockstep parity; arithmetic unchanged)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `scripts/check_no_escape_hatches.sh`
- `cargo test -p astrodyn --test invariant_coverage` — 6/6
- `cargo test -p astrodyn --test self_ref_self_planet_discipline` — 2/2

Heavy Tier 3 attitude-trajectory tests (Apollo `tier3_dyncomp_*`,
NESC `tier3_nesc_cc8_*`) deferred to CI on the bit-identity
argument — arithmetic is unchanged, only the signatures shift.

## Test plan

- [x] Unit + tier 2 (`cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'`)
- [x] All 302 `bevy_parity_*` lockstep parity tests
- [x] `check_no_escape_hatches.sh` (typed-integrator seams documented with `// allowed:`)
- [x] `self_ref_self_planet_discipline` (file-level TS.01 markers on new `SelfRef` sites)
- [x] `invariant_coverage` (no new JEOD_INV catalog churn — the existing FD.02 / DB.19 tags carry through)
- [ ] CI Tier 3 attitude tests (Apollo, dyncomp, CC8) — deferred to PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)