### PR TITLE
[#65] Batch mass-tree recompute in staging_system

### DIFF
--- a/crates/astrodyn_bevy/src/systems/integration.rs
+++ b/crates/astrodyn_bevy/src/systems/integration.rs
@@ -1044,8 +1044,13 @@ fn apply_cross_integ_frame_attach<P: Planet>(
 /// 1. snapshots both bodies' pre-attach composite-body inertial state
 ///    (`TranslationalStateC` + `RotationalStateC`) and pre-attach
 ///    composite mass properties,
-/// 2. mutates the [`crate::MassTreeR`] arena (which recomputes composite
-///    mass properties for every affected node),
+/// 2. mutates the [`crate::MassTreeR`] arena via the deferred-recompute
+///    variant ([`astrodyn::MassTree::attach_with_reroot_without_recompute`]);
+///    composite mass properties for every affected node are refreshed
+///    by a single end-of-system [`astrodyn::MassTree::recompute_composites`]
+///    call rather than per-event, collapsing a tick that fires N attach
+///    events from `O(N × num_nodes)` recompute work to
+///    `O(N + num_nodes)`,
 /// 3. runs [`astrodyn::stage_attach_combine`] (the
 ///    momentum-conservation port of JEOD's `combine_states_at_attach`,
 ///    `models/dynamics/dyn_body/src/dyn_body_attach.cc`) to derive the
@@ -1095,8 +1100,12 @@ fn apply_cross_integ_frame_attach<P: Planet>(
 /// 1. captures the about-to-be-detached subtree's instantaneous
 ///    composite-body inertial state via
 ///    [`astrodyn::stage_detach_capture`],
-/// 2. mutates the arena (which recomputes the former parent's composite
-///    mass to reflect the lost subtree),
+/// 2. mutates the arena via the deferred-recompute variant
+///    ([`astrodyn::MassTree::detach_without_recompute`]); the former
+///    parent's composite mass is refreshed by a recompute fence (either
+///    immediately, before the next detach iteration's pre-mutation
+///    composite reads fire, or at end-of-system, before the
+///    composite-mass sync) rather than per-event,
 /// 3. inserts [`crate::DetachedSubtreeStateC`] on the detached entity
 ///    so [`step_detached_system`] can advance the subtree ballistically
 ///    each tick.
@@ -1275,6 +1284,49 @@ pub fn staging_system<P: Planet>(
     // `integrate()` panics with the IG.37 diagnostic rather than
     // silently propagating stale predictor history.
     let mut affected_ids: Vec<astrodyn::MassBodyId> = Vec::new();
+
+    // Tracks whether a `*_without_recompute` topology mutation has
+    // landed in `tree` since the last `recompute_composites` call.
+    //
+    // The two event loops below mutate the `MassTree` via the
+    // deferred-recompute variants
+    // (`attach_with_reroot_without_recompute` / `detach_without_recompute`)
+    // so a tick that processes N staging events runs the post-order
+    // composite walk at most a small constant number of times rather
+    // than N times. The cost model collapses from
+    // `O(num_events × num_nodes)` to `O(num_events + num_nodes)` for
+    // the realistic attach-heavy case (e.g. chained-attach scenarios
+    // that fire two `AttachEvent`s in one tick).
+    //
+    // Recompute fences are placed at every site where a downstream
+    // read of `tree.get(...).composite_properties`,
+    // `composite_wrt_pstr`, or `core_wrt_composite` would otherwise
+    // observe a stale composite:
+    //
+    //   1. Before the detach loop starts (only if the attach loop
+    //      mutated `tree`), so the detach chain walk reads
+    //      post-attach composites — same observability as the prior
+    //      per-call `attach().recompute_composites()` pattern.
+    //   2. At the top of every detach iteration after the first (only
+    //      if the prior iteration mutated `tree`), so each detach's
+    //      pre-mutation chain walk and `parent_pre_composite_props`
+    //      read see the post-prior-detach composites — same
+    //      observability as the prior per-call
+    //      `detach().recompute_composites()` pattern.
+    //   3. After both loops finish (only if any mutation has happened
+    //      since the last recompute), so the trailing composite-mass
+    //      sync / attach-combine / parent-shift loops below all read
+    //      live composites.
+    //
+    // Net: the attach loop reads no composites (only topology
+    // accessors: `tree.children`, `tree.subtree_ids`,
+    // `tree.ancestors_inclusive`, `tree.root_of`, `tree.parent`), so
+    // N back-to-back `AttachEvent`s collapse to a single recompute
+    // when no detach follows. Each subsequent detach iteration still
+    // pays one recompute to match the prior per-event semantics
+    // bit-for-bit; the only saved recompute on the detach side is
+    // the one merged into the trailing fence (3).
+    let mut tree_dirty = false;
 
     // Per-attach work item: captures the pre-attach snapshot needed by
     // `combine_states_at_attach` plus the post-mutation parent entity
@@ -2261,24 +2313,37 @@ pub fn staging_system<P: Planet>(
             cross_integ,
         });
 
-        // `tree.attach_with_reroot` takes raw structural-frame DVec3;
-        // drop the typed phantom at this kernel boundary. The typed
-        // `AttachEvent.offset` field guards the structural-frame
-        // contract at the writer site. The reroot-aware kernel handles
-        // both the simple root-subject case (bit-identical to plain
-        // `attach`) and the chained-attach case (recomputes geometry
-        // and reparents the subject's existing tree root under
-        // `parent_id`). Mirrors JEOD `dyn_body_attach.cc:521-567`'s
-        // `attach_child` path.
+        // `tree.attach_with_reroot_without_recompute` takes raw
+        // structural-frame DVec3; drop the typed phantom at this
+        // kernel boundary. The typed `AttachEvent.offset` field guards
+        // the structural-frame contract at the writer site. The
+        // reroot-aware kernel handles both the simple root-subject
+        // case (bit-identical to plain `attach_without_recompute`) and
+        // the chained-attach case (recomputes geometry and reparents
+        // the subject's existing tree root under `parent_id`). Mirrors
+        // JEOD `dyn_body_attach.cc:521-567`'s `attach_child` path.
+        //
+        // The deferred-recompute variant skips the per-call composite
+        // walk; the `tree_dirty` flag below routes the recompute to
+        // the next consumer fence (start of detach loop / trailing
+        // composite-mass sync) so a tick with N back-to-back
+        // `AttachEvent`s pays one composite recompute, not N. The
+        // attach loop body reads no composite-derived data (only
+        // `tree.children`, `tree.subtree_ids`,
+        // `tree.ancestors_inclusive`, `tree.root_of`, `tree.parent` —
+        // all pure topology) so consecutive iterations see the same
+        // observable tree they would have seen under the
+        // recomputing-each-call path.
         // JEOD_INV: BA.12 — Bevy adapter dispatches every attach through
         // the reroot-aware kernel so chained-attach scenarios pick the
         // JEOD `dyn_body_attach.cc:521-567` path automatically.
-        let _attached_root = tree.attach_with_reroot(
+        let _attached_root = tree.attach_with_reroot_without_recompute(
             child_id,
             parent_id,
             evt.offset.raw_si(),
             evt.t_parent_child.matrix(),
         );
+        tree_dirty = true;
     }
 
     // Per-detach post-mutation work: tree_root entity whose
@@ -2303,6 +2368,30 @@ pub fn staging_system<P: Planet>(
     // `detach_subtree` which indexes `self.bodies` by id directly.
 
     for evt in detach_events.read() {
+        // Recompute fence between deferred-mutation iterations: the
+        // detach loop body's pre-mutation reads
+        // (`parent_pre_composite_props` and the chain walk's
+        // `composite_properties` / `composite_wrt_pstr` accesses)
+        // require live composites. Flush any pending topology
+        // mutations from the attach loop or a prior detach iteration
+        // before the reads fire, so each iteration's observable
+        // composite state matches the prior per-call
+        // `attach().recompute_composites()` /
+        // `detach().recompute_composites()` semantics bit-for-bit.
+        // JEOD_INV: MA.06 — composite reads see post-order recomputed
+        // composites for every prior mutation in this batch.
+        //
+        // No `tree_dirty = false` reset is needed inside this
+        // if-block: the `tree.detach_without_recompute` call at the
+        // tail of every loop body unconditionally sets `tree_dirty =
+        // true`, so the conditional read at the top of the *next*
+        // iteration is unaffected by whether we cleared the flag
+        // here. The trailing recompute fence after the loop reads
+        // the post-final-detach value (always `true` if the loop
+        // ran any iterations) and flushes once.
+        if tree_dirty {
+            tree.recompute_composites();
+        }
         let (_, child_body_id, _, _, _) = bodies.get(evt.child).unwrap_or_else(|_| {
             panic!(
                 "DetachEvent.child = {:?} is not a mass body — entity is missing MassBodyIdC \
@@ -2523,11 +2612,47 @@ pub fn staging_system<P: Planet>(
         // BEFORE mutating the tree.
         affected_ids.push(child_id);
         affected_ids.extend(tree.ancestors_inclusive(tree_root_id));
-        tree.detach(child_id);
+        // Defer the post-detach composite walk to the recompute fence
+        // at the top of the next iteration (or the trailing fence
+        // below if this is the last detach event). The link mutation,
+        // the child's parent-relative reset, and the detached child's
+        // inverse-inertia refresh land here; the surviving parent
+        // tree's composites are written when the fence fires.
+        tree.detach_without_recompute(child_id);
+        tree_dirty = true;
     }
 
     if affected_ids.is_empty() && attach_work.is_empty() && detach_work.is_empty() {
+        // Both loops were no-ops (no staging events landed) so no
+        // deferred-recompute work is outstanding. The `tree_dirty`
+        // flag is structurally `false` in this branch because nothing
+        // could have flipped it without populating one of the
+        // collections above; assert that invariant rather than
+        // silently `return`ing with pending mutations on the tree.
+        assert!(
+            !tree_dirty,
+            "staging_system: pending deferred-recompute mutations but no event work \
+             accumulated — every `attach_without_recompute` / `detach_without_recompute` \
+             call site in this function must populate `attach_work`, `detach_work`, or \
+             `affected_ids` so the trailing recompute fence runs."
+        );
         return;
+    }
+    // Trailing recompute fence: flush any deferred topology mutation
+    // accumulated by the detach loop (or by the attach loop when no
+    // detach event followed) so the composite-mass sync below — and
+    // every other post-loop consumer that reads
+    // `tree.get(...).composite_properties` (the attach-combine kernel
+    // input, the parent-post-detach CoM-shift formula) — sees live
+    // composites. Skipping this flush is the bug the
+    // deferred-recompute split is built to make impossible: with the
+    // fence in place, a tick that fires N staging events runs at
+    // most one composite recompute per consumer-fence boundary
+    // (collapsed from N per-call recomputes). `tree_dirty` is not
+    // read after this fence — every downstream tree read in the rest
+    // of the system sees a live, just-recomputed composite.
+    if tree_dirty {
+        tree.recompute_composites();
     }
     affected_ids.sort_unstable();
     affected_ids.dedup();

--- a/crates/astrodyn_dynamics/src/mass_body.rs
+++ b/crates/astrodyn_dynamics/src/mass_body.rs
@@ -310,11 +310,54 @@ impl MassTree {
         offset: DVec3,
         t_parent_child: DMat3,
     ) -> MassBodyId {
+        let attached_root =
+            self.attach_with_reroot_link_only(child_id, parent_id, offset, t_parent_child);
+        self.recompute_composites();
+        attached_root
+    }
+
+    /// Same as [`Self::attach_with_reroot`], but defers the
+    /// composite-property recomputation to the caller.
+    ///
+    /// Mirrors the [`Self::attach_without_recompute`] contract for the
+    /// reroot-aware path: link / parent / structure-point mutations are
+    /// applied in place, but every node's `composite_properties`,
+    /// `composite_wrt_pstr`, and `core_wrt_composite` are left in their
+    /// pre-call state. The caller takes responsibility for invoking
+    /// [`Self::recompute_composites`] before any consumer reads composite
+    /// data — see [`Self::attach_without_recompute`] for the full
+    /// invariant statement and the intended batch-mutation use case.
+    ///
+    /// # Panics
+    /// Panics on the same conditions as [`Self::attach_with_reroot`]
+    /// (cycle, self-attach, same-tree reroot).
+    // JEOD_INV: BA.12 — chained attach re-roots the subject's existing tree under the new parent
+    pub fn attach_with_reroot_without_recompute(
+        &mut self,
+        child_id: MassBodyId,
+        parent_id: MassBodyId,
+        offset: DVec3,
+        t_parent_child: DMat3,
+    ) -> MassBodyId {
+        self.attach_with_reroot_link_only(child_id, parent_id, offset, t_parent_child)
+    }
+
+    /// Reroot-aware link mutation shared by [`Self::attach_with_reroot`]
+    /// and [`Self::attach_with_reroot_without_recompute`]. Performs the
+    /// same-tree / cycle validation, the geometric reroot, and the
+    /// underlying `attach_link_only` call — but never touches composites.
+    fn attach_with_reroot_link_only(
+        &mut self,
+        child_id: MassBodyId,
+        parent_id: MassBodyId,
+        offset: DVec3,
+        t_parent_child: DMat3,
+    ) -> MassBodyId {
         // Subject case A: child is itself a root → no reroot needed,
-        // delegate to the plain `attach` (which handles the cycle and
-        // self-attach checks already).
+        // delegate to the plain link-only attach (which handles the
+        // cycle and self-attach checks already).
         if self.parent[child_id].is_none() {
-            self.attach(child_id, parent_id, offset, t_parent_child);
+            self.attach_link_only(child_id, parent_id, offset, t_parent_child);
             return child_id;
         }
 
@@ -363,7 +406,7 @@ impl MassTree {
         //  i.e. xyz_rstr_wrt_pstr -= T_pstr_to_rstr^T · subj_in_root.position).
         let xyz_rstr_wrt_pstr = offset - t_pstr_to_rstr.transpose() * subj_in_root.position;
 
-        self.attach(child_root, parent_id, xyz_rstr_wrt_pstr, t_pstr_to_rstr);
+        self.attach_link_only(child_root, parent_id, xyz_rstr_wrt_pstr, t_pstr_to_rstr);
         child_root
     }
 
@@ -627,6 +670,54 @@ impl MassTree {
         offset: DVec3,
         t_parent_child: DMat3,
     ) {
+        self.attach_link_only(child_id, parent_id, offset, t_parent_child);
+        self.recompute_composites();
+    }
+
+    /// Same as [`Self::attach`], but defers the composite-property
+    /// recomputation to the caller.
+    ///
+    /// Use this when applying a batch of mass-tree mutations
+    /// (multiple attaches and/or detaches) within a single tick where
+    /// the per-call `recompute_composites` walks would each redo work
+    /// the next mutation will invalidate. The caller takes
+    /// responsibility for invoking [`Self::recompute_composites`]
+    /// **before any consumer reads composite-derived data**
+    /// (`composite_properties`, `composite_wrt_pstr`,
+    /// `core_wrt_composite`) for any node in the affected forest.
+    /// Until that final recompute fires, the topology mutation is
+    /// in place but every composite field reflects the pre-call
+    /// state — reads against it will silently see stale composites.
+    ///
+    /// Default mass-tree edits should keep using [`Self::attach`] —
+    /// the deferred-recompute variant is intended for batch mutators
+    /// (e.g. the Bevy adapter's `staging_system`) that own the
+    /// recompute lifecycle for the whole batch.
+    ///
+    /// # Panics
+    /// Panics on the same conditions as [`Self::attach`] (child
+    /// already has a parent, self-attach, cycle).
+    pub fn attach_without_recompute(
+        &mut self,
+        child_id: MassBodyId,
+        parent_id: MassBodyId,
+        offset: DVec3,
+        t_parent_child: DMat3,
+    ) {
+        self.attach_link_only(child_id, parent_id, offset, t_parent_child);
+    }
+
+    /// Link mutation shared by [`Self::attach`] and
+    /// [`Self::attach_without_recompute`]. Performs the cycle /
+    /// self-attach validation and writes the parent / children /
+    /// `structure_point` slots — but never touches composite properties.
+    fn attach_link_only(
+        &mut self,
+        child_id: MassBodyId,
+        parent_id: MassBodyId,
+        offset: DVec3,
+        t_parent_child: DMat3,
+    ) {
         // JEOD_INV: BA.03 — attachment requires non-null parent; the `parent_id` argument
         // is `MassBodyId` (non-null by type); invalid IDs panic at the index site below.
         assert!(
@@ -662,8 +753,6 @@ impl MassTree {
             position: offset,
             t_parent_this: t_parent_child,
         };
-
-        self.recompute_composites();
     }
 
     /// Detach `child_id` from its parent.
@@ -676,6 +765,42 @@ impl MassTree {
     ///
     /// Panics if the child has no parent.
     pub fn detach(&mut self, child_id: MassBodyId) {
+        self.detach_link_only(child_id);
+        // Recompute composites for the tree the parent still belongs to.
+        self.recompute_composites();
+    }
+
+    /// Same as [`Self::detach`], but defers the composite-property
+    /// recomputation to the caller.
+    ///
+    /// The link mutation, the child's `structure_point` /
+    /// `composite_wrt_pstr` reset, and the new-root inverse-inertia
+    /// refresh are all applied in place; only the post-mutation
+    /// `recompute_composites` walk over the forest is skipped. The
+    /// caller takes responsibility for invoking
+    /// [`Self::recompute_composites`] **before any consumer reads
+    /// composite-derived data** for the former parent's surviving tree
+    /// — until then, the parent's composite still reflects the
+    /// pre-detach mass distribution. See
+    /// [`Self::attach_without_recompute`] for the full
+    /// batch-mutator contract.
+    ///
+    /// # Panics
+    /// Panics on the same conditions as [`Self::detach`] (child has no
+    /// parent; or the detached child's composite inertia is singular).
+    // JEOD_INV: MA.15 — detach recomputes inverse inertia for new root
+    pub fn detach_without_recompute(&mut self, child_id: MassBodyId) {
+        self.detach_link_only(child_id);
+    }
+
+    /// Link mutation shared by [`Self::detach`] and
+    /// [`Self::detach_without_recompute`]. Removes the parent edge,
+    /// resets the child's parent-relative fields, and refreshes the
+    /// detached child's inverse inertia (JEOD's `detach_update_properties`
+    /// per-child step) — but never recomputes the surviving parent
+    /// tree's composites.
+    // JEOD_INV: MA.15 — detach recomputes inverse inertia for new root
+    fn detach_link_only(&mut self, child_id: MassBodyId) {
         let parent_id = self.parent[child_id].expect("detach called on a body with no parent");
 
         self.children[parent_id].retain(|&c| c != child_id);
@@ -685,7 +810,6 @@ impl MassTree {
         self.nodes[child_id].structure_point = MassPointState::default();
         self.nodes[child_id].composite_wrt_pstr = MassPointState::default();
 
-        // JEOD_INV: MA.15 — detach recomputes inverse inertia for new root
         // Recompute inverse inertia on detached child (JEOD mass_detach.cc:328-335).
         let child = &mut self.nodes[child_id];
         if child.composite_properties.mass > 0.0 {
@@ -700,9 +824,6 @@ impl MassTree {
         } else {
             child.composite_properties.inverse_inertia = DMat3::ZERO;
         }
-
-        // Recompute composites for the tree the parent still belongs to.
-        self.recompute_composites();
     }
 
     // -- composite recomputation (JEOD algorithm) ---------------------------
@@ -2126,5 +2247,248 @@ mod tests {
         // Concretely: attach root `a` under `b` (which is a descendant
         // of `a`). The walk-up from `b` reaches `a` and must panic.
         tree.attach(a, b, DVec3::ZERO, DMat3::IDENTITY);
+    }
+
+    // =======================================================================
+    // Deferred-recompute parity: the `*_without_recompute` variants must
+    // produce a tree whose final composite-property state (after the
+    // caller's mandatory `recompute_composites`) is bit-identical to the
+    // sequential `attach` / `detach` path. The attach loop in the Bevy
+    // adapter's `staging_system` relies on this equivalence to batch
+    // composite recomputation across multiple staged events without
+    // perturbing downstream physics.
+    //
+    // Each test sets up a non-trivial tree where every node carries a
+    // distinct mass, every edge carries a non-identity offset, and at
+    // least one edge carries a non-trivial rotation — so any divergence
+    // in the composite walk shows up in mass / CoM / inertia bits. The
+    // bit-exact `==` checks (rather than approximate) guard that the
+    // deferred path is the same arithmetic in the same order.
+    // =======================================================================
+
+    /// Two-edge attach batch (chained-attach pattern from
+    /// `bevy_parity_chained_attach_reroot.rs`): the deferred variant
+    /// followed by a single recompute must produce bit-identical
+    /// composite properties to two sequential `attach` calls.
+    #[test]
+    fn attach_without_recompute_batch_matches_sequential() {
+        let parent_core = MassProperties::new(10.0);
+        let mid_core = MassProperties::new(7.0);
+        let leaf_core = MassProperties::new(3.0);
+
+        let mid_offset = DVec3::new(2.0, -1.0, 0.5);
+        let mid_t = DMat3::from_cols(
+            DVec3::new(0.0, 1.0, 0.0),
+            DVec3::new(-1.0, 0.0, 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+        );
+        let leaf_offset = DVec3::new(0.5, 0.0, -0.25);
+        let leaf_t = DMat3::IDENTITY;
+
+        // Sequential reference: each attach recomputes internally.
+        let mut tree_ref = MassTree::new();
+        let p_ref = tree_ref.add_root("parent".into(), parent_core);
+        let m_ref = tree_ref.add_body("middle".into(), mid_core);
+        let l_ref = tree_ref.add_body("leaf".into(), leaf_core);
+        tree_ref.attach(m_ref, p_ref, mid_offset, mid_t);
+        tree_ref.attach(l_ref, m_ref, leaf_offset, leaf_t);
+
+        // Deferred batch: link mutations only, then a single end-of-batch
+        // recompute. Final composite must match the reference bit-for-bit.
+        let mut tree_def = MassTree::new();
+        let p_def = tree_def.add_root("parent".into(), parent_core);
+        let m_def = tree_def.add_body("middle".into(), mid_core);
+        let l_def = tree_def.add_body("leaf".into(), leaf_core);
+        tree_def.attach_without_recompute(m_def, p_def, mid_offset, mid_t);
+        tree_def.attach_without_recompute(l_def, m_def, leaf_offset, leaf_t);
+        tree_def.recompute_composites();
+
+        for (id_ref, id_def) in [(p_ref, p_def), (m_ref, m_def), (l_ref, l_def)] {
+            let r = tree_ref.get(id_ref);
+            let d = tree_def.get(id_def);
+            assert_eq!(
+                r.composite_properties.mass, d.composite_properties.mass,
+                "composite mass mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.position, d.composite_properties.position,
+                "composite position mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.inertia, d.composite_properties.inertia,
+                "composite inertia mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.inverse_inertia, d.composite_properties.inverse_inertia,
+                "composite inverse_inertia mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_wrt_pstr.position, d.composite_wrt_pstr.position,
+                "composite_wrt_pstr.position mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_wrt_pstr.t_parent_this, d.composite_wrt_pstr.t_parent_this,
+                "composite_wrt_pstr.t_parent_this mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.core_wrt_composite.position, d.core_wrt_composite.position,
+                "core_wrt_composite.position mismatch on {}",
+                r.name
+            );
+        }
+    }
+
+    /// Detach with deferred recompute must match the sequential
+    /// `detach` path bit-for-bit on every node — including the
+    /// detached child's `inverse_inertia` (which `detach_link_only`
+    /// refreshes inline) and the surviving parent's composite.
+    #[test]
+    fn detach_without_recompute_matches_sequential() {
+        let parent_core = MassProperties::new(10.0);
+        let child_core = MassProperties::new(4.0);
+        let offset = DVec3::new(1.5, 0.0, -0.25);
+        let t_parent_child = DMat3::from_cols(
+            DVec3::new(1.0, 0.0, 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+            DVec3::new(0.0, -1.0, 0.0),
+        );
+
+        // Sequential reference.
+        let mut tree_ref = MassTree::new();
+        let p_ref = tree_ref.add_root("parent".into(), parent_core);
+        let c_ref = tree_ref.add_body("child".into(), child_core);
+        tree_ref.attach(c_ref, p_ref, offset, t_parent_child);
+        tree_ref.detach(c_ref);
+
+        // Deferred batch: detach without recompute, then a single
+        // end-of-batch recompute over the surviving forest.
+        let mut tree_def = MassTree::new();
+        let p_def = tree_def.add_root("parent".into(), parent_core);
+        let c_def = tree_def.add_body("child".into(), child_core);
+        tree_def.attach(c_def, p_def, offset, t_parent_child);
+        tree_def.detach_without_recompute(c_def);
+        tree_def.recompute_composites();
+
+        for (id_ref, id_def) in [(p_ref, p_def), (c_ref, c_def)] {
+            let r = tree_ref.get(id_ref);
+            let d = tree_def.get(id_def);
+            assert_eq!(
+                r.composite_properties.mass, d.composite_properties.mass,
+                "composite mass mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.position, d.composite_properties.position,
+                "composite position mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.inertia, d.composite_properties.inertia,
+                "composite inertia mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.inverse_inertia, d.composite_properties.inverse_inertia,
+                "composite inverse_inertia mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.structure_point.position, d.structure_point.position,
+                "structure_point.position mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_wrt_pstr.position, d.composite_wrt_pstr.position,
+                "composite_wrt_pstr.position mismatch on {}",
+                r.name
+            );
+        }
+    }
+
+    /// `attach_with_reroot_without_recompute` followed by a single
+    /// recompute must match `attach_with_reroot` bit-for-bit on the
+    /// chained-attach (re-root) path. Mirrors the
+    /// `bevy_parity_chained_attach_reroot.rs` topology.
+    #[test]
+    fn attach_with_reroot_without_recompute_matches_sequential() {
+        let top_core = MassProperties::new(8.0);
+        let middle_core = MassProperties::new(5.0);
+        let leaf_core = MassProperties::new(2.0);
+        let middle_leaf_offset = DVec3::new(0.4, 0.1, 0.0);
+        let middle_leaf_t = DMat3::IDENTITY;
+        let middle_top_offset = DVec3::new(1.0, 0.0, 0.5);
+        let middle_top_t = DMat3::from_cols(
+            DVec3::new(0.0, 1.0, 0.0),
+            DVec3::new(-1.0, 0.0, 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+        );
+
+        // Sequential reference. The (leaf → middle) attach builds the
+        // subject tree first, then the chained (middle → top) reroot
+        // attach pulls (middle, leaf) under top.
+        let mut tree_ref = MassTree::new();
+        let top_ref = tree_ref.add_root("top".into(), top_core);
+        let mid_ref = tree_ref.add_root("middle".into(), middle_core);
+        let leaf_ref = tree_ref.add_body("leaf".into(), leaf_core);
+        tree_ref.attach(leaf_ref, mid_ref, middle_leaf_offset, middle_leaf_t);
+        let _ = tree_ref.attach_with_reroot(mid_ref, top_ref, middle_top_offset, middle_top_t);
+
+        // Deferred batch: replicates the topology + offsets via the
+        // `_without_recompute` variants, then fires one recompute.
+        let mut tree_def = MassTree::new();
+        let top_def = tree_def.add_root("top".into(), top_core);
+        let mid_def = tree_def.add_root("middle".into(), middle_core);
+        let leaf_def = tree_def.add_body("leaf".into(), leaf_core);
+        tree_def.attach_without_recompute(leaf_def, mid_def, middle_leaf_offset, middle_leaf_t);
+        let _ = tree_def.attach_with_reroot_without_recompute(
+            mid_def,
+            top_def,
+            middle_top_offset,
+            middle_top_t,
+        );
+        tree_def.recompute_composites();
+
+        for (id_ref, id_def) in [(top_ref, top_def), (mid_ref, mid_def), (leaf_ref, leaf_def)] {
+            let r = tree_ref.get(id_ref);
+            let d = tree_def.get(id_def);
+            assert_eq!(
+                r.composite_properties.mass, d.composite_properties.mass,
+                "composite mass mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.position, d.composite_properties.position,
+                "composite position mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.inertia, d.composite_properties.inertia,
+                "composite inertia mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.composite_properties.inverse_inertia, d.composite_properties.inverse_inertia,
+                "composite inverse_inertia mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.structure_point.position, d.structure_point.position,
+                "structure_point.position mismatch on {}",
+                r.name
+            );
+            assert_eq!(
+                r.structure_point.t_parent_this, d.structure_point.t_parent_this,
+                "structure_point.t_parent_this mismatch on {}",
+                r.name
+            );
+        }
+        assert_eq!(tree_ref.parent(mid_ref), tree_def.parent(mid_def));
+        assert_eq!(tree_ref.parent(leaf_ref), tree_def.parent(leaf_def));
     }
 }


### PR DESCRIPTION
## Summary

Closes the third and final sub-item of #65 — the Bevy adapter's
`staging_system` previously called `tree.attach_with_reroot(...)` /
`tree.detach(...)` inside its two event loops, each of which ran
`MassTree::recompute_composites()` internally. A tick that processed N
staging events ran the post-order composite walk N times
(`O(num_events × num_nodes)`). The canonical multi-event case is the
chained-attach scenario (`bevy_parity_chained_attach_reroot`), which
fires two `AttachEvent`s in one tick.

### New `MassTree` API surface

Three deferred-recompute variants on `MassTree`:

- `attach_without_recompute(child_id, parent_id, offset, t_parent_child)`
- `attach_with_reroot_without_recompute(child_id, parent_id, offset, t_parent_child) -> MassBodyId`
- `detach_without_recompute(child_id)`

Each documents the batch-mutator contract: link / structure-point
mutations land in place, but the post-mutation
`recompute_composites` walk is the caller's responsibility — every
consumer that reads `composite_properties`, `composite_wrt_pstr`, or
`core_wrt_composite` for a node in the affected forest must see
post-recompute state. The default `attach` / `detach` /
`attach_with_reroot` methods still recompute synchronously; nothing
about their semantics changes.

Internally `attach` / `detach` / `attach_with_reroot` now factor
through private `attach_link_only` / `detach_link_only` /
`attach_with_reroot_link_only` helpers, so the deferred variants
share the exact arithmetic with the recomputing default (no
duplicate logic, no possibility of divergence in a future edit).

### `staging_system` refactor

`staging_system` switches both event loops to the deferred variants.
Composite recomputes are now flushed only at the three fence points
where downstream reads require live composites:

1. **Before the detach loop** (only if the attach loop mutated `tree`),
   so the detach chain walk reads post-attach composites.
2. **At the top of every detach iteration after the first** (only if
   the prior iteration mutated `tree`), so each detach's pre-mutation
   chain walk and `parent_pre_composite_props` read see the
   post-prior-detach composites.
3. **After both loops finish** (only if any mutation has happened
   since the last recompute), so the trailing composite-mass sync /
   attach-combine / parent-shift loops all read live composites.

### Cost model

| pattern | before | after |
| --- | --- | --- |
| 0 attach + 0 detach | 0 recomputes | 0 recomputes |
| N attach + 0 detach | N recomputes | **1** recompute |
| 0 attach + 1 detach | 1 recompute | 1 recompute |
| 0 attach + N detach | N recomputes | N recomputes |
| N attach + 1 detach | N + 1 recomputes | **2** recomputes |
| N attach + M detach | N + M recomputes | **M + 1** recomputes |

i.e. the attach-heavy case collapses to the spec's `O(num_events +
num_nodes)`. The detach side keeps the per-iteration recompute
because each iteration's loop body reads composite-derived data
before mutating — flushing that into a single batch would change the
observable composite state seen by detach iteration 2+ (a behavioural
change in an untested multi-detach-per-tree scenario; the
conservative choice was to preserve the per-iteration semantics
bit-for-bit).

### Bit-identity verification

Three new tests in `crates/astrodyn_dynamics/src/mass_body.rs`
(`attach_without_recompute_batch_matches_sequential`,
`detach_without_recompute_matches_sequential`,
`attach_with_reroot_without_recompute_matches_sequential`) assert
bit-exact (`assert_eq!`) equality across `composite_properties`,
`composite_wrt_pstr`, `core_wrt_composite`, and `structure_point` for
every node in non-trivial multi-edge trees, comparing the deferred
path's final state to the sequential reference.

The 44 staging-related parity tests confirm runner ↔ Bevy bit-identity
on every existing scenario: `bevy_parity_mass_attach_detach*` (incl.
with_abm4 / with_gj multi-step-integrator variants),
`bevy_parity_chained_attach_reroot*`,
`bevy_parity_attach_detach_momentum*`,
`bevy_parity_detach_non_root_integ_source*`.

Sub-items 1 (coupled integrator scratch preallocation) and 3 (gravity
wrapper allocation) landed in #555 and commit 37370d6 respectively;
this PR closes the third — `Closes #65`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity_)'` — 1388 passed
- [x] `cargo nextest run -p astrodyn_dynamics` — 315 passed (3 new bit-identity tests for the deferred variants)
- [x] `cargo nextest run -p astrodyn_bevy` — 149 passed
- [x] `cargo nextest run -p astrodyn_runner` — 59 passed
- [x] All 44 staging-related parity tests bit-identical pre/post (the bit-identity backstop):
  - `bevy_parity_mass_attach_detach*` (incl. abm4, gj)
  - `bevy_parity_chained_attach_reroot*`
  - `bevy_parity_attach_detach_momentum*`
  - `bevy_parity_detach_non_root_integ_source*`
- [x] tier3 attach/detach tests pass (10/10): `tier3_sim_attach_detach_trajectory`,
  `tier3_mass_attach_detach`, `tier3_sim_complex_attach_detach`,
  `tier3_apollo_mass_tree`, `tier3_sim_attach_mass`,
  `tier3_sim_kinematic_propagation`, `tier3_sim_ref_attach`,
  `tier3_sim_dyncomp_run_attach_to_ref_frame`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_bypass_deps.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)