### PR TITLE
Add negative tests for IN section (#535 sweep, IN section)

### DIFF
--- a/crates/astrodyn_interactions/src/contact.rs
+++ b/crates/astrodyn_interactions/src/contact.rs
@@ -1629,4 +1629,49 @@ mod tests {
         }));
         assert!(result.is_err(), "inactive ground facet should panic");
     }
+
+    /// `compute_ground_contact_geometry` asserts the ground facet is
+    /// active. Sibling of `ground_facet_inactive_panics` above, recast
+    /// as a `#[should_panic]` test so the negative-test scanner picks
+    /// up the row.
+    #[test]
+    #[should_panic(expected = "ground_facet must be active")]
+    fn in_35_panics_on_inactive_ground_facet_at_compute() {
+        // JEOD_INV: IN.35 — inactive GroundFacet rejected at compute site
+        let mat = ContactMaterial::jeod_spring(1000.0, 0.0, 0.0);
+        let vehicle = ContactFacet::point(DVec3::ZERO, 1.0, mat);
+        let mut ground = GroundFacet::new(Arc::new(SphericalTerrain::new(6378137.0)), 0.0, mat);
+        ground.active = false;
+        let pos = DVec3::new(6378137.0, 0.0, 0.0);
+        let _ = compute_ground_contact_geometry(
+            &vehicle,
+            &ground,
+            pos,
+            DMat3::IDENTITY,
+            DMat3::IDENTITY,
+            DMat3::IDENTITY,
+            Phase::Initialization,
+        );
+    }
+
+    /// `GroundFacet::new` rejects non-finite `alt_offset`. A NaN/±inf
+    /// offset would propagate through the pfix-frame ground-point
+    /// comparison and produce undefined contact detection.
+    #[test]
+    #[should_panic(expected = "alt_offset must be finite")]
+    fn in_36_panics_on_nan_alt_offset() {
+        // JEOD_INV: IN.36 — GroundFacet.alt_offset must be finite
+        let mat = ContactMaterial::jeod_spring(1000.0, 0.0, 0.0);
+        let _ = GroundFacet::new(Arc::new(SphericalTerrain::new(6378137.0)), f64::NAN, mat);
+    }
+
+    /// `SphericalTerrain::new` rejects a zero or negative radius. A
+    /// non-positive radius collapses the ground point to the planet
+    /// center and yields a NaN normal.
+    #[test]
+    #[should_panic(expected = "radius must be finite and > 0")]
+    fn in_37_panics_on_zero_radius() {
+        // JEOD_INV: IN.37 — SphericalTerrain.radius > 0
+        let _ = SphericalTerrain::new(0.0);
+    }
 }

--- a/crates/astrodyn_interactions/src/forces.rs
+++ b/crates/astrodyn_interactions/src/forces.rs
@@ -154,3 +154,34 @@ pub fn collect_and_resolve_forces_typed<V: Vehicle>(
         FrameDerivativesTyped::<RootInertial, V>::from_untyped_unchecked(&derivs),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// aero drag requires body orientation. JEOD's `aero_drag()`
+    /// takes `T_inertial_struct` as a mandatory parameter derived
+    /// from the body's rotational state. If a body carries a
+    /// non-zero aerodynamic force but no `RotationalState`, the
+    /// structural→inertial transform collapses to identity and the
+    /// rotated force vector silently lands in a wrong frame. Reject
+    /// loudly at the collection boundary.
+    #[test]
+    #[should_panic(expected = "Non-zero aerodynamic force but no RotationalState")]
+    fn in_15_panics_on_aero_force_without_rotational_state() {
+        // JEOD_INV: IN.15 — aero drag requires body orientation
+        let aero = AerodynamicForce {
+            force: DVec3::new(1.0, 0.0, 0.0),
+            torque: DVec3::ZERO,
+        };
+        let _ = collect_and_resolve_forces(
+            Some(&aero),
+            None,
+            None,
+            None, // no RotationalState — triggers the panic
+            DMat3::IDENTITY,
+            None,
+            DVec3::ZERO,
+        );
+    }
+}

