### PR TITLE
[#413] Bevy parity: apollo_trajectory wrapper via BevySimContext subtree ops

### DIFF
--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -26,6 +26,7 @@
 //! }
 //! ```
 
+pub mod sim_apollo_trajectory;
 pub mod sim_attach_detach_trajectory;
 pub mod sim_derived_state;
 pub mod sim_drag_6dof;
@@ -203,6 +204,98 @@ impl SimContext for Simulation {
         };
         Simulation::attach_to_frame(self, body_idx, frame_id, offset, t_parent_child);
     }
+
+    fn detach_subtree(&mut self, subtree_root: astrodyn::MassBodyId) {
+        // `Simulation::detach_subtree` takes the integrated body index
+        // explicitly because the algorithm needs to know which `SimBody`
+        // owns the tree root **iff the parent is integrated**: when the
+        // current tree root above `subtree_root` is a SimBody, that body's
+        // `body.trans` / `body.rot` is shifted by the post-detach CoM
+        // delta; when the tree root sits inside `detached_subtrees`, the
+        // algorithm reads from the HashMap entry instead and
+        // `integrated_body_idx` is unused (but still indexed into for
+        // the `parent_is_integrated` equality check, so it must be a
+        // valid body index). Resolve the index in two steps: if the
+        // current tree root is backed by a SimBody, use that body's
+        // index; otherwise fall back to any registered integrated body
+        // (the parent_is_integrated check will return false and the
+        // body's state is left untouched). Mirrors the runner's
+        // root-walk plus the Bevy adapter's `staging_system`
+        // `id_to_entity` lookup.
+        let tree = self
+            .mass_tree
+            .as_ref()
+            .expect("SimContext::detach_subtree: no mass tree configured");
+        let mut root_id = subtree_root;
+        while let Some(p) = tree.parent(root_id) {
+            root_id = p;
+        }
+        let integrated_body_idx = pick_integrated_body_idx(self, root_id, "detach_subtree");
+        Simulation::detach_subtree(self, integrated_body_idx, subtree_root);
+    }
+
+    fn attach_subtree_aligned(
+        &mut self,
+        subtree_root: astrodyn::MassBodyId,
+        subtree_point: &str,
+        parent: astrodyn::MassBodyId,
+        parent_point: &str,
+    ) {
+        // Same integrated-body resolution rule as detach_subtree: the
+        // parent's pre-attach composite state is read from a SimBody
+        // when the tree root above `parent` is integrated, otherwise
+        // from `detached_subtrees`. For the integrated branch the
+        // resolved body's `body.trans` is also where the combined
+        // composite is written back.
+        let tree = self
+            .mass_tree
+            .as_ref()
+            .expect("SimContext::attach_subtree_aligned: no mass tree configured");
+        let mut root_id = parent;
+        while let Some(p) = tree.parent(root_id) {
+            root_id = p;
+        }
+        let integrated_body_idx = pick_integrated_body_idx(self, root_id, "attach_subtree_aligned");
+        Simulation::attach_subtree_aligned(
+            self,
+            integrated_body_idx,
+            subtree_root,
+            subtree_point,
+            parent,
+            parent_point,
+        );
+    }
+}
+
+/// Resolve a SimBody index for the runner-side
+/// `Simulation::detach_subtree` / `attach_subtree_aligned` call. If the
+/// tree root above the subtree is backed by an integrated SimBody, that
+/// body's index is the load-bearing answer (it's where the combine
+/// kernel writes back the merged composite). Otherwise the parent is a
+/// detached subtree and the index only feeds the
+/// `parent_is_integrated` boolean — any registered integrated body is
+/// safe to pass.
+fn pick_integrated_body_idx(sim: &Simulation, tree_root: astrodyn::MassBodyId, op: &str) -> usize {
+    if let Some(idx) = (0..sim.num_bodies()).find(|&i| sim.body_mass_id(i) == Some(tree_root)) {
+        return idx;
+    }
+    // Tree root is a detached subtree (no SimBody backs it). Fall back
+    // to any body that has a `mass_body_id` so the runner's pre-call
+    // `self.bodies[integrated_body_idx].mass_body_id` read succeeds —
+    // the parent_is_integrated comparison against `tree_root` returns
+    // false in this branch, so the body's state is never read.
+    (0..sim.num_bodies())
+        .find(|&i| sim.body_mass_id(i).is_some())
+        .unwrap_or_else(|| {
+            panic!(
+                "SimContext::{op}: no SimBody is registered in the mass tree. \
+                 The runner's subtree-detach / -attach algorithm requires at \
+                 least one integrated body to anchor the `parent_is_integrated` \
+                 check. Register the integration root via `add_body_to_tree` \
+                 (or `SimulationBuilder::register_in_mass_tree`) before firing \
+                 subtree events."
+            )
+        })
 }
 
 /// Per-family typed records held alongside the [`StateLog`] vec so

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_apollo_trajectory.rs
@@ -1,0 +1,690 @@
+//! Shared SIM_Apollo `apollo_trajectory` recipe + topology helpers.
+//!
+//! Factored out of `crates/astrodyn_verif_jeod/tests/tier3_sim_apollo_trajectory.rs`
+//! so the runner-vs-JEOD tier3 test and the runner-vs-Bevy parity wrapper
+//! (`crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs`)
+//! drive the same scenario through their respective runtimes.
+//!
+//! The apollo mass tree pairs *one integrated body* (`cm`, the Command
+//! Module — the launch-stack integration root) with *seven tree-only mass
+//! bodies* (`sm`, `lm`, `dm`, `s3`, `s2`, `s1`, `les`) plus fourteen
+//! named attachment points and seven `launch_stack` aligned attaches.
+//! That topology does not fit `SimulationBuilder`'s declarative shape
+//! (the builder only registers integrated bodies), so the recipe is
+//! split into:
+//!
+//! 1. [`apollo_trajectory_builder`] — returns a `SimulationBuilder`
+//!    carrying time, sources, ephemeris, atmosphere, and the single
+//!    integrated `cm` body (registered in the mass tree). Consumed by
+//!    `Simulation::from_builder` and `SimulationBuilderBevyExt::populate_app`
+//!    identically.
+//!
+//! 2. [`setup_apollo_arena`] — given a `&mut MassTree` already
+//!    containing the `cm` integrated body, adds the seven tree-only
+//!    mass bodies, fourteen named mass points, and seven launch-stack
+//!    aligned attaches. Both adapters call this on their own arena
+//!    (`Simulation::mass_tree` for the runner; `MassTreeR.0` for Bevy)
+//!    after the basic build is done. Mass-id allocation is
+//!    deterministic — the same insertion order produces the same
+//!    `MassBodyId`s on both sides.
+//!
+//! 3. [`Event`] / [`EVENTS`] — the eleven SIM_Apollo
+//!    `RUN_test/input.py:230..345` mass-tree events scheduled at
+//!    integer seconds. [`apply_event`] dispatches each event through
+//!    a `&mut dyn SimContext`, calling the subtree-detach /
+//!    subtree-attach-aligned methods both runtimes implement.
+//!
+//! ### JEOD source-defect note
+//!
+//! `sims/SIM_Apollo/SET_test/RUN_test/input.py` calls
+//! `set_vehicle_grav_controls()` only on `les_dyn` and never on
+//! `cm_dyn` (the integration root after launch_stack assembly). As
+//! shipped, JEOD's recorded trajectory is therefore essentially
+//! gravity-free. The Docker reference-regen wrapper
+//! (`trick/generate_references.sh:run_apollo_group`) injects the
+//! missing `set_vehicle_grav_controls(cm_dyn)` +
+//! `set_vehicle_sv_at_earth(cm_dyn, earth)` calls before the sim
+//! runs, restoring the 8x8 GGM05C + Moon/Sun gravity that the
+//! per-vehicle data files (`Modified_data/vehicle/grav_controls.py`,
+//! `Modified_data/vehicle/sv_at_earth.py`) clearly intend. This
+//! recipe therefore wires the *intended* gravity configuration
+//! rather than the as-shipped (broken) one.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "Apollo recipe step counts and indices fit exactly in f64 mantissa and usize"
+)]
+
+use crate::verification::SimContext;
+use astrodyn::{
+    AtmosphereConfig, AtmosphereModel, GeoIndexType, GravityControl, GravityControls,
+    GravityGradient, GravityModel, GravitySource, GravitySourceEntry, JeodQuat, MassBodyId,
+    MassProperties, MassTree, MetAtmosphere, RotationalState, SimulationBuilder, SimulationTime,
+    TranslationalState, VehicleConfig, EARTH,
+};
+use astrodyn_runner::RotationModel;
+use glam::{DMat3, DVec3};
+use std::path::PathBuf;
+
+// ── JEOD source constants ────────────────────────────────────────────
+
+/// `S_define:72` — `#define DYNAMICS 0.02`.
+pub const DT: f64 = 0.02;
+/// `RUN_test/input.py:350` — `exec_set_terminate_time(12.0)`.
+pub const SIM_DURATION_S: f64 = 12.0;
+
+/// `Modified_data/Earth/params.py` — Earth rotation rate.
+pub const OMEGA_EARTH: f64 = 7.292_115_146_706_388e-5;
+
+/// `Modified_data/vehicle/sv_at_earth.py` — earth gravity 8x8 degree.
+pub const GRAV_DEGREE: usize = 8;
+/// `Modified_data/vehicle/sv_at_earth.py` — earth gravity 8x8 order.
+pub const GRAV_ORDER: usize = 8;
+
+// ── Unit conversions for JEOD English-unit mass data ─────────────────
+
+/// Pounds-mass → kilograms (exact).
+pub const LB_TO_KG: f64 = 0.453_592_37;
+/// Feet → meters (exact).
+pub const FT_TO_M: f64 = 0.3048;
+const LB_FT2_TO_KG_M2: f64 = LB_TO_KG * FT_TO_M * FT_TO_M;
+
+// ── Topology ─────────────────────────────────────────────────────────
+
+/// MassBodyId handles for the eight Apollo bodies, returned by
+/// [`setup_apollo_arena`]. Pre_step closures capture this struct and
+/// dispatch the eleven scheduled detach / attach events on it.
+#[derive(Debug, Clone, Copy)]
+pub struct ApolloTopology {
+    /// Command Module — the *only* integrated body (the launch stack's
+    /// post-assembly tree root and JEOD integration target).
+    pub cm: MassBodyId,
+    /// Service Module — tree-only.
+    pub sm: MassBodyId,
+    /// Lunar Module (Ascent) — tree-only.
+    pub lm: MassBodyId,
+    /// Descent Module — tree-only.
+    pub dm: MassBodyId,
+    /// Saturn V stage 3 — tree-only.
+    pub s3: MassBodyId,
+    /// Saturn V stage 2 — tree-only.
+    pub s2: MassBodyId,
+    /// Saturn V stage 1 — tree-only.
+    pub s1: MassBodyId,
+    /// Launch Escape System — tree-only.
+    pub les: MassBodyId,
+}
+
+// ── 180° yaw rotation about Z ────────────────────────────────────────
+
+/// JEOD's `pt_orientation = yaw_180`: `diag(-1, -1, 1)` — used as
+/// `t_struct_to_body` on CM / LES / DM / Ascent module (each declares
+/// `eigen_angle = 180°` about Z). Identity for SM / S1 / S2 / S3.
+pub fn yaw_180() -> DMat3 {
+    DMat3::from_cols(
+        DVec3::new(-1.0, 0.0, 0.0),
+        DVec3::new(0.0, -1.0, 0.0),
+        DVec3::new(0.0, 0.0, 1.0),
+    )
+}
+
+/// Apollo per-body mass properties from `Modified_data/mass/*.py`.
+/// `mass_lb` in pounds, `cm_x_ft` in feet (Y/Z = 0), inertia in lb·ft².
+/// `t_struct_to_body` per JEOD `pt_orientation`.
+pub fn apollo_mass(
+    mass_lb: f64,
+    cm_x_ft: f64,
+    ixx: f64,
+    iyy: f64,
+    izz: f64,
+    t_struct_to_body: DMat3,
+) -> MassProperties {
+    MassProperties::with_inertia(
+        mass_lb * LB_TO_KG,
+        DMat3::from_diagonal(DVec3::new(
+            ixx * LB_FT2_TO_KG_M2,
+            iyy * LB_FT2_TO_KG_M2,
+            izz * LB_FT2_TO_KG_M2,
+        )),
+        DVec3::new(cm_x_ft * FT_TO_M, 0.0, 0.0),
+    )
+    .with_t_parent_this(t_struct_to_body)
+}
+
+// ── Time setup ───────────────────────────────────────────────────────
+
+/// `Modified_data/date_n_time/UTC_16Jul1969.py` — 1969-07-16 13:44:00 UTC,
+/// leap_sec_override = 4.2 s, tai_to_ut1_override = 0.0115221 - 4.2.
+pub fn apollo_time() -> SimulationTime {
+    // JD(1969-07-16 0h UT) = 2440418.5 → TJT = 418.0 (TJT = JD - 2440000.5).
+    // 13h44m = 49440 s = 0.572222... days.
+    let utc_tjt = 418.0 + (13.0 * 3600.0 + 44.0 * 60.0) / 86_400.0;
+    // SIM_Apollo overrides TAI-UTC to 4.2 s instead of the historical
+    // value (which differs at this epoch). Hand-roll the conversion so
+    // we don't rely on the leap-second table for this date.
+    let tai_tjt = utc_tjt + 4.2 / 86_400.0;
+    let mut time = SimulationTime::new(tai_tjt, astrodyn::default_leap_second_table());
+    // tai_to_ut1_override_val = 0.0115221 - 4.2 = UT1-TAI offset.
+    time.set_ut1_tai_offset(0.011_522_1 - 4.2);
+    time
+}
+
+// ── Reference-CSV initial state ──────────────────────────────────────
+
+/// Apollo CSV row 0: JEOD's logged `core_body` inertial state at t=0,
+/// after `launch_stack` assembled the full stack. Used by the recipe
+/// to seed the integrated `cm` body's translational + rotational
+/// state; `convert_body_trans_core_to_composite` flips the
+/// interpretation to `composite_body` once the mass tree is finalized.
+#[derive(Debug, Clone, Copy)]
+pub struct ApolloCsvRow0 {
+    /// Position in Earth.inertial (m).
+    pub position: DVec3,
+    /// Velocity in Earth.inertial (m/s).
+    pub velocity: DVec3,
+    /// Inertial-to-body left-quaternion (JEOD scalar-first layout).
+    pub quaternion: JeodQuat,
+    /// Body-frame angular velocity (rad/s).
+    pub ang_vel_body: DVec3,
+}
+
+/// Locate the apollo_trajectory.csv fixture relative to the verif_jeod
+/// crate root. Both runtime adapters read row 0 here at scenario-build
+/// time (no per-tick CSV access).
+pub fn apollo_test_data_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR is the directory containing the verif_jeod
+    // crate's Cargo.toml. The reference CSV lives under
+    // `test_data/apollo_trajectory.csv` in the same crate.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data")
+}
+
+/// Read row 0 of `apollo_trajectory.csv` — the integration root's
+/// initial `core_body` inertial state at the SIM_Apollo epoch.
+///
+/// Reading CSV row 0 (rather than hard-coding constants) keeps the
+/// recipe self-consistent with whatever frame the JEOD reference
+/// snippet was logging at t=0. `Modified_data/state/sv_leo_lvlh.py`
+/// sets the composite_body state at t=0, but the snippet logs core_body;
+/// using row 0 absorbs the structure-to-composite offset times the
+/// row-0 rotation without re-deriving it here.
+pub fn load_apollo_csv_row0() -> ApolloCsvRow0 {
+    let csv_path = apollo_test_data_dir().join("apollo_trajectory.csv");
+    assert!(
+        csv_path.exists(),
+        "apollo_trajectory.csv missing at {}. Generate with: cargo xtask regenerate-tier3",
+        csv_path.display()
+    );
+    let content = std::fs::read_to_string(&csv_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", csv_path.display()));
+    // Skip the header, take the first data row.
+    let first = content
+        .lines()
+        .nth(1)
+        .unwrap_or_else(|| panic!("{} has no data rows", csv_path.display()));
+    let fields: Vec<&str> = first.split(',').map(str::trim).collect();
+    assert_eq!(
+        fields.len(),
+        14,
+        "{} row 0: expected 14 columns, got {} ({first:?})",
+        csv_path.display(),
+        fields.len(),
+    );
+    let parse = |col: usize| -> f64 {
+        fields[col].parse::<f64>().unwrap_or_else(|e| {
+            panic!(
+                "{} row 0: failed to parse column {col} ({:?}): {e}",
+                csv_path.display(),
+                fields[col]
+            )
+        })
+    };
+    ApolloCsvRow0 {
+        position: DVec3::new(parse(1), parse(3), parse(5)),
+        velocity: DVec3::new(parse(2), parse(4), parse(6)),
+        // JEOD scalar-first [q0, q1, q2, q3] — stored with same convention.
+        quaternion: JeodQuat::new(parse(7), parse(8), parse(9), parse(10)),
+        ang_vel_body: DVec3::new(parse(11), parse(12), parse(13)),
+    }
+}
+
+// ── SimulationBuilder factory ────────────────────────────────────────
+
+/// Builder shape returned by [`apollo_trajectory_builder`]. The
+/// integrated `cm` body's index in `bodies` is always 0, and `cm` is
+/// registered in the mass tree under the name `"cm"`.
+pub struct ApolloBuilderHandles {
+    /// Pre-built `SimulationBuilder` carrying time, sources, ephemeris,
+    /// atmosphere, and the single integrated `cm` body.
+    pub builder: SimulationBuilder,
+    /// Source index of Earth (`central = true`, RNP rotation).
+    pub earth_source_idx: usize,
+    /// Source index of the Moon (ephemeris-driven point mass).
+    pub moon_source_idx: usize,
+    /// Source index of the Sun (ephemeris-driven point mass).
+    pub sun_source_idx: usize,
+    /// Cached row-0 state used downstream to seed the integrated body
+    /// and (after the mass tree is assembled) to convert the `cm`
+    /// body's `trans` from `core_body` to `composite_body`.
+    pub csv_row0: ApolloCsvRow0,
+}
+
+/// Build the SIM_Apollo `apollo_trajectory` simulation as a
+/// [`SimulationBuilder`]. Materializing the builder produces a
+/// runtime that has the integrated CM body but no tree-only mass
+/// bodies — those are added next via [`setup_apollo_arena`] against
+/// the runtime's mass-tree arena, mirroring JEOD's two-step setup
+/// (DynBody init → MassTree augmentation).
+pub fn apollo_trajectory_builder() -> ApolloBuilderHandles {
+    // Earth: 8x8 GGM05C non-spherical, with the Earth-RNP rotation model
+    // so the planet-fixed frame updates each step (matches JEOD's
+    // `earth_GGM05C_MET_RNP.sm`).
+    let earth_grav = astrodyn::gravity_fixtures::load_ggm05c();
+    let mu_moon = astrodyn::gravity_fixtures::load_moon_grail150_mu();
+    let mu_sun = astrodyn::gravity_fixtures::load_sun_spherical_mu();
+
+    let mut sb = SimulationBuilder::new(apollo_time(), DT);
+
+    let earth = sb.add_source(
+        "Earth",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: earth_grav.mu,
+                model: GravityModel::SphericalHarmonics(Box::new(earth_grav)),
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: Some(DMat3::IDENTITY),
+            delta_c20: 0.0,
+            rotation_model: RotationModel::EarthRNP,
+            tidal_config: None,
+            planet_omega: OMEGA_EARTH,
+            central: true,
+            marker_only: false,
+        },
+    );
+    let moon = sb.add_source(
+        "Moon",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_moon,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+            marker_only: false,
+        },
+    );
+    let sun = sb.add_source(
+        "Sun",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: mu_sun,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
+            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: false,
+            marker_only: false,
+        },
+    );
+    sb.set_source_ephemeris(
+        moon,
+        astrodyn::EphemerisBody::Moon,
+        astrodyn::EphemerisBody::Earth,
+    );
+    sb.set_source_ephemeris(
+        sun,
+        astrodyn::EphemerisBody::Sun,
+        astrodyn::EphemerisBody::Earth,
+    );
+
+    // Mean solar activity per `Modified_data/Earth/soflx_mean.py`.
+    sb = sb.atmosphere(
+        AtmosphereConfig {
+            model: AtmosphereModel::Met(MetAtmosphere {
+                f10: 128.8,
+                f10b: 128.8,
+                geo_index: 15.7,
+                geo_index_type: GeoIndexType::Ap,
+            }),
+            r_eq: EARTH.shape.r_eq(),
+            r_pol: EARTH.shape.r_pol(),
+            planet_omega: OMEGA_EARTH,
+        },
+        earth,
+    );
+
+    // The body starts with CM-only mass; the tree-only bodies + launch
+    // stack added in `setup_apollo_arena` augment the composite at runtime
+    // via `sync_body_mass_from_tree`.
+    let cm_only_mass = apollo_mass(12_807.0, 8.7, 157_372.0, 64_624.0, 64_624.0, yaw_180());
+
+    let csv_row0 = load_apollo_csv_row0();
+
+    sb.add_body(VehicleConfig {
+        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
+            position: csv_row0.position,
+            velocity: csv_row0.velocity,
+        }),
+        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
+            &(RotationalState {
+                quaternion: csv_row0.quaternion,
+                ang_vel_body: csv_row0.ang_vel_body,
+            }),
+        )),
+        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&cm_only_mass)),
+        gravity_controls: GravityControls {
+            controls: vec![
+                GravityControl::new_nonspherical(
+                    earth,
+                    GRAV_DEGREE,
+                    GRAV_ORDER,
+                    GravityGradient::Skip,
+                ),
+                GravityControl::new_third_body(moon),
+                GravityControl::new_third_body(sun),
+            ],
+        },
+        ..Default::default()
+    });
+
+    // Register cm in the mass tree under the canonical name "cm" so the
+    // arena ID allocated by `from_builder` / `populate_app` is the same
+    // on both runtimes (insertion order is deterministic).
+    sb.register_in_mass_tree(0, "cm");
+
+    // astrodyn_runner uses the BSP for Moon/Sun ephemeris evaluation each
+    // step. SIM_Apollo's 12 s window sits comfortably within DE421
+    // coverage.
+    let bsp_path = astrodyn::ephemeris_assets::de421_path();
+    assert!(
+        bsp_path.exists(),
+        "DE421 ephemeris missing at {}",
+        bsp_path.display()
+    );
+    let ephemeris =
+        astrodyn::Ephemeris::from_bsp(&bsp_path).expect("failed to load DE421 ephemeris");
+    sb = sb.ephemeris(ephemeris);
+
+    ApolloBuilderHandles {
+        builder: sb,
+        earth_source_idx: earth,
+        moon_source_idx: moon,
+        sun_source_idx: sun,
+        csv_row0,
+    }
+}
+
+// ── Mass-tree arena setup ────────────────────────────────────────────
+
+/// Given a `&mut MassTree` that already contains the integrated `cm`
+/// body, augment it with the seven tree-only mass bodies, fourteen
+/// named mass points (per `Modified_data/attach/*.py`), and seven
+/// launch_stack aligned attaches.
+///
+/// `cm` is the integrated body's `MassBodyId` (allocated by
+/// `Simulation::from_builder` or `SimulationBuilderBevyExt::populate_app`
+/// from `register_in_mass_tree(0, "cm")`). Both runtimes pass their
+/// own arena's matching id here; the tree-only bodies are then
+/// allocated in deterministic order so both arenas end up holding
+/// the same `MassBodyId`s for every node.
+///
+/// Per `Modified_data/mass/*.py`: SM, S1, S2, S3 use identity
+/// struct→body rotation; LM (Ascent), DM, LES use yaw_180.
+pub fn setup_apollo_arena(tree: &mut MassTree, cm: MassBodyId) -> ApolloTopology {
+    // Allocate the seven tree-only bodies in the same order the
+    // pre-refactor inline setup used. Both arenas share the
+    // post-`cm` allocation sequence, so their `MassBodyId`s match
+    // index-for-index.
+    let sm = tree.add_body(
+        "sm".into(),
+        apollo_mass(
+            54_064.0,
+            12.3,
+            1_107_231.0,
+            1_235_227.0,
+            1_235_227.0,
+            DMat3::IDENTITY,
+        ),
+    );
+    let lm = tree.add_body(
+        "lm".into(),
+        apollo_mass(10_582.0, 5.45, 259_259.0, 155_822.0, 155_822.0, yaw_180()),
+    );
+    let dm = tree.add_body(
+        "dm".into(),
+        apollo_mass(25_640.0, 5.0, 628_180.0, 367_506.0, 367_506.0, yaw_180()),
+    );
+    let s3 = tree.add_body(
+        "s3".into(),
+        apollo_mass(
+            274_171.0,
+            30.65,
+            16_138_048.0,
+            29_532_558.0,
+            29_532_558.0,
+            DMat3::IDENTITY,
+        ),
+    );
+    let s2 = tree.add_body(
+        "s2".into(),
+        apollo_mass(
+            1_083_480.0,
+            40.75,
+            147_488_715.0,
+            223_676_545.0,
+            223_676_545.0,
+            DMat3::IDENTITY,
+        ),
+    );
+    let s1 = tree.add_body(
+        "s1".into(),
+        apollo_mass(
+            5_031_023.0,
+            69.0,
+            684_848_006.0,
+            2_338_482_378.0,
+            2_338_482_378.0,
+            DMat3::IDENTITY,
+        ),
+    );
+    let les = tree.add_body(
+        "les".into(),
+        apollo_mass(9_200.0, 16.25, 5_566.0, 205_231.0, 205_231.0, yaw_180()),
+    );
+
+    // CM points
+    tree.add_mass_point(
+        cm,
+        "SM interface",
+        DVec3::new(11.6 * FT_TO_M, 0.0, 0.0),
+        DMat3::IDENTITY,
+    );
+    tree.add_mass_point(
+        cm,
+        "CM docking port",
+        DVec3::new(4.0 * FT_TO_M, 0.0, 0.0),
+        yaw_180(),
+    );
+    // SM points
+    tree.add_mass_point(
+        sm,
+        "Stage 3 interface",
+        DVec3::new(-20.9 * FT_TO_M, 0.0, 0.0),
+        yaw_180(),
+    );
+    tree.add_mass_point(
+        sm,
+        "CM interface",
+        DVec3::new(24.6 * FT_TO_M, 0.0, 0.0),
+        DMat3::IDENTITY,
+    );
+    // LM points
+    tree.add_mass_point(
+        lm,
+        "LM docking port",
+        DVec3::new(10.9 * FT_TO_M, 0.0, 0.0),
+        DMat3::IDENTITY,
+    );
+    tree.add_mass_point(lm, "Descent Module interface", DVec3::ZERO, yaw_180());
+    tree.add_mass_point(
+        lm,
+        "Stage 3 interface",
+        DVec3::new(-10.0 * FT_TO_M, 0.0, 0.0),
+        yaw_180(),
+    );
+    // DM points
+    tree.add_mass_point(dm, "Ascent Module interface", DVec3::ZERO, DMat3::IDENTITY);
+    tree.add_mass_point(
+        dm,
+        "Stage 3 interface",
+        DVec3::new(-10.0 * FT_TO_M, 0.0, 0.0),
+        yaw_180(),
+    );
+    // S3 points
+    tree.add_mass_point(s3, "Stage 2 interface", DVec3::ZERO, yaw_180());
+    tree.add_mass_point(
+        s3,
+        "LEM/SM/CM interface",
+        DVec3::new(61.3 * FT_TO_M, 0.0, 0.0),
+        DMat3::IDENTITY,
+    );
+    // S2 points
+    tree.add_mass_point(s2, "Stage 1 interface", DVec3::ZERO, yaw_180());
+    tree.add_mass_point(
+        s2,
+        "Stage 3 interface",
+        DVec3::new(81.5 * FT_TO_M, 0.0, 0.0),
+        DMat3::IDENTITY,
+    );
+    // S1 points
+    tree.add_mass_point(
+        s1,
+        "Stage 2 interface",
+        DVec3::new(138.0 * FT_TO_M, 0.0, 0.0),
+        DMat3::IDENTITY,
+    );
+    // LES points
+    tree.add_mass_point(les, "CM interface", DVec3::ZERO, yaw_180());
+
+    // Apply the seven `Modified_data/attach/launch_stack.py`
+    // attachments. Bottom-up order matters for the composite-mass
+    // recomputation that runs after each `attach_aligned`.
+    tree.attach_aligned(
+        dm,
+        "Ascent Module interface",
+        lm,
+        "Descent Module interface",
+    );
+    tree.attach_aligned(sm, "CM interface", cm, "SM interface");
+    tree.attach_aligned(s3, "LEM/SM/CM interface", sm, "Stage 3 interface");
+    tree.attach_aligned(lm, "Stage 3 interface", s3, "LEM/SM/CM interface");
+    tree.attach_aligned(s2, "Stage 3 interface", s3, "Stage 2 interface");
+    tree.attach_aligned(s1, "Stage 2 interface", s2, "Stage 1 interface");
+    tree.attach_aligned(les, "CM interface", cm, "CM docking port");
+
+    ApolloTopology {
+        cm,
+        sm,
+        lm,
+        dm,
+        s3,
+        s2,
+        s1,
+        les,
+    }
+}
+
+// ── Mass-tree event schedule (RUN_test/input.py:230..345) ────────────
+
+/// The eleven SIM_Apollo mass-tree events: five staged stage drops
+/// (S1 → S2 → LES → S3 → LM), the t=6 SM→CM attach, the t=7..10
+/// LM-extract / DM-detach / LM-re-dock / LM-jettison sequence, and
+/// the t=11 SM detach.
+#[derive(Debug, Clone, Copy)]
+pub enum Event {
+    /// t=1: drop Stage 1.
+    DetachS1,
+    /// t=2: drop Stage 2.
+    DetachS2,
+    /// t=3: jettison Launch Escape System.
+    DetachLes,
+    /// t=4: drop Stage 3.
+    DetachS3,
+    /// t=5: separate the LM (transposition + docking sequence start).
+    DetachLm,
+    /// t=6: dock LM to CM via the named CM-docking-port mass points.
+    AttachLmCm,
+    /// t=7: undock LM from CM (LM descent begins).
+    DetachLm2,
+    /// t=8: jettison the descent module (LM-ascent only).
+    DetachDm,
+    /// t=9: re-dock the LM-ascent stage to the CM.
+    AttachLmCm2,
+    /// t=10: jettison the LM-ascent stage.
+    DetachLm3,
+    /// t=11: jettison the Service Module.
+    DetachSm,
+}
+
+/// The eleven scheduled events with their integer-second firing times,
+/// per `RUN_test/input.py:230..345` (`trick.add_read(t, …)` calls).
+/// `trick.add_read(t, …)` fires at the END of the cycle ending at `t` —
+/// after the integrator has advanced state to `t`. The lockstep driver
+/// must step both runtimes up to and including `event_t`, then apply
+/// the event before continuing.
+pub const EVENTS: &[(f64, Event)] = &[
+    (1.0, Event::DetachS1),
+    (2.0, Event::DetachS2),
+    (3.0, Event::DetachLes),
+    (4.0, Event::DetachS3),
+    (5.0, Event::DetachLm),
+    (6.0, Event::AttachLmCm),
+    (7.0, Event::DetachLm2),
+    (8.0, Event::DetachDm),
+    (9.0, Event::AttachLmCm2),
+    (10.0, Event::DetachLm3),
+    (11.0, Event::DetachSm),
+];
+
+/// Dispatch one [`Event`] through a `&mut dyn SimContext`. Both runtime
+/// adapters expose [`SimContext::detach_subtree`] and
+/// [`SimContext::attach_subtree_aligned`]; the runner forwards to
+/// `Simulation::detach_subtree` / `attach_subtree_aligned`, and the
+/// Bevy adapter resolves the `MassBodyId` to its backing mass-only
+/// entity and fires an `AttachEvent` / `DetachEvent` (looking up the
+/// named mass points in `MassTreeR` to compute offset/rotation per the
+/// `MassTree::attach_aligned` chain).
+pub fn apply_event(ctx: &mut dyn SimContext, topology: &ApolloTopology, event: Event) {
+    match event {
+        Event::DetachS1 => ctx.detach_subtree(topology.s1),
+        Event::DetachS2 => ctx.detach_subtree(topology.s2),
+        Event::DetachLes => ctx.detach_subtree(topology.les),
+        Event::DetachS3 => ctx.detach_subtree(topology.s3),
+        Event::DetachLm | Event::DetachLm2 | Event::DetachLm3 => {
+            ctx.detach_subtree(topology.lm);
+        }
+        Event::DetachDm => ctx.detach_subtree(topology.dm),
+        Event::DetachSm => ctx.detach_subtree(topology.sm),
+        Event::AttachLmCm | Event::AttachLmCm2 => {
+            ctx.attach_subtree_aligned(
+                topology.lm,
+                "LM docking port",
+                topology.cm,
+                "CM docking port",
+            );
+        }
+    }
+}

