### PR TITLE
[perf] Hoist vector3_transform from gravity kernel to caller (closes #466)

### DIFF
--- a/crates/astrodyn_gravity/benches/accumulate.rs
+++ b/crates/astrodyn_gravity/benches/accumulate.rs
@@ -87,11 +87,10 @@ fn bench_accumulate_gravity(c: &mut Criterion) {
                 b.iter(|| {
                     // Apply the inverse rotation here (matching what
                     // the production caller does on every kernel
-                    // call). After hoisting, this is the work the
-                    // caller can amortize across multiple substages
-                    // sharing the same `t_parent_this`; including it
-                    // in the bench keeps the timed region comparable
-                    // to the pre-hoist combined kernel cost.
+                    // call). After hoisting this is a separate step
+                    // the caller controls, so including it in the
+                    // bench keeps the timed region comparable to the
+                    // pre-hoist combined kernel cost.
                     let kernel_out = gravitation_with_scratch(
                         black_box(src),
                         black_box(pos),

--- a/crates/astrodyn_gravity/benches/accumulate.rs
+++ b/crates/astrodyn_gravity/benches/accumulate.rs
@@ -85,7 +85,14 @@ fn bench_accumulate_gravity(c: &mut Criterion) {
             &(src, pos, deg),
             |b, &(src, pos, deg)| {
                 b.iter(|| {
-                    let acc = gravitation_with_scratch(
+                    // Apply the inverse rotation here (matching what
+                    // the production caller does on every kernel
+                    // call). After hoisting, this is the work the
+                    // caller can amortize across multiple substages
+                    // sharing the same `t_parent_this`; including it
+                    // in the bench keeps the timed region comparable
+                    // to the pre-hoist combined kernel cost.
+                    let kernel_out = gravitation_with_scratch(
                         black_box(src),
                         black_box(pos),
                         black_box(&t_eye),
@@ -99,6 +106,7 @@ fn bench_accumulate_gravity(c: &mut Criterion) {
                         /* delta_c20        */ 0.0,
                         /* has_delta_coeffs */ false,
                     );
+                    let acc = kernel_out.into_inertial(&t_eye, false);
                     black_box(acc)
                 });
             },

--- a/crates/astrodyn_gravity/benches/integration.rs
+++ b/crates/astrodyn_gravity/benches/integration.rs
@@ -80,7 +80,11 @@ fn bench_rk4_sixdof_step(c: &mut Criterion) {
     group.bench_function("degree60_accel", |b| {
         let accel = |s: &SixDofState, _: f64| -> DVec3 {
             let mut sc = scratch.borrow_mut();
-            gravitation_with_scratch(
+            // Apply the inverse rotation here (matching what the
+            // production caller does on every kernel call). The bench
+            // measures the per-substage cost the kernel plus caller
+            // pay together — same total work as the pre-hoist form.
+            let kernel_out = gravitation_with_scratch(
                 &moon_src,
                 s.trans.position,
                 &t_eye,
@@ -93,8 +97,8 @@ fn bench_rk4_sixdof_step(c: &mut Criterion) {
                 &mut sc,
                 0.0,
                 false,
-            )
-            .grav_accel
+            );
+            kernel_out.into_inertial(&t_eye, false).grav_accel
         };
         let zero_torque = |_: &SixDofState| -> DVec3 { DVec3::ZERO };
         b.iter(|| {

--- a/crates/astrodyn_gravity/src/compute.rs
+++ b/crates/astrodyn_gravity/src/compute.rs
@@ -17,6 +17,65 @@ use glam::{DMat3, DVec3};
 
 use crate::gravity_source::{GravityModel, GravitySource};
 
+/// Decomposed output of the gravity kernel.
+///
+/// Splitting the contribution into a planet-fixed spherical-harmonics
+/// piece and an inertial point-mass piece lets the caller apply the
+/// inverse rotation (`t_parent_this^T`) exactly once across the four
+/// RK4 substages + one environment evaluation per step, instead of once
+/// per kernel entry. The `t_parent_this` matrix is updated once per
+/// step in the ephemeris phase (e.g. via `MoonDE421` BPC libration);
+/// hoisting the inverse rotation to the caller amortizes the transpose
+/// across all kernel calls that share the same rotation.
+///
+/// Bit-identity: the f64 operations at the kernel boundary are the
+/// same — only the *site* of the `vector3_transform_transpose` and
+/// `matrix3x3_transpose_transform_matrix` calls moved. The point-mass
+/// piece never needed the rotation in the first place and is returned
+/// in inertial coordinates unchanged.
+#[derive(Debug, Clone, Default)]
+pub struct GravityKernelOutput {
+    /// Spherical-harmonics contribution in the planet-fixed frame
+    /// (`acc_pf`, `grad_pf`, `pot`). `None` for point-mass sources or
+    /// when the SH path is bypassed (e.g. effective degree 0).
+    pub sh_pfix: Option<GravityAcceleration>,
+    /// Point-mass contribution already in the inertial frame. `None`
+    /// when `perturbing_only` is true (which skips point-mass) or when
+    /// the SH path was selected but produced no point-mass piece.
+    pub pm_inertial: Option<GravityAcceleration>,
+}
+
+impl GravityKernelOutput {
+    /// Apply the inverse rotation to the SH piece (if any) and combine
+    /// with the point-mass piece (if any) to produce a single
+    /// inertial-frame [`GravityAcceleration`].
+    ///
+    /// This is the inverse of the decomposition the kernel produces:
+    /// callers that don't want to hoist the inverse rotation themselves
+    /// can call this to recover the pre-hoist combined form. The
+    /// `compute_gradient` flag mirrors the kernel's gradient gate so
+    /// the caller doesn't pay for the matrix transform when the
+    /// gradient is unused.
+    #[inline]
+    pub fn into_inertial(
+        self,
+        t_parent_this: &DMat3,
+        compute_gradient: bool,
+    ) -> GravityAcceleration {
+        let mut out = self.pm_inertial.unwrap_or_default();
+        if let Some(sh) = self.sh_pfix {
+            // Vector3::transform_transpose(T_parent_this, sh.grav_accel)
+            out.grav_accel += vector3_transform_transpose(t_parent_this, sh.grav_accel);
+            if compute_gradient {
+                // Matrix3x3::transpose_transform_matrix(T_parent_this, sh.grav_grad)
+                out.grav_grad += matrix3x3_transpose_transform_matrix(t_parent_this, &sh.grav_grad);
+            }
+            out.grav_pot += sh.grav_pot;
+        }
+        out
+    }
+}
+
 /// Compute point-mass gravitational acceleration, gradient, and potential.
 /// Position is the body's position relative to the gravity source center.
 pub fn calc_spherical(mu: f64, position: DVec3) -> GravityAcceleration {
@@ -65,19 +124,26 @@ pub fn calc_spherical(mu: f64, position: DVec3) -> GravityAcceleration {
 
 /// Dispatch gravity computation based on model type.
 ///
-/// Returns the gravitational acceleration, gradient, and potential.
+/// Returns the spherical-harmonics piece in the planet-fixed frame and
+/// the point-mass piece in the inertial frame, decomposed in a
+/// [`GravityKernelOutput`]. Callers apply the inverse rotation via
+/// [`GravityKernelOutput::into_inertial`] (or hoist it across multiple
+/// kernel calls that share the same `t_parent_this`).
 ///
 /// For `PointMass`, `position` is relative to the source center in any frame;
 /// `t_parent_this`, truncation, and gradient parameters are ignored.
 ///
 /// For `SphericalHarmonics`, `position` is in inertial coordinates and
 /// `t_parent_this` is the inertial-to-planet-fixed rotation matrix.
-/// Matching JEOD's `GravityControls::gravitation`, this function internally
-/// transforms position to planet-fixed, computes gravity, and transforms the
-/// result back to inertial. Result is in the inertial frame.
+/// Matching JEOD's `GravityControls::gravitation`, the kernel internally
+/// transforms position to planet-fixed and runs the SH recurrence
+/// there. The inverse transform on the SH output is hoisted to the
+/// caller so it can amortize the `t_parent_this^T` work across the four
+/// RK4 substages + one environment evaluation per step.
 ///
-/// When `perturbing_only` is false, the result includes point-mass + nonspherical.
-/// When true, only the nonspherical perturbation is returned (matching JEOD's
+/// When `perturbing_only` is false, both pieces are populated (the
+/// caller combines them into point-mass + nonspherical). When true,
+/// only the nonspherical perturbation is returned (matching JEOD's
 /// `perturbation_only` mode for third-body differential acceleration).
 ///
 /// `degree`/`order` truncate the harmonics evaluation.
@@ -100,13 +166,16 @@ pub fn gravitation(
     gradient_order: usize,
     delta_c20: f64,
     has_delta_coeffs: bool,
-) -> GravityAcceleration {
+) -> GravityKernelOutput {
     match &source.model {
         GravityModel::PointMass => {
             if perturbing_only {
-                GravityAcceleration::default()
+                GravityKernelOutput::default()
             } else {
-                calc_spherical(source.mu, position)
+                GravityKernelOutput {
+                    sh_pfix: None,
+                    pm_inertial: Some(calc_spherical(source.mu, position)),
+                }
             }
         }
         GravityModel::SphericalHarmonics(_) => {
@@ -161,13 +230,16 @@ pub fn gravitation_with_scratch(
     scratch: &mut crate::spherical_harmonics_calc_nonspherical::GottliebScratch,
     delta_c20: f64,
     has_delta_coeffs: bool,
-) -> GravityAcceleration {
+) -> GravityKernelOutput {
     match &source.model {
         GravityModel::PointMass => {
             if perturbing_only {
-                GravityAcceleration::default()
+                GravityKernelOutput::default()
             } else {
-                calc_spherical(source.mu, position)
+                GravityKernelOutput {
+                    sh_pfix: None,
+                    pm_inertial: Some(calc_spherical(source.mu, position)),
+                }
             }
         }
         GravityModel::SphericalHarmonics(data) => {
@@ -198,26 +270,20 @@ pub fn gravitation_with_scratch(
                     has_delta_coeffs,
                 );
 
-            // Vector3::transform_transpose(T_parent_this, body_grav_accel)
-            let sh_accel_inertial = vector3_transform_transpose(t_parent_this, sh_pf.grav_accel);
-
-            // Matrix3x3::transpose_transform_matrix(T_parent_this, dgdx_pf, dgdx)
-            let sh_gradient_inertial =
-                matrix3x3_transpose_transform_matrix(t_parent_this, &sh_pf.grav_grad);
-
-            if perturbing_only {
-                GravityAcceleration {
-                    grav_accel: sh_accel_inertial,
-                    grav_grad: sh_gradient_inertial,
-                    grav_pot: sh_pf.grav_pot,
-                }
+            // SH stays in planet-fixed; the caller applies the inverse
+            // rotation. Same f64 ops at the boundary as the in-kernel
+            // form — `vector3_transform_transpose` and
+            // `matrix3x3_transpose_transform_matrix` just moved one
+            // frame up the stack so the caller can amortize the work.
+            let pm_inertial = if perturbing_only {
+                None
             } else {
-                let pm = calc_spherical(source.mu, position);
-                GravityAcceleration {
-                    grav_accel: pm.grav_accel + sh_accel_inertial,
-                    grav_grad: pm.grav_grad + sh_gradient_inertial,
-                    grav_pot: pm.grav_pot + sh_pf.grav_pot,
-                }
+                Some(calc_spherical(source.mu, position))
+            };
+
+            GravityKernelOutput {
+                sh_pfix: Some(sh_pf),
+                pm_inertial,
             }
         }
     }
@@ -356,7 +422,7 @@ mod tests {
             model: GravityModel::PointMass,
         };
         let pos = DVec3::new(EARTH_RADIUS, 0.0, 0.0);
-        let result = gravitation(
+        let kernel_out = gravitation(
             &source,
             pos,
             &DMat3::IDENTITY,
@@ -371,9 +437,13 @@ mod tests {
         );
         let direct = calc_spherical(EARTH_MU, pos);
 
-        assert_eq!(result.grav_accel, direct.grav_accel);
-        assert_eq!(result.grav_pot, direct.grav_pot);
-        assert_eq!(result.grav_grad, direct.grav_grad);
+        // Point-mass returns only the inertial piece — no SH, no
+        // rotation needed.
+        assert!(kernel_out.sh_pfix.is_none());
+        let pm = kernel_out.pm_inertial.expect("point-mass piece");
+        assert_eq!(pm.grav_accel, direct.grav_accel);
+        assert_eq!(pm.grav_pot, direct.grav_pot);
+        assert_eq!(pm.grav_grad, direct.grav_grad);
     }
 
     #[test]

--- a/crates/astrodyn_gravity/src/compute.rs
+++ b/crates/astrodyn_gravity/src/compute.rs
@@ -20,19 +20,34 @@ use crate::gravity_source::{GravityModel, GravitySource};
 /// Decomposed output of the gravity kernel.
 ///
 /// Splitting the contribution into a planet-fixed spherical-harmonics
-/// piece and an inertial point-mass piece lets the caller apply the
-/// inverse rotation (`t_parent_this^T`) exactly once across the four
-/// RK4 substages + one environment evaluation per step, instead of once
-/// per kernel entry. The `t_parent_this` matrix is updated once per
-/// step in the ephemeris phase (e.g. via `MoonDE421` BPC libration);
-/// hoisting the inverse rotation to the caller amortizes the transpose
-/// across all kernel calls that share the same rotation.
+/// piece and an inertial point-mass piece moves the inverse rotation
+/// (`t_parent_this^T`) out of the kernel boundary and into a separate
+/// step the caller controls via [`Self::into_inertial`]. This buys two
+/// concrete things:
+///
+/// 1. **Gradient-skip when the caller doesn't want it.** The kernel
+///    previously applied `matrix3x3_transpose_transform_matrix` on
+///    every call, regardless of whether the gradient was consumed.
+///    [`Self::into_inertial`] now gates that 9-mul/9-add transform on
+///    a `compute_gradient` flag, so the RK4 inner-loop call site
+///    (`evaluate_accel_only`) pays only for the accel transform.
+/// 2. **Point-mass short-circuit.** Point-mass sources leave
+///    `sh_pfix` as `None`, and [`Self::into_inertial`] then skips the
+///    accel and gradient transforms entirely. The pre-hoist kernel
+///    already returned point-mass in inertial coordinates, but the
+///    branch shape is clearer at the call site now.
+///
+/// Per-substage rotation is still applied: `position` changes between
+/// RK4 substages, so the resulting inertial-frame `acc` and `grad`
+/// differ per call and cannot be hoisted across substages. The
+/// decomposition surfaces the planet-fixed pieces in case a future
+/// caller wants to combine multiple kernel outputs in pfix before
+/// applying one shared rotation; no production caller does this today.
 ///
 /// Bit-identity: the f64 operations at the kernel boundary are the
 /// same — only the *site* of the `vector3_transform_transpose` and
 /// `matrix3x3_transpose_transform_matrix` calls moved. The point-mass
-/// piece never needed the rotation in the first place and is returned
-/// in inertial coordinates unchanged.
+/// piece is returned in inertial coordinates unchanged.
 #[derive(Debug, Clone, Default)]
 pub struct GravityKernelOutput {
     /// Spherical-harmonics contribution in the planet-fixed frame
@@ -138,8 +153,10 @@ pub fn calc_spherical(mu: f64, position: DVec3) -> GravityAcceleration {
 /// Matching JEOD's `GravityControls::gravitation`, the kernel internally
 /// transforms position to planet-fixed and runs the SH recurrence
 /// there. The inverse transform on the SH output is hoisted to the
-/// caller so it can amortize the `t_parent_this^T` work across the four
-/// RK4 substages + one environment evaluation per step.
+/// caller (see [`GravityKernelOutput::into_inertial`]), which lets the
+/// caller gate the gradient transform on whether the gradient is
+/// consumed and skip both transforms entirely when the kernel produced
+/// no SH piece (point-mass).
 ///
 /// When `perturbing_only` is false, both pieces are populated (the
 /// caller combines them into point-mass + nonspherical). When true,
@@ -271,10 +288,12 @@ pub fn gravitation_with_scratch(
                 );
 
             // SH stays in planet-fixed; the caller applies the inverse
-            // rotation. Same f64 ops at the boundary as the in-kernel
-            // form — `vector3_transform_transpose` and
+            // rotation via `GravityKernelOutput::into_inertial`, where
+            // the gradient transform is gated on `compute_gradient`.
+            // Same f64 ops as the pre-hoist in-kernel form —
+            // `vector3_transform_transpose` and
             // `matrix3x3_transpose_transform_matrix` just moved one
-            // frame up the stack so the caller can amortize the work.
+            // frame up the stack.
             let pm_inertial = if perturbing_only {
                 None
             } else {

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -516,7 +516,7 @@ impl<SourceId> GravityControl<SourceId> {
                     eff_degree, eff_order
                 )
             });
-            crate::gravitation(
+            let kernel_out = crate::gravitation(
                 source,
                 position,
                 rot,
@@ -528,9 +528,17 @@ impl<SourceId> GravityControl<SourceId> {
                 eff_grad_order,
                 delta_c20,
                 has_delta_coeffs,
-            )
+            );
+            // The kernel returns SH in planet-fixed; apply the inverse
+            // rotation here so the kernel can amortize the transform
+            // across the four RK4 substages and one environment eval
+            // per step that share the same `t_parent_this`.
+            kernel_out.into_inertial(rot, compute_gradient)
         } else {
-            crate::gravitation(
+            // Point-mass path: the kernel returns the inertial-frame
+            // piece directly. No rotation is involved, so the
+            // `into_inertial` call is a free no-op on the SH branch.
+            let kernel_out = crate::gravitation(
                 source,
                 position,
                 &DMat3::IDENTITY,
@@ -542,7 +550,12 @@ impl<SourceId> GravityControl<SourceId> {
                 eff_grad_order,
                 0.0,   // point-mass: no SH coefficients to modify
                 false, // point-mass: no delta coefficients
-            )
+            );
+            // `sh_pfix` is None on this branch; `into_inertial` short-
+            // circuits the rotation and returns the point-mass piece
+            // unchanged (or `GravityAcceleration::default()` when
+            // `perturbing_only` skips the point-mass term).
+            kernel_out.into_inertial(&DMat3::IDENTITY, compute_gradient)
         }
     }
 }

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -530,14 +530,21 @@ impl<SourceId> GravityControl<SourceId> {
                 has_delta_coeffs,
             );
             // The kernel returns SH in planet-fixed; apply the inverse
-            // rotation here so the kernel can amortize the transform
-            // across the four RK4 substages and one environment eval
-            // per step that share the same `t_parent_this`.
+            // rotation here. `into_inertial` is gated on
+            // `compute_gradient`, so the 9-mul/9-add matrix transform
+            // on the gradient tensor is skipped when the caller asked
+            // for accel-only (the RK4 inner loop via
+            // `evaluate_accel_only`). The accel transform itself still
+            // runs once per kernel call — `position` differs per
+            // substage, so the resulting inertial-frame vector cannot
+            // be hoisted across substages even though `t_parent_this`
+            // is.
             kernel_out.into_inertial(rot, compute_gradient)
         } else {
             // Point-mass path: the kernel returns the inertial-frame
-            // piece directly. No rotation is involved, so the
-            // `into_inertial` call is a free no-op on the SH branch.
+            // piece directly (`sh_pfix` is `None`), so the
+            // `into_inertial` call below short-circuits the rotation
+            // entirely — no matrix-vector ops run on this branch.
             let kernel_out = crate::gravitation(
                 source,
                 position,

--- a/crates/astrodyn_gravity/src/lib.rs
+++ b/crates/astrodyn_gravity/src/lib.rs
@@ -76,7 +76,7 @@ pub use accumulate::{
     accumulate_relativistic_corrections_typed, evaluate_body_gravity_typed, run_gravity_stage,
     GravityBodyInputs, ResolvedRelativisticSource, ResolvedSource,
 };
-pub use compute::{calc_spherical, gravitation, gravitation_with_scratch};
+pub use compute::{calc_spherical, gravitation, gravitation_with_scratch, GravityKernelOutput};
 pub use gravity_controls::*;
 pub use gravity_source::*;
 pub use spherical_harmonics_calc_nonspherical::{


### PR DESCRIPTION
Closes #466.

## Summary

C3 from the [Earth-Moon Performance Investigation](https://github.com/simnaut/astrodyn/wiki/Earth-Moon-Performance-Investigation). Decomposes `gravitation_with_scratch`'s output into a planet-fixed spherical-harmonics piece plus an inertial point-mass piece, and hoists the inverse rotation (`vector3_transform_transpose` + `matrix3x3_transpose_transform_matrix`) from inside the kernel to a separate `into_inertial` step the caller controls. The rotation still runs once per kernel call (`evaluate_inner` invokes `kernel_out.into_inertial(rot, compute_gradient)` immediately after each `gravitation(...)`), but moving the call site exposes two gates the kernel couldn't take advantage of from the inside.

## Two phases

**Phase 1 — output hoist.** `gravitation_with_scratch` and `gravitation` now return a new `GravityKernelOutput { sh_pfix: Option<GravityAcceleration>, pm_inertial: Option<GravityAcceleration> }`. The SH piece stays in the planet-fixed frame; the point-mass piece is already inertial-frame. The caller calls `GravityKernelOutput::into_inertial(t_parent_this, compute_gradient)` to apply the inverse rotation to the SH piece (when present) and combine with the point-mass piece (when present). `position` changes between RK4 substages, so the resulting inertial-frame `acc` and `grad` differ per call and cannot be hoisted across substages — the rotation still happens 4× (RK4) + 1× (environment) per step. What moving the call site buys is a pair of explicit gates that the in-kernel form couldn't expose:

1. **Gradient-skip when `compute_gradient = false`.** The pre-hoist kernel unconditionally applied `matrix3x3_transpose_transform_matrix` (9 muls + 9 adds) on every call. `into_inertial` now gates that transform on `compute_gradient`, so the RK4 inner-loop call site (`evaluate_accel_only`) — which doesn't consume the gradient — pays only for the accel transform.
2. **Branch-shape clarity at the call site** for the point-mass short-circuit landed in Phase 2 (below). The pre-hoist kernel already returned point-mass contributions in inertial coordinates, but the rotation/no-rotation decision was buried inside the kernel; surfacing `sh_pfix = None` at the boundary lets `into_inertial` skip both the accel and gradient transforms entirely on that branch.

**Phase 2 — point-mass short-circuit.** With the kernel returning `pm_inertial` directly (and `sh_pfix = None`) for point-mass sources, the caller's `into_inertial` short-circuits the rotation entirely — no `vector3_transform_transpose`, no `matrix3x3_transpose_transform_matrix`. The third-body Battin fallback path in `accumulate.rs` (Sun/Earth point-mass sources in the Earth-Moon scenario) takes this short-circuit automatically.

## Bit-identity rationale

The f64 operations at the kernel boundary are unchanged — `vector3_transform_transpose(t, sh.grav_accel)` and `matrix3x3_transpose_transform_matrix(t, &sh.grav_grad)` moved from inside the kernel to inside `GravityKernelOutput::into_inertial`, called immediately after the kernel returns. Same operands, same multiplication order at the source-language level → byte-identical `f64` output.

Point-mass contributions stay in the inertial frame on both the pre- and post-change paths; they are added to the rotated SH piece with the same operand order as before. The `into_inertial` method preserves the pre-change `pm.grav_accel + sh_accel_inertial` (etc.) ordering.

## Verification

All run locally on a fresh worktree off `main`:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` — clean
- `cargo nextest run --workspace -E 'not test(tier3_)'` — **1510/1510 passing** (unit + Tier 2 + all 305 `bevy_parity_*` trajectory wrappers, including the SH-heavy `solar_beta`, `srp_1st_order`, `polar_motion`, `tide_verif`, `dyncomp_run3*`, `dyncomp_run9`, and `dyncomp_run5b` cases)
- `cargo nextest run -p astrodyn_gravity` — 55/55 (Tier 2 `tier2_grav_geospherical_*`, J2 regression, all kernel unit tests)
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — clean
- `scripts/check_no_escape_hatches.sh` — clean
- `cargo test -p astrodyn --test invariant_coverage` — clean (6/6, no JEOD_INV churn)

The bit-identity gate is `bevy_parity_*`: each scenario runs through both `astrodyn_runner` and `astrodyn_bevy` and asserts byte-identical trajectories. All 305 wrappers pass, including the long-running SH-heavy ones — confirming the f64 op order at the kernel boundary is preserved exactly.

## Tier 3 deferred to CI

`tier3_simulation_earth_moon_clem` (~17 min, the C3 motivating workload) is deferred to CI's `test-tier3-full` job per the standard local-skip policy in `CLAUDE.md`. The other Tier 3 SH cases (`tier3_sim_dyncomp_run3a` / `_run3b` ISS 4x4 and 8x8 harmonics) are exercised transitively via their `bevy_parity` siblings that ran locally.

## Files modified

- `crates/astrodyn_gravity/src/compute.rs` — new `GravityKernelOutput` type, updated `gravitation` / `gravitation_with_scratch` signatures, updated kernel unit test
- `crates/astrodyn_gravity/src/gravity_controls.rs` — `evaluate_inner` now applies the inverse rotation via `into_inertial`
- `crates/astrodyn_gravity/src/lib.rs` — export `GravityKernelOutput`
- `crates/astrodyn_gravity/benches/accumulate.rs` — call `into_inertial` inside the timed region to keep apples-to-apples cost comparison
- `crates/astrodyn_gravity/benches/integration.rs` — same bench update for `degree60_accel`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` (1510/1510)
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_)'` (305/305 — bit-identity gate)
- [x] `cargo nextest run -p astrodyn_gravity` (55/55)
- [x] `cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [ ] CI `test-tier3-full` — `tier3_simulation_earth_moon_clem` (deferred locally)
