### PR TITLE
Flesh out per-crate README stubs (closes #502)

### DIFF
--- a/crates/astrodyn_atmosphere/README.md
+++ b/crates/astrodyn_atmosphere/README.md
@@ -9,6 +9,44 @@ from [NASA JEOD v5.4.0](https://github.com/nasa/jeod), including the
 Marshall Engineering Thermosphere (MET) implementation in
 [`models/environment/atmosphere/MET/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/atmosphere/MET/).
 
+## When to use
+
+- **Aerodynamic drag** — pair an `AtmosphereState` evaluation with
+  `astrodyn_interactions::aero_drag` (scalar Cd) or `flat_plate_aero`
+  (per-facet panel method) to compute drag force on a LEO vehicle.
+- **Density / temperature / pressure profiles** for thermal,
+  out-gassing, or trajectory-energy diagnostics at sub-1000-km
+  altitudes.
+- **Inertial-frame wind** (`compute_corotation_wind`) — every drag
+  computation needs the vehicle velocity *relative to the
+  co-rotating atmosphere*, not relative to the bare inertial frame.
+
+This crate stays pure; orchestration (pulling the body position, the
+current epoch, the planet's angular velocity, and feeding `aero_drag`)
+lives in `astrodyn`.
+
+## Key concepts
+
+Every atmosphere evaluation returns one type — `AtmosphereState` —
+holding density (kg/m³), temperature (K), pressure (Pa), and the
+inertial-frame wind velocity (m/s). Consumers that need only density
+or only wind read the matching field; there is no "fast path" that
+elides the rest, by design, because the cost of computing them
+together is already amortized inside the MET kernel.
+
+Two models are provided. `exponential` is the
+`rho = rho_0 * exp(-(h - h_0) / H)` single-scale-height fallback,
+intended as a unit-test baseline and as a stand-in for studies that
+don't need MET fidelity. `met` is the JEOD-faithful port of the
+Marshall Engineering Thermosphere — Jacchia 1970/1971 temperature
+profiles integrated via Gauss quadrature plus seasonal-latitude
+density corrections — and is the production choice for LEO drag.
+
+Co-rotation wind specializes to planets whose angular velocity points
+along the inertial Z axis (Earth, Mars, Venus to good approximation):
+`wind = omega × r`. JEOD makes the same simplification; bodies with
+significant axis tilt would require a per-step rotation-axis input.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_bevy/README.md
+++ b/crates/astrodyn_bevy/README.md
@@ -14,6 +14,47 @@ adapter so they slot into any Bevy app.
 (see the [Tier3-Regeneration wiki page](https://github.com/simnaut/astrodyn/wiki/Tier3-Regeneration)).
 API may change before 1.0.
 
+## When to use
+
+- **Building a Bevy-based mission simulation** — Earth-orbit
+  constellation, lunar / Mars approach, station-keeping study,
+  rendezvous-and-proximity scenarios — where the Bevy `App` is the
+  runtime and the ECS world is the single source of truth for
+  state.
+- **Composing a scenario** — sources, bodies, ephemeris, mass tree,
+  integrator config — with `SimulationBuilder::populate_app::<P>`
+  and the typestate `VehicleBuilder` (canonical entry point per
+  CLAUDE.md).
+- **Inserting a single vehicle** into an existing `App` (a smaller
+  example, a follow-up insert during a running sim) via
+  `VehicleConfig::spawn_bevy`.
+
+For non-Bevy use — Tier 3 cross-validation tests, batch propagation,
+offline studies — `astrodyn_runner` is the parallel arena-state
+consumer of the same `astrodyn` pipeline. For pure physics math
+(coordinate conversions, attitude algebra, gravity evaluation) without
+either runtime, depend on `astrodyn` directly.
+
+## Key concepts
+
+The crate is the **thin glue** layer of the three-layer architecture
+(see below): components are typed newtypes around `astrodyn`
+quantities, systems delegate to `astrodyn` pipeline functions, and
+the `AstrodynPlugin` wires the seven `AstrodynSet` variants into
+`FixedUpdate` in JEOD-step order. There is no physics in this crate
+— a CI lint refuses any `astrodyn_*`-physics-crate direct dep, so
+the adapter cannot quietly reimplement what the gateway re-exports.
+
+The typestate `VehicleBuilder` makes vehicle construction a compile-
+time refusal of misconfigurations: `.three_dof_point_mass(...)` is
+unavailable until a state is set, `.rk4()` until mass is set,
+`.build()` until an integrator is chosen. Frame mismatches at
+`spawn_bevy` boundaries surface as physics-language errors
+(*"expected `Position<RootInertial>`, found `Position<Ecef>` — apply
+a `FrameTransform<Ecef, RootInertial>` first"*) via
+`#[diagnostic::on_unimplemented]`, not as raw `PhantomData`
+type-mismatch walls.
+
 ## Architecture
 
 Three layers, separated by hard dependency rules:

--- a/crates/astrodyn_dynamics/README.md
+++ b/crates/astrodyn_dynamics/README.md
@@ -11,6 +11,50 @@ and
 from [NASA JEOD v5.4.0](https://github.com/nasa/jeod). Decomposes JEOD's
 1200-line `DynBody` god-class into ~10 narrow components.
 
+## When to use
+
+- **Propagating a rigid body's state** — translational (3-DOF) or
+  full 6-DOF — through an RK4, RKF45, Adams-Bashforth-Moulton, or
+  Gauss-Jackson integrator step.
+- **Composing mass trees** with parallel-axis-theorem (Steiner)
+  contributions from offset child masses, and re-deriving the
+  composite center of mass / inertia tensor after attach / detach.
+- **Initializing a body** from orbital elements, mean anomaly,
+  time-since-periapsis, LVLH, or NED — all five JEOD `BodyAction`
+  pathways are ported.
+- **Pre-/post-step frame propagation** — moving state between a
+  body's `structure`, `composite_body`, and `core_body` frames, and
+  applying holonomic constraints (tethers, articulated joints).
+
+Mission code rarely calls into this crate directly; the
+`VehicleBuilder` typestate in `astrodyn` and the `astrodyn_bevy`
+components wrap these primitives. Reach for `astrodyn_dynamics`
+directly when porting JEOD `BodyAction` subclasses, when adding a new
+integrator, or when implementing a custom constraint.
+
+## Key concepts
+
+Translational state is stored **absolute in the integration frame**
+(typically J2000 ECI), not parent-relative — this is the JEOD
+convention and it's enforced at the type level via
+`TranslationalStateTyped<IntegrationFrame>`. Consumers that require
+root-inertial coordinates (gravity, SRP, solar beta, Earth lighting)
+must apply the integration-origin shift through
+`body.trans.to_inertial(&integ_origin)`; the compiler refuses to pass
+integration-frame state where root-inertial is required. See `RF.10`
+in `docs/JEOD_invariants.md` for the structural rationale.
+
+Mass properties carry both `mass` and the pre-computed
+`inverse_mass` (similarly `inertia` and `inverse_inertia`), refreshed
+once per step so the inner force-to-acceleration loop is
+multiply-only. The `MassTree` keeps subtree composition in Steiner
+form, so a leaf re-attach updates the composite CoM / inertia at the
+root via the same algorithm JEOD uses. Integrators (`rk4_*`,
+`rkf45`, `abm4`, `gauss_jackson`) all reduce to the same per-stage
+derivative call (`compute_translational_derivatives` /
+`compute_frame_derivatives`), so adding a new integrator is purely
+adding a new dispatch arm to `IntegrationMethod`.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_ephemeris/README.md
+++ b/crates/astrodyn_ephemeris/README.md
@@ -11,6 +11,41 @@ the file format and Chebyshev evaluation to the
 [`anise`](https://crates.io/crates/anise) crate (a pure-Rust SPICE/NAIF
 reimplementation) and exposes a thin, frame-tagged API on top.
 
+## When to use
+
+- **Third-body gravity** — query Sun/Moon/Mars/Venus positions in
+  J2000 ICRF to feed `astrodyn_gravity` for third-body
+  perturbations on an Earth orbit, or for an interplanetary
+  trajectory's central-body switch.
+- **Radiation pressure and shadow geometry** — every SRP step
+  needs the Sun's inertial position; every Earth-orbit lighting
+  computation needs the Sun, Moon, and Earth in the same frame.
+- **Mission-design epoch queries** — read body positions at a
+  specific TDB epoch for plotting, mission planning, or comparing
+  against published trajectories.
+
+The crate's default `fetch` feature downloads the required `.bsp`
+kernels from the project's GitHub Releases on first use; for
+air-gapped builds, set `$ASTRODYN_EPHEMERIS_KERNELS_DIR` to a directory
+holding pre-downloaded kernels and disable the feature.
+
+## Key concepts
+
+Every position / velocity returned by `Ephemeris` is wrapped as
+`Position<RootInertial>` / `Velocity<RootInertial>` from
+`astrodyn_quantities`, in meters and m/s, in J2000 ICRF. There is no
+"raw f64 array" public surface — the frame phantom is the contract
+that lets gravity, SRP, and lighting code treat the ephemeris output
+as a drop-in source position without re-tagging.
+
+`EphemerisBody` is the workspace's body-identifier enum; it maps
+JEOD's `EphemerisBody` constants to `anise`'s NAIF integer IDs so the
+two codebases agree on what "Mars barycenter" means. `EphemerisError`
+is a fail-loudly type — missing files, unsupported bodies, and
+out-of-range epochs all panic with a diagnostic that names the
+mismatch and the kernel that would resolve it, rather than returning
+a silent zero.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_frames/README.md
+++ b/crates/astrodyn_frames/README.md
@@ -11,6 +11,47 @@ JEOD) and
 (precession, nutation, polar motion) from
 [NASA JEOD v5.4.0](https://github.com/nasa/jeod).
 
+## When to use
+
+- **Storing a hierarchy of reference frames** — Earth inertial,
+  Earth body-fixed, Moon body-fixed, vehicle structure, vehicle
+  composite-body / core-body — with parent/child links and
+  relative state at every node.
+- **Computing Earth's body-fixed rotation** — precession (J2000 →
+  mean-of-date), nutation (mean-of-date → true-of-date, IAU-1980
+  106-term series), and polar motion / GMST-driven sidereal
+  rotation, all of which must compose in JEOD's order to match
+  reference trajectories.
+- **Mars and Moon body-fixed rotation** for Mars / Apollo verification
+  sims, including lunar libration models.
+
+Mission code rarely touches `FrameTree` directly; the `astrodyn`
+pipeline maintains the tree and the `astrodyn_bevy` adapter mirrors it
+into ECS components. Reach in here when porting a new RNP series, when
+adding a new target body's body-fixed rotation, or when implementing a
+custom frame relative to an existing parent.
+
+## Key concepts
+
+Every node in `FrameTree` stores its state **relative to its
+parent** (not absolute / inertial), matching JEOD's `RefFrame`
+convention. Relative state between arbitrary frames is computed by
+walking to the common ancestor and composing — typed
+`RefFrameStateTyped<P, C>` siblings at the public boundary make those
+compositions frame-checked, so the compiler refuses to combine a
+"vehicle wrt Earth-inertial" with a "Moon wrt Sun" without explicitly
+re-parenting. The tree is a flat `Vec` with parallel
+`Option<FrameId>` parent pointers, which keeps lookups cache-friendly
+and avoids the pointer chasing of JEOD's intrusive linked lists.
+
+Earth rotation composes as `polar_motion · sidereal · nutation ·
+precession`, with each factor a left-transformation,
+scalar-first quaternion (`JeodQuat`). `t_parent_this` is a derived
+cache of `q_parent_this`; the quaternion is the canonical source of
+truth (RF.04), so any update writes the quaternion and refreshes the
+matrix, never the reverse. Mars and Moon rotation models follow the
+same pattern with body-specific pole-direction series.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_gravity/README.md
+++ b/crates/astrodyn_gravity/README.md
@@ -14,6 +14,47 @@ a numerically stable normalized Legendre recursion that scales to high
 degree and order without the underflow / overflow problems of the
 classical formulation.
 
+## When to use
+
+- **Evaluating gravitational acceleration** at a body's inertial
+  position against one or more sources — point-mass through the
+  full Gottlieb spherical-harmonics expansion at the source's full
+  degree / order.
+- **Computing the gravity-gradient tensor** for tidal forces,
+  gravity-gradient torque (consumed by `astrodyn_interactions`), or
+  diagnostics.
+- **Configuring a vehicle's gravity controls** — choosing which
+  sources to include, whether to add Battin / relativistic
+  corrections, and whether to evaluate the gradient.
+- **Loading JEOD coefficient files** (`earth_GGM05C.hh`,
+  `moon_GRAIL150.hh`, …) into the binary fixture format consumed at
+  runtime — via the `extract_grav_coeffs` regen binary.
+
+Production pipelines never parse JEOD `.cc` files at runtime;
+`extract_grav_coeffs` runs offline and writes binary fixtures under
+`test_data/gravity/` that the runtime loads.
+
+## Key concepts
+
+The Gottlieb algorithm replaces the classical
+unnormalized-associated-Legendre recursion with a **normalized**
+recursion that pushes the dynamic-range problem out of the polynomial
+tail. This is the only formulation that stays numerically valid past
+degree ~30; JEOD uses it for GGM05C (up to 360×360) and we port it
+verbatim, with the same row-major coefficient layout and the same
+recursion order so test vectors match bit-for-bit.
+
+`GravityControl` is **per-source**: a vehicle can pull spherical
+harmonics from Earth while taking the Sun and Moon as point masses,
+and toggle Battin third-body or post-Newtonian relativistic
+corrections independently. `GottliebScratch` holds the recursion's
+intermediate buffers so they can be reused across timesteps without
+reallocating. Gravity acceleration here **excludes** the integration
+frame's own acceleration toward the source — third-body contributions
+arrive as the differential acceleration (vehicle-toward-Sun minus
+Earth-toward-Sun), which is the JEOD convention and the only choice
+that keeps Earth-centered inertial integration consistent.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_interactions/README.md
+++ b/crates/astrodyn_interactions/README.md
@@ -10,6 +10,50 @@ and the surface-model utilities under
 [`models/utils/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/)
 from [NASA JEOD v5.4.0](https://github.com/nasa/jeod).
 
+## When to use
+
+- **Aerodynamic drag** — scalar-Cd ballistic-coefficient
+  (`aero_drag`) or per-facet panel method (`flat_plate_aero`)
+  against an atmospheric state from `astrodyn_atmosphere`.
+- **Solar radiation pressure** — `radiation_pressure` against a
+  surface model with absorption / specular / diffuse coefficients,
+  shadow-corrected via umbra / penumbra geometry and optionally
+  Earth-albedo / IR contributions for Earth-orbit vehicles.
+- **Gravity-gradient torque** — `compute_gravity_torque` consumes
+  the gradient tensor from `astrodyn_gravity` and projects through
+  the body's inertia tensor and attitude.
+- **Surface models** — `SurfaceFacet`, `ArticulatedFacet`,
+  `SurfaceShape` are the shared per-facet geometry inputs that
+  aero, SRP, contact, and thermal all read from.
+- **Contact and thermal** — `contact` (collision response) and
+  `thermal_rider` (per-facet power balance) for articulated
+  spacecraft and EVA / robotic-arm studies.
+
+The orchestration that sums these contributions into a body's
+`astrodyn_dynamics::TotalForce` lives in `astrodyn`; this crate keeps
+each model side-effect-free so it composes cleanly.
+
+## Key concepts
+
+Every interaction module follows the same shape: it takes a vehicle's
+state (position, velocity, attitude), an environmental input (an
+`AtmosphereState`, a Sun position, a gravity-gradient tensor), and a
+geometry input (a `SurfaceFacet` for panel methods, a ballistic
+coefficient + cross-section for scalar models), and returns a force,
+torque, or scalar without mutating its inputs. That separation is
+what lets the orchestration layer drive aero + SRP + gravity-gradient
+in any order or in parallel.
+
+The surface model `SurfaceFacet` is shared across aero, SRP,
+contact, and thermal — one facet definition, four physical responses
+— with `ArticulatedFacet` adding a hinge so robotic arms / solar
+panels / antenna gimbals can sweep through their commanded angles.
+Shadow geometry (`shadow`) is a separate module from
+`radiation_pressure` because shadow is also consumed by
+`earth_lighting` and by thermal calculations; the umbra / penumbra
+calculation runs once per step regardless of how many interactions
+depend on it.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_math/README.md
+++ b/crates/astrodyn_math/README.md
@@ -16,6 +16,42 @@ from [NASA JEOD v5.4.0](https://github.com/nasa/jeod). Specifically:
 and the inline helpers under
 [`math/`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/utils/math/include/).
 
+## When to use
+
+- **Coordinate / orbital-element conversions** — Cartesian ↔ Keplerian
+  (`OrbitalElements`), geodetic ↔ Cartesian, body-frame ↔ LVLH ↔ NED.
+- **Attitude algebra** — composing or interpolating JEOD-convention
+  quaternions, computing Euler-angle sequences, building rotation
+  matrices that round-trip with JEOD source.
+- **Lighting / pointing scalars** — solar beta angle for thermal /
+  power budgeting against an orbit.
+
+If you're an upstream physics crate (gravity, dynamics, frames,
+interactions) that needs a battle-tested coordinate or attitude
+primitive, reach here rather than rolling your own. If you're mission
+code, the recipes / typed components in `astrodyn` and `astrodyn_bevy`
+already wrap these — you rarely call `astrodyn_math` directly.
+
+## Key concepts
+
+The crate is organized around a single attitude type — `JeodQuat`, the
+unified scalar-first, left-transformation `Quat<ScalarFirst,
+LeftTransform>` re-exported from `astrodyn_quantities` — so there is
+only one quaternion convention in the workspace, enforced by the type
+system rather than by comments. Algebra (composition, conjugation,
+interpolation), conversions (to/from Euler angles and rotation
+matrices), and the witness-gated `NormalizedQuat` constructor all
+operate on that one type.
+
+Coordinate kernels follow JEOD's source layout faithfully:
+`cartesian_to_geodetic` uses Borkowski's iterative latitude solver
+(stable at the poles and at low altitude); `mat3_from_rows` matches
+JEOD's row-major matrix convention; `OrbitalElements` keeps the same
+true/mean/orbital anomaly trio JEOD carries. Angles are radians,
+lengths meters, throughout. The typed `*_typed` siblings drop into
+those raw kernels via `.raw_si()` and re-wrap on exit, so the public
+surface stays frame- and unit-checked without taxing the inner loop.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_planet/README.md
+++ b/crates/astrodyn_planet/README.md
@@ -10,6 +10,42 @@ shape parameters (gravitational parameter, equatorial and polar radii,
 flattening) consumed by gravity, geodetic, atmospheric, and
 frame-rotation code.
 
+## When to use
+
+- **Building a gravity source** — every `astrodyn_gravity` source
+  needs `mu`; `PlanetShape::mu` is the canonical accessor.
+- **Geodetic conversions** — `astrodyn_math::geodetic` needs
+  `r_eq`, `r_pol`, and the flattening for the ellipsoidal latitude
+  / longitude / altitude solver.
+- **Atmosphere models** — MET and the exponential fallback both
+  need the reference radius to compute altitude above the
+  ellipsoid.
+- **Reusing canonical bodies** — `presets::EARTH` / `MOON` /
+  `SUN` / `MARS` give the JEOD-matched parameter blocks so
+  cross-validation tests don't drift from JEOD numerics.
+
+Most mission code reaches the preset constants via the recipe layer
+in `astrodyn::recipes::earth` / `moon` / `mars`; this crate is the
+pure parameter source those recipes wrap.
+
+## Key concepts
+
+`PlanetShape` is a value type — `name`, `mu` (m³/s²), `r_eq` (m),
+`r_pol` (m), `flat_coeff` — plus a small handful of derived helpers
+(`flat_inv`, `e_ellipsoid`). It carries no state and no allocations,
+so it is freely `Copy`-passable through the physics pipeline. There
+is no separate "live planet" struct: the gravity source, the geodetic
+solver, and the frame-rotation models all read from `PlanetShape` and
+combine it with their own model-specific data (gravity coefficients,
+nutation tables) downstream.
+
+`presets::EARTH` follows the GGM05C `mu = 3.986004415e14 m³/s²`
+rather than IERS 2010, which differs by ~3e6 m³/s² — we follow JEOD's
+choice so Tier 3 cross-validation against JEOD trajectories doesn't
+chase a 7-ppm `mu` offset for hundreds of orbits. The other presets
+similarly track the JEOD source data files
+(`planet/data/src/<body>.cc`) verbatim.
+
 ## Layered architecture
 
 ```

--- a/crates/astrodyn_quantities/README.md
+++ b/crates/astrodyn_quantities/README.md
@@ -8,6 +8,47 @@ Sits at the bottom of the workspace dependency graph. Every other
 Bevy glue, depends on `astrodyn_quantities` for typed quantities and the
 phantom frame / time-scale tags.
 
+## When to use
+
+- **Mission / scenario code** declaring positions, velocities, masses,
+  epochs, angular rates, or quaternions — reach for `F64Ext`
+  (`400.0.km()`, `51.6.deg()`) and the typed aliases (`Position<F>`,
+  `Velocity<F>`, `SecondsSince<S>`, `NormalizedQuat`).
+- **Authors of a new `astrodyn_*` physics function** adding a public
+  surface — wrap inputs/outputs in the typed quantities so the
+  compiler refuses cross-frame, cross-scale, or scalar-vs-vector
+  quaternion mismatches before they become silent numerical bugs.
+- **Adapter / glue authors** (Bevy components, parity wrappers) — use
+  the typed quantities as the storage representation so the witness
+  invariants (e.g. `NormalizedQuat`) cannot be forged at the boundary.
+
+Do *not* reach for this crate from raw integration-kernel math; the
+arithmetic-density path drops into `glam::DVec3` / `f64` via
+`.raw_si()` and re-wraps on exit (see the three-layer facade below).
+
+## Key concepts
+
+Phantom-frame tags (`RootInertial`, `PlanetInertial<P>`,
+`IntegrationFrame`, `Ecef`, `PlanetFixed<P>`, `BodyFrame<V>`, …) are
+zero-cost markers attached to `Qty3<D, F>` so that
+`Position<RootInertial>` and `Position<Ecef>` are *different types* —
+the only legal path between them is a `FrameTransform<From, To>`,
+itself only composable when the inner frames match. Time scales work
+the same way via `SecondsSince<S: TimeScale>` (`TAI`, `TT`, `TDB`,
+`UT1`, `UTC`, …). Quaternion convention is similarly typed: a `Quat<L,
+T>` carries both its scalar-position layout and its transform side, so
+JEOD's scalar-first / left-transformation convention can be named once
+and enforced everywhere.
+
+Witness types like `NormalizedQuat` are constructor-gated — they can
+only be produced by an explicit `.normalize()` call (or an
+algebraically-closed operation), so any function that takes a
+`NormalizedQuat` parameter is guaranteed at the type level that the
+input is unit norm. The `F64Ext` facade
+(`400.0.km()`, `51.6.deg()`, `420_000.0.kg()`) makes the typed surface
+ergonomic enough that mission code never has to spell out `uom::si::*`
+paths.
+
 ## Three-layer facade
 
 ```

--- a/crates/astrodyn_runner/README.md
+++ b/crates/astrodyn_runner/README.md
@@ -6,13 +6,47 @@ pipeline.
 
 `astrodyn_runner` is a parallel non-Bevy consumer of `astrodyn`. It owns
 its own state and drives the same pipeline functions the Bevy adapter
-runs from system schedules. Used for:
+runs from system schedules.
 
-- **Tier 3 cross-validation tests** (`tests/tier3_*.rs`) — propagating
-  from JEOD initial conditions and comparing against Trick reference
-  CSVs without standing up a Bevy `App`.
-- **Batch propagation, scripting, and offline studies** that don't
-  need ECS scheduling, parallelism, or Bevy plugins.
+## When to use
+
+- **Tier 3 cross-validation tests** propagating from JEOD initial
+  conditions and comparing against Trick reference CSVs without
+  standing up a Bevy `App` — `astrodyn_verif_jeod`'s 70+
+  `tier3_*` tests drive `Simulation` end-to-end.
+- **Batch propagation, scripting, offline studies, and Jupyter-style
+  exploration** that don't need ECS scheduling, parallelism, or Bevy
+  plugins.
+- **Lockstep parity verification** — `astrodyn_verif_parity` runs
+  identical scenarios through both `astrodyn_runner` and
+  `astrodyn_bevy` and asserts every component is bit-identical, the
+  guard that gives Bevy adapter Tier 3 coverage by transitivity.
+
+For the production target — Bevy ECS as the runtime, with mission
+code expressed as systems and components — reach for `astrodyn_bevy`
+instead. Don't reach for `astrodyn_runner` from a mission crate; its
+state-container shape is incompatible with the ECS world.
+
+## Key concepts
+
+`Simulation` is an arena-state struct: it owns one
+`SimulationContext` (time, ephemeris, gravity sources) and one
+contiguous `Vec` of body states, and steps everything in lockstep.
+The arena layout is deliberate — it makes the runner trivial to
+checkpoint (snapshot the `Vec`), trivial to compare against Trick
+output (the body index is stable across the run), and free of the
+ECS scheduling and change-detection machinery that the Bevy adapter
+takes on.
+
+The pipeline functions it drives — `pre_step`, the per-step
+`TimeUpdate / EphemerisUpdate / Environment / Interaction /
+ForceCollection / Integration / DerivedState` sets — live in
+`astrodyn`, not here, so any improvement that lands there benefits
+both consumers identically. The runner is **not** a dependency of
+`astrodyn_bevy`; both crates depend on `astrodyn` and only
+`astrodyn` for physics, and a CI lint
+(`scripts/check_no_bypass_deps.sh`) refuses any
+`astrodyn_*`-physics-crate direct dep on the four consumer crates.
 
 ## Layered architecture
 

--- a/crates/astrodyn_time/README.md
+++ b/crates/astrodyn_time/README.md
@@ -9,6 +9,44 @@ from [NASA JEOD v5.4.0](https://github.com/nasa/jeod), including the
 [`Leap_Second.dat`](https://github.com/nasa/jeod/blob/jeod_v5.4.0/models/environment/time/data/Leap_Second.dat)
 table.
 
+## When to use
+
+- **Driving the per-step simulation clock** — `SimulationTime`
+  holds the current epoch in every registered scale; the
+  integration loop advances it once per step and downstream
+  consumers (gravity, ephemeris, atmosphere) read from it rather
+  than keeping their own clocks.
+- **Converting between scales** — TAI ↔ UTC ↔ UT1 ↔ TT ↔ TDB ↔ GPS
+  via the registered `TimeConverter_*` pipeline, plus
+  UT1 → GMST for Earth body-fixed rotation.
+- **Mission elapsed time / user-defined epoch** —
+  `MissionElapsedTime` is the relative-time scale most operators
+  log against; `UserDefinedEpoch` is the per-sim zero.
+- **Leap-second-aware date arithmetic** — `CalendarDate` +
+  `LeapSecondTable` handle UTC's leap-second discontinuities
+  rather than papering over them.
+
+## Key concepts
+
+Time scales are typed at the `astrodyn_quantities` boundary as
+`SecondsSince<S: TimeScale>` (`TAI`, `TT`, `TDB`, `UT1`, `UTC`, `GPS`,
+…), so any function that takes "seconds since TAI epoch" cannot
+accidentally be called with "seconds since UTC epoch" — a class of
+sign-and-offset bug that JEOD catches via runtime checks and which
+the typed surface elides at compile time. `TimeManager` keeps the
+currently registered scales and answers conversions by composing
+per-pair `TimeConverter_*` functions, mirroring JEOD's class layout.
+
+Leap seconds are not optional. UTC → TAI is a piecewise-constant
+discontinuity at every leap-second boundary, and silently smearing
+it (the "UTC seconds since epoch" mistake) produces 1-second
+position errors that cascade through every downstream conversion.
+`LeapSecondTable` parses JEOD's `Leap_Second.dat` verbatim and the
+`time_converter_*` family threads it through every relevant
+conversion. GMST in particular drives Earth body-fixed rotation in
+`astrodyn_frames`, so any GMST error propagates directly into ECEF
+positions.
+
 ## Layered architecture
 
 ```


### PR DESCRIPTION
Closes #502.

## Summary

Adds explicit **When to use** and **Key concepts** sections to each of
the 12 publishable crate READMEs under `crates/*`, per Audit-2026-05 §
M-10. The audit observed that per-crate READMEs were stubs from a
crates.io browser's perspective — title + project description + wiki
link, but no sense of when to reach for the crate or what its
load-bearing invariants are.

Architecture content stays pointers-only, per the documentation
convention in CLAUDE.md (non-Rust-crate docs live on the wiki). The new
sections do not duplicate the Strategy / Type-System /
Tier3-Regeneration wiki pages — they tell a caller *whether* to read
those pages.

## Crates updated

- `astrodyn_quantities` — typed quantities, phantom-frame tags, witness types.
- `astrodyn_math` — quaternions, Euler angles, orbital elements, geodetic, LVLH.
- `astrodyn_time` — TAI/UTC/UT1/TT/TDB/GPS scales, leap seconds, GMST.
- `astrodyn_frames` — RefFrame tree, Earth/Mars/Moon body-fixed rotation.
- `astrodyn_planet` — reference-ellipsoid parameters + JEOD-matched presets.
- `astrodyn_ephemeris` — JPL DE-series SPK queries, NAIF body IDs.
- `astrodyn_atmosphere` — exponential + MET density / wind models.
- `astrodyn_gravity` — Gottlieb spherical harmonics, third-body, tides, relativistic.
- `astrodyn_dynamics` — state, mass tree, integrators, body initialization.
- `astrodyn_interactions` — aero drag, SRP, gravity torque, shadow, contact, thermal.
- `astrodyn_runner` — arena-state harness (Tier 3, batch propagation, parity).
- `astrodyn_bevy` — Bevy adapter (mission code, scenario composition).

The four verif crates (`publish = false`) are out of scope — they do
not surface on crates.io. Docs-only, no runtime API change.

## Verify

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)