--- a/crates/astrodyn_verif_jeod/src/verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/verification/mod.rs
@@ -241,6 +241,66 @@ pub trait SimContext {
              path (e.g. FrameAttachEvent on the Bevy bus)"
         );
     }
+
+    /// Detach the subtree rooted at `subtree_root` from its current
+    /// parent in the mass tree. Mirrors the runner's
+    /// [`Simulation::detach_subtree`](https://docs.rs/astrodyn_runner/latest/astrodyn_runner/simulation/struct.Simulation.html#method.detach_subtree)
+    /// runtime entry point used by Apollo's staged separation events
+    /// (S-IC drop, LM extraction, …): the subtree's composite-body
+    /// inertial state is captured at the separation instant, the
+    /// parent's composite-CoM-shift is propagated through its
+    /// integrated state, and the subtree advances ballistically from
+    /// then on until the matching [`Self::attach_subtree_aligned`]
+    /// re-merges it. Addressed by `MassBodyId` rather than body index
+    /// because the subtree root is typically a tree-only body (no
+    /// `SimBody` / no Bevy dynamic entity), e.g. the apollo LM /
+    /// service module sub-stages.
+    ///
+    /// The default implementation panics so existing `SimContext`
+    /// implementors stay source-compatible. Adapters that own the
+    /// subtree-detach surface (runner's `Simulation::detach_subtree`,
+    /// the Bevy adapter's `DetachEvent` against a mass-only entity)
+    /// override this.
+    fn detach_subtree(&mut self, subtree_root: astrodyn::MassBodyId) {
+        let _ = subtree_root;
+        panic!(
+            "detach_subtree not supported by this SimContext implementation; \
+             provide a SimContext impl that drives the adapter's subtree-detach \
+             path (e.g. DetachEvent on the Bevy bus against a mass-only entity)"
+        );
+    }
+
+    /// Re-attach `subtree_root` (previously detached via
+    /// [`Self::detach_subtree`]) under `parent` in the mass tree using
+    /// named attachment points, running JEOD's
+    /// `combine_states_at_attach` momentum-conservation kernel so the
+    /// merged composite-body state is bit-identical to the runner's
+    /// [`Simulation::attach_subtree_aligned`](https://docs.rs/astrodyn_runner/latest/astrodyn_runner/simulation/struct.Simulation.html#method.attach_subtree_aligned).
+    /// The mass-tree must already contain the named mass points on
+    /// both bodies (typically declared at scenario-build time); the
+    /// adapter looks them up and computes the structural-frame offset
+    /// and rotation chain (`mass_attach.cc:103-115` — invert the child
+    /// point, apply 180° docking yaw, compose with the parent point)
+    /// internally so callers only carry around the symbolic names.
+    ///
+    /// The default implementation panics so existing `SimContext`
+    /// implementors stay source-compatible. Adapters that own the
+    /// subtree-attach surface override this.
+    fn attach_subtree_aligned(
+        &mut self,
+        subtree_root: astrodyn::MassBodyId,
+        subtree_point: &str,
+        parent: astrodyn::MassBodyId,
+        parent_point: &str,
+    ) {
+        let _ = (subtree_root, subtree_point, parent, parent_point);
+        panic!(
+            "attach_subtree_aligned not supported by this SimContext implementation; \
+             provide a SimContext impl that drives the adapter's subtree-attach \
+             path (e.g. AttachEvent against a mass-only entity with offset / \
+             rotation derived from named mass points)"
+        );
+    }
 }
 
 /// Which of a gravity source's reference frames to attach to.

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_apollo_trajectory.rs
@@ -16,14 +16,19 @@
 //! trajectory against the reference CSV. The sim has 11 scheduled
 //! `add_read` events at integer seconds — 9 detaches and 2 attaches.
 //! The full event sequence is applied to our mass tree (so the pipeline
