### PR TITLE
Make gravity controls panic on misconfiguration instead of warn!() (closes #489)

### DIFF
--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -954,9 +954,9 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
             // after `register_body_frames_system::<P>` so the body's
             // `FrameEntityC` parent chain is wired (the frame-switch
             // and non-root-integ checks walk it), before
-            // `AstrodynSet::EphemerisUpdate` so consumers of validated
-            // state see the post-validation gravity-control
-            // auto-corrections.
+            // `AstrodynSet::EphemerisUpdate` so any gravity-control
+            // misconfiguration trips the validator's panic before the
+            // first ephemeris/gravity evaluation runs.
             validation::validate_jeod_invariants::<P>
                 .after(systems::register_body_frames_system::<P>)
                 .before(AstrodynSet::EphemerisUpdate),

--- a/crates/astrodyn_bevy/src/validation.rs
+++ b/crates/astrodyn_bevy/src/validation.rs
@@ -102,26 +102,30 @@ pub(crate) fn is_root_equivalent_entity(
 ///   idempotent (each pass evaluates the same world state and reaches
 ///   the same conclusion).
 /// * **Per-body invariant checks** (SRP mutual exclusion, the full
-///   `astrodyn::validate_body` pass, gravity-control `check_validity`
-///   auto-corrections) iterate the `Added`-filtered `bodies` query, so
-///   they validate only newly-attached bodies. Existing bodies were
-///   validated on the tick they first appeared, and the per-body
-///   invariants do not depend on inter-body state, so re-running them
-///   for unchanged bodies would be wasteful.
+///   `astrodyn::validate_body` pass, gravity-control `check_validity`)
+///   iterate the `Added`-filtered `bodies` query, so they validate only
+///   newly-attached bodies. Existing bodies were validated on the tick
+///   they first appeared, and the per-body invariants do not depend on
+///   inter-body state, so re-running them for unchanged bodies would be
+///   wasteful.
 ///
-/// Delegates per-body checks to [`astrodyn::validate_body`] and applies
-/// gravity control auto-corrections via `check_validity()`.
+/// Delegates per-body checks to [`astrodyn::validate_body`] and runs
+/// `GravityControl::check_validity()` on every control. The latter
+/// panics on any gravity misconfiguration (out-of-range degree/order,
+/// gradient ordinals outside their valid ranges, non-spherical against
+/// a point-mass source) rather than silently auto-correcting — see
+/// CLAUDE.md "Fail Loudly".
 ///
 /// # Panics
 /// Panics with a descriptive message for any violated invariant.
 // JEOD_INV: DM.03 — `Added<GravityControlsC>` filter on the body query fires on every body addition; bodies added mid-simulation are validated on the following tick
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn validate_jeod_invariants<P: Planet>(
-    mut bodies: Query<
+    bodies: Query<
         (
             Entity,
             &DynamicsConfigC,
-            &mut GravityControlsC,
+            &GravityControlsC,
             Option<&GravityAccelerationC>,
             Option<&MassPropertiesC>,
             Option<&RotationalStateC>,
@@ -266,8 +270,7 @@ pub fn validate_jeod_invariants<P: Planet>(
         }
     }
 
-    for (entity, config, mut controls, grav_accel, mass, rot_state, trans_state, flat_plates) in
-        &mut bodies
+    for (entity, config, controls, grav_accel, mass, rot_state, trans_state, flat_plates) in &bodies
     {
         // Compute plate counts for validation
         let plate_counts = flat_plates.map(|fp| {
@@ -448,11 +451,11 @@ pub fn validate_jeod_invariants<P: Planet>(
             }
         }
 
-        // ── Gravity control auto-corrections ──
+        // ── Gravity control startup validation ──
         // JEOD_INV: GV.03 — check_validity() called at startup
-        // This mutates controls (degree/order clamping), so it must be done
-        // after validation, not inside validate_body().
-        for ctrl in &mut controls.0.controls {
+        // Panics on any out-of-range gravity control parameter (degree,
+        // order, gradient ordinals) — see CLAUDE.md "Fail Loudly".
+        for ctrl in &controls.0.controls {
             if let Ok((_source_entity, source)) = sources.get(ctrl.source_name) {
                 ctrl.check_validity(&source.0);
             }

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -227,8 +227,12 @@ impl<SourceId> GravityControl<SourceId> {
     /// with a different gravity model than the operator requested.
     ///
     /// # Panics
-    /// - `spherical` is false and `degree == 0` (use
-    ///   `GravityControl::new_spherical` for point-mass).
+    /// - `spherical` is false and `degree < 2` (use
+    ///   `GravityControl::new_spherical` for point-mass). `degree == 1`
+    ///   is also rejected here because Gottlieb returns zero perturbation
+    ///   for degree < 2 — accepting it would let `effective_orders`
+    ///   silently collapse the request to point-mass and violate Fail
+    ///   Loudly.
     /// - `spherical` is false against a `GravityModel::PointMass` source.
     /// - `degree > source.degree` or `order > source.order`.
     /// - `order > degree`.
@@ -241,16 +245,27 @@ impl<SourceId> GravityControl<SourceId> {
             return;
         }
 
-        // JEOD_INV: GV.07 — degree=0 with spherical=false panics
+        // JEOD_INV: GV.07 — degree < 2 with spherical=false panics
         // (JEOD `spherical_harmonics_gravity_controls.cc:334-346` logs a
         // non-fatal MessageHandler::error and flips spherical=true; we
         // surface the misconfiguration instead — silently flipping the
         // gravity model under the caller violates Fail Loudly.)
+        //
+        // `degree == 1` is also rejected: Gottlieb returns zero
+        // perturbation for degree < 2 (`calc_nonspherical_with_scratch`),
+        // so the per-step `effective_orders` clamp collapses it to 0
+        // and the runtime path takes the spherical branch. Accepting
+        // `degree == 1` at startup would let that silent fixup propagate
+        // to a kernel that produces point-mass acceleration under a
+        // control whose configuration *says* non-spherical — exactly the
+        // silent-model-change failure mode this gate exists to prevent.
         assert!(
-            self.degree > 0,
-            "Non-spherical gravity (spherical=false) requested with degree=0. \
+            self.degree >= 2,
+            "Non-spherical gravity (spherical=false) requested with degree={} (< 2). \
              Set spherical=true via `GravityControl::new_spherical(...)` \
-             for point-mass gravity, or set degree >= 2."
+             for point-mass gravity, or set degree >= 2. degree=1 is meaningless \
+             for spherical harmonics (Gottlieb returns zero perturbation for degree < 2).",
+            self.degree
         );
 
         match &source.model {
@@ -1008,13 +1023,36 @@ mod tests {
     /// JEOD silently flips it; we panic so the operator sees the
     /// inconsistency.
     #[test]
-    #[should_panic(expected = "Non-spherical gravity (spherical=false) requested with degree=0")]
+    #[should_panic(
+        expected = "Non-spherical gravity (spherical=false) requested with degree=0 (< 2)"
+    )]
     fn check_validity_panics_on_zero_degree_with_spherical_false() {
         let src = dummy_sh_source(8, 8);
         let ctrl = GravityControl::<usize> {
             spherical: false,
             degree: 0,
             order: 0,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `spherical=false` with `degree=1` is a misconfiguration: the per-step
+    /// `effective_orders` clamp collapses degree=1 to 0 (Gottlieb returns
+    /// zero perturbation for degree < 2), which would silently change the
+    /// gravity model under the operator. The startup gate rejects it so the
+    /// inconsistency between the configured `spherical=false` and the
+    /// effectively-point-mass runtime path surfaces immediately.
+    #[test]
+    #[should_panic(
+        expected = "Non-spherical gravity (spherical=false) requested with degree=1 (< 2)"
+    )]
+    fn check_validity_panics_on_degree_one_with_spherical_false() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 1,
+            order: 1,
             ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
         };
         ctrl.check_validity(&src);

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -16,7 +16,6 @@ use glam::DMat3;
 use glam::DVec3;
 
 use crate::gravity_source::{GravityModel, GravitySource};
-use log::warn;
 
 /// Self-documenting selector for the gravity-gradient tensor flag at
 /// the [`GravityControl`] constructor seam. Replaces the bare `bool`
@@ -214,38 +213,45 @@ impl<SourceId> GravityControl<SourceId> {
         }
     }
 
-    /// Validate this control against its gravity source, matching JEOD's
-    /// `SphericalHarmonicsGravityControls::check_validity()`.
+    /// Validate this control against its gravity source.
+    ///
+    /// Ported from JEOD's
+    /// `SphericalHarmonicsGravityControls::check_validity()`, but with
+    /// fail-loud semantics: where JEOD logs a non-fatal
+    /// `MessageHandler::error` and silently auto-corrects the control,
+    /// we panic. A physics simulation has no graceful-degradation mode
+    /// (CLAUDE.md "Fail Loudly"); a mission crate that swaps planet
+    /// sources and forgets to update the gravity degree, or whose
+    /// gradient ordinals fall out of range, must surface the
+    /// misconfiguration at construction rather than silently propagate
+    /// with a different gravity model than the operator requested.
     ///
     /// # Panics
-    /// - `spherical` is false but source is `PointMass`
-    /// - degree > source degree
-    /// - order > source order
-    /// - order > degree
-    ///
-    /// # Notes
-    /// - If `spherical` is false and `degree` is 0, `spherical` is auto-corrected
-    ///   to true with a warning (matches JEOD's non-fatal auto-correction).
-    /// - Invalid `gradient_degree` and `gradient_order` values do not panic;
-    ///   they are clamped to valid ranges and a warning is logged.
+    /// - `spherical` is false and `degree == 0` (use
+    ///   `GravityControl::new_spherical` for point-mass).
+    /// - `spherical` is false against a `GravityModel::PointMass` source.
+    /// - `degree > source.degree` or `order > source.order`.
+    /// - `order > degree`.
+    /// - `gradient` is true and any of:
+    ///   `gradient_degree > degree`, `gradient_degree == 1`,
+    ///   `gradient_order > gradient_degree`, `gradient_order > order`.
     // JEOD_INV: GV.03 — check_validity() called on degree/order mutation
-    pub fn check_validity(&mut self, source: &GravitySource) {
+    pub fn check_validity(&self, source: &GravitySource) {
         if self.spherical {
             return;
         }
 
-        // JEOD_INV: GV.07 — degree=0 with spherical=false auto-corrects to spherical
-        // JEOD spherical_harmonics_gravity_controls.cc:334-346:
-        // degree=0 with spherical=false is auto-corrected to spherical=true
-        // via MessageHandler::error (non-fatal).
-        if self.degree == 0 {
-            warn!(
-                "Non-spherical gravity requested but degree is 0; \
-                 setting spherical=true (matches JEOD auto-correction)."
-            );
-            self.spherical = true;
-            return;
-        }
+        // JEOD_INV: GV.07 — degree=0 with spherical=false panics
+        // (JEOD `spherical_harmonics_gravity_controls.cc:334-346` logs a
+        // non-fatal MessageHandler::error and flips spherical=true; we
+        // surface the misconfiguration instead — silently flipping the
+        // gravity model under the caller violates Fail Loudly.)
+        assert!(
+            self.degree > 0,
+            "Non-spherical gravity (spherical=false) requested with degree=0. \
+             Set spherical=true via `GravityControl::new_spherical(...)` \
+             for point-mass gravity, or set degree >= 2."
+        );
 
         match &source.model {
             GravityModel::SphericalHarmonics(ref data) => {
@@ -280,38 +286,49 @@ impl<SourceId> GravityControl<SourceId> {
             self.degree
         );
 
-        // Gradient validation: JEOD spherical_harmonics_gravity_controls.cc:395-454
-        // uses MessageHandler::error (non-fatal) and auto-corrects invalid values.
+        // Gradient validation: JEOD `spherical_harmonics_gravity_controls.cc:395-454`
+        // uses MessageHandler::error (non-fatal) and silently auto-corrects
+        // invalid ordinals. We treat the same misconfigurations as fatal:
+        // an out-of-range gradient ordinal means the caller's expectation
+        // of which terms contribute to the gradient tensor diverges from
+        // what the kernel will compute, and propagating that divergence
+        // produces a wrong (but plausible-looking) torque trajectory.
         if self.gradient {
-            // JEOD_INV: GV.08 — gradient_degree <= degree (clamped)
-            if self.gradient_degree > self.degree {
-                warn!(
-                    "Gravity gradient degree ({}) > gravity degree ({}); clamping.",
-                    self.gradient_degree, self.degree
-                );
-                self.gradient_degree = self.degree;
-            }
-            // JEOD_INV: GV.09 — gradient_degree != 1 (reset to 0)
-            if self.gradient_degree == 1 {
-                warn!("Gravity gradient degree must not equal 1; resetting to 0.");
-                self.gradient_degree = 0;
-            }
-            // JEOD_INV: GV.10 — gradient_order <= gradient_degree (clamped)
-            if self.gradient_order > self.gradient_degree {
-                warn!(
-                    "Gravity gradient order ({}) > gradient degree ({}); clamping.",
-                    self.gradient_order, self.gradient_degree
-                );
-                self.gradient_order = self.gradient_degree;
-            }
-            // JEOD_INV: GV.11 — gradient_order <= order (clamped)
-            if self.gradient_order > self.order {
-                warn!(
-                    "Gravity gradient order ({}) > gravity order ({}); clamping.",
-                    self.gradient_order, self.order
-                );
-                self.gradient_order = self.order;
-            }
+            // JEOD_INV: GV.08 — gradient_degree <= degree
+            assert!(
+                self.gradient_degree <= self.degree,
+                "Gravity gradient degree ({}) > gravity degree ({}). \
+                 Set gradient_degree <= degree, or set gradient_degree=0 to \
+                 skip the spherical-harmonics gradient contribution.",
+                self.gradient_degree,
+                self.degree
+            );
+            // JEOD_INV: GV.09 — gradient_degree != 1
+            // (Gottlieb returns zero perturbation for degree < 2, so a
+            // gradient_degree of exactly 1 is meaningless — every n=1 term
+            // collapses to point-mass and produces no SH gradient.)
+            assert!(
+                self.gradient_degree != 1,
+                "Gravity gradient degree must not equal 1 (no SH gradient \
+                 contribution from degree-1 terms). Set gradient_degree=0 \
+                 to skip the SH gradient, or gradient_degree >= 2."
+            );
+            // JEOD_INV: GV.10 — gradient_order <= gradient_degree
+            assert!(
+                self.gradient_order <= self.gradient_degree,
+                "Gravity gradient order ({}) > gradient degree ({}). \
+                 Set gradient_order <= gradient_degree.",
+                self.gradient_order,
+                self.gradient_degree
+            );
+            // JEOD_INV: GV.11 — gradient_order <= order
+            assert!(
+                self.gradient_order <= self.order,
+                "Gravity gradient order ({}) > gravity order ({}). \
+                 Set gradient_order <= order.",
+                self.gradient_order,
+                self.order
+            );
         }
     }
 
@@ -348,14 +365,14 @@ impl<SourceId> GravityControl<SourceId> {
     /// quadruple after clamping to the source's bounds. Does not mutate `self`.
     ///
     /// This is the per-step variant of [`Self::check_validity`]: where
-    /// `check_validity` is a startup gate that mutates `self` and panics on
-    /// out-of-range degree/order (matching JEOD's "fatal" classification
-    /// for GV.04 / GV.05 / GV.06 at initialization), `effective_orders`
-    /// is the runtime path used by [`Self::evaluate_inner`] on every
-    /// step. It clamps gracefully instead of panicking so a control that
-    /// was constructed outside the validation pipeline (or mutated
-    /// mid-mission) doesn't crash deep inside the spherical-harmonics
-    /// kernel.
+    /// `check_validity` is a startup gate that panics on any out-of-range
+    /// ordinal (Fail Loudly), `effective_orders` is the runtime path used
+    /// by [`Self::evaluate_inner`] on every step. It clamps gracefully
+    /// rather than panicking so a control mutated mid-mission, or one
+    /// constructed by a test that deliberately bypasses the validation
+    /// pipeline, doesn't crash deep inside the spherical-harmonics
+    /// kernel. For controls that have passed `check_validity`, the
+    /// per-step clamp is a no-op.
     ///
     /// Returns `(0, 0, 0, 0)` for spherical controls, point-mass sources,
     /// or any case where the request collapses to point-mass gravity
@@ -375,10 +392,11 @@ impl<SourceId> GravityControl<SourceId> {
         }
         let (src_degree, src_order) = match &source.model {
             GravityModel::SphericalHarmonics(data) => (data.degree, data.order),
-            // JEOD_INV: GV.07 — non-spherical against point-mass collapses
-            // to spherical at startup; here we mirror by returning the
-            // zero quadruple so `evaluate_inner` takes the spherical
-            // branch.
+            // JEOD_INV: GV.07 — non-spherical against point-mass panics at
+            // startup (`check_validity`); here we mirror that with a
+            // safety zero quadruple for the rare path where a control
+            // bypasses `check_validity`, so `evaluate_inner` takes the
+            // spherical branch instead of panicking inside the kernel.
             GravityModel::PointMass => return (0, 0, 0, 0),
         };
         let mut degree = self.degree.min(src_degree);
@@ -676,21 +694,14 @@ impl<SourceId: Clone> GravityControlTyped<SourceId> {
     ///
     /// Delegates to [`GravityControl::check_validity`] on the untyped
     /// projection — runtime-checked invariants (`GV.03`–`GV.11`)
-    /// stay in the canonical f64 path. Mutations the validator
-    /// performs (e.g., auto-correcting `degree == 0` to
-    /// `spherical = true`, clamping out-of-range gradient_degree /
-    /// gradient_order) are reflected back into `self` via the
-    /// `HarmonicDegree` newtypes.
+    /// stay in the canonical f64 path. The validator panics on any
+    /// misconfiguration (see [`GravityControl::check_validity`] for
+    /// the exhaustive list); on success the typed control is
+    /// unchanged.
     // JEOD_INV: GV.03 — check_validity() called on degree/order mutation
-    pub fn check_validity(&mut self, source: &GravitySource) {
-        let mut untyped = self.to_untyped();
+    pub fn check_validity(&self, source: &GravitySource) {
+        let untyped = self.to_untyped();
         untyped.check_validity(source);
-        // Reflect any auto-corrections back into the typed surface.
-        self.spherical = untyped.spherical;
-        self.degree = HarmonicDegree::from(untyped.degree);
-        self.order = HarmonicDegree::from(untyped.order);
-        self.gradient_degree = HarmonicDegree::from(untyped.gradient_degree);
-        self.gradient_order = HarmonicDegree::from(untyped.gradient_order);
     }
 
     /// Drop the [`HarmonicDegree`] newtypes and emit the untyped
@@ -983,6 +994,141 @@ mod tests {
         // contributes zero for degree < 2 and `perturbing_only` is false).
         assert!(result.grav_accel.is_finite());
         assert!(result.grav_accel.length() > 0.0);
+    }
+
+    // ---- check_validity fail-loud sites ------------------------------
+    //
+    // `check_validity` panics on every misconfiguration that JEOD's
+    // `MessageHandler::error` would have silently auto-corrected. Each
+    // test below pins one panic class so a future regression that
+    // re-introduces silent auto-correction trips immediately.
+
+    /// `spherical=false` with `degree=0` is a misconfiguration: the
+    /// caller meant point-mass gravity but did not flip `spherical`.
+    /// JEOD silently flips it; we panic so the operator sees the
+    /// inconsistency.
+    #[test]
+    #[should_panic(expected = "Non-spherical gravity (spherical=false) requested with degree=0")]
+    fn check_validity_panics_on_zero_degree_with_spherical_false() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 0,
+            order: 0,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `gradient_degree > degree`: JEOD clamps; we panic — clamping
+    /// silently changes which SH terms contribute to the gradient
+    /// tensor and produces a torque trajectory that differs from what
+    /// the operator requested.
+    #[test]
+    #[should_panic(expected = "Gravity gradient degree (12) > gravity degree (4)")]
+    fn check_validity_panics_on_gradient_degree_above_degree() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 4,
+            order: 4,
+            gradient: true,
+            gradient_degree: 12,
+            gradient_order: 0,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `gradient_degree == 1`: Gottlieb returns zero perturbation for
+    /// degree < 2, so a gradient_degree of exactly 1 is meaningless.
+    /// JEOD resets to 0; we panic so the misconfiguration surfaces.
+    #[test]
+    #[should_panic(expected = "Gravity gradient degree must not equal 1")]
+    fn check_validity_panics_on_gradient_degree_equal_one() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 4,
+            order: 4,
+            gradient: true,
+            gradient_degree: 1,
+            gradient_order: 0,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `gradient_order > gradient_degree`: JEOD clamps; we panic.
+    #[test]
+    #[should_panic(expected = "Gravity gradient order (5) > gradient degree (2)")]
+    fn check_validity_panics_on_gradient_order_above_gradient_degree() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 4,
+            order: 4,
+            gradient: true,
+            gradient_degree: 2,
+            gradient_order: 5,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `gradient_order > order`: JEOD clamps; we panic. The
+    /// `gradient_order` check fires before the `> order` check when
+    /// both fail, so this test sets `gradient_order` *below*
+    /// `gradient_degree` and *above* `order` to isolate GV.11.
+    #[test]
+    #[should_panic(expected = "Gravity gradient order (4) > gravity order (2)")]
+    fn check_validity_panics_on_gradient_order_above_order() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 8,
+            order: 2,
+            gradient: true,
+            gradient_degree: 4,
+            gradient_order: 4,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// A control that satisfies every invariant must not panic. Pinned
+    /// alongside the panic tests above so a future overzealous tightening
+    /// of `check_validity` is caught immediately rather than at the next
+    /// downstream test run.
+    #[test]
+    fn check_validity_accepts_well_formed_control() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 4,
+            order: 4,
+            gradient: true,
+            gradient_degree: 4,
+            gradient_order: 4,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src); // does not panic
+    }
+
+    /// The typed sibling delegates to the untyped validator; the same
+    /// misconfiguration must panic on the typed surface too.
+    #[test]
+    #[should_panic(expected = "Non-spherical gravity (spherical=false) requested with degree=0")]
+    fn typed_check_validity_panics_on_zero_degree_with_spherical_false() {
+        use astrodyn_quantities::aliases::HarmonicDegree;
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControlTyped::<usize> {
+            spherical: false,
+            degree: HarmonicDegree::from(0_usize),
+            order: HarmonicDegree::from(0_usize),
+            ..GravityControlTyped::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
     }
 
     // ---- proptest round-trips (#398) ----------------------------------

--- a/crates/astrodyn_runner/src/simulation/validate.rs
+++ b/crates/astrodyn_runner/src/simulation/validate.rs
@@ -10,15 +10,22 @@ use uom::si::mass::kilogram;
 use super::Simulation;
 
 impl Simulation {
-    /// Validate all bodies against JEOD invariants and apply auto-corrections.
+    /// Validate all bodies against JEOD invariants.
     ///
     /// Call once before the first `step()`. Returns `Ok(())` if all bodies are
     /// valid, or `Err(errors)` with all validation errors found.
     ///
-    /// Also runs `GravityControl::check_validity()` on each control to
-    /// auto-correct degree/order (matching JEOD's `initialize_gravity_controls()`
-    /// and the Bevy adapter's startup validation).
-    // JEOD_INV: GV.03 — check_validity() called at startup (auto-corrections applied in-place)
+    /// Also runs [`GravityControl::check_validity`] on each control. That
+    /// validator panics on any gravity-control misconfiguration (out-of-range
+    /// degree/order/gradient ordinals, non-spherical against a point-mass
+    /// source, etc.) rather than silently auto-correcting — see CLAUDE.md
+    /// "Fail Loudly". Where JEOD would log a non-fatal `MessageHandler::error`
+    /// and continue with a clamped control, we surface the misconfiguration
+    /// at validation time so the operator sees the divergence between the
+    /// requested gravity model and what would actually be evaluated.
+    ///
+    /// [`GravityControl::check_validity`]: astrodyn::GravityControl::check_validity
+    // JEOD_INV: GV.03 — check_validity() called at startup
     pub fn validate(&mut self) -> Result<(), Vec<ValidationError>> {
         let num_sources = self.gravity_data.len();
         let mut all_errors = Vec::new();
@@ -202,9 +209,12 @@ impl Simulation {
                 }
             }
 
-            // Apply gravity control auto-corrections (degree/order clamping).
-            // JEOD_INV: GV.03 — check_validity() auto-corrects out-of-range settings
-            for ctrl in &mut body.gravity_controls.controls {
+            // Gravity control startup validation. `check_validity` panics
+            // on any misconfiguration (see CLAUDE.md "Fail Loudly"); we
+            // intentionally do not gather these into `all_errors` because
+            // a wrong gravity model is not recoverable downstream.
+            // JEOD_INV: GV.03 — check_validity() called at startup
+            for ctrl in &body.gravity_controls.controls {
                 if let Some(grav) = self.gravity_data.get(ctrl.source_name) {
                     ctrl.check_validity(&grav.source);
                 }

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -163,7 +163,7 @@ the source site under the opt-in arm.
 | GV.04 | degree ≤ source degree | fatal | runtime | enforced (`gravity_controls.rs check_validity`) |
 | GV.05 | order ≤ source order | fatal | runtime | enforced (`gravity_controls.rs check_validity`) |
 | GV.06 | order ≤ degree | fatal | runtime | enforced (`gravity_controls.rs check_validity`) |
-| GV.07 | degree=0 with spherical=false (JEOD auto-corrects to spherical; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics; intentional divergence from JEOD's non-fatal `MessageHandler::error`) |
+| GV.07 | degree<2 with spherical=false (JEOD auto-corrects to spherical for degree=0 and clamps degree=1 to point-mass at the kernel; we panic at startup for both per Fail Loudly, since degree<2 produces zero SH perturbation from Gottlieb) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics; intentional divergence from JEOD's non-fatal `MessageHandler::error`) |
 | GV.08 | gradient_degree ≤ degree (JEOD clamps; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics; per-step `effective_orders` still clamps so kernel-side asserts never trip for an already-validated control) |
 | GV.09 | gradient_degree ≠ 1 (JEOD resets to 0; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics) |
 | GV.10 | gradient_order ≤ gradient_degree (JEOD clamps; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics) |

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -163,11 +163,11 @@ the source site under the opt-in arm.
 | GV.04 | degree ≤ source degree | fatal | runtime | enforced (`gravity_controls.rs check_validity`) |
 | GV.05 | order ≤ source order | fatal | runtime | enforced (`gravity_controls.rs check_validity`) |
 | GV.06 | order ≤ degree | fatal | runtime | enforced (`gravity_controls.rs check_validity`) |
-| GV.07 | degree=0 with spherical=false auto-corrects to spherical | error | consistency | enforced (`gravity_controls.rs check_validity`) |
-| GV.08 | gradient_degree ≤ degree (clamped) | error | consistency | enforced (`gravity_controls.rs check_validity`) |
-| GV.09 | gradient_degree ≠ 1 (reset to 0) | error | consistency | enforced (`gravity_controls.rs check_validity`) |
-| GV.10 | gradient_order ≤ gradient_degree (clamped) | error | consistency | enforced (`gravity_controls.rs check_validity`) |
-| GV.11 | gradient_order ≤ order (clamped) | error | consistency | enforced (`gravity_controls.rs check_validity`) |
+| GV.07 | degree=0 with spherical=false (JEOD auto-corrects to spherical; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics; intentional divergence from JEOD's non-fatal `MessageHandler::error`) |
+| GV.08 | gradient_degree ≤ degree (JEOD clamps; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics; per-step `effective_orders` still clamps so kernel-side asserts never trip for an already-validated control) |
+| GV.09 | gradient_degree ≠ 1 (JEOD resets to 0; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics) |
+| GV.10 | gradient_order ≤ gradient_degree (JEOD clamps; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics) |
+| GV.11 | gradient_order ≤ order (JEOD clamps; we panic per Fail Loudly) | error | consistency | enforced — fail-loud (`gravity_controls.rs check_validity` panics) |
 | GV.12 | Gravity source must exist for control | error | initialization | enforced (`crates/astrodyn_bevy/src/validation.rs` + `crates/astrodyn_bevy/src/systems/environment.rs` panic) |
 | GV.13 | Gravity source must have inertial frame | error | initialization | enforced (`crates/astrodyn_bevy/src/systems/environment.rs` panics if nonspherical without PlanetFixedRotationC) |
 | GV.14 | Third-body vs direct gravity classification | structural | initialization | enforced (`GravityControl.differential` flag, set explicitly per control; JEOD derives from frame tree ancestry via `is_progeny_of`) |


### PR DESCRIPTION
Closes #489.

## Summary

`GravityControl::check_validity` previously logged a `warn!()` and silently
auto-corrected five misconfiguration classes. Mission crates that swapped
planet sources or fell out of the valid gradient-ordinal range saw a log
line and a different gravity model evaluated under their feet — a violation
of the project's "Fail Loudly" non-negotiable. Each site now panics with a
diagnostic that names the offending parameter, its value, and how to fix
the call site.

### Converted sites (`crates/astrodyn_gravity/src/gravity_controls.rs`)

| Invariant | Predicate | Panic message |
|-----------|-----------|---------------|
| GV.07 | `spherical == false && degree == 0` | `Non-spherical gravity (spherical=false) requested with degree=0. Set spherical=true via `GravityControl::new_spherical(...)` for point-mass gravity, or set degree >= 2.` |
| GV.08 | `gradient && gradient_degree > degree` | `Gravity gradient degree (N) > gravity degree (M). Set gradient_degree <= degree, or set gradient_degree=0 to skip the spherical-harmonics gradient contribution.` |
| GV.09 | `gradient && gradient_degree == 1` | `Gravity gradient degree must not equal 1 (no SH gradient contribution from degree-1 terms). Set gradient_degree=0 to skip the SH gradient, or gradient_degree >= 2.` |
| GV.10 | `gradient && gradient_order > gradient_degree` | `Gravity gradient order (N) > gradient degree (M). Set gradient_order <= gradient_degree.` |
| GV.11 | `gradient && gradient_order > order` | `Gravity gradient order (N) > gravity order (M). Set gradient_order <= order.` |

`check_validity` no longer mutates the control, so its receiver dropped to
`&self`. Bevy and runner validators updated accordingly. The per-step
`effective_orders` path keeps clamping gracefully so controls that bypass
the validator do not crash deep inside the kernel — for any control that
has passed `check_validity` the clamp is a no-op.

### Public API change (caller-visible)

The constructors themselves are unchanged. `check_validity` panics on
inputs that previously got silently auto-corrected. Any caller passing one
of the five misconfigurations above through the startup validator
(`Simulation::validate()` for the runner; `validate_jeod_invariants` for
the Bevy adapter) now sees an immediate panic with a fix-it message
instead of a `log::warn!` line and a silently mutated control.

Now-rejected input patterns:

1. `spherical=false, degree=0` (caller meant point-mass but forgot to flip
   the flag).
2. `gradient=true, gradient_degree > degree`.
3. `gradient=true, gradient_degree == 1`.
4. `gradient=true, gradient_order > gradient_degree`.
5. `gradient=true, gradient_order > order`.

### Related

Sibling PR #511 landed the broader fail-loudly sweep including the
`scripts/check_no_silent_warn.sh` lint; this PR applies the same policy
to `gravity_controls.rs`. The `scripts/check_no_silent_warn.sh` lint stays
green after this change because the converted sites no longer emit `warn!`
in the first place.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo test -p astrodyn_gravity --lib --tests` (56 lib + 6 tier 2 + 1 J2 passing; six new `#[should_panic]` tests pinning the new fail-loud sites pass)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_silent_warn.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage` (catalog rows GV.07–GV.11 rephrased + still covered by the source tags)
- [x] `cargo test -p astrodyn_bevy --test validation_added_trigger` (pre-existing late-add panic regression still trips on the `PointMass`-source case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)