### PR TITLE
Document geodetic polar-singularity behavior at public API (closes #497)

### DIFF
--- a/crates/astrodyn_bevy/src/components/derived.rs
+++ b/crates/astrodyn_bevy/src/components/derived.rs
@@ -81,6 +81,18 @@ pub struct LvlhFrameC(pub astrodyn::LvlhFrame);
 /// Geodetic state (latitude, longitude, altitude) computed each step.
 ///
 /// Written by `geodetic_system` for entities that also have `GeodeticConfigC`.
+///
+/// # Numerical stability at the poles
+///
+/// The inner [`astrodyn::GeodeticState`] inherits the longitude
+/// instability of the underlying chart: at 89.8° latitude, longitude has
+/// roughly `3.7e-6 rad/m` sensitivity to planet-fixed position drift, and
+/// at the pole itself the kernel assigns `longitude = 0.0` by convention
+/// because all meridians converge. Mission code reading this component
+/// near the poles should treat longitude as low-confidence (the Tier 3 NED
+/// suite uses `~3.3e-5 rad` polar tolerance vs `~6.5e-8 rad` inclined-orbit
+/// tolerance). This is fundamental geometry, not a bug — see
+/// [`astrodyn::GeodeticState`] for the full rationale.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct GeodeticStateC(pub astrodyn::GeodeticState);
 

--- a/crates/astrodyn_math/src/geodetic.rs
+++ b/crates/astrodyn_math/src/geodetic.rs
@@ -29,11 +29,45 @@ use uom::si::length::meter;
 const MAX_ITERATION_LIMIT: usize = 10;
 
 /// Geodetic coordinates on a reference ellipsoid.
+///
+/// # Numerical stability at the poles
+///
+/// Longitude is geometrically undefined at latitudes `±π/2`: all meridians
+/// converge at the pole, so no value of `atan2(y, x)` is more correct than
+/// any other. The conversion kernel returns `0.0` by convention exactly at
+/// the pole (when the equatorial radius `√(x² + y²)` falls within machine
+/// precision of zero) and otherwise applies `atan2(y, x)` to the
+/// planet-fixed coordinates.
+///
+/// `atan2(y, x)` is also numerically unstable in the polar neighborhood: at
+/// 89.8° latitude on Earth, longitude has roughly `3.7e-6 rad/m`
+/// sensitivity to planet-fixed `(x, y)` position drift, so sub-millimeter
+/// trajectory error translates into microradian longitude error. This is a
+/// property of the coordinate chart, not of any specific implementation —
+/// JEOD's `planet_fixed_posn.cc` exhibits the same sensitivity.
+///
+/// Callers near the poles have three options:
+///
+/// 1. Skip longitude entirely (e.g., over-the-pole flyovers where the value
+///    is not load-bearing).
+/// 2. Treat near-pole longitude as low-confidence and widen comparison
+///    tolerances. The Tier 3 NED cross-validation suite uses
+///    `~3.3e-5 rad` for polar-orbit longitude vs `~6.5e-8 rad` for
+///    inclined-orbit longitude (`crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs`).
+/// 3. Use spherical (geocentric) coordinates via [`SphericalState`] when
+///    only an angular distance from the pole is needed.
+///
+/// This is fundamental geometry, **not** a code bug.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct GeodeticState {
     /// Geodetic latitude in radians (positive north, range `±π/2`).
     pub latitude: f64,
     /// Geodetic longitude in radians (positive east).
+    ///
+    /// Numerically unstable near the poles and assigned `0.0` by convention
+    /// exactly at the pole; see the type-level
+    /// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+    /// section for the recommended caller-side handling.
     pub longitude: f64,
     /// Height above the reference ellipsoid, in meters.
     pub altitude: f64,
@@ -46,6 +80,10 @@ impl GeodeticState {
     /// callers (e.g., NED initializers) where the planet phantom is not
     /// available at the call site. Bit-identical numerics to
     /// [`cartesian_to_geodetic_typed`].
+    ///
+    /// Returned longitude is numerically unstable near the poles; see
+    /// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+    /// for the caller-side handling.
     pub fn from_planet_fixed(cart: DVec3, r_eq: f64, r_pol: f64) -> Self {
         cartesian_to_geodetic_impl(cart, r_eq, r_pol)
     }
@@ -66,6 +104,10 @@ impl GeodeticState {
 /// [`GeodeticState::from_planet_fixed`] (sole owner of the JEOD Borkowski
 /// iteration kernel). Bit-identical numerics to the typed sibling
 /// [`compute_body_geodetic_typed`].
+///
+/// Returned longitude is numerically unstable near the poles; see
+/// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+/// for the caller-side handling.
 pub fn compute_body_geodetic(
     position: DVec3,
     t_inertial_pfix: &DMat3,
@@ -83,6 +125,10 @@ pub fn compute_body_geodetic(
 /// [`GeodeticState::from_planet_fixed`] (sole owner of the JEOD Borkowski
 /// iteration kernel). Returns the f64 [`GeodeticState`] used by Bevy
 /// components; bit-identical to the f64 surface.
+///
+/// Returned longitude is numerically unstable near the poles; see
+/// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+/// for the caller-side handling.
 pub fn compute_body_geodetic_typed<P: Planet>(
     position: Position<astrodyn_quantities::frame::PlanetInertial<P>>,
     t_inertial_pfix: &DMat3,
@@ -97,11 +143,20 @@ pub fn compute_body_geodetic_typed<P: Planet>(
 ///
 /// Companion to [`GeodeticState`] carrying `uom` dimensioned scalars so
 /// signatures expressed with this type are unit-safe.
+///
+/// The polar-singularity behavior is identical to [`GeodeticState`]; see
+/// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+/// for the caller-side handling.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct GeodeticStateTyped {
     /// Geodetic latitude (positive north, range ±π/2).
     pub latitude: Angle,
     /// Geodetic longitude (positive east).
+    ///
+    /// Numerically unstable near the poles and assigned `0.0` by convention
+    /// exactly at the pole; see
+    /// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+    /// for the recommended caller-side handling.
     pub longitude: Angle,
     /// Height above the reference ellipsoid.
     pub altitude: Length,
@@ -337,6 +392,10 @@ pub(crate) fn geodetic_to_cartesian_impl(geo: &GeodeticState, r_eq: f64, r_pol: 
 /// frame; the ellipsoid dimensions are supplied numerically via `r_eq` /
 /// `r_pol` (matching the existing f64 API). The geodetic representation is
 /// defined with respect to the body-fixed frame of the named planet.
+///
+/// Returned longitude is numerically unstable near the poles; see
+/// [Numerical stability at the poles](GeodeticState#numerical-stability-at-the-poles)
+/// for the caller-side handling.
 pub fn cartesian_to_geodetic_typed<P: Planet>(
     pos: Position<PlanetFixed<P>>,
     r_eq: Length,

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs
@@ -293,7 +293,10 @@ pub fn ned_ell_inc() -> VerificationCase {
 
 /// SIM_NED RUN_ell_polar — ellipsoidal Earth, polar orbit, 24h.
 /// Polar singularity: longitude becomes hypersensitive to sub-mm
-/// position drift; tolerance widened per CLAUDE.md.
+/// position drift; tolerance widened per CLAUDE.md. See the
+/// `# Numerical stability at the poles` section on
+/// `astrodyn_math::GeodeticState` for the geometric rationale and the
+/// fixed `~3.3e-5 rad` polar vs `~6.5e-8 rad` inclined tolerance ratio.
 pub fn ned_ell_polar() -> VerificationCase {
     VerificationCase {
         name: "tier3_simulation_ned_polar",


### PR DESCRIPTION
Closes #497.

## Summary

Docs-only: add a "Numerical stability at the poles" rustdoc section to
the public geodetic-conversion surface so mission engineers see the
longitude singularity / sensitivity at the API site instead of having
to read `CLAUDE.md` or the kernel implementation.

The canonical note lives on `astrodyn_math::GeodeticState`. Each of the
other public entry points carries a short pointer back to the canonical
section so the rationale isn't duplicated:

- `astrodyn_math::compute_body_geodetic`
- `astrodyn_math::compute_body_geodetic_typed`
- `astrodyn_math::GeodeticState::from_planet_fixed`
- `astrodyn_math::cartesian_to_geodetic_typed`
- `astrodyn_math::GeodeticStateTyped` (struct + `longitude` field)
- `astrodyn_math::GeodeticState::longitude` field
- `astrodyn_bevy::components::GeodeticStateC` (Bevy component wrapper)

The note enumerates the three caller-side strategies (skip / widen
tolerance / spherical fallback), names the concrete Tier 3 polar
(~3.3e-5 rad) vs inclined (~6.5e-8 rad) longitude tolerance ratio, and
emphasises that this is fundamental geometry rather than a code bug —
JEOD's `planet_fixed_posn.cc` exhibits the same sensitivity.

The Tier 3 SIM_NED `ned_ell_polar` case docstring now cross-links to
the new section for traceability from the test back to the geometric
rationale.

## Runtime behavior

No runtime behavior change. Rustdoc additions only — no public type
signatures changed, no kernel logic touched, no test assertions
modified.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` (primary signal — passes cleanly, no broken intra-doc links)
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [x] `cargo test -p astrodyn_math --lib geodetic` (sanity — round-trips still pass)
- [ ] CI workspace test suite (unit + tier 2 + tier 3 + parity) runs on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)