-//! exercises all 11 events end-to-end) via `Simulation::detach_subtree`
-//! and `Simulation::attach_subtree_aligned`. `attach_subtree_aligned`
-//! ports JEOD's `DynBody::attach_child` momentum-conservation algorithm
-//! into [`astrodyn_dynamics::attach::combine_states_at_attach`], with full
-//! struct↔body-frame distinctions per
-//! `MassProperties::t_parent_this` (set per body from
-//! `Modified_data/mass/*.py:pt_orientation` — `yaw_180` for CM/LES/DM/LM,
-//! identity for SM/S1/S2/S3).
+//! exercises all 11 events end-to-end) via the runner's
+//! `Simulation::detach_subtree` and `Simulation::attach_subtree_aligned`
+//! routed through the shared
+//! [`run_verification::sim_apollo_trajectory`](astrodyn_verif_jeod::run_verification::sim_apollo_trajectory)
+//! recipe (the same module the Bevy parity wrapper at
+//! `crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs`
+//! consumes — keeping both runtimes byte-for-byte in lockstep).
+//! `attach_subtree_aligned` ports JEOD's `DynBody::attach_child`
+//! momentum-conservation algorithm into
+//! [`astrodyn_dynamics::attach::combine_states_at_attach`], with full
+//! struct↔body-frame distinctions per `MassProperties::t_parent_this`
+//! (set per body from `Modified_data/mass/*.py:pt_orientation` —
+//! `yaw_180` for CM/LES/DM/LM, identity for SM/S1/S2/S3).
 //!
 //! Trajectory diffs are asserted through the full 12 s sim — all 11
 //! attach/detach events execute and the CSM `core_body` trajectory is
@@ -37,21 +42,6 @@
 //! `composite_body`-integration refactor (commit `bd279c2`) and the
 //! `step_ballistic` quaternion-multiply-order fix (routed through
 //! `BodyAttitude::advance_under_body_rate` after issue #252).
-//!
-//! ### JEOD source-defect note
-//!
-//! `sims/SIM_Apollo/SET_test/RUN_test/input.py` calls
-//! `set_vehicle_grav_controls()` only on `les_dyn` and never on
-//! `cm_dyn` (the integration root after launch_stack assembly). As
-//! shipped, JEOD's recorded trajectory is therefore essentially
-//! gravity-free. The Docker reference-regen wrapper
-//! (`trick/generate_references.sh:run_apollo_group`) injects the
-//! missing `set_vehicle_grav_controls(cm_dyn)` + `set_vehicle_sv_at_earth(cm_dyn, earth)`
-//! calls before the sim runs, restoring the 8x8 GGM05C + Moon/Sun
-//! gravity that the per-vehicle data files (`Modified_data/vehicle/grav_controls.py`,
-//! `Modified_data/vehicle/sv_at_earth.py`) clearly intend. This test
-//! therefore validates against the *intended* JEOD configuration
-//! rather than the as-shipped (broken) one.
 //!
 //! ### Scope
 //!
