### PR TITLE
Add negative tests for GV.04/.05/.06/.14/.17/.19/.21/.22 (#535 sweep, GV remaining)

### DIFF
--- a/crates/astrodyn_gravity/src/accumulate.rs
+++ b/crates/astrodyn_gravity/src/accumulate.rs
@@ -1028,4 +1028,52 @@ mod tests {
             },
         );
     }
+
+    /// A `differential` (third-body) control whose source is at the
+    /// integration frame origin is degenerate: the third-body
+    /// correction `mu/|rho|^3 * rho` divides by `|rho| = 0`. JEOD
+    /// derives the third-body classification structurally from the
+    /// frame tree (`is_progeny_of`) and never produces this
+    /// configuration; in our ECS the `differential` flag is set
+    /// explicitly per control, so the misconfiguration is reachable
+    /// (e.g., a recipe that tags Earth as a third-body while
+    /// integrating in an Earth-centered frame). Panicking here
+    /// surfaces that configuration error before the singular
+    /// arithmetic produces NaN forces silently.
+    // JEOD_INV: GV.14 — negative test: third-body source at integration origin
+    #[test]
+    #[should_panic(expected = "is at the integration frame origin")]
+    fn gv_14_panics_on_third_body_at_integration_origin() {
+        let mu = 1.327_124_400e20;
+        let source = GravitySource {
+            mu,
+            model: GravityModel::PointMass,
+        };
+        let mut ctrl = GravityControl::new_third_body(0_usize);
+        // `new_third_body` already sets `differential = true`; assert
+        // here so the test's intent is independent of constructor
+        // defaults.
+        assert!(ctrl.differential);
+        ctrl.battin_method = false;
+        let controls = GravityControls {
+            controls: vec![ctrl],
+        };
+        // Source position == integration origin == ZERO: the
+        // third-body branch's `frame_pos_relative_to_source` is the
+        // zero vector and trips the assert.
+        let _ = accumulate_gravity(
+            DVec3::new(1.5e11, 0.0, 0.0),
+            &controls,
+            DVec3::ZERO,
+            |_id: usize| -> Option<ResolvedSource<'_>> {
+                Some(ResolvedSource {
+                    source: &source,
+                    rotation: None,
+                    position: DVec3::ZERO, // ← coincides with integration origin
+                    delta_c20: 0.0,
+                    has_delta_coeffs: false,
+                })
+            },
+        );
+    }
 }

--- a/crates/astrodyn_gravity/src/gravity_controls.rs
+++ b/crates/astrodyn_gravity/src/gravity_controls.rs
@@ -1176,6 +1176,120 @@ mod tests {
         ctrl.check_validity(&src);
     }
 
