### PR TITLE
[#556] Bevy parity: fall back to TranslationalStateC velocity for source motion

### DIFF
--- a/crates/astrodyn_bevy/src/systems/integration.rs
+++ b/crates/astrodyn_bevy/src/systems/integration.rs
@@ -311,6 +311,7 @@ pub fn integration_system<P: Planet>(
             Option<&PlanetFixedRotationC<P>>,
             &SourceInertialPositionC,
             Option<&SourceInertialVelocityC>,
+            Option<&TranslationalStateC<P>>,
             Option<&TidalDeltaC20C>,
             Option<&TidalConfigC>,
         ),
@@ -382,45 +383,50 @@ pub fn integration_system<P: Planet>(
         let typed_abs_vel = Velocity::<RootInertial>::from_raw_si(vel + integ_origin_vel); // allowed: integrator-kernel boundary
         let typed_origin = Position::<RootInertial>::from_raw_si(stage_origin_pos); // allowed: integrator-kernel boundary
 
-        // Helper: resolve a source's effective velocity from the
-        // typed `SourceInertialVelocityC` (which is
-        // `Velocity<RootInertial>` — planet-agnostic). Sources that
-        // lack this component coast at zero velocity within the step.
+        // Helper: resolve a source's effective velocity, mirroring
+        // [`sync_source_to_frame_system`]'s precedence so per-stage
+        // gravity interpolation and PPN corrections read the same
+        // value the source's frame entity carries:
         //
-        // `SourceInertialVelocityC` is opt-in: `PlanetBundle`,
-        // `SunBundle`, and `MoonBundle` do not insert it, and
-        // `ephemeris_update_system` only writes through it when it is
-        // already present (it does not auto-insert from
-        // `EphemerisBodyC`). Callers who want a moving source for
-        // per-stage gravity interpolation or relativistic source
-        // resolution must attach `SourceInertialVelocityC` explicitly.
+        // 1. [`SourceInertialVelocityC`] when present — the explicit
+        //    per-source velocity component (`Velocity<RootInertial>`,
+        //    planet-agnostic).
+        // 2. Otherwise [`TranslationalStateC<P>`]'s velocity —
+        //    `ephemeris_update_system` writes through it for
+        //    ephemeris-driven sources that don't carry the standalone
+        //    velocity component (Sun / Moon via `SunBundle` /
+        //    `MoonBundle`). The `<P>` tag is the body-side phantom
+        //    (per `spawn_source`'s convention) — at this kernel
+        //    boundary we extract `raw_si()` and treat the value as
+        //    the source's root-inertial velocity, matching what
+        //    `sync_source_to_frame_system` writes into the source's
+        //    `FrameTransC.velocity` and what
+        //    `astrodyn_runner::run_integration` reads from
+        //    `frame_tree.get(source_inertial).state.trans.velocity`.
+        // 3. Otherwise treat the source as stationary within the step.
         //
-        // No `TranslationalStateC<P>` fallback is offered here. The
-        // `<P>` instantiation runs gravity-computation in
-        // `PlanetInertial<P>` for the body's planet, and a Sun /
-        // ephemeris source's `TranslationalStateC<P>` carries that
-        // body-side `<P>` tag (per `SunBundle` / `MoonBundle`'s
-        // construction-time convention) — so the velocity it stores
-        // is "Sun's velocity tagged as the central planet's inertial
-        // frame," which has no well-defined source-motion meaning.
-        // Treating the source as stationary when no
-        // `SourceInertialVelocityC` is present matches
-        // `sync_source_to_frame_system`'s precedence: explicit
-        // velocity component first, otherwise treat as no source-
-        // motion contribution to the per-step kernel.
-        let source_vel = |v: Option<&SourceInertialVelocityC>| -> DVec3 {
-            v.map(|v| v.0.raw_si()).unwrap_or(DVec3::ZERO)
-        };
+        // Without the fallback, post-frame-switch integration drops
+        // each ephemeris-driven source's per-stage position
+        // interpolation (the `sub_dt != 0` branch below), so a
+        // Moon-centered body whose third bodies include
+        // ephemeris-driven Sun / Earth diverges from the runner at
+        // ULP scale once the body's integ frame starts moving.
+        let source_vel =
+            |v: Option<&SourceInertialVelocityC>, t: Option<&TranslationalStateC<P>>| -> DVec3 {
+                v.map(|v| v.0.raw_si())
+                    .or_else(|| t.map(|t| t.0.velocity.raw_si()))
+                    .unwrap_or(DVec3::ZERO)
+            };
 
         let typed_accel = astrodyn::accumulate_gravity_typed(
             typed_abs_pos,
             &controls.0,
             typed_origin,
             |source_entity| match sources.get(source_entity) {
-                Ok((s, r, p, v, tidal, tidal_config)) => {
+                Ok((s, r, p, v, t, tidal, tidal_config)) => {
                     let base_pos = p.0.raw_si();
                     let stage_pos = if sub_dt != 0.0 {
-                        base_pos + source_vel(v) * sub_dt
+                        base_pos + source_vel(v, t) * sub_dt
                     } else {
                         base_pos
                     };
@@ -452,16 +458,19 @@ pub fn integration_system<P: Planet>(
             typed_abs_vel,
             &controls.0,
             |source_entity| {
-                sources.get(source_entity).ok().map(|(s, _, p, v, _, _)| {
-                    // Step-start values for PPN — runner does the
-                    // same (snapshots `src_pos`/`src_vel` outside
-                    // the per-stage closure).
-                    astrodyn::ResolvedRelativisticSource {
-                        mu: s.mu,
-                        position: p.0.raw_si(),
-                        velocity: source_vel(v),
-                    }
-                })
+                sources
+                    .get(source_entity)
+                    .ok()
+                    .map(|(s, _, p, v, t, _, _)| {
+                        // Step-start values for PPN — runner does the
+                        // same (snapshots `src_pos`/`src_vel` outside
+                        // the per-stage closure).
+                        astrodyn::ResolvedRelativisticSource {
+                            mu: s.mu,
+                            position: p.0.raw_si(),
+                            velocity: source_vel(v, t),
+                        }
+                    })
             },
         );
         accel += rel.raw_si();

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_apollo8_frame_switch.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_apollo8_frame_switch.rs
@@ -14,9 +14,7 @@
 //! * [`bevy_parity_apollo8_frame_switch`] — same scenario plus a
 //!   distance-based [`FrameSwitchConfig`] that reparents the body
 //!   from Earth-inertial to Moon-inertial when the body approaches
-//!   within 66.1 Mm of the Moon. Currently `#[ignore]`d on a known
-//!   ULP-scale Bevy-adapter divergence at the switch tick (see the
-//!   per-test attribute reason).
+//!   within 66.1 Mm of the Moon. Bit-identical between runtimes.
 //!
 //! Single-planet bridge note: the `<P>` tag stays `<Earth>` across the
 //! frame switch — `TranslationalStateC<P>` is the scenario-wide
@@ -26,7 +24,7 @@
 //! velocity values in Moon-centered coordinates, identically to the
 //! runner's `evaluate_and_apply_frame_switch` path. See
 //! `bevy_parity_frame_switch.rs` for the simpler synthetic-Moon
-//! version of the same machinery, which is bit-identical.
+//! version of the same machinery.
 
 #![allow(
     clippy::float_cmp,
@@ -275,26 +273,13 @@ fn bevy_parity_apollo8_eci_integ() {
 
 /// Frame-switch parity: same baseline scenario plus a distance-based
 /// `FrameSwitchConfig` that reparents the body to Moon-inertial on
-/// approach (≤ 66.1 Mm).
-///
-/// Currently `#[ignore]`d: ULP-scale drift appears at the switch tick
-/// (≈ tick 80, velocity component ≈ 2 ns/m) when the Moon's
-/// `SourceInertialPositionC` is driven by `ephemeris_update_system`.
-/// The synthetic-Moon variant in `bevy_parity_frame_switch.rs` (Moon
-/// position pinned via `SourceMutator` rather than DE405-driven) is
-/// bit-identical, isolating the failure mode to the
-/// frame_switch_system ↔ ephemeris_update_system interaction. The
-/// baseline `apollo8_eci_integ` case above passes bit-identically,
-/// confirming the ephemeris path itself is parity-safe; the
-/// divergence is specific to how the frame-switch transformation
-/// reads the Moon's post-ephemeris-update position relative to where
-/// the runner's `evaluate_and_apply_frame_switch` reads it. Tracked
-/// as a separate Bevy-adapter bug; lifting the `#[ignore]` is
-/// blocked on that investigation.
+/// approach (≤ 66.1 Mm). Post-switch the body integrates in
+/// Moon-inertial — i.e. the integ origin is now moving — so the
+/// per-stage gravity interpolation for ephemeris-driven third bodies
+/// (Sun, Earth) exercises the source-velocity path that the
+/// pre-switch root-integrated baseline (`apollo8_eci_integ`) leaves
+/// dormant.
 #[test]
-#[ignore = "parity-gap (#556): frame_switch_system + ephemeris-driven \
-            SourceInertialPositionC interaction — Moon position diverges \
-            from runner at the switch tick (ULP-scale)."]
 fn bevy_parity_apollo8_frame_switch() {
     let steps = (TOTAL_TIME / DT).round() as usize;
     assert_parity("apollo8_frame_switch", true, steps);


### PR DESCRIPTION
## Root cause

Bevy's `integration_system` per-stage gravity interpolation read source velocity only from the opt-in `SourceInertialVelocityC` component, treating ephemeris-driven sources as stationary within an RK4 step. The runner reads the same value from `frame_tree.get(source.inertial).state.trans.velocity`, which `update_ephemeris` populates with the DE4xx velocity.

The mismatch is invisible while the body's integration frame is the root — then the closure short-circuits via `sub_dt == 0` and no per-stage source position interpolation happens — but it breaks bit-identity the instant the body's integ origin starts moving, which is what a `FrameSwitchConfig` does the tick it reparents the body under a moving central source.

The `bevy_parity_apollo8_frame_switch` case hits this at the Earth → Moon switch (tick 80): one step of Moon-inertial integration with the per-stage Sun / Earth third-body interpolation now active. The synthetic-Moon control case (`bevy_parity_frame_switch`) doesn't trip it because that test pins the Moon's position via `SourceMutator` rather than driving it from DE405, so the Moon's velocity is zero in both runtimes regardless of where the velocity is read from.

## Fix

Extend `integration_system`'s source query with `Option<&TranslationalStateC<P>>` and add it as the second-tier fallback in the per-source `source_vel` closure, mirroring `sync_source_to_frame_system`'s existing precedence:

1. `SourceInertialVelocityC` when present (planet-agnostic `Velocity<RootInertial>`).
2. Otherwise `TranslationalStateC<P>.velocity` — `ephemeris_update_system` already writes through it for ephemeris-driven sources without the standalone velocity component.
3. Otherwise zero.

Both gravity per-stage interpolation and PPN relativistic-source resolution share the same closure, so both pick up the fallback together.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1385 passed
- [x] `cargo nextest run -p astrodyn_verif_parity -E 'test(bevy_parity_)'` — 315 passed (including the previously-`#[ignore]`d `bevy_parity_apollo8_frame_switch`)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — meta-test still passes (PR #554 had already dropped the entry from `DEFERRED_GAPS`)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_bypass_deps.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Lifting the `#[ignore]` restores transitive Tier 3 coverage for the apollo8 frame-switch trajectory (#389 superset invariant). No `KNOWN_PARITY_GAPS` change needed — PR #554 had already dropped `apollo8_frame_switch` from `DEFERRED_GAPS` once the wrapper file existed.

Closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)