### PR TITLE
Lock in no-unsafe via #![forbid(unsafe_code)] at every crate root (closes #528)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,19 @@ rule above — it is its operational corollary. A test or implementation
 that compiles and runs but silently produces wrong physics is the
 half-baked failure mode the previous section forbids.
 
+## Lints & invariants
+
+Every workspace crate forbids `unsafe` at the crate root via
+`#![forbid(unsafe_code)]` (on every `lib.rs`, every `main.rs`, every
+binary under `src/bin/`, and every `example` target). The lint
+operates at the type-system layer, so an AI-assisted port that
+introduces an `unsafe` block fails the build rather than slipping
+through review. If a future crate genuinely needs `unsafe` (FFI, SIMD
+intrinsics, a proven safety-critical performance path), it opts out
+per-crate with `#![allow(unsafe_code)]` and a documented justification
+in the crate's `lib.rs`, mirroring how `scripts/check_no_bypass_deps.sh`
+enumerates exceptions to the dep-layering rule.
+
 ## Precision
 
 Use `f64` everywhere. Do NOT use Bevy's `Transform`/`GlobalTransform` (f32).

--- a/crates/astrodyn_bevy/examples/kepler_orbit.rs
+++ b/crates/astrodyn_bevy/examples/kepler_orbit.rs
@@ -18,6 +18,8 @@
 //! extension on `&mut Commands` is a separate, system-friendly form
 //! that's distinct from the existing `&mut App` terminal.
 
+#![forbid(unsafe_code)]
+
 use astrodyn::init_from_orbital_elements_typed;
 use astrodyn::recipes::{constants, earth, orbital_elements, vehicle};
 use astrodyn::{GravityControl, GravityControls, GravityGradient};

--- a/crates/astrodyn_bevy/examples/multi_body_scenario.rs
+++ b/crates/astrodyn_bevy/examples/multi_body_scenario.rs
@@ -28,6 +28,8 @@
 //! cargo run -p astrodyn_bevy --example multi_body_scenario
 //! ```
 
+#![forbid(unsafe_code)]
+
 use std::time::Duration;
 
 use astrodyn::recipes::scenarios::apollo;

--- a/crates/astrodyn_bevy/examples/typed_mission.rs
+++ b/crates/astrodyn_bevy/examples/typed_mission.rs
@@ -12,6 +12,8 @@
 //! by the same typestate builder, so mission code can swap between Bevy
 //! and the standalone runner without rebuilding the configuration.
 
+#![forbid(unsafe_code)]
+
 use std::time::Duration;
 
 use astrodyn::recipes::{constants, earth, orbital_elements, vehicle};

--- a/crates/astrodyn_gravity/src/bin/extract_grav_coeffs.rs
+++ b/crates/astrodyn_gravity/src/bin/extract_grav_coeffs.rs
@@ -22,6 +22,8 @@
 //!
 //! The binary prints a summary of each generated file on success.
 
+#![forbid(unsafe_code)]
+
 use std::io::Write;
 use std::path::{Path, PathBuf};
 

--- a/crates/astrodyn_gravity/src/bin/extract_mars_data.rs
+++ b/crates/astrodyn_gravity/src/bin/extract_mars_data.rs
@@ -45,6 +45,8 @@
 //!
 //! The binary prints each destination path on success.
 
+#![forbid(unsafe_code)]
+
 use std::io::Write;
 use std::path::{Path, PathBuf};
 

--- a/crates/astrodyn_planet/src/bin/extract_planet_pfixposn.rs
+++ b/crates/astrodyn_planet/src/bin/extract_planet_pfixposn.rs
@@ -16,6 +16,8 @@
 //!
 //! The binary prints the destination path on success.
 
+#![forbid(unsafe_code)]
+
 use std::io::Write;
 
 use regex::Regex;

--- a/crates/astrodyn_runner/examples/apollo.rs
+++ b/crates/astrodyn_runner/examples/apollo.rs
@@ -16,6 +16,8 @@
 //! cargo run -p astrodyn_runner --example apollo
 //! ```
 