+    /// `degree > source.degree`: the requested expansion exceeds the
+    /// stored coefficient table. JEOD clamps via
+    /// `MessageHandler::error`; we panic so a control configured for
+    /// (say) 70x70 against an 8x8 source does not silently degenerate
+    /// to 8x8 and produce a quietly-wrong trajectory.
+    // JEOD_INV: GV.04 — negative test: degree > source.degree
+    #[test]
+    #[should_panic(
+        expected = "Gravity field degree requested (12) is greater than max gravity field degree (8)."
+    )]
+    fn gv_04_panics_on_degree_above_source_degree() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 12,
+            order: 8,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `order > source.order`: the requested order exceeds the stored
+    /// coefficient table. Source is built with `order < degree` so the
+    /// GV.05 check fires before the GV.06 `order <= degree` check.
+    // JEOD_INV: GV.05 — negative test: order > source.order
+    #[test]
+    #[should_panic(
+        expected = "Gravity field order requested (6) is greater than max gravity field order (4)."
+    )]
+    fn gv_05_panics_on_order_above_source_order() {
+        // Source: degree=8, order=4 (sectorial truncation).
+        let src = dummy_sh_source(8, 4);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 6,
+            order: 6,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// `order > degree`: order exceeds the requested degree even though
+    /// both are within the source's bounds. JEOD clamps; we panic — a
+    /// silently-clamped order would change which sectorial harmonics
+    /// contribute to acceleration.
+    // JEOD_INV: GV.06 — negative test: order > degree
+    #[test]
+    #[should_panic(expected = "Gravity field order (5) is greater than gravity field degree (4).")]
+    fn gv_06_panics_on_order_above_degree() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 4,
+            order: 5,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// Source-side degree clamp at initialization: a request whose
+    /// degree exceeds the stored coefficient table fails before the
+    /// kernel runs. JEOD's
+    /// `SphericalHarmonicsGravitySource::initialize_source` clamps
+    /// `degree`/`order` to `max_degree` at startup; we enforce the same
+    /// bound at `check_validity` and fail loudly rather than clamping,
+    /// so an out-of-table request surfaces as a configuration error.
+    /// Shares the panic site with GV.04 — same `assert!` — and is
+    /// catalogued separately to mirror JEOD's source-side line.
+    // JEOD_INV: GV.19 — negative test: source-side degree clamp
+    #[test]
+    #[should_panic(
+        expected = "Gravity field degree requested (50) is greater than max gravity field degree (8)."
+    )]
+    fn gv_19_panics_on_degree_above_source_max() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 50,
+            order: 8,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        ctrl.check_validity(&src);
+    }
+
+    /// Active nonspherical control must subscribe to the planet-fixed
+    /// rotation: `evaluate_inner` panics when `eff_degree > 0` and the
+    /// caller passes `None` for the rotation matrix. JEOD subscribes
+    /// to the planet-fixed frame unconditionally for non-spherical
+    /// gravity (`gravity_controls.cc::initialize_control` registers the
+    /// subscription as a structural pre-step). We surface the missing
+    /// rotation as a fatal error rather than producing zero / NaN
+    /// acceleration silently. Shares the runtime enforcement site
+    /// with GV.13 but the catalog tracks the subscription invariant
+    /// separately.
+    // JEOD_INV: GV.17 — negative test: active nonspherical control without rotation
+    #[test]
+    #[should_panic(
+        expected = "Non-spherical gravity (degree=4/order=4) requires planet-fixed rotation matrix."
+    )]
+    fn gv_17_panics_on_nonspherical_without_rotation() {
+        let src = dummy_sh_source(8, 8);
+        let ctrl = GravityControl::<usize> {
+            spherical: false,
+            degree: 4,
+            order: 4,
+            ..GravityControl::new_spherical(0_usize, GravityGradient::Skip)
+        };
+        // `evaluate` (not `accumulate_gravity`) drives the kernel-level
+        // assert in `evaluate_inner` directly; this test pins the
+        // panic site closest to where the rotation matrix is consumed.
+        let pos = DVec3::new(7_000_000.0, 0.0, 0.0);
+        let _ = ctrl.evaluate(&src, pos, None, 0.0, false);
+    }
+
     // ---- proptest round-trips (#398) ----------------------------------
 
     use proptest::prelude::*;

--- a/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
+++ b/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
@@ -609,3 +609,76 @@ pub fn calc_nonspherical_typed<P: Planet>(
     );
     GravityAccelerationTyped::<PlanetFixed<P>>::from_untyped_unchecked(&untyped)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spherical_harmonics_gravity_source::SphericalHarmonicsData;
+
+    /// Build a small SH source for kernel-precondition tests. The
+    /// coefficient arrays follow the triangular `cnm[n].len() == n+1`
+    /// shape that `SphericalHarmonicsData::new` expects. Numerics are
+    /// irrelevant — these tests drive the panic preconditions before
+    /// the recurrence runs.
+    fn dummy_sh(degree: usize, order: usize) -> SphericalHarmonicsData {
+        let mu = 3.986_004_415e14;
+        let radius = 6_378_137.0;
+        let cnm: Vec<Vec<f64>> = (0..=degree).map(|n| vec![0.0_f64; n + 1]).collect();
+        let snm: Vec<Vec<f64>> = (0..=degree).map(|n| vec![0.0_f64; n + 1]).collect();
+        SphericalHarmonicsData::new(degree, order, radius, mu, cnm, snm, true, 0.0)
+    }
+
+    /// Scratch sized smaller than the requested degree: the recurrence
+    /// indexes `pnm[ii]` for `ii <= degree`, so a buffer allocated for
+    /// (say) degree-2 cannot serve a degree-8 request without writing
+    /// out of bounds. JEOD's `calc_nonspherical` keeps its own scratch
+    /// owned by the source, so the size invariant is structural there;
+    /// our `calc_nonspherical_with_scratch` exposes the buffer to
+    /// callers (RK4 reuse), so the invariant must be runtime-checked
+    /// at the kernel boundary.
+    // JEOD_INV: GV.21 — negative test: scratch smaller than requested degree
+    #[test]
+    #[should_panic(expected = "GottliebScratch degree (2) must be >= requested degree (8)")]
+    fn gv_21_panics_on_scratch_smaller_than_degree() {
+        let data = dummy_sh(8, 8);
+        let mut scratch = GottliebScratch::new(2);
+        let _ = calc_nonspherical_with_scratch(
+            &data,
+            DVec3::new(7e6, 0.0, 0.0),
+            8, // requested degree exceeds scratch.degree
+            8,
+            false,
+            0,
+            0,
+            &mut scratch,
+            0.0,
+            false,
+        );
+    }
+
+    /// Zero-vector position: the Gottlieb recurrence normalizes by
+    /// `r = |posn_pf|`, so a zero input would silently produce
+    /// `NaN`/`inf` acceleration. JEOD's documentation calls out the
+    /// origin singularity in `spherical_harmonics_calc_nonspherical.cc`;
+    /// we assert at the kernel boundary so the caller sees the
+    /// configuration error rather than a quietly-poisoned trajectory.
+    // JEOD_INV: GV.22 — negative test: zero-vector input position
+    #[test]
+    #[should_panic(expected = "position must be non-zero")]
+    fn gv_22_panics_on_zero_position() {
+        let data = dummy_sh(4, 4);
+        let mut scratch = GottliebScratch::new(4);
+        let _ = calc_nonspherical_with_scratch(
+            &data,
+            DVec3::ZERO, // ← zero-length input
+            4,
+            4,
+            false,
+            0,
+            0,
+            &mut scratch,
+            0.0,
+            false,
+        );
+    }
+}