--- a/crates/astrodyn_interactions/src/radiation_pressure.rs
+++ b/crates/astrodyn_interactions/src/radiation_pressure.rs
@@ -1632,6 +1632,69 @@ mod tests {
         );
     }
 
+    /// `FlatPlate.area` must be > 0. JEOD's
+    /// `ThermalFacetRider::initialize` (`thermal_facet_rider.cc:129-136`)
+    /// errors on `surface_area <= 0`. We fold the check into the SRP
+    /// hot loop and panic on misconfiguration rather than computing
+    /// nonsensical force/torque. Drive with `illum_factor > 0` and
+    /// `flux_mag > 0` to clear the early return and reach the
+    /// per-plate assert.
+    #[test]
+    #[should_panic(expected = "FlatPlate.area must be > 0")]
+    fn in_33_panics_on_zero_plate_area_in_srp() {
+        // JEOD_INV: IN.33 — FlatPlate.area must be > 0
+        let plate = FlatPlate::<SelfRef> {
+            area: 0.0,
+            normal: DVec3::new(-1.0, 0.0, 0.0),
+            position: DVec3::ZERO.m_at::<StructuralFrame<SelfRef>>(),
+        };
+        let params = FlatPlateParams {
+            albedo: 0.0,
+            diffuse: 0.0,
+        };
+        let _ = compute_flat_plate_srp(
+            &[(plate, params)],
+            DVec3::new(1.0, 0.0, 0.0),
+            1000.0,
+            DVec3::ZERO,
+            1.0,
+        );
+    }
+
+    /// `FlatPlateThermal.emissivity` must be > 0. Port of JEOD's
+    /// `thermal_facet_rider.cc:109-126` fatal-bound check. Drive
+    /// `compute_flat_plate_srp_thermal` with a positive area but zero
+    /// emissivity so the second assert in the same per-plate hot loop
+    /// fires.
+    #[test]
+    #[should_panic(expected = "FlatPlateThermal.emissivity must be > 0")]
+    fn in_33_panics_on_zero_emissivity_in_srp_thermal() {
+        // JEOD_INV: IN.33 — FlatPlateThermal.emissivity must be > 0
+        let plate = FlatPlate::<SelfRef> {
+            area: 10.0,
+            normal: DVec3::new(-1.0, 0.0, 0.0),
+            position: DVec3::ZERO.m_at::<StructuralFrame<SelfRef>>(),
+        };
+        let params = FlatPlateParams {
+            albedo: 0.0,
+            diffuse: 0.0,
+        };
+        let thermal = FlatPlateThermal {
+            emissivity: 0.0, // violates IN.33
+            heat_capacity_per_area: 50.0,
+            thermal_power_dump: 0.0,
+        };
+        let t_pow4_cached = [270.0_f64.powi(4)];
+        let _ = compute_flat_plate_srp_thermal(
+            &[(plate, params, thermal)],
+            &t_pow4_cached,
+            DVec3::new(1.0, 0.0, 0.0),
+            1000.0,
+            DVec3::ZERO,
+            1.0,
+        );
+    }
+
     /// `FlatPlate::assert_vehicle::<W>()` is a zero-cost type-witness
     /// no-op when `V == W`. The negative branch (cross-vehicle
     /// mismatch) is covered by the method's `compile_fail` doctest;

--- a/crates/astrodyn_interactions/src/shadow.rs
+++ b/crates/astrodyn_interactions/src/shadow.rs
@@ -414,6 +414,41 @@ mod tests {
         );
     }
 