@@ -75,36 +65,25 @@
 //! complements it by exercising the full `Simulation::step()` pipeline
 //! end-to-end through the same event sequence.
 
-use astrodyn::GeoIndexType;
 use astrodyn::JeodQuat;
-use astrodyn::{
-    AtmosphereConfig, AtmosphereModel, GravityControl, GravityControls, GravityGradient,
-    GravityModel, GravitySource, MetAtmosphere, RotationalState, SimulationBuilder, SimulationTime,
-    TranslationalState, EARTH,
-};
-use astrodyn::{GravitySourceEntry, VehicleConfig};
-use astrodyn::{MassBodyId, MassProperties, MassTree};
-use astrodyn_runner::{RotationModel, Simulation, SimulationBuilderExt};
+use astrodyn_runner::{Simulation, SimulationBuilderExt};
 use astrodyn_verif_jeod::apollo_truth::{
     load_apollo_attach_truth, nearest_truth_at, ApolloTruthError, ApolloTruthRow,
 };
 use astrodyn_verif_jeod::crossval::{CrossvalReport, StateLog};
-use glam::{DMat3, DVec3};
+use astrodyn_verif_jeod::run_verification::sim_apollo_trajectory::{
+    apollo_trajectory_builder, apply_event, setup_apollo_arena, ApolloTopology, Event, EVENTS,
+    SIM_DURATION_S,
+};
+use astrodyn_verif_jeod::verification::SimContext;
+use glam::DVec3;
 use std::path::PathBuf;
 
-// ── JEOD source constants ────────────────────────────────────────────
-//
-// The body's initial state comes from CSV row 0 rather than a hardcoded
-// constant: JEOD's `Modified_data/state/sv_leo_lvlh.py` sets the
-// composite_body state at t=0, but the snippet logs core_body (which
-// differs by the structure→composite offset times a rotation). Reading
-// CSV row 0 keeps the test self-consistent with whatever frame the
-// snippet is logging.
+// JEOD constants and helpers live in the shared recipe; only the
+// per-test bits (CSV loader for ALL rows, trajectory-validation window,
+// LM diagnostic) stay inline.
 
-/// `S_define:72` — `#define DYNAMICS 0.02`.
-const DT: f64 = 0.02;
-/// `RUN_test/input.py:350` — `exec_set_terminate_time(12.0)`.
-const SIM_DURATION_S: f64 = 12.0;
+const DT: f64 = astrodyn_verif_jeod::run_verification::sim_apollo_trajectory::DT;
 
 /// Trajectory comparison window: full 12 s sim. Asserts every 0.1 s
 /// sample through all 11 attach/detach events (5 stage detaches, the
@@ -113,105 +92,8 @@ const SIM_DURATION_S: f64 = 12.0;
 /// for the residual budget.
 const TRAJECTORY_VALIDATION_END_S: f64 = 12.0;
 
-/// `Modified_data/Earth/params.py` — Earth rotation rate.
-const OMEGA_EARTH: f64 = 7.292_115_146_706_388e-5;
-
-/// `Modified_data/vehicle/sv_at_earth.py` — earth gravity 8x8.
-const GRAV_DEGREE: usize = 8;
-/// `Modified_data/vehicle/sv_at_earth.py` — earth gravity 8x8.
-const GRAV_ORDER: usize = 8;
-
-// ── Unit conversions for JEOD English-unit mass data ─────────────────
-
-const LB_TO_KG: f64 = 0.453_592_37;
-const FT_TO_M: f64 = 0.3048;
-const LB_FT2_TO_KG_M2: f64 = LB_TO_KG * FT_TO_M * FT_TO_M;
-
-// ── Helpers ──────────────────────────────────────────────────────────
-
 fn test_data_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_data")
-}
-
-fn yaw_180() -> DMat3 {
-    DMat3::from_cols(
-        DVec3::new(-1.0, 0.0, 0.0),
-        DVec3::new(0.0, -1.0, 0.0),
-        DVec3::new(0.0, 0.0, 1.0),
-    )
-}
-
-/// Apollo per-body mass properties from `Modified_data/mass/*.py`.
-/// `mass_lb` in pounds, `cm_x_ft` in feet (Y/Z = 0), inertia in lb·ft².
-/// `t_struct_to_body` per JEOD `pt_orientation` — `yaw_180` for the CM,
-/// LES, DM, and Ascent module (each declares `eigen_angle = 180°` about
-/// Z); identity for SM, S1, S2, S3.
-fn apollo_mass(
-    mass_lb: f64,
-    cm_x_ft: f64,
-    ixx: f64,
-    iyy: f64,
-    izz: f64,
-    t_struct_to_body: DMat3,
-) -> MassProperties {
-    MassProperties::with_inertia(
-        mass_lb * LB_TO_KG,
-        DMat3::from_diagonal(DVec3::new(
-            ixx * LB_FT2_TO_KG_M2,
-            iyy * LB_FT2_TO_KG_M2,
-            izz * LB_FT2_TO_KG_M2,
-        )),
-        DVec3::new(cm_x_ft * FT_TO_M, 0.0, 0.0),
-    )
-    .with_t_parent_this(t_struct_to_body)
-}
-
-/// Per-body baseline definitions and named attachment points, ported from
-/// `Modified_data/mass/*.py` and `Modified_data/attach/*.py`. Shared with
-/// `crates/astrodyn_dynamics/tests/tier3_apollo_mass_tree.rs` (kept inline here
-/// to avoid pulling astrodyn_dynamics tests into the runner crate's dep graph).
-struct BodyIds {
-    cm: MassBodyId,
-    sm: MassBodyId,
-    lm: MassBodyId,
-    dm: MassBodyId,
-    s3: MassBodyId,
-    s2: MassBodyId,
-    s1: MassBodyId,
-    les: MassBodyId,
-}
-
-/// Apply the seven `Modified_data/attach/launch_stack.py` attachments
-/// to a freshly built tree.
-fn assemble_launch_stack(tree: &mut MassTree, ids: &BodyIds) {
-    tree.attach_aligned(
-        ids.dm,
-        "Ascent Module interface",
-        ids.lm,
-        "Descent Module interface",
-    );
-    tree.attach_aligned(ids.sm, "CM interface", ids.cm, "SM interface");
-    tree.attach_aligned(ids.s3, "LEM/SM/CM interface", ids.sm, "Stage 3 interface");
-    tree.attach_aligned(ids.lm, "Stage 3 interface", ids.s3, "LEM/SM/CM interface");
-    tree.attach_aligned(ids.s2, "Stage 3 interface", ids.s3, "Stage 2 interface");
-    tree.attach_aligned(ids.s1, "Stage 2 interface", ids.s2, "Stage 1 interface");
-    tree.attach_aligned(ids.les, "CM interface", ids.cm, "CM docking port");
-}
-
-/// `Modified_data/date_n_time/UTC_16Jul1969.py` — 1969-07-16 13:44:00 UTC,
-/// leap_sec_override = 4.2 s, tai_to_ut1_override = 0.0115221 - 4.2.
-fn apollo_time() -> SimulationTime {
-    // JD(1969-07-16 0h UT) = 2440418.5 → TJT = 418.0 (TJT = JD - 2440000.5).
-    // 13h44m = 49440 s = 0.572222... days.
-    let utc_tjt = 418.0 + (13.0 * 3600.0 + 44.0 * 60.0) / 86_400.0;
-    // SIM_Apollo overrides TAI-UTC to 4.2 s instead of the historical
-    // value (which differs at this epoch). Hand-roll the conversion so
-    // we don't rely on the leap-second table for this date.
-    let tai_tjt = utc_tjt + 4.2 / 86_400.0;
-    let mut time = SimulationTime::new(tai_tjt, astrodyn::default_leap_second_table());
-    // tai_to_ut1_override_val = 0.0115221 - 4.2 = UT1-TAI offset.
-    time.set_ut1_tai_offset(0.011_522_1 - 4.2);
-    time
 }
 
 /// Apollo CSV reference state at one logged timestamp.
@@ -275,381 +157,34 @@ fn load_apollo_reference() -> Vec<ApolloRef> {
     out
 }
 