+#![forbid(unsafe_code)]
+
 use astrodyn::recipes::scenarios::apollo;
 use astrodyn::recipes::{ephemeris as ephemeris_recipes, Mission};
 use astrodyn::{

--- a/crates/astrodyn_runner/examples/batch_propagation.rs
+++ b/crates/astrodyn_runner/examples/batch_propagation.rs
@@ -5,6 +5,8 @@
 //! [`Mission::iss_leo`](astrodyn::recipes::Mission::iss_leo) as the
 //! starting scenario.
 
+#![forbid(unsafe_code)]
+
 use astrodyn::recipes::{constants, Mission};
 use astrodyn_runner::SimulationBuilderExt;
 use glam::DVec3;

--- a/crates/astrodyn_runner/examples/leo_drag.rs
+++ b/crates/astrodyn_runner/examples/leo_drag.rs
@@ -4,6 +4,8 @@
 //! atmosphere model and shows altitude decay over 24 hours. Uses
 //! [`Mission::iss_leo_drag`](astrodyn::recipes::Mission::iss_leo_drag).
 
+#![forbid(unsafe_code)]
+
 use astrodyn::recipes::{constants, Mission};
 use astrodyn_runner::SimulationBuilderExt;
 use glam::DVec3;

--- a/crates/astrodyn_verif_jeod/examples/earth_moon.rs
+++ b/crates/astrodyn_verif_jeod/examples/earth_moon.rs
@@ -17,6 +17,8 @@
 //! cargo run -p astrodyn_verif_jeod --example earth_moon
 //! ```
 
+#![forbid(unsafe_code)]
+
 use astrodyn_runner::SimulationBuilderExt;
 use astrodyn_verif_jeod::setups::earth_moon_clem::{earth_moon_clem, moon_mu};
 

--- a/crates/astrodyn_verif_jeod/examples/mars_orbit.rs
+++ b/crates/astrodyn_verif_jeod/examples/mars_orbit.rs
@@ -16,6 +16,8 @@
 //! cargo run -p astrodyn_verif_jeod --example mars_orbit
 //! ```
 
+#![forbid(unsafe_code)]
+
 use astrodyn::recipes::{self, epoch, sun, vehicle};
 use astrodyn::vehicle_builder::VehicleBuilder;
 use astrodyn::{

--- a/crates/astrodyn_verif_jeod/src/bin/extract_body_init.rs
+++ b/crates/astrodyn_verif_jeod/src/bin/extract_body_init.rs
@@ -36,6 +36,8 @@
 //! crate (see `planet_geodetic_verif.rs`); the JSON is hand-written and
 //! parsed back via `body_init_fixtures::parse_*` helpers.
 
+#![forbid(unsafe_code)]
+
 use std::io::Write;
 
 use astrodyn_verif_jeod::body_init_fixtures::{

--- a/crates/astrodyn_verif_jeod/src/bin/extract_jeod_validation.rs
+++ b/crates/astrodyn_verif_jeod/src/bin/extract_jeod_validation.rs
@@ -37,6 +37,8 @@
 //! level `tests/fixture_metadata.rs` so a regen that drops or
 //! desynchronises a sidecar fails CI.
 
+#![forbid(unsafe_code)]
+
 use std::io::Write;
 use std::path::{Path, PathBuf};
 

--- a/crates/astrodyn_verif_jeod/src/bin/tier3_baseline_diff.rs
+++ b/crates/astrodyn_verif_jeod/src/bin/tier3_baseline_diff.rs
@@ -34,6 +34,8 @@
 //! Prerequisite: `target/tier3_crossval/*.json` must exist (run
 //! `cargo nextest run --workspace -E 'test(tier3_)'` first).
 
+#![forbid(unsafe_code)]
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::PathBuf;

--- a/crates/astrodyn_verif_jeod/src/bin/tier3_perf_runner.rs
+++ b/crates/astrodyn_verif_jeod/src/bin/tier3_perf_runner.rs
@@ -32,6 +32,8 @@
 //! schema; see the README's Performance toolkit section for the
 //! consumer (`perf-history.csv` append in `perf-baseline-track`).
 
+#![forbid(unsafe_code)]
+
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::{Duration, Instant};

--- a/crates/astrodyn_verif_jeod/src/bin/tier3_report.rs
+++ b/crates/astrodyn_verif_jeod/src/bin/tier3_report.rs
@@ -16,6 +16,8 @@
 //! #101's type-system refactor: every refactor-only phase must satisfy
 //! `max_error_new ≤ max(baseline · 1.0 + 1e-12 · magnitude, 1e-12)`.
 
+#![forbid(unsafe_code)]
+
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;

--- a/crates/astrodyn_verif_nesc/src/bin/extract_nesc.rs
+++ b/crates/astrodyn_verif_nesc/src/bin/extract_nesc.rs
@@ -35,6 +35,8 @@
 //! cargo run -p astrodyn_verif_nesc --bin extract_nesc -- --nesc-home /path/to/nesc
 //! ```
 
+#![forbid(unsafe_code)]
+
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/crates/astrodyn_verif_parity/src/lib.rs
+++ b/crates/astrodyn_verif_parity/src/lib.rs
@@ -38,6 +38,8 @@
 //! within the same tolerance. Issue #389 closes the gap by making the
 //! `bevy_parity_*` test set a superset of every Tier 3 topic.
 
+#![forbid(unsafe_code)]
+
 use std::time::Duration;
 
 use astrodyn_bevy::{RotationalStateC, SimulationBuilderBevyExt, TranslationalStateC};

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,8 @@
 //! (<https://github.com/simnaut/astrodyn/wiki/Tier3-Regeneration>) for the
 //! canonical workflow, the incremental-vs-force semantics, and how to add a new sim.
 
+#![forbid(unsafe_code)]
+
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};


### PR DESCRIPTION
Closes #528.

Part of #517 ("Harden verification gates against AI-assisted regressions") sub-task 1.

## Summary

The 14 library crates already carried `#![forbid(unsafe_code)]`. This PR extends the same attribute to every remaining target so that **every crate root in the workspace** forbids `unsafe` at the type-system layer. The lint applies at compile time, so an AI-assisted port that introduces an `unsafe` block fails the build rather than slipping through review.

Per cargo's view, each `bin` / `example` target is its own crate root — the parent `lib.rs` attribute does not transit into a binary or example target — so the attribute is added per-file.

### Targets that gained the attribute

Binaries:
- `crates/astrodyn_gravity/src/bin/extract_grav_coeffs.rs`
- `crates/astrodyn_gravity/src/bin/extract_mars_data.rs`
- `crates/astrodyn_planet/src/bin/extract_planet_pfixposn.rs`
- `crates/astrodyn_verif_jeod/src/bin/extract_body_init.rs`
- `crates/astrodyn_verif_jeod/src/bin/extract_jeod_validation.rs`
- `crates/astrodyn_verif_jeod/src/bin/tier3_baseline_diff.rs`
- `crates/astrodyn_verif_jeod/src/bin/tier3_perf_runner.rs`
- `crates/astrodyn_verif_jeod/src/bin/tier3_report.rs`
- `crates/astrodyn_verif_nesc/src/bin/extract_nesc.rs`
- `xtask/src/main.rs`

Examples:
- `crates/astrodyn_bevy/examples/kepler_orbit.rs`
- `crates/astrodyn_bevy/examples/multi_body_scenario.rs`
- `crates/astrodyn_bevy/examples/typed_mission.rs`
- `crates/astrodyn_runner/examples/apollo.rs`
- `crates/astrodyn_runner/examples/batch_propagation.rs`
- `crates/astrodyn_runner/examples/leo_drag.rs`
- `crates/astrodyn_verif_jeod/examples/earth_moon.rs`
- `crates/astrodyn_verif_jeod/examples/mars_orbit.rs`

Library:
- `crates/astrodyn_verif_parity/src/lib.rs` (was missing the attribute despite the other 13 lib crates carrying it).

After this PR, all 35 lib/bin/example crate roots in the workspace declare `#![forbid(unsafe_code)]`.

### Policy doc

A new `Lints & invariants` subsection in `CLAUDE.md` documents the policy, including the per-crate `#![allow(unsafe_code)]` opt-out recipe for any future crate that genuinely needs `unsafe` (FFI, SIMD intrinsics, proven safety-critical perf path).

## Approach

Issue #528 lists two equivalent shapes. Option A (`#![forbid(unsafe_code)]` at every crate root) was preferred over Option B (`scripts/check_no_unsafe.sh` + CI wire-in) because:
- The lint operates at the type-system layer, not just CI — strictly stronger.
- It is self-documenting (visible at the top of every `lib.rs` / `main.rs`).
- It does not need redundant CI infrastructure.
- The codebase already carries zero `unsafe`, so Option A is uniformly applicable.

## Public API change

None. The lint operates at compile time with no runtime behavior change. Callers attempting to add an `unsafe` block in any workspace crate will now get a hard compiler error rather than relying on convention or review.

## Verify checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo build --workspace`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

CI handles the full test suite.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>