+    /// `RadiationThirdBody.radius > 0` is validated during JEOD's
+    /// `RadiationThirdBody::initialize()`. Our stateless kernel must
+    /// reject the same misconfiguration once the geometry is far
+    /// enough into the shadow algorithm that `r_ratio` would otherwise
+    /// be computed against a zero/negative body radius. Drive geometry
+    /// that lands past the early-return branches (vehicle behind, but
+    /// offset enough to enter the penumbra cone) so the assert sites
+    /// in `compute_shadow_fraction` actually fire rather than the
+    /// `r_par < 0` or `r_mag2 <= 0` early returns.
+    #[test]
+    #[should_panic(expected = "body_radius must be positive")]
+    fn in_11_panics_on_zero_third_body_radius() {
+        // JEOD_INV: IN.11 — RadiationThirdBody.radius > 0
+        let sun = DVec3::new(AU, 0.0, 0.0);
+        let body = DVec3::ZERO;
+        // Behind Earth with a y-offset → past Region A and Region B
+        // boundary tests, into the assert region.
+        let vehicle = DVec3::new(-1_000_000.0, EARTH_RADIUS + 1000.0, 0.0);
+        let _ = compute_shadow_fraction(vehicle, sun, body, 0.0, SUN_RADIUS);
+    }
+
+    /// `RadiationSource.radius > 0` is validated during JEOD's
+    /// `RadiationThirdBody::initialize()`. Same rationale as the
+    /// IN.11 sibling: a non-positive source radius reaches the
+    /// assert site rather than any of the geometry early returns.
+    #[test]
+    #[should_panic(expected = "source_radius must be positive")]
+    fn in_12_panics_on_zero_source_radius() {
+        // JEOD_INV: IN.12 — RadiationSource.radius > 0
+        let sun = DVec3::new(AU, 0.0, 0.0);
+        let body = DVec3::ZERO;
+        let vehicle = DVec3::new(-1_000_000.0, EARTH_RADIUS + 1000.0, 0.0);
+        let _ = compute_shadow_fraction(vehicle, sun, body, EARTH_RADIUS, 0.0);
+    }
+
     /// Typed wrapper round-trips bit-identically to the untyped kernel
     /// for representative geometry (a partial-eclipse penumbra case
     /// and a full-sun case).

--- a/crates/astrodyn_runner/src/simulation/bodies.rs
+++ b/crates/astrodyn_runner/src/simulation/bodies.rs
@@ -952,6 +952,96 @@ mod tests {
         sim.register_ground_contact_pair(0, veh, ground, 0);
     }
 
