### PR TITLE
Seed negative-test gate for JEOD invariant catalog (closes #531)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,22 @@ copy ctors). We catalog every invariant we encounter in
    invariant in the catalog must have at least one source tag, and
    every source tag must reference a catalog entry.
 
+4. **Negative-test coverage** (same file, `enforced_rows_have_negative_tests_or_warn`):
+   every `enforced` catalog row *should* have a `#[should_panic(expected
+   = "…")]` test that drives the misconfiguration and pins the panic
+   message. Recognised by a `// JEOD_INV: XX.YY` tag inside the test
+   function or in the few lines immediately above the `#[should_panic]`
+   attribute. **The bidirectional tag-↔-catalog check only proves the
+   panic site *exists* — the negative test proves it actually fires**;
+   without it a future refactor could neuter an `assert!` to a silent
+   `if … return` and CI would stay green. The gate is informational
+   (warning report, exit 0) in this round and is promoted to a hard
+   assertion in a follow-up PR once the catalog body of negative tests
+   lands per section (DB / RF / IG / GV / TM / …). To add one: write
+   `#[should_panic(expected = "<substring>")]` near the enforcement
+   site, drive the failure with a minimal misconfiguration, and tag
+   the test with `// JEOD_INV: XX.YY`.
+
 ### When you encounter an unrecorded invariant
 
 When reading JEOD source and you find a `MessageHandler::fail()`,

--- a/crates/astrodyn_dynamics/src/mass.rs
+++ b/crates/astrodyn_dynamics/src/mass.rs
@@ -856,24 +856,28 @@ mod tests {
     //   guarded separately by the scale-invariant
     //   `checked_inertia_inverse`.
 
+    // JEOD_INV: MA.02 — negative test for `MassProperties::new(0.0)`
     #[test]
     #[should_panic(expected = "out of safe range")]
     fn untyped_new_panics_on_zero_mass() {
         let _ = MassProperties::new(0.0);
     }
 
+    // JEOD_INV: MA.02 — negative test for negative mass
     #[test]
     #[should_panic(expected = "out of safe range")]
     fn untyped_new_panics_on_negative_mass() {
         let _ = MassProperties::new(-1.0);
     }
 
+    // JEOD_INV: MA.02 — negative test for NaN mass
     #[test]
     #[should_panic(expected = "out of safe range")]
     fn untyped_new_panics_on_nan_mass() {
         let _ = MassProperties::new(f64::NAN);
     }
 
+    // JEOD_INV: MA.02 — negative test for +Inf mass
     #[test]
     #[should_panic(expected = "out of safe range")]
     fn untyped_new_panics_on_infinite_mass() {

--- a/crates/astrodyn_gravity/src/accumulate.rs
+++ b/crates/astrodyn_gravity/src/accumulate.rs
@@ -952,4 +952,76 @@ mod tests {
         assert_eq!(kernel.grav_pot, plain.grav_pot);
         assert_eq!(kernel.grav_grad, plain.grav_grad);
     }
+
+    // ---- fail-loud negative tests (#531 seed gate) -------------------
+    //
+    // Pin the panic sites in `accumulate_gravity` so a future refactor
+    // that converts the `unwrap_or_else(panic!)` to `unwrap_or_default`
+    // or to a silent-skip branch trips a `should_panic` check rather
+    // than producing wrong physics under a missing-source config.
+
+    /// JEOD logs a non-fatal error and skips when a `GravityControl`
+    /// references a source that doesn't exist; we panic instead so the
+    /// silent omission can't propagate to a wrong trajectory.
+    // JEOD_INV: GV.12 — negative test: missing source panics
+    #[test]
+    #[should_panic(expected = "does not exist")]
+    fn accumulate_gravity_panics_on_missing_source() {
+        let controls = GravityControls {
+            controls: vec![GravityControl::new_spherical(
+                0_usize,
+                GravityGradient::Skip,
+            )],
+        };
+        let _ = accumulate_gravity(
+            DVec3::new(7e6, 0.0, 0.0),
+            &controls,
+            DVec3::ZERO,
+            |_id: usize| -> Option<ResolvedSource<'_>> { None },
+        );
+    }
+
+    /// A non-spherical `GravityControl` paired with a
+    /// `SphericalHarmonics` source whose `rotation` is `None` must
+    /// panic: the kernel needs the planet-fixed rotation matrix to
+    /// evaluate Gottlieb. JEOD subscribes to the planet-fixed frame
+    /// unconditionally; we surface the missing rotation as a fatal
+    /// error.
+    // JEOD_INV: GV.13 — negative test: nonspherical without rotation panics
+    #[test]
+    #[should_panic(expected = "no planet-fixed rotation matrix")]
+    fn accumulate_gravity_panics_on_missing_rotation_for_nonspherical() {
+        use crate::spherical_harmonics_gravity_source::SphericalHarmonicsData;
+        let mu = 3.986_004_415e14;
+        let radius = 6_378_137.0;
+        let cnm: Vec<Vec<f64>> = (0..=4).map(|n| vec![0.0_f64; n + 1]).collect();
+        let snm: Vec<Vec<f64>> = (0..=4).map(|n| vec![0.0_f64; n + 1]).collect();
+        let sh = SphericalHarmonicsData::new(4, 4, radius, mu, cnm, snm, true, 0.0);
+        let source = GravitySource {
+            mu,
+            model: GravityModel::SphericalHarmonics(Box::new(sh)),
+        };
+        let controls = GravityControls {
+            controls: vec![GravityControl::new_nonspherical(
+                0_usize,
+                4,
+                4,
+                GravityGradient::Skip,
+            )],
+        };
+        let _ = accumulate_gravity(
+            DVec3::new(7e6, 0.0, 0.0),
+            &controls,
+            DVec3::ZERO,
+            |_id: usize| -> Option<ResolvedSource<'_>> {
+                Some(ResolvedSource {
+                    source: &source,
+                    rotation: None, // ← missing rotation triggers GV.13
+                    position: DVec3::ZERO,
+                    delta_c20: 0.0,
+                    has_delta_coeffs: false,
+                })
+            },
+        );
+    }
 }

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -1022,6 +1022,7 @@ mod tests {
     /// caller meant point-mass gravity but did not flip `spherical`.
     /// JEOD silently flips it; we panic so the operator sees the
     /// inconsistency.
+    // JEOD_INV: GV.07 — negative test for degree < 2 with spherical=false
     #[test]
     #[should_panic(
         expected = "Non-spherical gravity (spherical=false) requested with degree=0 (< 2)"
@@ -1043,6 +1044,7 @@ mod tests {
     /// gravity model under the operator. The startup gate rejects it so the
     /// inconsistency between the configured `spherical=false` and the
     /// effectively-point-mass runtime path surfaces immediately.
+    // JEOD_INV: GV.07 — negative test for degree == 1 with spherical=false
     #[test]
     #[should_panic(
         expected = "Non-spherical gravity (spherical=false) requested with degree=1 (< 2)"
@@ -1062,6 +1064,7 @@ mod tests {
     /// silently changes which SH terms contribute to the gradient
     /// tensor and produces a torque trajectory that differs from what
     /// the operator requested.
+    // JEOD_INV: GV.08 — negative test for gradient_degree > degree
     #[test]
     #[should_panic(expected = "Gravity gradient degree (12) > gravity degree (4)")]
     fn check_validity_panics_on_gradient_degree_above_degree() {
@@ -1081,6 +1084,7 @@ mod tests {
     /// `gradient_degree == 1`: Gottlieb returns zero perturbation for
     /// degree < 2, so a gradient_degree of exactly 1 is meaningless.
     /// JEOD resets to 0; we panic so the misconfiguration surfaces.
+    // JEOD_INV: GV.09 — negative test for gradient_degree == 1
     #[test]
     #[should_panic(expected = "Gravity gradient degree must not equal 1")]
     fn check_validity_panics_on_gradient_degree_equal_one() {
@@ -1098,6 +1102,7 @@ mod tests {
     }
 
     /// `gradient_order > gradient_degree`: JEOD clamps; we panic.
+    // JEOD_INV: GV.10 — negative test for gradient_order > gradient_degree
     #[test]
     #[should_panic(expected = "Gravity gradient order (5) > gradient degree (2)")]
     fn check_validity_panics_on_gradient_order_above_gradient_degree() {
@@ -1118,6 +1123,7 @@ mod tests {
     /// `gradient_order` check fires before the `> order` check when
     /// both fail, so this test sets `gradient_order` *below*
     /// `gradient_degree` and *above* `order` to isolate GV.11.
+    // JEOD_INV: GV.11 — negative test for gradient_order > order
     #[test]
     #[should_panic(expected = "Gravity gradient order (4) > gravity order (2)")]
     fn check_validity_panics_on_gradient_order_above_order() {
@@ -1155,6 +1161,7 @@ mod tests {
 
     /// The typed sibling delegates to the untyped validator; the same
     /// misconfiguration must panic on the typed surface too.
+    // JEOD_INV: GV.07 — negative test for the typed surface
     #[test]
     #[should_panic(expected = "Non-spherical gravity (spherical=false) requested with degree=0")]
     fn typed_check_validity_panics_on_zero_degree_with_spherical_false() {

--- a/crates/astrodyn_quantities/tests/quat_normalize_panic.rs
+++ b/crates/astrodyn_quantities/tests/quat_normalize_panic.rs
@@ -1,0 +1,20 @@
+//! Negative tests for quaternion normalization invariants (#531 seed
+//! tests for the negative-test gate in `tests/invariant_coverage.rs`).
+//!
+//! These pin the `assert!`/`panic!` sites in
+//! `crates/astrodyn_quantities/src/quat.rs::JeodQuat::normalize` and
+//! prove that an attempt to normalize a zero-magnitude quaternion
+//! produces the expected diagnostic, not a silent NaN. A future
+//! refactor that downgrades the `assert!` to a `return` would trip
+//! the `should_panic` here even though the existing
+//! `tests/invariant_coverage.rs` tag-↔-catalog gate would still pass.
+
+use astrodyn_quantities::prelude::*;
+
+// JEOD_INV: QT.03 — cannot normalize a zero quaternion (panic site)
+#[test]
+#[should_panic(expected = "cannot normalize a zero quaternion")]
+fn normalize_panics_on_zero_quaternion() {
+    let mut q = JeodQuat::from_array([0.0, 0.0, 0.0, 0.0]);
+    q.normalize();
+}

--- a/tests/invariant_coverage.rs
+++ b/tests/invariant_coverage.rs
@@ -10,6 +10,18 @@
 //! 2. Every `// JEOD_INV: XX.YY` tag in source MUST reference an invariant
 //!    that exists in the catalog.
 //!
+//! 3. (Informational, seed gate from #531) Every `enforced` invariant row
+//!    SHOULD have at least one `#[should_panic]` negative test that drives
+//!    the misconfiguration and verifies the panic message — this proves
+//!    the `assert!`/`panic!` site actually fires rather than being a
+//!    silently-dead branch. The negative test is recognised by a
+//!    `// JEOD_INV: XX.YY` tag inside or immediately preceding a
+//!    `#[should_panic]` test function. This third leg is informational
+//!    this round (prints a `::warning::`-style coverage report but does
+//!    not fail the build); subsequent PRs add the body of negative tests
+//!    per catalog section, and the assertion is promoted to a hard gate
+//!    once the catalog is fully covered.
+//!
 //! Fails CI if someone:
 //! - Marks an invariant as `enforced` without adding a source tag
 //! - Removes a source tag without updating the catalog status
@@ -376,6 +388,233 @@ fn no_duplicate_catalog_ids() {
     );
 }
 
+/// Scan source files for `#[should_panic]` test functions whose
+/// surrounding context (immediately preceding lines or function body)
+/// carries a `// JEOD_INV: XX.YY` tag, and return the set of catalog
+/// IDs that have at least one such negative test.
+///
+/// Matching window: any `JEOD_INV:` tag within the test function's
+/// body, OR on any of the 6 lines immediately preceding the
+/// `#[should_panic]` attribute (covers a leading doc comment, the
+/// `#[test]` attribute, and a tag-bearing comment above it).
+///
+/// Tags appearing only in unrelated source comments (i.e. outside a
+/// `#[should_panic]`-attributed test) are NOT counted as negative
+/// tests — the existing `// JEOD_INV: GV.04` tag at the
+/// panic-emitting `assert!` call site is documentation of the
+/// enforcement site, not proof that the panic actually fires.
+fn find_negative_tests() -> BTreeMap<String, Vec<String>> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut tagged: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    let mut roots = vec![
+        manifest_dir.join("crates"),
+        manifest_dir.join("src"),
+        manifest_dir.join("tests"),
+    ];
+    // Also scan per-crate `tests/` directories explicitly — the recursive
+    // walk below picks them up via `crates/<crate>/tests/`, but listing
+    // the top-level `tests/` separately ensures the workspace-root
+    // integration tests are covered too.
+    let crates_dir = manifest_dir.join("crates");
+    if let Ok(entries) = fs::read_dir(&crates_dir) {
+        for entry in entries.flatten() {
+            let tests_dir = entry.path().join("tests");
+            if tests_dir.is_dir() {
+                roots.push(tests_dir);
+            }
+        }
+    }
+
+    for root in roots {
+        scan_negative_tests_recursive(&root, manifest_dir, &mut tagged);
+    }
+    tagged
+}
+
+fn scan_negative_tests_recursive(
+    dir: &Path,
+    manifest_root: &Path,
+    tagged: &mut BTreeMap<String, Vec<String>>,
+) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_negative_tests_recursive(&path, manifest_root, tagged);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            let Ok(content) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let rel_path = path.strip_prefix(manifest_root).unwrap_or(&path);
+            let lines: Vec<&str> = content.lines().collect();
+
+            for (idx, line) in lines.iter().enumerate() {
+                let trimmed = line.trim_start();
+                if !trimmed.starts_with("#[should_panic") {
+                    continue;
+                }
+                // Collect tags from a window: 6 lines above through the
+                // closing brace of the function body. The brace search
+                // counts depth from the first `{` on or after the
+                // `#[should_panic]` line.
+                let window_start = idx.saturating_sub(6);
+                let body_end = find_test_fn_body_end(&lines, idx);
+                let window_end = body_end.unwrap_or(lines.len().min(idx + 80));
+
+                let mut window_tags = BTreeSet::new();
+                for window_line in &lines[window_start..window_end] {
+                    for tag in extract_inv_tags(window_line) {
+                        window_tags.insert(tag);
+                    }
+                }
+                let location = format!("{}:{}", rel_path.display(), idx + 1);
+                for tag in window_tags {
+                    tagged.entry(tag).or_default().push(location.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Given a `#[should_panic]` attribute line at `attr_idx`, find the
+/// line index just past the test function's closing brace by simple
+/// brace counting. Returns `None` if no balanced body is found within
+/// 200 lines (defensive — keeps the scanner fast on malformed input).
+fn find_test_fn_body_end(lines: &[&str], attr_idx: usize) -> Option<usize> {
+    let mut depth: i32 = 0;
+    let mut started = false;
+    let limit = lines.len().min(attr_idx + 200);
+    for (i, line) in lines.iter().enumerate().take(limit).skip(attr_idx) {
+        for c in line.chars() {
+            match c {
+                '{' => {
+                    depth += 1;
+                    started = true;
+                }
+                '}' => {
+                    depth -= 1;
+                }
+                _ => {}
+            }
+        }
+        if started && depth == 0 {
+            return Some(i + 1);
+        }
+    }
+    None
+}
+
+/// Direction 6 (informational seed from #531): every `enforced`
+/// catalog row should have at least one negative test driving the
+/// misconfiguration. Emits a `::warning::`-style coverage report and
+/// PASSES regardless — the bidirectional gate is staged in chunks
+/// (this PR seeds the matcher + a handful of tests; subsequent PRs
+/// fill in the per-section bodies; the final PR in the chain promotes
+/// this to a hard `assert!`).
+///
+/// Rationale: today the bidirectional `tag ↔ catalog` checks above
+/// only prove the tag *exists* at the enforcement site. They do not
+/// prove the `assert!` actually fires under misconfiguration — an
+/// AI-authored refactor could neuter a panic site to a silent
+/// `if … return` and CI would stay green. A `#[should_panic(expected
+/// = "…")]` negative test that drives the failure and pins the panic
+/// message text closes that gap.
+#[test]
+fn enforced_rows_have_negative_tests_or_warn() {
+    let catalog = parse_catalog();
+    let neg_tests = find_negative_tests();
+
+    let mut covered_enforced: Vec<&String> = Vec::new();
+    let mut missing_enforced: Vec<&String> = Vec::new();
+    let mut covered_partial: Vec<&String> = Vec::new();
+    let mut missing_partial: Vec<&String> = Vec::new();
+
+    for (tag, status) in &catalog {
+        // Skip rows that are not in scope for negative tests:
+        // - `structural` is enforced at compile time (deleted ctor,
+        //   value member, typestate witness) — there is no runtime
+        //   panic to drive.
+        // - `deferred` and `n/a` are out of scope by definition.
+        let scope_enforced = status.starts_with("enforced");
+        let scope_partial = status.starts_with("partial");
+        if !scope_enforced && !scope_partial {
+            continue;
+        }
+        let has_test = neg_tests.contains_key(tag);
+        match (scope_enforced, has_test) {
+            (true, true) => covered_enforced.push(tag),
+            (true, false) => missing_enforced.push(tag),
+            (false, true) => covered_partial.push(tag),
+            (false, false) => missing_partial.push(tag),
+        }
+    }
+
+    let enforced_total = covered_enforced.len() + missing_enforced.len();
+    let partial_total = covered_partial.len() + missing_partial.len();
+
+    eprintln!();
+    eprintln!("=== Negative-test coverage (#531 seed gate, informational) ===");
+    eprintln!(
+        "enforced: {}/{} rows have a #[should_panic] negative test",
+        covered_enforced.len(),
+        enforced_total
+    );
+    eprintln!(
+        "partial:  {}/{} rows have a #[should_panic] negative test (best-effort)",
+        covered_partial.len(),
+        partial_total
+    );
+    if !missing_enforced.is_empty() {
+        eprintln!();
+        eprintln!(
+            "::warning:: {} `enforced` row(s) lack a #[should_panic] negative test.",
+            missing_enforced.len()
+        );
+        eprintln!(
+            "::warning:: Add `#[should_panic(expected = \"<substring>\")]` test(s) near \
+             the enforcement site, tagged with `// JEOD_INV: XX.YY`."
+        );
+        eprintln!("Missing (enforced):");
+        for tag in &missing_enforced {
+            eprintln!("  - {tag}");
+        }
+    }
+    if !missing_partial.is_empty() {
+        eprintln!();
+        eprintln!(
+            "(`partial` rows without negative tests — informational, lower priority): {}",
+            missing_partial
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    eprintln!("================================================================");
+    eprintln!();
+
+    // Pass unconditionally this round. The gate is promoted to an
+    // assertion once the catalog body lands (tracked as follow-up
+    // sub-issues of #517 / #531).
+    //
+    // Sanity check: the matcher must locate at least the seed tests
+    // landed alongside this gate; if zero rows are covered, the
+    // scanner is broken and the informational-mode escape hatch is
+    // hiding the breakage.
+    assert!(
+        !covered_enforced.is_empty(),
+        "Negative-test scanner found zero covered `enforced` rows. \
+         The seed tests in `gravity_controls.rs`, `mass.rs`, and \
+         `crates/astrodyn_quantities/tests/quat_normalize_panic.rs` \
+         should each contribute coverage; if all of them are missing \
+         the scanner has regressed (window, brace-counting, or root \
+         set), not the test suite."
+    );
+}
+
 /// Print a coverage summary (informational, not an assertion).
 /// Run with: `cargo test --test invariant_coverage coverage_summary -- --ignored --nocapture`
 #[test]
@@ -419,6 +658,13 @@ fn coverage_summary() {
     eprintln!("  n/a:       {na}");
     eprintln!("  not enforced: {not_enforced}");
     eprintln!("Source tags: {tagged_count} unique IDs, {tag_sites} total sites");
+
+    let neg_tests = find_negative_tests();
+    let neg_covered: usize = catalog
+        .iter()
+        .filter(|(tag, status)| status.starts_with("enforced") && neg_tests.contains_key(*tag))
+        .count();
+    eprintln!("Negative tests (`#[should_panic]` + JEOD_INV tag): {neg_covered}/{enforced} enforced rows covered");
     eprintln!();
 
     // Per-section breakdown.


### PR DESCRIPTION
Closes #531. Part of #517 sub-task 2 (the largest of the four sub-tasks) — landed here as the bidirectional gate skeleton + initial seed tests; the per-section bodies of negative tests are tracked as a follow-up at #535.

## Summary

- Extend `tests/invariant_coverage.rs` with a third leg: `enforced_rows_have_negative_tests_or_warn` scans the workspace for `#[should_panic]` test functions whose body or 6 preceding lines carry a `// JEOD_INV: XX.YY` tag, and emits a `::warning::`-style coverage report listing the catalog rows without a negative test.
- **Severity this round: informational.** The check passes regardless (with a sanity assert that the scanner found at least the seed tests), so CI stays green while the per-section bodies of negative tests land in follow-up PRs (#535). The gate is promoted to a hard assertion once the catalog is fully covered.
- Seed coverage (10/109 `enforced` rows): GV.07/08/09/10/11 (existing `check_validity_panics_on_*` tests, now JEOD_INV-tagged), GV.12 (new `accumulate_gravity_panics_on_missing_source`), GV.13 (new `accumulate_gravity_panics_on_missing_rotation_for_nonspherical`), MA.02 (existing `untyped_new_panics_on_{zero,negative,nan,infinite}_mass` tests, now tagged), QT.03 (new `normalize_panics_on_zero_quaternion` integration test under `crates/astrodyn_quantities/tests/`).

## Why this matters

The existing bidirectional `tag ↔ catalog` checks in `invariant_coverage.rs` only prove the `// JEOD_INV` tag *exists* at the enforcement site. They do not prove the `assert!`/`panic!` actually fires under misconfiguration — an AI-authored refactor could neuter a panic to a silent `if … return` and CI would stay green. A `#[should_panic(expected = "...")]` test that drives the failure and pins the message text closes that gap.

The matching mechanism is grep-based (lighter cut than a proc-macro attribute, per #531's sequencing note): a `// JEOD_INV: XX.YY` tag inside the test function body OR on any of the 6 lines immediately preceding the `#[should_panic]` attribute counts.

## Follow-ups

- #535 tracks the per-section bodies of negative tests (99 rows). When complete, a final small PR flips `enforced_rows_have_negative_tests_or_warn` from warn to `assert!(missing_enforced.is_empty(), …)`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo test --test invariant_coverage` (all 7 active + 1 ignored tests pass; new check finds 10/109 enforced rows covered)
- [x] `cargo nextest run -p astrodyn_quantities -p astrodyn_gravity -p astrodyn_dynamics` (all seed `#[should_panic]` tests pass; 505 quantities tests, 9 affected gravity tests all green)
- [x] `cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)