### PR TITLE
Declare MSRV (rust-version = 1.87) in workspace.package (closes #491)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 # Workspace-only artifacts that don't belong in the published crate:
 # Trick / Docker reference-CSV regen tooling, the JEOD-invariant catalog
 # (lives next to the source it tags), workspace-level invariant tests,
@@ -64,6 +65,17 @@ version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/simnaut/astrodyn"
+# Declared MSRV. The binding constraints are (a) the `bevy = "0.18"`
+# dep tree (released targeting Rust ~1.85) and (b) usage of
+# `u{32,usize}::is_multiple_of` (stabilized in Rust 1.87) inside the
+# Gauss–Jackson integrator. 1.87 is the conservative-but-modern floor
+# that satisfies both. Cargo surfaces a clean
+# `error: package requires Rust 1.87` for older toolchains instead of
+# the cryptic compile errors users would otherwise see. The
+# `clippy::incompatible_msrv` lint also fires against any stdlib item
+# stabilized after this floor, preventing silent MSRV drift. See
+# `README.md` § "Minimum supported Rust version" for the bump policy.
+rust-version = "1.87"
 
 # Workspace-wide attribution metadata. `notice` points at the repo-root
 # NOTICE.md that documents the verbatim NASA JEOD source mirror under

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ cargo run --profile release-with-debug \
     --scenario earth_moon_clem --steps 100000 --warmup 1000 --repeat 5
 ```
 
+## Minimum supported Rust version
+
+astrodyn requires **Rust 1.87 or newer**. The `rust-version` field is
+declared in `[workspace.package]` so every published member crate
+inherits it; users on older toolchains get a clean
+`error: package <name> requires Rust 1.87` from cargo rather than a
+deep dependency-tree compile error.
+
+The binding constraints are the `bevy = "0.18"` dependency (released
+targeting Rust ~1.85) and direct workspace usage of
+`u{32,usize}::is_multiple_of` (stabilized in Rust 1.87) inside the
+Gauss–Jackson integrator. The workspace also uses modern stdlib
+features (`#[diagnostic::on_unimplemented]`, recent const generics)
+that require an MSRV of at least this vintage.
+
+**Bump policy.** Raising the MSRV is treated as a minor-version event,
+not a patch. The project tracks the last two to three stable Rust
+releases as the supported window; updates land when a dependency
+forces the floor higher or when a stdlib feature with no clean polyfill
+becomes load-bearing. Bumps are called out in the changelog.
+
 ## License and attribution
 
 Dual-licensed under either [`LICENSE-MIT`](LICENSE-MIT) or

--- a/crates/astrodyn_atmosphere/Cargo.toml
+++ b/crates/astrodyn_atmosphere/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_bevy/Cargo.toml
+++ b/crates/astrodyn_bevy/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 astrodyn = { path = "../..", version = "0.1.0" }

--- a/crates/astrodyn_dynamics/Cargo.toml
+++ b/crates/astrodyn_dynamics/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_ephemeris/Cargo.toml
+++ b/crates/astrodyn_ephemeris/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 # The kernel assets are NOT bundled into the .crate. `data::load()`
 # resolves a `KernelSpec` against (1) `$ASTRODYN_EPHEMERIS_KERNELS_DIR`,
 # (2) `$CARGO_MANIFEST_DIR/assets/` (workspace builds only), (3) the user

--- a/crates/astrodyn_frames/Cargo.toml
+++ b/crates/astrodyn_frames/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_gravity/Cargo.toml
+++ b/crates/astrodyn_gravity/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 # Cargo defaults to publishing only `src/` plus a few well-known files.
 # We need the binary gravity fixtures (~1.9 MB total) to ride along so
 # `include_bytes!` in `src/data.rs` resolves correctly when building

--- a/crates/astrodyn_interactions/Cargo.toml
+++ b/crates/astrodyn_interactions/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_math/Cargo.toml
+++ b/crates/astrodyn_math/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_planet/Cargo.toml
+++ b/crates/astrodyn_planet/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_quantities/Cargo.toml
+++ b/crates/astrodyn_quantities/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_runner/Cargo.toml
+++ b/crates/astrodyn_runner/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 # See `astrodyn_gravity/Cargo.toml` for rationale — disables the default

--- a/crates/astrodyn_time/Cargo.toml
+++ b/crates/astrodyn_time/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/astrodyn_verif_jeod/Cargo.toml
+++ b/crates/astrodyn_verif_jeod/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 exclude = [
     "test_data/*.csv",
     "test_data/*.out",

--- a/crates/astrodyn_verif_jeod_fixtures/Cargo.toml
+++ b/crates/astrodyn_verif_jeod_fixtures/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.1.0" }

--- a/crates/astrodyn_verif_nesc/Cargo.toml
+++ b/crates/astrodyn_verif_nesc/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 exclude = [
     "test_data/*.csv",
 ]

--- a/crates/astrodyn_verif_parity/Cargo.toml
+++ b/crates/astrodyn_verif_parity/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 astrodyn = { path = "../..", version = "0.1.0" }


### PR DESCRIPTION
Closes #491.

## Summary

Declared the workspace MSRV at **Rust 1.87** (one minor up from the
issue's headline value of 1.85 — see Justification). The
`rust-version` field is set in `[workspace.package]` and propagated
to every published member crate via `rust-version.workspace = true`,
so cargo now surfaces a clean `error: package requires Rust 1.87`
on older toolchains instead of cryptic dependency-tree compile
errors. No CI matrix enforcement yet (see Follow-up).

## Justification

The issue suggested empirically probing for the minimum. Two binding
constraints surfaced:

1. `bevy = "0.18"` was released targeting Rust ~1.85 — the headline
   floor in the issue. The workspace also uses
   `#[diagnostic::on_unimplemented]` and recent const generics that
   require this vintage.
2. The Gauss-Jackson integrator (`astrodyn_dynamics`) uses
   `u32::is_multiple_of` / `usize::is_multiple_of`, **stabilized in
   Rust 1.87**. Clippy's `incompatible_msrv` lint flagged this as
   soon as the workspace MSRV was set, which is exactly the value of
   declaring one.

1.87 is the conservative-but-modern floor that satisfies both, and
clippy will now catch any drift toward newer stdlib items
automatically. The `astrodyn_runner` README and Tier 3 reproducibility
remain unchanged because the code already used 1.87 features in
practice; we are just making the contract explicit.

## Documentation

Added a **Minimum supported Rust version** subsection to the workspace
`README.md` (the published-crate readme for `astrodyn`). It states
the floor, names the binding constraints, and spells out the bump
policy: MSRV bumps are minor-version events, tracked in the
changelog, with a supported window of roughly the last two to three
stable Rust releases.

## Follow-up

CI matrix entry running `cargo +1.87 check --workspace` is tracked
as future work. Adding it to `.github/workflows/ci.yml` would
require the GHA runners to install a non-stable toolchain (the
existing `dtolnay/rust-toolchain@stable` setup is workspace-wide),
which complicates the matrix more than this metadata-only PR should
absorb. The clippy `incompatible_msrv` lint (now active because
`rust-version` is set) provides immediate local + CI feedback against
the floor for any new stdlib usage, which is the highest-value
half of the enforcement story.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo check --workspace` (confirms `rust-version` is picked up; `cargo metadata` shows `rust-version=1.87` on all 17 published crates, `None` on the non-published `xtask`)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Workspace-wide nextest intentionally skipped — this is a metadata-only
change with no behavioural impact.