+    /// Contact pair bodies must be distinct (JEOD `unique_pair`
+    /// invariant in `contact.cc`). Hand the same body index for both
+    /// halves of the pair; the body-count and material-equality
+    /// checks both pass when `body_a == body_b` with one body
+    /// registered, so the next assert is the unique-pair one.
+    #[test]
+    #[should_panic(expected = "body A and body B must be distinct")]
+    fn in_30_panics_on_same_body_a_b() {
+        // JEOD_INV: IN.30 — contact pair bodies must be distinct
+        let mut sim = Mission::iss_leo_drag()
+            .into_builder()
+            .build()
+            .expect("Mission::iss_leo_drag must validate");
+        // Add a second body so the body-range asserts pass and we
+        // reach the `body_a != body_b` check.
+        let extra = Mission::iss_leo_drag()
+            .into_builder()
+            .build()
+            .expect("Mission::iss_leo_drag must validate")
+            .bodies
+            .remove(0);
+        sim.bodies.push(extra);
+        let mat = dummy_material();
+        let facet = ContactFacet::point(DVec3::ZERO, 1.0, mat);
+        // Same index on both sides → unique_pair violation.
+        sim.register_contact_pair(0, facet, 0, facet);
+    }
+
+    /// The contact-coupled integration path requires RK4 on every
+    /// body in the sim because contact forces are recomputed at each
+    /// stage from the intermediate states — and only RK4's stage
+    /// pattern is supported. Swap one body's integrator to a
+    /// non-RK4 type after registering a contact pair, then `step()`
+    /// to drive the assertion.
+    #[test]
+    #[should_panic(expected = "contact-coupled path")]
+    fn in_31_panics_on_non_rk4_body_in_contact_coupled_path() {
+        use astrodyn::IntegratorType;
+        // JEOD_INV: IN.31 — contact-coupled path requires RK4 on all bodies
+        let mut sim = Mission::iss_leo_drag()
+            .into_builder()
+            .build()
+            .expect("Mission::iss_leo_drag must validate");
+        // Need a second body so a contact pair is well-formed
+        // (`body_a != body_b`). Take another iss_leo_drag-built body
+        // and push it onto our existing sim's body list.
+        let extra = Mission::iss_leo_drag()
+            .into_builder()
+            .build()
+            .expect("Mission::iss_leo_drag must validate")
+            .bodies
+            .remove(0);
+        sim.bodies.push(extra);
+        let mat = dummy_material();
+        let facet = ContactFacet::point(DVec3::ZERO, 1.0, mat);
+        sim.register_contact_pair(0, facet, 1, facet);
+        // Switch body 0's integrator to a non-RK4 type so the
+        // coupled-path RK4 assertion fires on the first `step()`.
+        sim.bodies[0].integrator = IntegratorType::Rkf45;
+        // Single step is enough to enter `integrate_bodies_contact_coupled`.
+        let _ = sim.step();
+    }
+
+    /// Only active `GroundFacet`s may register. JEOD's
+    /// `check_contact_ground` silently skips inactive ground facets;
+    /// our Fail Loudly policy rejects them at registration so a
+    /// misconfigured surface model can't silently drop its
+    /// contribution.
+    #[test]
+    #[should_panic(expected = "ground_facet.active must be true")]
+    fn in_35_panics_on_inactive_ground_facet_at_registration() {
+        // JEOD_INV: IN.35 — only active GroundFacets may register
+        let mut sim = Mission::iss_leo_drag()
+            .into_builder()
+            .build()
+            .expect("Mission::iss_leo_drag must validate");
+        let mat = dummy_material();
+        let veh = ContactFacet::point(DVec3::ZERO, 1.0, mat);
+        // Bypass `GroundFacet::new` (which forces `active = true`)
+        // by direct field construction so we can drive the
+        // registration-site assertion.
+        let ground = GroundFacet {
+            terrain: Arc::new(SphericalTerrain::new(6_378_137.0)),
+            alt_offset: 0.0,
+            material: mat,
+            active: false,
+        };
+        sim.register_ground_contact_pair(0, veh, ground, 0);
+    }
+
     /// `set_body_rot` must mirror the new attitude / angular velocity
     /// onto the body's frame-tree node, in the same way
     /// `set_body_position` / `set_body_velocity` mirror their halves.

