### PR TITLE
[#450] Bevy parity: unblock single-planet non-Earth scenarios

### DIFF
--- a/crates/astrodyn_bevy/src/validation.rs
+++ b/crates/astrodyn_bevy/src/validation.rs
@@ -92,15 +92,23 @@ pub(crate) fn is_root_equivalent_entity(
 ///
 /// Two scopes participate:
 ///
-/// * **Global state checks** (Sun/Moon marker counts, tidal-config pairing
-///   on gravity sources) iterate the *unfiltered* `derived_state_markers`
-///   and `tidal_sources` queries, so they re-evaluate the entire world's
-///   marker/source set on every trigger. Adding a stray second
-///   `SunMarker` mid-mission is therefore caught the next tick a body
-///   with `GravityControlsC` is added. In multi-planet configs these
-///   global checks run once per registered planet — wasteful but
-///   idempotent (each pass evaluates the same world state and reaches
-///   the same conclusion).
+/// * **Per-`<P>` global state checks** (Sun/Moon marker counts, tidal-config
+///   pairing on gravity sources) iterate the unfiltered `derived_state_markers`
+///   and `tidal_sources` queries, then narrow each entity to those whose
+///   `TranslationalStateC<P>` matches *this* validator's `<P>`. The
+///   marker count therefore counts only Sun/Moon entities tagged for
+///   this planet's integration frame. Adding a stray second
+///   `<P>`-tagged `SunMarker` mid-mission is caught the next tick a
+///   body with `GravityControlsC` is added under the same `<P>`. In
+///   multi-planet configs each `<P>` validator counts only its own
+///   `<P>`-tagged markers — the `<Mars>` validator catches a duplicate
+///   Mars-tagged Sun, the `<Earth>` validator catches a duplicate
+///   Earth-tagged Sun, neither steps on the other. Without this
+///   `<P>`-scoping, the `<Earth>` validator that `AstrodynPlugin::build`
+///   registers by default would panic on a Sun tagged for any other
+///   planet's frame — the marker check would observe the marker
+///   without an `<Earth>`-tagged trans even though the matching
+///   `<Mars>` validator owned the assertion.
 /// * **Per-body invariant checks** (SRP mutual exclusion, the full
 ///   `astrodyn::validate_body` pass, gravity-control `check_validity`)
 ///   iterate the `Added`-filtered `bodies` query, so they validate only
@@ -222,35 +230,56 @@ pub fn validate_jeod_invariants<P: Planet>(
     // Matches Simulation::validate() which errors on missing sun_source/moon_source.
     // Count markers and validate they have TranslationalStateC (required by
     // solar_beta_system/earth_lighting_system queries).
+    //
+    // The marker-trans assertion is scoped to entities whose `TranslationalStateC<P>`
+    // matches *this* validator's `<P>`. In a multi-planet world the Sun /
+    // Moon entity is tagged with the scenario's chosen integration frame
+    // (e.g. `TranslationalStateC<Mars>` in a Mars-central scenario); the
+    // `<Earth>` validator instance — which `AstrodynPlugin::build` registers
+    // by default — would otherwise observe the marker without an
+    // `<Earth>`-tagged trans and panic, even though the `<Mars>` validator
+    // that `register_planet_systems::<Mars>` installs is the one
+    // responsible for that entity. Skipping when this `<P>` has no trans
+    // hands ownership of the assertion to the validator whose `<P>` does
+    // match. A truly-bare SunMarker entity with no `TranslationalStateC<P>`
+    // for any registered planet is caught downstream when
+    // `solar_beta_system::<P>` / `earth_lighting_system::<P>` (or any
+    // `Query<&TranslationalStateC<P>, With<SunMarker>>`) finds an empty
+    // query result.
     let mut sun_count = 0;
     let mut moon_count = 0;
-    for (entity, _, _, sun, moon, trans) in &derived_state_markers {
+    for (_entity, _, _, sun, moon, trans) in &derived_state_markers {
+        if trans.is_none() {
+            continue;
+        }
         if sun.is_some() {
             sun_count += 1;
-            assert!(
-                trans.is_some(),
-                "Entity {entity:?}: SunMarker present but TranslationalStateC is missing. \
-                 Sun entity requires TranslationalStateC for position queries."
-            );
         }
         if moon.is_some() {
             moon_count += 1;
-            assert!(
-                trans.is_some(),
-                "Entity {entity:?}: MoonMarker present but TranslationalStateC is missing. \
-                 Moon entity requires TranslationalStateC for position queries."
-            );
         }
     }
     assert!(
         sun_count <= 1,
-        "Multiple SunMarker entities found. JEOD assumes exactly one Sun body."
+        "Multiple SunMarker entities found with TranslationalStateC for this validator's planet. \
+         JEOD assumes exactly one Sun body per integration frame."
     );
     assert!(
         moon_count <= 1,
-        "Multiple MoonMarker entities found. JEOD assumes exactly one Moon body."
+        "Multiple MoonMarker entities found with TranslationalStateC for this validator's planet. \
+         JEOD assumes exactly one Moon body per integration frame."
     );
-    for (entity, solar_beta, earth_lighting, _, _, _) in &derived_state_markers {
+    // SolarBetaC / EarthLightingConfigC consumers are themselves
+    // generic over `<P>` and query `Query<&TranslationalStateC<P>, With<SunMarker>>`.
+    // Only bodies tagged for *this* validator's `<P>` can reach those
+    // queries, so the "must have a Sun / Moon" precondition is also
+    // scoped to `<P>`-tagged bodies. A `<Mars>`-tagged body with
+    // `SolarBetaC` is validated by the `<Mars>` validator (which finds
+    // the `<Mars>`-tagged Sun); this `<P>` validator skips it.
+    for (entity, solar_beta, earth_lighting, _, _, body_trans) in &derived_state_markers {
+        if body_trans.is_none() {
+            continue;
+        }
         if solar_beta.is_some() && sun_count == 0 {
             panic!(
                 "Entity {entity:?}: SolarBetaC present but no SunMarker entity exists. \

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mars_orbit.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mars_orbit.rs
@@ -1,0 +1,113 @@
+//! Bevy ↔ runner parity for the `mars_orbit` recipe.
+//!
+//! Drives `astrodyn::recipes::scenarios::mars_orbit::mars_orbit()` through
+//! both runtimes — [`astrodyn_runner::Simulation`] and the Bevy
+//! `populate_app::<Mars>` bridge — and asserts bit-identical translational
+//! state at every checkpoint over a one-hour parity window.
+//!
+//! Single-planet bridge note: every body integrates in
+//! `PlanetInertial<Mars>`. The Sun is a third-body *source* (not an
+//! integration frame), tagged with `TranslationalStateC<Mars>` by
+//! `populate_app::<Mars>`.
+//!
+//! The runner-side counterpart is
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_mars_orbit.rs::tier3_simulation_mars_dawn`;
+//! transitivity of the two assertions is the goal.
+
+#![allow(
+    clippy::float_cmp,
+    reason = "bevy-parity tests assert bit-exact identity between runner and Bevy state fields"
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "test step counts fit exactly in f64 mantissa and usize"
+)]
+
+use std::time::Duration;
+
+use astrodyn::recipes::scenarios::mars_orbit::mars_orbit;
+use astrodyn_bevy::{SimulationBuilderBevyExt, TranslationalStateC};
+use astrodyn_runner::SimulationBuilderExt;
+use bevy::prelude::*;
+
+/// Parity-window cap, in seconds of simulation time.
+///
+/// Bit-identity divergence between two runtimes that share the same
+/// `astrodyn_*` math is monotonic — once they drift, they stay drifted —
+/// so a coarse checkpoint set is equivalent in detection strength to
+/// a per-tick scan. 3600 s of sim time at dt = 10 s is 360 ticks, a
+/// fraction of a second of CI runtime.
+const PARITY_WINDOW_S: f64 = 3600.0;
+
+/// Compare cadence in seconds. Picked to land cleanly on the recipe's
+/// `dt = 10 s` integration step so each checkpoint is exactly a whole
+/// number of fixed-update ticks ahead of the previous one.
+const CHECKPOINT_CADENCE_S: f64 = 60.0;
+
+#[test]
+fn bevy_parity_mars_orbit() {
+    // Runner side.
+    let runner_builder = mars_orbit();
+    let dt = runner_builder.dt;
+    let mut runner = runner_builder.build().expect("runner build");
+
+    // Bevy side — same recipe factory, materialized into a fresh App under <Mars>.
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    let handles = mars_orbit()
+        .populate_app::<astrodyn::Mars>(&mut app)
+        .expect("populate_app under <Mars>");
+    let vehicle = handles.body_entities[0];
+
+    // Run startup so per-source frame trees / source-frame-id resources
+    // are wired before stepping. `MinimalPlugins` does not auto-run
+    // `Startup`; the parity loop drives `FixedUpdate` directly.
+    app.world_mut().run_schedule(Startup);
+
+    let steps_per_checkpoint = (CHECKPOINT_CADENCE_S / dt).round() as usize;
+    assert!(
+        steps_per_checkpoint >= 1,
+        "checkpoint cadence ({CHECKPOINT_CADENCE_S}s) must be a positive multiple of dt ({dt}s)"
+    );
+
+    let mut t = 0.0_f64;
+    while t + CHECKPOINT_CADENCE_S <= PARITY_WINDOW_S {
+        // Step both runtimes forward by exactly one checkpoint window.
+        runner.step_n(steps_per_checkpoint).expect("runner step_n");
+        for _ in 0..steps_per_checkpoint {
+            app.world_mut()
+                .resource_mut::<Time<Fixed>>()
+                .advance_by(Duration::from_secs_f64(dt));
+            app.world_mut().run_schedule(FixedUpdate);
+        }
+        t += CHECKPOINT_CADENCE_S;
+
+        let r_pos = runner.body(0).trans.position.raw_si();
+        let r_vel = runner.body(0).trans.velocity.raw_si();
+        let bevy_trans = app
+            .world()
+            .get::<TranslationalStateC<astrodyn::Mars>>(vehicle)
+            .expect("vehicle entity carries TranslationalStateC<Mars>")
+            .0;
+        let b_pos = bevy_trans.position.raw_si();
+        let b_vel = bevy_trans.velocity.raw_si();
+
+        for i in 0..3 {
+            assert!(
+                r_pos[i].to_bits() == b_pos[i].to_bits(),
+                "mars_orbit translational bit-parity broke at t={t} on position[{i}]: \
+                 runner={} bevy={}",
+                r_pos[i],
+                b_pos[i],
+            );
+            assert!(
+                r_vel[i].to_bits() == b_vel[i].to_bits(),
+                "mars_orbit translational bit-parity broke at t={t} on velocity[{i}]: \
+                 runner={} bevy={}",
+                r_vel[i],
+                b_vel[i],
+            );
+        }
+    }
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mercury.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mercury.rs
@@ -1,0 +1,113 @@
+//! Bevy ↔ runner parity for the `mercury_relativistic` recipe.
+//!
+//! Drives `astrodyn::recipes::scenarios::mercury::mercury_relativistic()`
+//! through both runtimes — [`astrodyn_runner::Simulation`] and the Bevy
+//! `populate_app::<Sun>` bridge — and asserts bit-identical translational
+//! state at every checkpoint over a Mercury-period parity window.
+//!
+//! Single-planet bridge note: every body integrates in
+//! `PlanetInertial<Sun>`. The Sun is the central gravity source and the
+//! integration frame; no third bodies. The runner-side counterpart is
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_mercury.rs` (the
+//! relativistic-effect / perihelion-advance tests). The parity wrapper
+//! validates that propagation through the Bevy bridge tracks the
+//! runner bit-for-bit, so the runner's GR-perihelion-advance result
+//! transfers transitively to the Bevy adapter.
+
+#![allow(
+    clippy::float_cmp,
+    reason = "bevy-parity tests assert bit-exact identity between runner and Bevy state fields"
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "test step counts fit exactly in f64 mantissa and usize"
+)]
+
+use std::time::Duration;
+
+use astrodyn::recipes::scenarios::mercury::mercury_relativistic;
+use astrodyn_bevy::{SimulationBuilderBevyExt, TranslationalStateC};
+use astrodyn_runner::SimulationBuilderExt;
+use bevy::prelude::*;
+
+/// Parity-window cap, in seconds of simulation time.
+///
+/// One full Mercury orbit is ~88 days. Bit-identity divergence between
+/// two runtimes that share the same `astrodyn_*` math is monotonic, so
+/// a fraction of an orbit is sufficient to catch any drift introduced
+/// by the bridge — pin the window at ~10 days = 8.64e5 s, ~9600 ticks
+/// at the recipe's `dt = 100 s`. A few seconds of CI runtime.
+const PARITY_WINDOW_S: f64 = 8.64e5;
+
+/// Compare cadence in seconds. Picked to land cleanly on the recipe's
+/// `dt = 100 s` integration step so each checkpoint is exactly a whole
+/// number of fixed-update ticks ahead of the previous one.
+const CHECKPOINT_CADENCE_S: f64 = 86_400.0;
+
+#[test]
+fn bevy_parity_mercury() {
+    // Runner side.
+    let runner_builder = mercury_relativistic();
+    let dt = runner_builder.dt;
+    let mut runner = runner_builder.build().expect("runner build");
+
+    // Bevy side — same recipe factory, materialized into a fresh App under <Sun>.
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    let handles = mercury_relativistic()
+        .populate_app::<astrodyn::Sun>(&mut app)
+        .expect("populate_app under <Sun>");
+    let vehicle = handles.body_entities[0];
+
+    // Run startup so per-source frame trees / source-frame-id resources
+    // are wired before stepping. `MinimalPlugins` does not auto-run
+    // `Startup`; the parity loop drives `FixedUpdate` directly.
+    app.world_mut().run_schedule(Startup);
+
+    let steps_per_checkpoint = (CHECKPOINT_CADENCE_S / dt).round() as usize;
+    assert!(
+        steps_per_checkpoint >= 1,
+        "checkpoint cadence ({CHECKPOINT_CADENCE_S}s) must be a positive multiple of dt ({dt}s)"
+    );
+
+    let mut t = 0.0_f64;
+    while t + CHECKPOINT_CADENCE_S <= PARITY_WINDOW_S {
+        // Step both runtimes forward by exactly one checkpoint window.
+        runner.step_n(steps_per_checkpoint).expect("runner step_n");
+        for _ in 0..steps_per_checkpoint {
+            app.world_mut()
+                .resource_mut::<Time<Fixed>>()
+                .advance_by(Duration::from_secs_f64(dt));
+            app.world_mut().run_schedule(FixedUpdate);
+        }
+        t += CHECKPOINT_CADENCE_S;
+
+        let r_pos = runner.body(0).trans.position.raw_si();
+        let r_vel = runner.body(0).trans.velocity.raw_si();
+        let bevy_trans = app
+            .world()
+            .get::<TranslationalStateC<astrodyn::Sun>>(vehicle)
+            .expect("vehicle entity carries TranslationalStateC<Sun>")
+            .0;
+        let b_pos = bevy_trans.position.raw_si();
+        let b_vel = bevy_trans.velocity.raw_si();
+
+        for i in 0..3 {
+            assert!(
+                r_pos[i].to_bits() == b_pos[i].to_bits(),
+                "mercury translational bit-parity broke at t={t} on position[{i}]: \
+                 runner={} bevy={}",
+                r_pos[i],
+                b_pos[i],
+            );
+            assert!(
+                r_vel[i].to_bits() == b_vel[i].to_bits(),
+                "mercury translational bit-parity broke at t={t} on velocity[{i}]: \
+                 runner={} bevy={}",
+                r_vel[i],
+                b_vel[i],
+            );
+        }
+    }
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_planetary.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_planetary.rs
@@ -1,0 +1,39 @@
+//! Bevy ↔ runner parity for SIM_Planetary derived-state regimes.
+//!
+//! Five orbit regimes (LEO inclined, polar, eccentric, equatorial, GEO)
+//! exercise coordinate singularities (equatorial RAAN, polar LVLH).
+//! All five share an Earth point-mass scenario, so each runs through
+//! `populate_app::<Earth>` and asserts bit-identical state at every CSV
+//! checkpoint.
+//!
+//! The runner-side counterpart is
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_planetary.rs`; transitivity
+//! of the two assertions is the goal.
+
+use astrodyn_verif_jeod::run_verification::sim_planetary;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_planetary_leo_inc() {
+    sim_planetary::leo_inc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_planetary_leo_polar() {
+    sim_planetary::leo_polar().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_planetary_leo_ecc() {
+    sim_planetary::leo_ecc().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_planetary_leo_equ() {
+    sim_planetary::leo_equ().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_planetary_geo() {
+    sim_planetary::geo().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -63,20 +63,6 @@ const DEFERRED_GAPS: &[(&str, &str)] = &[
         "earth_moon",
         "Earth ⇄ Moon dual-body sim — multi-planet gap (#389 risk)",
     ),
-    (
-        "mars_orbit",
-        "Mars-centered scenario — bridge today fixes <P=Earth> across the \
-         scenario; multi-planet generic dispatch tracked as #389 follow-up",
-    ),
-    (
-        "mercury",
-        "Heliocentric Mercury orbit — same single-planet bridge gap as \
-         mars_orbit (#389 risk)",
-    ),
-    (
-        "planetary",
-        "Multi-planet planetary integration sim — bridge gap (#389 risk)",
-    ),
     // ── Pre-recipe tier3 siblings: the `VerificationCase` factory
     //    doesn't exist yet, so the parity trait has nothing to drive.
     //    Recipe migration is tracked as a follow-up to #389. Each


### PR DESCRIPTION
## Summary

- Scope the `validate_jeod_invariants::<P>` SunMarker/MoonMarker prerequisite
  check to entities whose `TranslationalStateC<P>` matches the validator's
  own `<P>`. Removes the residual Earth-coupling crash that blocked
  `populate_app::<Mars>` / `populate_app::<Sun>` after the CC8 prep auto-
  registration fix landed.
- Add three new bit-identical parity wrappers:
  - `bevy_parity_mars_orbit.rs` — `populate_app::<Mars>(mars_orbit())`
  - `bevy_parity_mercury.rs` — `populate_app::<Sun>(mercury_relativistic())`
  - `bevy_parity_planetary.rs` — five Earth-orbit regimes (`planetary` is
    structurally single-planet Earth, not multi-planet as previously
    classified)
- Drop the corresponding entries from `DEFERRED_GAPS` in
  `crates/astrodyn_verif_parity/tests/parity_coverage.rs`. The genuine
  multi-planet entries (`apollo_*`, `earth_moon`) remain as gaps until
  per-body `<P>` dispatch lands — tracked in #413 (sibling
  `populate_app_multi` API) and audited as #490 (H-03).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1681 tests passed
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_mars_orbit`
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_mercury`
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_planetary`
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage`
- [x] Canonical regressions: `bevy_parity_dyncomp_run2_3dof` (Earth) and
  `bevy_parity_nesc_cc8_nrho` (Moon) still pass
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Closes #450