-// ── Mass-tree event schedule (RUN_test/input.py:230..345) ────────────
+// ── Test setup helper ────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy)]
-enum Event {
-    DetachS1,
-    DetachS2,
-    DetachLes,
-    DetachS3,
-    DetachLm,    // also: print "LEM_Sep" + "Apollo"
-    AttachLmCm,  // attach lm under cm via "LM docking port" / "CM docking port"
-    DetachLm2,   // also: print "LM_Descent" + "Lunar_Orbit"
-    DetachDm,    // print "LM_Ascent"
-    AttachLmCm2, // attach lm again under cm — print "Lunar_Rendezvous"
-    DetachLm3,   // print "Return"
-    DetachSm,    // print "Entry" + "Final"
-}
+fn build_apollo_sim() -> (Simulation, ApolloTopology) {
+    let handles = apollo_trajectory_builder();
+    let mut sim = handles
+        .builder
+        .build()
+        .expect("apollo simulation must validate");
+    // `from_builder` allocates the integrated `cm` body's MassBodyId via
+    // `register_in_mass_tree(0, "cm")`. Resolve it now so the arena
+    // setup can register the 7 tree-only bodies + 14 mass points + 7
+    // launch_stack attaches on top.
+    let cm_id = sim
+        .body_mass_id(0)
+        .expect("cm body must be registered in mass tree by the builder");
+    let tree = sim.mass_tree.as_mut().expect("mass tree was just created");
+    let topology = setup_apollo_arena(tree, cm_id);
 
-const EVENTS: &[(f64, Event)] = &[
-    (1.0, Event::DetachS1),
-    (2.0, Event::DetachS2),
-    (3.0, Event::DetachLes),
-    (4.0, Event::DetachS3),
-    (5.0, Event::DetachLm),
-    (6.0, Event::AttachLmCm),
-    (7.0, Event::DetachLm2),
-    (8.0, Event::DetachDm),
-    (9.0, Event::AttachLmCm2),
-    (10.0, Event::DetachLm3),
-    (11.0, Event::DetachSm),
-];
+    // Sync the integrated cm body's mass from the fully-assembled tree
+    // composite, then flip its `body.trans` from `core_body` to
+    // `composite_body` (the integration variable).
+    sim.sync_body_mass_from_tree(0);
+    sim.convert_body_trans_core_to_composite(0);
 
-fn apply_event(sim: &mut Simulation, body_idx: usize, ids: &BodyIds, event: Event) {
-    match event {
-        Event::DetachS1 => sim.detach_subtree(body_idx, ids.s1),
-        Event::DetachS2 => sim.detach_subtree(body_idx, ids.s2),
-        Event::DetachLes => sim.detach_subtree(body_idx, ids.les),
-        Event::DetachS3 => sim.detach_subtree(body_idx, ids.s3),
-        Event::DetachLm | Event::DetachLm2 | Event::DetachLm3 => {
-            sim.detach_subtree(body_idx, ids.lm)
-        }
-        Event::DetachDm => sim.detach_subtree(body_idx, ids.dm),
-        Event::DetachSm => sim.detach_subtree(body_idx, ids.sm),
-        Event::AttachLmCm | Event::AttachLmCm2 => sim.attach_subtree_aligned(
-            body_idx,
-            ids.lm,
-            "LM docking port",
-            ids.cm,
-            "CM docking port",
-        ),
-    }
+    (sim, topology)
 }
 
 // ── Test ─────────────────────────────────────────────────────────────
-
-fn build_apollo_sim() -> (Simulation, usize, BodyIds) {
-    // Earth: 8x8 GGM05C non-spherical, with the Earth-RNP rotation model so
-    // the planet-fixed frame updates each step (matches JEOD's
-    // `earth_GGM05C_MET_RNP.sm`).
-    let earth_grav = astrodyn::gravity_fixtures::load_ggm05c();
-    let mu_moon = astrodyn::gravity_fixtures::load_moon_grail150_mu();
-    let mu_sun = astrodyn::gravity_fixtures::load_sun_spherical_mu();
-
-    // Note: SIM_Apollo's Modified_data/Earth/params.py overrides Earth mu
-    // to the historic 3.98600436e14 value, but `set_vehicle_grav_controls`
-    // doesn't propagate that override into the body's Earth grav control —
-    // the coefficient set's own mu is what matters. We use the GGM05C
-    // fixture's mu directly to stay consistent with the harmonics.
-
-    let mut sb = SimulationBuilder::new(apollo_time(), DT);
-
-    let earth = sb.add_source(
-        "Earth",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: earth_grav.mu,
-                model: GravityModel::SphericalHarmonics(Box::new(earth_grav)),
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: Some(DMat3::IDENTITY),
-            delta_c20: 0.0,
-            rotation_model: RotationModel::EarthRNP,
-            tidal_config: None,
-            planet_omega: OMEGA_EARTH,
-            central: true,
-            marker_only: false,
-        },
-    );
-    let moon = sb.add_source(
-        "Moon",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_moon,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-            marker_only: false,
-        },
-    );
-    let sun = sb.add_source(
-        "Sun",
-        GravitySourceEntry {
-            source: GravitySource {
-                mu: mu_sun,
-                model: GravityModel::PointMass,
-            },
-            position: astrodyn::Position::<astrodyn::RootInertial>::zero(),
-            velocity: astrodyn::Velocity::<astrodyn::RootInertial>::zero(),
-            t_inertial_pfix: None,
-            delta_c20: 0.0,
-            rotation_model: RotationModel::None,
-            tidal_config: None,
-            planet_omega: 0.0,
-            central: false,
-            marker_only: false,
-        },
-    );
-    sb.set_source_ephemeris(
-        moon,
-        astrodyn::EphemerisBody::Moon,
-        astrodyn::EphemerisBody::Earth,
-    );
-    sb.set_source_ephemeris(
-        sun,
-        astrodyn::EphemerisBody::Sun,
-        astrodyn::EphemerisBody::Earth,
-    );
-
-    // Mean solar activity per `Modified_data/Earth/soflx_mean.py`.
-    sb = sb.atmosphere(
-        AtmosphereConfig {
-            model: AtmosphereModel::Met(MetAtmosphere {
-                f10: 128.8,
-                f10b: 128.8,
-                geo_index: 15.7,
-                geo_index_type: GeoIndexType::Ap,
-            }),
-            r_eq: EARTH.shape.r_eq(),
-            r_pol: EARTH.shape.r_pol(),
-            planet_omega: OMEGA_EARTH,
-        },
-        earth,
-    );
-
-    // The body starts with CM-only mass; launch_stack assembly below
-    // augments it to the full-stack composite via `add_body_to_tree` +
-    // `sync_body_mass_from_tree`.
-    let cm_only_mass = apollo_mass(12_807.0, 8.7, 157_372.0, 64_624.0, 64_624.0, yaw_180());
-
-    // Initial attitude (sv_leo_lvlh.py): LVLH-aligned with Yaw_Pitch_Roll
-    // = [0, 0, 0]. For a circular LEO, LVLH-aligned bodies have angular
-    // velocity = -orbit-rate about body Y (matches CSV row 0:
-    // ang_vel_this[1] = -1.134e-3 rad/s). The CSV row 0 quaternion is
-    // the JEOD-computed scalar-first orientation of the LVLH frame
-    // relative to Earth.inertial at the epoch.
-    let csv = load_apollo_reference();
-    assert!(!csv.is_empty(), "apollo_trajectory.csv is empty");
-    let row0 = &csv[0];
-
-    sb.add_body(VehicleConfig {
-        trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
-            position: row0.position,
-            velocity: row0.velocity,
-        }),
-        rot: Some(astrodyn::typed_bridge::rot_raw_to_self_ref(
-            &(RotationalState {
-                quaternion: row0.quaternion,
-                ang_vel_body: row0.ang_vel_body,
-            }),
-        )),
-        mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(
-            &(cm_only_mass),
-        )),
-        gravity_controls: GravityControls {
-            controls: vec![
-                GravityControl::new_nonspherical(
-                    earth,
-                    GRAV_DEGREE,
-                    GRAV_ORDER,
-                    GravityGradient::Skip,
-                ),
-                GravityControl::new_third_body(moon),
-                GravityControl::new_third_body(sun),
-            ],
-        },
-        ..Default::default()
-    });
-
-    // astrodyn_runner uses the BSP for Moon/Sun ephemeris evaluation each
-    // step. Phase 1 SIM_Apollo runs are 12 s, well within DE405/DE421
-    // coverage.
-    let bsp_path = astrodyn::ephemeris_assets::de421_path();
-    assert!(
-        bsp_path.exists(),
-        "DE421 ephemeris missing at {}",
-        bsp_path.display()
-    );
-    let ephemeris =
-        astrodyn::Ephemeris::from_bsp(&bsp_path).expect("failed to load DE421 ephemeris");
-    sb = sb.ephemeris(ephemeris);
-
-    let mut sim = sb.build().expect("apollo simulation must validate");
-
-    // Register cm in the simulation's mass tree, then add the other 7
-    // bodies and attachment points directly on the tree (they are
-    // tree-only — never integrated as separate bodies, since after
-    // launch_stack assembly only the root cm is integrated).
-    let cm_id = sim.add_body_to_tree(0, "cm");
-    let tree = sim.mass_tree.as_mut().expect("mass tree was just created");
-
-    // Add the 7 non-cm bodies and their attachment points.
-    // Per `Modified_data/mass/*.py`: SM, S1, S2, S3 use identity
-    // struct→body rotation; LM (Ascent), DM, LES use yaw_180.
-    let sm = tree.add_body(
-        "sm".into(),
-        apollo_mass(
-            54_064.0,
-            12.3,
-            1_107_231.0,
-            1_235_227.0,
-            1_235_227.0,
-            DMat3::IDENTITY,
-        ),
-    );
-    let lm = tree.add_body(
-        "lm".into(),
-        apollo_mass(10_582.0, 5.45, 259_259.0, 155_822.0, 155_822.0, yaw_180()),
-    );
-    let dm = tree.add_body(
-        "dm".into(),
-        apollo_mass(25_640.0, 5.0, 628_180.0, 367_506.0, 367_506.0, yaw_180()),
-    );
-    let s3 = tree.add_body(
-        "s3".into(),
-        apollo_mass(
-            274_171.0,
-            30.65,
-            16_138_048.0,
-            29_532_558.0,
-            29_532_558.0,
-            DMat3::IDENTITY,
-        ),
-    );
-    let s2 = tree.add_body(
-        "s2".into(),
-        apollo_mass(
-            1_083_480.0,
-            40.75,
-            147_488_715.0,
-            223_676_545.0,
-            223_676_545.0,
-            DMat3::IDENTITY,
-        ),
-    );
-    let s1 = tree.add_body(
-        "s1".into(),
-        apollo_mass(
-            5_031_023.0,
-            69.0,
-            684_848_006.0,
-            2_338_482_378.0,
-            2_338_482_378.0,
-            DMat3::IDENTITY,
-        ),
-    );
-    let les = tree.add_body(
-        "les".into(),
-        apollo_mass(9_200.0, 16.25, 5_566.0, 205_231.0, 205_231.0, yaw_180()),
-    );
-
-    // CM points
-    tree.add_mass_point(
-        cm_id,
-        "SM interface",
-        DVec3::new(11.6 * FT_TO_M, 0.0, 0.0),
-        DMat3::IDENTITY,
-    );
-    tree.add_mass_point(
-        cm_id,
-        "CM docking port",
-        DVec3::new(4.0 * FT_TO_M, 0.0, 0.0),
-        yaw_180(),
-    );
-    // SM points
-    tree.add_mass_point(
-        sm,
-        "Stage 3 interface",
-        DVec3::new(-20.9 * FT_TO_M, 0.0, 0.0),
-        yaw_180(),
-    );
-    tree.add_mass_point(
-        sm,
-        "CM interface",
-        DVec3::new(24.6 * FT_TO_M, 0.0, 0.0),
-        DMat3::IDENTITY,
-    );
-    // LM points
-    tree.add_mass_point(
-        lm,
-        "LM docking port",
-        DVec3::new(10.9 * FT_TO_M, 0.0, 0.0),
-        DMat3::IDENTITY,
-    );
-    tree.add_mass_point(lm, "Descent Module interface", DVec3::ZERO, yaw_180());
-    tree.add_mass_point(
-        lm,
-        "Stage 3 interface",
-        DVec3::new(-10.0 * FT_TO_M, 0.0, 0.0),
-        yaw_180(),
-    );
-    // DM points
-    tree.add_mass_point(dm, "Ascent Module interface", DVec3::ZERO, DMat3::IDENTITY);
-    tree.add_mass_point(
-        dm,
-        "Stage 3 interface",
-        DVec3::new(-10.0 * FT_TO_M, 0.0, 0.0),
-        yaw_180(),
-    );
-    // S3 points
-    tree.add_mass_point(s3, "Stage 2 interface", DVec3::ZERO, yaw_180());
-    tree.add_mass_point(
-        s3,
-        "LEM/SM/CM interface",
-        DVec3::new(61.3 * FT_TO_M, 0.0, 0.0),
-        DMat3::IDENTITY,
-    );
-    // S2 points
-    tree.add_mass_point(s2, "Stage 1 interface", DVec3::ZERO, yaw_180());
-    tree.add_mass_point(
-        s2,
-        "Stage 3 interface",
-        DVec3::new(81.5 * FT_TO_M, 0.0, 0.0),
-        DMat3::IDENTITY,
-    );
-    // S1 points
-    tree.add_mass_point(
-        s1,
-        "Stage 2 interface",
-        DVec3::new(138.0 * FT_TO_M, 0.0, 0.0),
-        DMat3::IDENTITY,
-    );
-    // LES points
-    tree.add_mass_point(les, "CM interface", DVec3::ZERO, yaw_180());
-
-    let ids = BodyIds {
-        cm: cm_id,
-        sm,
-        lm,
-        dm,
-        s3,
-        s2,
-        s1,
-        les,
-    };
-    assemble_launch_stack(tree, &ids);
-
-    // Sync cm body's mass from the now-assembled tree composite.
-    sim.sync_body_mass_from_tree(0);
-
-    // SimulationBuilder set body.trans = row0 (JEOD's logged core_body
-    // at t=0, after launch_stack assembled the full Apollo stack).
-    // Our integration convention is body.trans = composite_body
-    // inertial state; convert by subtracting the kinematic offset
-    // through the now-fully-assembled mass tree.
-    sim.convert_body_trans_core_to_composite(0);
-
-    (sim, 0, ids)
-}
 
 // non-recipe: SIM_Apollo's launch-stack topology, JEOD English-unit
 // per-body mass data, and 11-event detach/attach schedule are
@@ -667,7 +202,7 @@ fn tier3_sim_apollo_trajectory() {
         csv.last().unwrap().time
     );
 
-    let (mut sim, body_idx, ids) = build_apollo_sim();
+    let (mut sim, topology) = build_apollo_sim();
 
     // Walk the simulation in 0.1-second log windows, applying the
     // mass-tree event at each integer-second boundary just before the
@@ -700,7 +235,11 @@ fn tier3_sim_apollo_trajectory() {
                     sim.step().expect("step failed");
                     current_t += DT;
                 }