### PR DESCRIPTION
Refs #535.

GV-remaining sweep — the per-section series so far:

- TM (#537, merged)
- QT (#538, merged)
- PF (#539, pending human review)
- EP (#540, in flight)
- OE (#541, in flight)
- GV-seed (#536, merged: GV.07-.13, with GV.12/.13 negative tests already in `accumulate.rs`)
- **GV-remaining** (this PR: GV.04, .05, .06, .14, .17, .19, .21, .22)

## Per-row outcomes

| Row | Outcome | Panic substring |
| --- | --- | --- |
| GV.04 | new test | `Gravity field degree requested (12) is greater than max gravity field degree (8).` |
| GV.05 | new test | `Gravity field order requested (6) is greater than max gravity field order (4).` |
| GV.06 | new test | `Gravity field order (5) is greater than gravity field degree (4).` |
| GV.14 | new test | `is at the integration frame origin` |
| GV.17 | new test | `Non-spherical gravity (degree=4/order=4) requires planet-fixed rotation matrix.` |
| GV.19 | new test | `Gravity field degree requested (50) is greater than max gravity field degree (8).` |
| GV.21 | new test | `GottliebScratch degree (2) must be >= requested degree (8)` |
| GV.22 | new test | `position must be non-zero` |

All eight are real `#[should_panic]` tests that drive the misconfiguration — no reclassifications. Per the PF.04/PF.05 caution, every GV row in this slice has a runtime-reachable misconfiguration path:

- GV.04/.05/.06/.19 fire in `GravityControl::check_validity` against a control built with an out-of-range ordinal pair. GV.19 shares its `assert!` site with GV.04 — JEOD catalogs them separately (controls-side validate + source-side init clamp), so they get separate tests with distinct out-of-range degrees.
- GV.14 fires in `accumulate_gravity` when a `differential=true` control's source coincides with the integration origin (singular `1/|rho|^3`). JEOD derives third-body classification structurally; our ECS surface has `differential` as an explicit flag, so the misconfiguration is reachable.
- GV.17 shares its runtime enforcement site with GV.13 but the catalog tracks the planet-fixed-frame subscription invariant separately. The new test drives the panic at `GravityControl::evaluate` (the kernel-adjacent site) rather than at the `accumulate_gravity` pre-check used by GV.13's existing test, so a refactor that neuters either gate trips a distinct test.
- GV.21/.22 fire kernel-side in `calc_nonspherical_with_scratch` — scratch sized below requested degree, and zero-vector input position. These are the two preconditions the kernel cannot meaningfully recover from (out-of-bounds buffer write, `1/r` singularity).

## Verify checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo test -p astrodyn_gravity --lib --tests` (all 67 lib + 7 integration tests pass; 8 new negative tests included)
- [x] `cargo test --test invariant_coverage` (7 passed)
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_silent_warn.sh`

## Coverage delta

`enforced_rows_have_negative_tests_or_warn`:

- **Before**: 10/109 enforced rows covered; missing list included GV.04, .05, .06, .14, .17, .19, .21, .22.
- **After**: 18/109 covered; none of the eight GV rows above appear in the missing list.