--- a/docs/JEOD_invariants.md
+++ b/docs/JEOD_invariants.md
@@ -302,8 +302,8 @@ Our port wraps ANISE (`crates/astrodyn_ephemeris`, 243 lines: `ephemeris.rs` + `
 | IN.10 | RadiationSource.luminosity ≥ 1e-6 for flux computation | flag-gate | runtime | n/a (luminosity is a compile-time constant; `distance < 1.0` guard prevents division by near-zero) |
 | IN.11 | RadiationThirdBody.radius > 0 | fatal | initialization | enforced (`shadow.rs` handles degenerate cases) |
 | IN.12 | RadiationSource.radius > 0 | fatal | initialization | enforced (`shadow.rs` handles degenerate cases) |
-| IN.13 | Shadow model: vehicle distance > 0 | error | runtime | enforced (`shadow.rs` returns 0.0 if r_mag2 <= 0) |
-| IN.14 | `d_source_to_third` > 0 | error | runtime | enforced (`shadow.rs` returns 1.0 if d <= 0) |
+| IN.13 | Shadow model: vehicle distance > 0 | error | runtime | partial (`shadow.rs` returns 0.0 if `r_mag2 <= 0` — JEOD errors here; we degrade gracefully to "total shadow" because the geometry kernel is stateless and the degenerate-coincident case can be expressed as a fractional-area-of-zero result rather than a fatal failure. IN.26 carries the same "partial" status for the equivalent JEOD-side check.) |
+| IN.14 | `d_source_to_third` > 0 | error | runtime | partial (`shadow.rs` returns 1.0 if `d_source_to_third <= 0` — JEOD errors; we degrade gracefully to "full sun" because a body and source that coincide cannot cast a shadow, so the geometrically-correct illumination fraction is unity rather than a fatal failure. Same rationale as IN.13.) |
 | IN.15 | Aero drag requires body orientation (T_inertial_struct) | structural (mandatory fn parameter) | runtime | enforced (`crates/astrodyn_bevy/src/systems/interaction.rs` — panics if AerodynamicForceC present without RotationalStateC) |
 | IN.16 | RadiationThirdBody requires inertial frame pointer | fatal | initialization | n/a (stateless function takes positions directly) |
 | IN.17 | RadiationSurface requires at least one facet (`num_facets > 0`) | fatal | initialization | deferred (caller passes plate slice; empty slice produces zero force) |

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -893,4 +893,46 @@ mod tests {
              expected {expected_tangent_dir:?}, got {got_tangent_dir:?}",
         );
     }
+
+    /// `IntegrableObject::advance_intermediate` requires `snapshot`
+    /// to have populated `scratch.temps_snapshot` to the same length
+    /// as `temperatures`. Without the preceding snapshot, the scratch
+    /// length is zero and the integrator would otherwise read past
+    /// the end of the snapshot vector and write truncated state.
+    /// Drive the length-parity assertion by constructing a
+    /// `FlatPlateState` with one plate, skipping the snapshot, and
+    /// calling `advance_intermediate`.
+    #[test]
+    #[should_panic(expected = "temps_snapshot length must equal temperatures length")]
+    fn in_32_panics_on_advance_intermediate_without_snapshot() {
+        // JEOD_INV: IN.32 — snapshot must precede advance_intermediate
+        use crate::SelfRef;
+        use astrodyn_interactions::{FlatPlate, FlatPlateParams, FlatPlateThermal};
+        use astrodyn_quantities::ext::Vec3Ext;
+        use astrodyn_quantities::frame::StructuralFrame;
+
+        let plate = FlatPlate::<SelfRef> {
+            area: 1.0,
+            normal: DVec3::new(1.0, 0.0, 0.0),
+            position: DVec3::ZERO.m_at::<StructuralFrame<SelfRef>>(),
+        };
+        let params = FlatPlateParams {
+            albedo: 0.0,
+            diffuse: 0.0,
+        };
+        let thermal = FlatPlateThermal {
+            emissivity: 1.0,
+            heat_capacity_per_area: 50.0,
+            thermal_power_dump: 0.0,
+        };
+        let mut state = FlatPlateState::<SelfRef> {
+            plates: vec![(plate, params, thermal)],
+            temperatures: vec![300.0],
+            t_pow4_cached: vec![300.0_f64.powi(4)],
+            ..Default::default()
+        };
+        // Deliberately omit `state.snapshot()` — `temps_snapshot` stays
+        // empty (len 0) while `temperatures` is len 1.
+        state.advance_intermediate(&[0.0], 0.1);
+    }
 }


### PR DESCRIPTION
Refs #535.

IN-section sweep of the negative-test gate seeded in #531: covers the
twelve catalog rows under the **interactions** umbrella (SRP shadow
geometry, aero drag preconditions, contact-pair registration, the
contact-coupled integration path, and ground-facet configuration). IN.09
was seeded in PR #526 and is out of scope here.

Sweep status so far: TM / QT / EP / OE / GV / MA / BA merged; PF
pending human review; IG and smalls in flight; this PR adds IN.

## Per-row outcomes

### SRP / shadow (`crates/astrodyn_interactions/src/shadow.rs`)

| Row | Outcome |
|-----|---------|
| IN.11 | `#[should_panic]` test driving `body_radius = 0` past the early-return branches |
| IN.12 | `#[should_panic]` test driving `source_radius = 0` past the early-return branches |
| IN.13 | Reclassify `enforced` → `partial`. JEOD errors on `r_mag2 <= 0`; our stateless kernel returns 0.0 (total shadow). Matches IN.26's existing `partial` rationale. |
| IN.14 | Reclassify `enforced` → `partial`. JEOD errors on `d_source_to_third <= 0`; we return 1.0 (full sun) — same shape as IN.13. |

### Aero drag (`crates/astrodyn_interactions/src/forces.rs`)

| Row | Outcome |
|-----|---------|
| IN.15 | `#[should_panic]` test for `collect_and_resolve_forces` panicking when a non-zero aerodynamic force is collected without `RotationalState` |

### Contact pairs (`crates/astrodyn_runner/src/simulation/bodies.rs`)

| Row | Outcome |
|-----|---------|
| IN.30 | `#[should_panic]` test driving `register_contact_pair` with `body_a == body_b` |
| IN.31 | `#[should_panic]` test stepping a contact-coupled sim with a non-RK4 body (drives the coupled-path RK4 precondition) |

### Thermal SRP (`crates/astrodyn_interactions/src/radiation_pressure.rs`)

| Row | Outcome |
|-----|---------|
| IN.33 | `#[should_panic]` for `FlatPlate.area = 0` in `compute_flat_plate_srp` *and* for `FlatPlateThermal.emissivity = 0` in `compute_flat_plate_srp_thermal` (both per-plate hot-loop asserts) |

### IntegrableObject protocol (`src/interactions.rs`)

| Row | Outcome |
|-----|---------|
| IN.32 | `#[should_panic]` test driving `FlatPlateState::advance_intermediate` without a preceding `snapshot`, hitting the `temps_snapshot length must equal temperatures length` assert |

### Ground contact (`crates/astrodyn_interactions/src/contact.rs` + `bodies.rs`)

| Row | Outcome |
|-----|---------|
| IN.35 | `#[should_panic]` tests at both enforcement sites: `register_ground_contact_pair` and `compute_ground_contact_geometry` |
| IN.36 | `#[should_panic]` test on `GroundFacet::new` with `f64::NAN` for `alt_offset` |
| IN.37 | `#[should_panic]` test on `SphericalTerrain::new(0.0)` |

## Scanner-window nuance

The negative-test scanner in `tests/invariant_coverage.rs` collects
`// JEOD_INV: XX.YY` tags from a window starting 6 lines before the
`#[should_panic]` attribute through the end of the test function body.
A doc comment more than 6 lines above the attribute is invisible to
the scanner — so each new test carries the tag-bearing comment *inside*
the test body. This keeps the documenting prose intact in the doc
comment above the test while the tag-line provides the scanner anchor.

## Coverage delta

Before this PR: 16 / 103 enforced rows covered.
After this PR: 21 / 103 enforced rows covered (IN.11, IN.12, IN.15,
IN.30, IN.31, IN.32, IN.33, IN.35, IN.36, IN.37). IN.13 / IN.14 moved
out of the enforced bucket via reclassification to `partial`.

## Verify checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo test -p astrodyn_interactions --lib --tests`
- [x] `cargo test -p astrodyn --lib --test invariant_coverage`
- [x] `cargo doc --workspace --no-deps` (with `RUSTDOCFLAGS=-D warnings`)
- [x] `scripts/check_no_escape_hatches.sh`

## Test plan

- [ ] CI green on `check`, `test`, `test-parity-trajectory`, `test-tier3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)