-                apply_event(&mut sim, body_idx, &ids, event);
+                // Route the event through the shared recipe's SimContext
+                // dispatch so the runner-vs-Bevy parity wrapper consumes
+                // the same event-table and per-event arguments.
+                let ctx: &mut dyn SimContext = &mut sim;
+                apply_event(ctx, &topology, event);
                 event_iter.next();
             } else {
                 break;
@@ -719,12 +258,12 @@ fn tier3_sim_apollo_trajectory() {
             continue;
         }
 
-        let body = sim.body(body_idx);
+        let body = sim.body(0);
         // body.trans is the composite_body inertial integration state;
         // JEOD's reference CSV logs core_body, so derive it via the
         // mass tree (composite and core share body axes — only
         // position+velocity differ).
-        let (core_position, core_velocity) = sim.body_core_inertial(body_idx);
+        let (core_position, core_velocity) = sim.body_core_inertial(0);
         our_log.push(StateLog {
             time: reference.time,
             position: Some(core_position),
@@ -867,12 +406,12 @@ fn quat_angle_between(a: JeodQuat, b: JeodQuat) -> f64 {
 
 fn capture_lm_diag(
     sim: &Simulation,
-    ids: &BodyIds,
+    topology: &ApolloTopology,
     truth_rows: &[ApolloTruthRow],
     time: f64,
     event_label: &str,
 ) -> LmDiagSample {
-    let our = sim.subtree_composite_inertial(ids.lm);
+    let our = sim.subtree_composite_inertial(topology.lm);
     let truth = nearest_truth_at(truth_rows, time);
     let truth_quat = truth.lm.quaternion;
 
@@ -880,7 +419,7 @@ fn capture_lm_diag(
     // Even when the truth row has no s3, we still walk our own simulation
     // for s3 so the function is total; the comparison is conditioned on
     // truth.s3 being Some.
-    let our_s3 = sim.subtree_composite_inertial(ids.s3);
+    let our_s3 = sim.subtree_composite_inertial(topology.s3);
     let s3_err_pos = truth
         .s3
         .as_ref()
@@ -949,13 +488,19 @@ fn tier3_sim_apollo_lm_state_vs_truth() {
         truth_rows.last().unwrap().time
     );
 
-    let (mut sim, body_idx, ids) = build_apollo_sim();
+    let (mut sim, topology) = build_apollo_sim();
 
     let mut event_iter = EVENTS.iter().peekable();
     let mut current_t = 0.0_f64;
     let mut samples: Vec<LmDiagSample> = Vec::new();
 
-    samples.push(capture_lm_diag(&sim, &ids, &truth_rows, current_t, "init"));
+    samples.push(capture_lm_diag(
+        &sim,
+        &topology,
+        &truth_rows,
+        current_t,
+        "init",
+    ));
 
     let n_steps = (SIM_DURATION_S / DT).round() as usize;
     for _ in 0..n_steps {
@@ -964,7 +509,8 @@ fn tier3_sim_apollo_lm_state_vs_truth() {
         let mut applied = String::new();
         while let Some(&&(event_t, event)) = event_iter.peek() {
             if event_t <= current_t + 1e-9 {
-                apply_event(&mut sim, body_idx, &ids, event);
+                let ctx: &mut dyn SimContext = &mut sim;
+                apply_event(ctx, &topology, event);
                 if !applied.is_empty() {
                     applied.push('+');
                 }
@@ -977,7 +523,7 @@ fn tier3_sim_apollo_lm_state_vs_truth() {
         if !applied.is_empty() {
             samples.push(capture_lm_diag(
                 &sim,
-                &ids,
+                &topology,
                 &truth_rows,
                 current_t,
                 &applied,
@@ -985,16 +531,17 @@ fn tier3_sim_apollo_lm_state_vs_truth() {
         }
         sim.step().expect("step failed");
         current_t += DT;
-        samples.push(capture_lm_diag(&sim, &ids, &truth_rows, current_t, ""));
+        samples.push(capture_lm_diag(&sim, &topology, &truth_rows, current_t, ""));
     }
     // Sweep any trailing events scheduled at current_t (none today, but
     // guard the loop for future schedule edits).
     while let Some(&&(event_t, event)) = event_iter.peek() {
         if event_t <= current_t + 1e-9 {
-            apply_event(&mut sim, body_idx, &ids, event);
+            let ctx: &mut dyn SimContext = &mut sim;
+            apply_event(ctx, &topology, event);
             samples.push(capture_lm_diag(
                 &sim,
-                &ids,
+                &topology,
                 &truth_rows,
                 current_t,
                 event_short_label(event),

--- a/crates/astrodyn_verif_parity/src/bevy_context.rs
+++ b/crates/astrodyn_verif_parity/src/bevy_context.rs
@@ -118,6 +118,31 @@ impl<'w, P: Planet> BevySimContext<'w, P> {
         })
     }
 
+    fn entity_for_mass_id(&mut self, mass_id: astrodyn::MassBodyId, op: &str) -> Entity {
+        // Linear scan over body entities is the same shape as
+        // `staging_system`'s pre-event `id_to_entity` map builder. The
+        // scenarios that hit this surface (apollo: 1 dyn + 7 tree-only
+        // bodies) are small enough that the scan cost is negligible
+        // versus building a HashMap in the context constructor — the
+        // SimContext is created fresh per `pre_step` invocation, so any
+        // setup cost amortises poorly. Bevy `Query` against
+        // `&MassBodyIdC` is the canonical iterator; using the world's
+        // `query` helper avoids requiring callers to pre-pack the map
+        // alongside the body / source entity slices.
+        let mut q = self.world.query::<(Entity, &astrodyn_bevy::MassBodyIdC)>();
+        for (entity, body_id) in q.iter(self.world) {
+            if body_id.0 == mass_id {
+                return entity;
+            }
+        }
+        panic!(
+            "BevySimContext::{op}: mass_body_id {mass_id:?} has no matching ECS entity. \
+             Every mass-tree node referenced by a subtree event must be backed by an entity \
+             carrying `MassBodyIdC` — spawn a mass-only entity for tree-only mass bodies \
+             before firing the event."
+        );
+    }
+
     fn frame_entity(&self, source: Entity) -> Entity {
         self.world
             .get::<FrameEntityC>(source)
@@ -455,6 +480,129 @@ impl<P: Planet> SimContext for BevySimContext<'_, P> {
                 )
             });
         rot.0.q_inertial_body.as_witness().inner().to_glam()
+    }
+
+    fn detach_subtree(&mut self, subtree_root: astrodyn::MassBodyId) {
+        // Subtree-detach against the Bevy world: resolve the subtree
+        // root's `MassBodyId` to its backing entity (mass-only or
+        // dynamic) and fire the existing `DetachEvent` against it. The
+        // staging-system handler already walks up to the tree root,
+        // composes the rigid-body state via `propagate_forward`,
+        // captures the subtree's composite-body inertial state, and
+        // inserts `DetachedSubtreeStateC` so `step_detached_system`
+        // advances it ballistically — exactly mirroring the runner's
+        // `Simulation::detach_subtree` data flow. No new event needed.
+        let child = self.entity_for_mass_id(subtree_root, "detach_subtree");
+        let mut messages = self.world.resource_mut::<Messages<DetachEvent>>();
+        messages.write(DetachEvent { child });
+        // Remove the ECS-native `MassChildOf` edge on the detached
+        // subtree root so `propagate_state_from_root_system`'s post-
+        // detach walks stop deriving the subtree's pose from the
+        // now-stale arena topology. Mirrors the same removal in the
+        // single-body `BevySimContext::detach` sibling: the staging
+        // system updates the arena tree (the source of truth for the
+        // composite-mass and detach-shift kernels), and the
+        // ECS-component `MassChildOf` is kept in sync from the call
+        // site so the kinematic-walk and wrench-aggregation systems
+        // see the same shape.
+        self.world.entity_mut(child).remove::<MassChildOf>();
+    }
+
+    fn attach_subtree_aligned(
+        &mut self,
+        subtree_root: astrodyn::MassBodyId,
+        subtree_point: &str,
+        parent: astrodyn::MassBodyId,
+        parent_point: &str,
+    ) {
+        // Look up the named mass points in the live arena and reduce
+        // them to the structural-frame `(offset, t_parent_child)` pair
+        // the existing `AttachEvent` carries. The reduction is JEOD's
+        // canonical chain (`mass_attach.cc:103-115`): invert the
+        // subtree's point, apply the 180° docking yaw, then compose
+        // through the parent's point. Performing the lookup here keeps
+        // the Bevy adapter's `AttachEvent` shape unchanged — the
+        // staging-system handler doesn't need to know about named
+        // points, mirroring the runner where
+        // `MassTree::attach_aligned` calls `MassTree::attach` after
+        // the same reduction.
+        let child = self.entity_for_mass_id(subtree_root, "attach_subtree_aligned/child");
+        let parent_entity = self.entity_for_mass_id(parent, "attach_subtree_aligned/parent");
+        let (offset, t_parent_child) = {
+            let tree = &self.world.resource::<astrodyn_bevy::MassTreeR>().0;
+            let child_pt = tree
+                .find_mass_point(subtree_root, subtree_point)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "BevySimContext::attach_subtree_aligned: mass point '{subtree_point}' not \
+                     found on subtree body {subtree_root:?}. Declare the named attachment \
+                     point via `MassTreeR.0.add_mass_point(...)` before firing the event."
+                    )
+                });
+            let parent_pt = tree
+                .find_mass_point(parent, parent_point)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "BevySimContext::attach_subtree_aligned: mass point '{parent_point}' not \
+                     found on parent body {parent:?}. Declare the named attachment point via \
+                     `MassTreeR.0.add_mass_point(...)` before firing the event."
+                    )
+                });
+            // JEOD mass_attach.cc:103-115. The 180° yaw is JEOD's
+            // hardcoded docking convention: two attachment points face
+            // each other with opposite X/Y axes.
+            let inv_pos = -(child_pt.t_parent_this * child_pt.position);
+            let inv_t = child_pt.t_parent_this.transpose();
+            let t_yaw = DMat3::from_cols(
+                DVec3::new(-1.0, 0.0, 0.0),
+                DVec3::new(0.0, -1.0, 0.0),
+                DVec3::new(0.0, 0.0, 1.0),
+            );
+            let pos_after_yaw = t_yaw * inv_pos;
+            let offset = parent_pt.t_parent_this.transpose() * pos_after_yaw + parent_pt.position;
+            let t_parent_child = inv_t * t_yaw * parent_pt.t_parent_this;
+            (offset, t_parent_child)
+        };
+        let event = AttachEvent::<SelfRef, SelfRef> {
+            child,
+            parent: parent_entity,
+            offset: offset.m_at::<StructuralFrame<SelfRef>>(),
+            t_parent_child:
+                FrameTransform::<StructuralFrame<SelfRef>, StructuralFrame<SelfRef>>::from_matrix(
+                    t_parent_child,
+                ),
+        };
+        let mut messages = self
+            .world
+            .resource_mut::<Messages<AttachEvent<SelfRef, SelfRef>>>();
+        messages.write(event);
+        // `MassChildOf` is intentionally NOT installed here. The
+        // staging-system reads the **child's** `TranslationalStateC`
+        // for the combine kernel's child-side composite; if the
+        // pre_step inserted `MassChildOf` linking the child back to
+        // the parent, the same-tick `propagate_state_from_root_system`
+        // pass (which runs `.before(Environment)`, ahead of staging)
+        // would derive the child's `TranslationalStateC` from the
+        // parent's *pre-combine* state — overwriting the
+        // detached-subtree value `step_detached_system` had written
+        // and feeding the combine kernel garbage. Leaving the child
+        // as a tree root keeps `propagate_state_from_root_system` from
+        // touching its state, and staging gets the correct
+        // detached-subtree value for the combine input. The runner's
+        // `attach_subtree_aligned` faces no such timing because it
+        // reads the subtree's state from the
+        // `detached_subtrees` HashMap directly (a separate channel
+        // unaffected by per-tick frame-tree walks).
+        //
+        // The Bevy-side cost of not installing the edge: lm's
+        // `TranslationalStateC` (and any descendants') will not be
+        // refreshed by `propagate_state_from_root_system` next tick.
+        // Apollo's parity assertion only reads the integrated cm
+        // body's state, so the stale lm value is benign. Subsequent
+        // subtree mutations against lm walk the arena tree directly
+        // through `tree.parent()` / `tree.root_of()`, not the ECS
+        // `MassChildOf` chain — both `BevySimContext::detach_subtree`
+        // and `attach_subtree_aligned` resolve through the arena.
     }
 
     fn attach_to_frame(

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs
@@ -1,0 +1,534 @@
+//! Bevy ↔ runner parity for the SIM_Apollo `apollo_trajectory` 12-second
+//! launch-stack sequence (11 mass-tree events: 9 detaches + 2 attaches).
+//!
+//! Drives the same builder + arena setup the runner-side tier3 test
+//! consumes
+//! (`crates/astrodyn_verif_jeod/tests/tier3_sim_apollo_trajectory.rs`)
+//! through both runtimes — `astrodyn_runner::Simulation` and the Bevy
+//! `populate_app::<Earth>` bridge — and asserts bit-identical
+//! translational state at every reference-CSV checkpoint over the
+//! full 12 s window. Each of the eleven mass-tree events fires on both
+//! sides at the same tick via
+//! [`SimContext::detach_subtree`] /
+//! [`SimContext::attach_subtree_aligned`], routed through the runner's
+//! mass-tree mutation surface and the Bevy adapter's
+//! `AttachEvent`/`DetachEvent` bus respectively (the Bevy adapter
+//! resolves the `MassBodyId` to a mass-only entity and computes the
+//! named-mass-point reduction internally — see
+//! [`BevySimContext::attach_subtree_aligned`]).
+//!
+//! ## Topology mirroring
+//!
+//! Apollo's mass tree pairs one integrated body (`cm`) with seven
+//! tree-only mass bodies (`sm`, `lm`, `dm`, `s3`, `s2`, `s1`, `les`)
+//! plus fourteen named attachment points and seven launch-stack
+//! attaches — a shape the declarative `SimulationBuilder` doesn't
+//! model. Both runtimes augment their post-build arena via the shared
+//! [`setup_apollo_arena`] helper, which allocates the seven tree-only
+//! bodies in deterministic order so the two arenas end up with
+//! identical `MassBodyId` layouts. The Bevy side additionally spawns
+//! a mass-only entity (`MassBodyIdC` + `MassPropertiesC` only) for
+//! each tree-only body so the existing `DetachEvent`/`AttachEvent`
+//! staging path — which already supports mass-only attach participants
+//! — can address the subtree roots without any new event types.
+//!
+//! ## Comparison cadence
+//!
+//! The CSV cadence is 0.1 s (5 dt-ticks at `dt = 0.02 s`); the parity
+//! assertion runs at every checkpoint in `apollo_trajectory.csv`.
+//! Bit-identity at the CSV cadence implies bit-identity at every
+//! intermediate integration tick by the monotonic-divergence argument
+//! `VerificationCaseParityExt::run_and_assert_parity` uses (once two
+//! runtimes drift, they stay drifted), so a coarser checkpoint set
+//! is equivalent in detection strength to a per-tick scan.
+
+#![allow(
+    clippy::float_cmp,
+    reason = "bevy-parity tests assert bit-exact identity between runner and Bevy state fields"
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    reason = "Apollo recipe step counts and indices fit exactly in f64 mantissa and usize"
+)]
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use astrodyn::{typed_bridge, JeodQuat, MassBodyId, TranslationalState};
+use astrodyn_bevy::{
+    DynamicsConfigC, KinematicChildC, MassBodyIdC, MassChildOf, MassPropertiesC, MassTreeR,
+    RotationalStateC, SimulationBuilderBevyExt, TranslationalStateC,
+};
+use astrodyn_runner::{Simulation, SimulationBuilderExt};
+use astrodyn_verif_jeod::run_verification::sim_apollo_trajectory::{
+    apollo_trajectory_builder, apply_event, setup_apollo_arena, ApolloTopology, Event, DT, EVENTS,
+    SIM_DURATION_S,
+};
+use astrodyn_verif_jeod::verification::SimContext;
+use astrodyn_verif_parity::BevySimContext;
+use bevy::prelude::*;
+use glam::DVec3;
+
+/// Load every reference-CSV timestamp from `apollo_trajectory.csv`.
+/// Only column 0 (sim time) is consumed — the parity assertion never
+/// reads JEOD-logged state, so the per-row position / velocity / quat
+/// payload is irrelevant. Skipping the t=0 row matches the trajectory
+/// loop's "skip CSV row 0 (initial state — no integration yet)"
+/// convention.
+fn load_apollo_times() -> Vec<f64> {
+    let csv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace crate dir")
+        .join("astrodyn_verif_jeod")
+        .join("test_data")
+        .join("apollo_trajectory.csv");
+    assert!(
+        csv_path.exists(),
+        "apollo_trajectory.csv missing at {}. Generate with: cargo xtask regenerate-tier3",
+        csv_path.display(),
+    );
+    let content = std::fs::read_to_string(&csv_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", csv_path.display()));
+    let mut times = Vec::new();
+    for line in content.lines().skip(1) {
+        let first = line.split(',').next().unwrap_or("");
+        let t: f64 = first
+            .trim()
+            .parse()
+            .unwrap_or_else(|e| panic!("apollo_trajectory.csv: bad time column {first:?}: {e}"));
+        times.push(t);
+    }
+    times
+}
+
+/// Build the runner-side `Simulation` for the apollo trajectory: shared
+/// builder + arena setup + sync_body_mass_from_tree + core-to-composite
+/// conversion. Returns the simulation plus the topology so the lockstep
+/// driver can address subtree roots by `MassBodyId`.
+fn build_runner() -> (Simulation, ApolloTopology) {
+    let handles = apollo_trajectory_builder();
+    let mut sim = handles
+        .builder
+        .build()
+        .expect("apollo simulation must validate");
+    let cm_id = sim
+        .body_mass_id(0)
+        .expect("cm body must be registered in mass tree by the builder");
+    let tree = sim.mass_tree.as_mut().expect("mass tree was just created");
+    let topology = setup_apollo_arena(tree, cm_id);
+    sim.sync_body_mass_from_tree(0);
+    sim.convert_body_trans_core_to_composite(0);
+    (sim, topology)
+}
+
+/// Build the Bevy app for the apollo trajectory: same builder fed to
+/// `populate_app::<Earth>`, then mirror the runner's post-build
+/// arena-setup steps on the Bevy world (augment `MassTreeR`, spawn
+/// mass-only entities for the seven tree-only bodies, sync the cm
+/// entity's `MassPropertiesC` from the composite, shift its
+/// `TranslationalStateC<Earth>` from core_body to composite_body).
+///
+/// Returns the app, the cm body entity, and the topology — bit-identical
+/// to the runner's `MassBodyId` layout because both adapters allocate
+/// `MassBodyId`s in the same order through the same
+/// [`setup_apollo_arena`] helper.
+fn build_bevy_app() -> (App, Entity, ApolloTopology) {
+    let handles_runner = apollo_trajectory_builder();
+    // Set up Bevy app from the same `SimulationBuilder`.
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    let scenario_handles = handles_runner
+        .builder
+        .populate_app::<astrodyn::Earth>(&mut app)
+        .expect("populate_app under <Earth>");
+    // `MinimalPlugins` does not auto-run `Startup`; the parity loop
+    // drives `FixedUpdate` directly. Trigger Startup so per-source
+    // frame trees are wired before the first integration tick.
+    app.world_mut().run_schedule(Startup);
+
+    let cm_entity = scenario_handles.body_entities[0];
+    let cm_id = app
+        .world()
+        .get::<MassBodyIdC>(cm_entity)
+        .expect("cm entity carries MassBodyIdC after populate_app")
+        .0;
+
+    // Augment the live arena with the seven tree-only bodies + named
+    // mass points + launch-stack attaches.
+    let topology = {
+        let mut tree_r = app.world_mut().resource_mut::<MassTreeR>();
+        setup_apollo_arena(&mut tree_r.0, cm_id)
+    };
+
+    // Spawn mass-only entities for the seven tree-only mass bodies.
+    // The staging-system `bodies` query filters on `MassBodyIdC` +
+    // `MassPropertiesC`; both components are sufficient for an entity
+    // to participate in attach / detach events as a mass-only body
+    // (no `DynamicsConfigC` / no `TranslationalStateC` — the
+    // staging-system carve-out at integration.rs:1700 documents the
+    // legitimate `MassBody`-without-`DynBody` shape this matches).
+    // Read the core mass for each tree-only body from the arena so the
+    // ECS `MassPropertiesC` mirrors the arena's `core_properties` — the
+    // staging system reads from the arena (not `MassPropertiesC`) for
+    // the composite-state walk, so this is for the kernel-input read on
+    // the child side of `attach_subtree_aligned` (the algorithm reads
+    // `subtree_composite_props = tree.get(subtree_root_id).composite_properties`
+    // before the topology mutation — that's an arena read; the bevy
+    // adapter's staging system mirrors the same arena reads).
+    // Spawn an entity for each of the seven tree-only mass bodies
+    // carrying the **full** state component set: `MassBodyIdC`,
+    // `MassPropertiesC`, `TranslationalStateC<Earth>`,
+    // `RotationalStateC`, plus the `KinematicChildC` integrator
+    // filter. The state components start at zero / identity; per-tick
+    // `propagate_state_from_root_system` overwrites them from the
+    // integrated cm root every step, so the seed values are
+    // immaterial — the same is true on the runner side, where the
+    // tree-only bodies have no `SimBody.trans` / `body.rot` (they
+    // live in `MassTree` alone and ride the integrated root's state
+    // through the arena composition kernel).
+    //
+    // `KinematicChildC` is mandatory: without it,
+    // `integration_system` would also visit these entities each
+    // tick, doubling the gravity reads against the cm root. The
+    // marker mirrors `wrench_aggregation_system`'s auto-insert on
+    // non-root nodes of a `MassChildOf` chain, just installed
+    // explicitly here because the apollo recipe never produces a
+    // tick where the wrench walk would see all eight bodies
+    // simultaneously (the very first staging tick already detaches
+    // s1).
+    let tree_only = [
+        topology.sm,
+        topology.lm,
+        topology.dm,
+        topology.s3,
+        topology.s2,
+        topology.s1,
+        topology.les,
+    ];
+    let mut mass_id_to_entity: std::collections::HashMap<MassBodyId, Entity> =
+        std::collections::HashMap::new();
+    mass_id_to_entity.insert(topology.cm, cm_entity);
+    for &mass_id in &tree_only {
+        let core = {
+            let tree_r = app.world().resource::<MassTreeR>();
+            tree_r.0.get(mass_id).core_properties
+        };
+        let entity = app
+            .world_mut()
+            .spawn((
+                MassBodyIdC(mass_id),
+                MassPropertiesC(typed_bridge::mass_raw_to_self_ref(&core)),
+                TranslationalStateC::<astrodyn::Earth>::default(),
+                RotationalStateC::default(),
+                DynamicsConfigC::default(),
+                KinematicChildC,
+            ))
+            .id();
+        mass_id_to_entity.insert(mass_id, entity);
+    }
+
+    // Install `MassChildOf` Relations to mirror the arena's
+    // parent↔child topology, taking the offset and rotation from
+    // each body's `structure_point`. The Bevy adapter's
+    // `composite_mass_system` slow path activates when at least one
+    // `MassChildOf` edge is present; without these edges the fast
+    // path activates and (post-staging detach) reverts cm's
+    // `MassPropertiesC` from the composite-after-detach back to the
+    // stale core seeded at first sight (the cache mismatch the
+    // staging system's `bypass_change_detection` write deliberately
+    // leaves behind). Installing the edges so composite_mass_system
+    // stays on the slow path keeps the Bevy-side composite in
+    // lock-step with the runner's `Simulation::sync_body_mass_from_tree`
+    // after every event.
+    let all_ids = [
+        topology.cm,
+        topology.sm,
+        topology.lm,
+        topology.dm,
+        topology.s3,
+        topology.s2,
+        topology.s1,
+        topology.les,
+    ];
+    for &mass_id in &all_ids {
+        let edge = {
+            let tree_r = app.world().resource::<MassTreeR>();
+            tree_r.0.parent(mass_id).map(|parent_id| {
+                let sp = tree_r.0.get(mass_id).structure_point;
+                (parent_id, sp.position, sp.t_parent_this)
+            })
+        };
+        if let Some((parent_id, offset, t_parent_child)) = edge {
+            let parent_entity = mass_id_to_entity[&parent_id];
+            let child_entity = mass_id_to_entity[&mass_id];
+            app.world_mut()
+                .entity_mut(child_entity)
+                .insert(MassChildOf::with_rotation(
+                    parent_entity,
+                    offset,
+                    t_parent_child,
+                ));
+        }
+    }
+
+    // Cm's `MassPropertiesC` is NOT manually overwritten with the
+    // composite here: the Bevy adapter's `composite_mass_system`
+    // walks `MassChildOf` chains from per-entity `CoreMassPropertiesC`
+    // each tick and writes the recomputed composite into
+    // `MassPropertiesC` automatically. The cm entity was spawned
+    // with its CORE mass (cm-only) via `populate_app`, and the
+    // tree-only entities just spawned above carry their own core
+    // masses — feeding the slow-path Steiner accumulation exactly
+    // the shape the arena tree holds. Manually writing the composite
+    // here would double-count (the slow-path walk would Steiner-shift
+    // the children's mass on top of an already-composite cm core).
+
+    // Mirror `Simulation::convert_body_trans_core_to_composite(0)`: the
+    // builder seeded `TranslationalStateC<Earth>` with the CSV row-0
+    // core_body inertial state; convert in place to composite_body.
+    {
+        let (cw_inertial, dvel_inertial) = {
+            let tree_r = app.world().resource::<MassTreeR>();
+            let node = tree_r.0.get(cm_id);
+            let cw_struct = node.core_wrt_composite.position;
+            let t_struct_to_body = node.composite_properties.t_parent_this;
+            let cw_body = t_struct_to_body * cw_struct;
+            let rot = app
+                .world()
+                .get::<RotationalStateC>(cm_entity)
+                .expect("cm carries RotationalStateC");
+            let body_quat = rot.0.q_inertial_body.to_jeod_quat();
+            let t_inertial_to_body = body_quat.left_quat_to_transformation();
+            let t_body_to_inertial = t_inertial_to_body.transpose();
+            let cw_inertial = t_body_to_inertial * cw_body;
+            let omega_body = rot.0.ang_vel_body.raw_si();
+            let dvel_inertial = t_body_to_inertial * omega_body.cross(cw_body);
+            (cw_inertial, dvel_inertial)
+        };
+        let mut entity = app.world_mut().entity_mut(cm_entity);
+        let mut trans = entity
+            .get_mut::<TranslationalStateC<astrodyn::Earth>>()
+            .expect("cm carries TranslationalStateC<Earth>");
+        // composite = core − cw_inertial; subtract the rigid-body
+        // ω × r contribution on velocity. All values stay in the body's
+        // integration frame, so the relabel-only `from_raw_si` lift
+        // matches the runner's `Position::<IntegrationFrame>::from_raw_si`.
+        let new_pos = trans.0.position.raw_si() - cw_inertial;
+        let new_vel = trans.0.velocity.raw_si() - dvel_inertial;
+        *trans = TranslationalStateC::from(typed_bridge::trans_raw_to_root(&TranslationalState {
+            position: new_pos,
+            velocity: new_vel,
+        }));
+    }
+
+    (app, cm_entity, topology)
+}
+
+/// Step the Bevy app by exactly one `dt` and assert the runner stayed
+/// in lockstep (advance the same `dt` on the runner separately).
+fn step_bevy(app: &mut App) {
+    app.world_mut()
+        .resource_mut::<Time<Fixed>>()
+        .advance_by(Duration::from_secs_f64(DT));
+    app.world_mut().run_schedule(FixedUpdate);
+}
+
+/// Apply one Apollo event to both runtimes through the SimContext
+/// surface. The runner forwards to `Simulation::detach_subtree` /
+/// `attach_subtree_aligned`; the Bevy adapter writes an
+/// `AttachEvent`/`DetachEvent` onto the message bus that the next
+/// `FixedUpdate`'s `staging_system` drains.
+fn apply_event_both<P: astrodyn::Planet>(
+    runner: &mut Simulation,
+    app: &mut App,
+    body_entities: &[Entity],
+    topology: &ApolloTopology,
+    event: Event,
+) {
+    {
+        let ctx: &mut dyn SimContext = runner;
+        apply_event(ctx, topology, event);
+    }
+    {
+        let world = app.world_mut();
+        // `BevySimContext::new` takes parallel slices of source +
+        // body entities. The apollo recipe doesn't drive any source
+        // operations from the SimContext, so the source slice is an
+        // empty placeholder.
+        let mut ctx = BevySimContext::<P>::new(world, &[], body_entities);
+        apply_event(&mut ctx, topology, event);
+    }
+}
+
+/// Read the runner-side cm composite translational state (raw glam).
+fn runner_cm_trans_raw(sim: &Simulation) -> (DVec3, DVec3) {
+    let trans = sim.body(0).trans;
+    (trans.position.raw_si(), trans.velocity.raw_si())
+}
+
+/// Read the Bevy-side cm composite translational state (raw glam).
+fn bevy_cm_trans_raw(app: &App, cm: Entity) -> (DVec3, DVec3) {
+    let trans = app
+        .world()
+        .get::<TranslationalStateC<astrodyn::Earth>>(cm)
+        .expect("cm entity carries TranslationalStateC<Earth>");
+    (trans.0.position.raw_si(), trans.0.velocity.raw_si())
+}
+
+/// Read the runner-side cm composite rotational state (raw glam).
+fn runner_cm_rot_raw(sim: &Simulation) -> (JeodQuat, DVec3) {
+    let body = sim.body(0);
+    let rot = body.rot.as_ref().expect("cm carries RotationalState");
+    let untyped = typed_bridge::rot_typed_to_raw(rot);
+    (untyped.quaternion, untyped.ang_vel_body)
+}
+
+/// Read the Bevy-side cm composite rotational state (raw glam).
+fn bevy_cm_rot_raw(app: &App, cm: Entity) -> (JeodQuat, DVec3) {
+    let rot = app
+        .world()
+        .get::<RotationalStateC>(cm)
+        .expect("cm entity carries RotationalStateC");
+    let untyped = typed_bridge::rot_typed_to_raw(&rot.0);
+    (untyped.quaternion, untyped.ang_vel_body)
+}
+
+fn assert_bit_eq_vec(case: &str, t: f64, label: &str, runner: DVec3, bevy: DVec3) {
+    for i in 0..3 {
+        assert!(
+            runner[i].to_bits() == bevy[i].to_bits(),
+            "{case} bit-parity broke at t = {t:.6}s on {label}[{i}]:\n  \
+             runner = {runner_v} (bits = {runner_bits:#018x})\n  \
+             bevy   = {bevy_v} (bits = {bevy_bits:#018x})",
+            runner_v = runner[i],
+            bevy_v = bevy[i],
+            runner_bits = runner[i].to_bits(),
+            bevy_bits = bevy[i].to_bits(),
+        );
+    }
+}
+
+fn assert_bit_eq_quat(case: &str, t: f64, runner: JeodQuat, bevy: JeodQuat) {
+    for i in 0..4 {
+        assert!(
+            runner.data[i].to_bits() == bevy.data[i].to_bits(),
+            "{case} bit-parity broke at t = {t:.6}s on quat[{i}]:\n  \
+             runner = {runner_v} (bits = {runner_bits:#018x})\n  \
+             bevy   = {bevy_v} (bits = {bevy_bits:#018x})",
+            runner_v = runner.data[i],
+            bevy_v = bevy.data[i],
+            runner_bits = runner.data[i].to_bits(),
+            bevy_bits = bevy.data[i].to_bits(),
+        );
+    }
+}
+
+#[test]
+fn bevy_parity_apollo_trajectory() {
+    let csv_times = load_apollo_times();
+    assert!(
+        (csv_times.last().copied().unwrap_or(0.0) - SIM_DURATION_S).abs() < 0.05,
+        "apollo_trajectory.csv last time {} disagrees with SIM_Apollo terminate_time={SIM_DURATION_S}",
+        csv_times.last().copied().unwrap_or(0.0),
+    );
+
+    let (mut runner, runner_topology) = build_runner();
+    let (mut app, cm_entity, bevy_topology) = build_bevy_app();
+    // Both arenas allocate ids in the same order through the shared
+    // `setup_apollo_arena`; check explicitly so a future refactor that
+    // diverges the two adapters' build orders fails here rather than
+    // at a confusing per-event arena lookup.
+    assert_eq!(
+        runner_topology.cm, bevy_topology.cm,
+        "cm MassBodyId mismatch between runtimes"
+    );
+    assert_eq!(
+        runner_topology.sm, bevy_topology.sm,
+        "sm MassBodyId mismatch between runtimes"
+    );
+    assert_eq!(
+        runner_topology.lm, bevy_topology.lm,
+        "lm MassBodyId mismatch between runtimes"
+    );
+    assert_eq!(
+        runner_topology.s3, bevy_topology.s3,
+        "s3 MassBodyId mismatch between runtimes"
+    );
+    let topology = runner_topology;
+
+    // Sanity check: at t = 0, both runtimes hold the same cm composite
+    // state (the bevy-side core-to-composite conversion above mirrors
+    // the runner's `convert_body_trans_core_to_composite`).
+    let (r_pos0, r_vel0) = runner_cm_trans_raw(&runner);
+    let (b_pos0, b_vel0) = bevy_cm_trans_raw(&app, cm_entity);
+    assert_bit_eq_vec("apollo_trajectory (init)", 0.0, "position", r_pos0, b_pos0);
+    assert_bit_eq_vec("apollo_trajectory (init)", 0.0, "velocity", r_vel0, b_vel0);
+
+    let body_entities = vec![cm_entity];
+    let mut event_iter = EVENTS.iter().peekable();
+    let mut current_t = 0.0_f64;
+
+    // Iterate the reference timestamps so the lockstep checkpoint
+    // cadence is identical to the runner-vs-JEOD tier3 test. Per-step
+    // structure of one iteration, mirroring JEOD's `add_read(t)`
+    // semantics (event fires at END of cycle ending at t):
+    //
+    //   1. Step both runtimes up to `reference_t` under the
+    //      currently-active mass-tree topology.
+    //   2. Compare bit-identity *before* firing any event at
+    //      `reference_t`. This is the integrator-output instant at
+    //      end of cycle `[reference_t - DT, reference_t]`; the
+    //      pre-event state is what the runner-vs-JEOD CSV row at the
+    //      previous reference time integrated forward to, and is the
+    //      naturally synchronised point between the two runtimes
+    //      (runner has not yet detached; bevy has nothing queued).
+    //   3. Fire events scheduled at `reference_t` through both
+    //      runtimes: runner detaches / attaches synchronously, bevy
+    //      queues `DetachEvent` / `AttachEvent` onto the message bus.
+    //
+    // The bevy queue is drained at the TOP of the next iteration's
+    // first `FixedUpdate` (staging_system runs before integration),
+    // so by the next comparison point both runtimes have applied
+    // the event AND integrated one tick under the post-event
+    // topology — matching the runner's "synchronous detach +
+    // integrate-next-cycle" flow tick-for-tick.
+    for &reference_t in csv_times.iter().skip(1) {
+        // Step both runtimes up to the reference timestamp.
+        while current_t + DT * 0.5 < reference_t {
+            runner.step().expect("runner step failed");
+            step_bevy(&mut app);
+            current_t += DT;
+        }
+
+        // Compare BEFORE firing any event scheduled at `reference_t`.
+        let (r_pos, r_vel) = runner_cm_trans_raw(&runner);
+        let (b_pos, b_vel) = bevy_cm_trans_raw(&app, cm_entity);
+        assert_bit_eq_vec("apollo_trajectory", reference_t, "position", r_pos, b_pos);
+        assert_bit_eq_vec("apollo_trajectory", reference_t, "velocity", r_vel, b_vel);
+        let (r_q, r_w) = runner_cm_rot_raw(&runner);
+        let (b_q, b_w) = bevy_cm_rot_raw(&app, cm_entity);
+        assert_bit_eq_quat("apollo_trajectory", reference_t, r_q, b_q);
+        assert_bit_eq_vec("apollo_trajectory", reference_t, "ang_vel", r_w, b_w);
+
+        // Fire events scheduled at exactly this reference time.
+        // `current_t` lands on `reference_t` within the half-DT loop-
+        // exit slack; the event-firing condition is the same one the
+        // runner-side tier3 test uses (event_t <= reference_t and
+        // strictly above the previous current_t).
+        while let Some(&&(event_t, event)) = event_iter.peek() {
+            if event_t <= current_t + 1e-9 {
+                apply_event_both::<astrodyn::Earth>(
+                    &mut runner,
+                    &mut app,
+                    &body_entities,
+                    &topology,
+                    event,
+                );
+                event_iter.next();
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -40,26 +40,17 @@ use std::path::Path;
 /// satisfy multiple closely-related tier3 topics, which is why the
 /// raw file counts do not need to match 1:1.
 const DEFERRED_GAPS: &[(&str, &str)] = &[
-    // ── apollo_trajectory: 12 s SIM_Apollo init sim with 11
-    //    mass-tree attach/detach events scheduled at integer seconds.
-    //    Body integrates in Earth-inertial (single-planet) so the
-    //    bridge generic suffices, but a parity wrapper needs the
-    //    scenario rebuilt as a `SimulationBuilder` (the tier3 test
-    //    uses direct `Simulation::add_*` + `Simulation::detach_subtree`
-    //    / `attach_subtree_aligned` APIs) plus a `pre_step` closure
-    //    that mirrors the 11-event sequence onto both runtimes via
-    //    `BevySimContext::attach` / `detach`. Out of scope for this
-    //    landing — the recipe-factory + pre-step plumbing is the
-    //    same shape as the other deferred `pre_step` rows below.
-    (
-        "apollo_trajectory",
-        "SIM_Apollo 12 s init sim with 11 mass-tree events — needs a \
-         SimulationBuilder-shaped recipe factory + pre_step closure to \
-         drive the attach/detach sequence through BevySimContext on \
-         both runtimes; the underlying physics is single-planet \
-         (Earth-inertial) so the existing `populate_app::<Earth>` is \
-         sufficient.",
-    ),
+    // `apollo_trajectory` covered by
+    // `bevy_parity_apollo_trajectory.rs`: shared `apollo_trajectory`
+    // recipe builds the SimulationBuilder once, the 11 mass-tree
+    // events fire through `SimContext::detach_subtree` /
+    // `attach_subtree_aligned` on both runtimes (the runner
+    // dispatches to `Simulation::detach_subtree` /
+    // `attach_subtree_aligned`; the Bevy adapter fires the existing
+    // `DetachEvent` / `AttachEvent` against the mass-only entities
+    // it spawns for the seven tree-only stack bodies). Listed here
+    // for the audit trail since this was the headline blocker the
+    // prior #413 partial close left open.
     // ── Pre-recipe tier3 siblings: the `VerificationCase` factory
     //    doesn't exist yet, so the parity trait has nothing to drive.
     //    Recipe migration is tracked as a follow-up to #389. Each


### PR DESCRIPTION
## Summary

Closes #413's last outstanding entry — the SIM_Apollo 12 s launch-stack sequence with 11 mass-tree events (9 detaches + 2 attaches) — and the last multi-planet topic from #490 (audit H-03). Bit-identical between `astrodyn_runner` and the Bevy `populate_app::<Earth>` bridge at every reference-CSV checkpoint over the full 12 s window.

### New API surface

- **`SimContext::detach_subtree(MassBodyId)`** + **`SimContext::attach_subtree_aligned(subtree_root, subtree_point, parent, parent_point)`** trait methods (default-panic, source-compatible with existing impls).
- **Runner-side impl**: forwards to `Simulation::detach_subtree` / `attach_subtree_aligned`. Resolves the integrated body index via an arena root walk; falls back to any registered integrated body when the tree root is a detached subtree (the `parent_is_integrated` branch of the runner algorithm reads from `detached_subtrees` in that case).
- **Bevy-side impl** (`BevySimContext`): resolves `MassBodyId` to its backing mass-only entity via a `MassBodyIdC` query, looks up the named mass points in `MassTreeR` to derive the structural-frame offset / rotation per the `MassTree::attach_aligned` chain (`mass_attach.cc:103-115`), and fires the existing `AttachEvent` / `DetachEvent` — **no new staging events needed**. Detach also removes the ECS `MassChildOf` edge to keep the kinematic walk in sync with the arena.

### Shared recipe

- **`run_verification::sim_apollo_trajectory`** new module: `apollo_trajectory_builder` (`SimulationBuilder` with the single integrated cm body) + `setup_apollo_arena(&mut MassTree, cm_id) -> ApolloTopology` (adds the 7 tree-only mass bodies, 14 named mass points, 7 launch_stack aligned attaches in deterministic order — both runtimes get the same `MassBodyId` layout). Both the runner-side `tier3_sim_apollo_trajectory` test and the new parity wrapper consume the same recipe + `apply_event` dispatch.

### Bevy-side mass-tree mirroring

The Bevy adapter's `composite_mass_system` fast-path relies on a `MassChildOf` chain to keep `CoreMassPropertiesC` honest, so the parity wrapper spawns mass-only entities for the 7 tree-only stack bodies carrying the full state component set (`TranslationalStateC<Earth>` / `RotationalStateC` seeded zero, derived each tick by `propagate_state_from_root_system`) plus `KinematicChildC` + `MassChildOf` mirroring the arena edges. `MassChildOf` is removed on `detach_subtree` and intentionally **not** reinstalled on `attach_subtree_aligned`: re-installing it in `pre_step` would let the same-tick `propagate_state_from_root_system` pass (which runs `.before(Environment)`, ahead of staging) overwrite the child's `TranslationalStateC` with values derived from the parent's pre-combine state, feeding garbage to the combine kernel.

### Coverage updates

- `DEFERRED_GAPS` drops `apollo_trajectory`.
- `parity_coverage` meta-test accepts the new shape.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_)'` — 1700 passed, 225 skipped (tier 3)
- [x] `cargo nextest run -p astrodyn_verif_parity --test bevy_parity_apollo_trajectory` — bit-identical
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — meta-test passes
- [x] Canonical regressions all bit-identical: `bevy_parity_chained_attach_reroot`, `bevy_parity_mass_attach_detach`, `bevy_parity_apollo8_eci_integ`, `bevy_parity_earth_moon`, `bevy_parity_mars_orbit`
- [x] `cargo nextest run -p astrodyn_verif_jeod --test tier3_sim_apollo_trajectory` — runner-side passes after the recipe refactor (residual budgets unchanged)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_bypass_deps.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`

Closes #413. Closes #490 (audit H-03) — this was the last outstanding multi-planet-frame entry on the H-03 list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)