### PR TITLE
[#562] Bevy schedule ambiguity audit feature + 8 ordering edges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,39 @@ jobs:
       - name: Run all bevy_parity_* tests
         run: cargo nextest run --workspace -E 'test(bevy_parity)'
 
+  schedule-audit:
+    # Regression fence on Bevy schedule ambiguities. The
+    # `astrodyn_bevy/schedule_audit` feature configures every
+    # `AstrodynPlugin`-touched schedule with
+    # `ScheduleBuildSettings { ambiguity_detection: LogLevel::Error, .. }`,
+    # so any pair of systems with conflicting component / resource access
+    # and no explicit `.before` / `.after` / `.ambiguous_with` edge
+    # panics on App build. The job exercises that gate against every
+    # example (one App build per example) and every `astrodyn_bevy` unit
+    # test (each `App::new()` site re-validates). Issue #562 introduced
+    # the feature; future PRs that add a system without an ordering
+    # edge fail loudly here instead of producing intermittent ULP drift
+    # at runtime.
+    #
+    # Examples cover the single-planet (Earth) and multi-planet
+    # (Earth + Moon + Sun) registration paths. `cargo nextest`
+    # exercises the unit-test App-build sites.
+    name: Schedule ambiguity audit (LogLevel::Error)
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Smoke-run examples under schedule_audit
+        run: |
+          cargo run -p astrodyn_bevy --features schedule_audit --example kepler_orbit -- --steps 1
+          cargo run -p astrodyn_bevy --features schedule_audit --example typed_mission -- --steps 1
+          cargo run -p astrodyn_bevy --features schedule_audit --example multi_body_scenario -- --steps 1
+      - name: Run astrodyn_bevy unit tests under schedule_audit
+        run: cargo nextest run -p astrodyn_bevy --features schedule_audit
+
   test-tier3:
     name: Test (Tier 3 fast)
     runs-on: ubuntu-latest

--- a/crates/astrodyn_bevy/Cargo.toml
+++ b/crates/astrodyn_bevy/Cargo.toml
@@ -10,6 +10,17 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+# Promote Bevy schedule ambiguity detection to `LogLevel::Error` on every
+# schedule the plugin populates. Any unordered conflicting access between
+# two systems panics on `App` build with the offending pair named.
+# Off by default — production builds keep Bevy's default
+# `LogLevel::Ignore`, which has zero runtime cost. The dedicated
+# `schedule-audit` CI job (`.github/workflows/ci.yml`) exercises the full
+# test suite with this feature on as a regression fence against future
+# additions that introduce a new ambiguity. See issue #562.
+schedule_audit = ["bevy/debug"]
+
 [dependencies]
 astrodyn = { path = "../..", version = "0.1.0" }
 glam = { workspace = true }

--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -527,6 +527,18 @@ impl Plugin for AstrodynPlugin {
                 // the frame-tree wiring.
                 validation::validate_jeod_invariants::<astrodyn::Earth>
                     .after(systems::register_body_frames_system::<astrodyn::Earth>)
+                    // Validator reads `MassPropertiesC`, `RotationalStateC`,
+                    // `TranslationalStateC<Earth>` to check JEOD invariants; it
+                    // must observe the post-update state, after
+                    // `body_action_system` has applied any queued state /
+                    // mass replacements and after `mass_update_system` +
+                    // `composite_mass_system` have refreshed the
+                    // per-entity and composite mass caches. Without these
+                    // edges the validator's read race with those writers
+                    // gives indeterminate ordering. See #562.
+                    .after(body_action::body_action_system::<astrodyn::Earth>)
+                    .after(systems::mass_update_system)
+                    .after(mass_tree::composite_mass_system)
                     .before(AstrodynSet::EphemerisUpdate),
                 // After ephemeris_update_system writes new source
                 // position / velocity, mirror the values into the
@@ -537,9 +549,28 @@ impl Plugin for AstrodynPlugin {
                     .in_set(AstrodynSet::EphemerisUpdate)
                     .after(systems::ephemeris_update_system::<astrodyn::Earth>)
                     .after(systems::planet_fixed_rotation_system::<astrodyn::Earth>),
-                // Planet-fixed rotation (RNP)
+                // Planet-fixed rotation (RNP).
+                //
+                // The `Query<&mut FrameRotC>` / `Query<&mut FrameAngVelC>`
+                // accesses are structurally disjoint by entity from the
+                // four `*_joint_kinematics_system`s in the same set:
+                // this system writes only to the planet's `PfixFrameEntityC`
+                // target (one entity per planet), while the joint
+                // kinematics systems write only to entities carrying a
+                // `JointKinematicsC` / `SinusoidalJointKinematicsC` /
+                // `ClosureJointKinematicsC` / `MultiDofJointKinematicsC`
+                // component (joint frame entities). No entity carries
+                // both `PfixFrameEntityC` (as a target) and a joint
+                // kinematics component, so the writes never collide.
+                // Marked `.ambiguous_with` because an explicit
+                // `.before/.after` would imply an ordering relationship
+                // the physics does not require. See #562.
                 systems::planet_fixed_rotation_system::<astrodyn::Earth>
-                    .in_set(AstrodynSet::EphemerisUpdate),
+                    .in_set(AstrodynSet::EphemerisUpdate)
+                    .ambiguous_with(systems::joint_kinematics_system)
+                    .ambiguous_with(systems::sinusoidal_joint_kinematics_system)
+                    .ambiguous_with(systems::closure_joint_kinematics_system)
+                    .ambiguous_with(systems::multi_dof_joint_kinematics_system),
                 // Ephemeris position updates (DE4xx)
                 systems::ephemeris_update_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::EphemerisUpdate),
@@ -594,6 +625,17 @@ impl Plugin for AstrodynPlugin {
                 // frame entity reflects the post-step body state.
                 systems::step_detached_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::Integration)
+                    // Structurally disjoint by entity from `integration_system`:
+                    // the integrator's body query filters
+                    // `Without<DetachedSubtreeStateC>`, while this system's
+                    // body query requires `&mut DetachedSubtreeStateC`.
+                    // No entity is in both populations, so the
+                    // `Query<&mut TranslationalStateC<P>>` conflict
+                    // Bevy detects has no runtime collision.
+                    // `.ambiguous_with` rather than `.before/.after`
+                    // because the design intent (see the block comment
+                    // above) is that the two can run in parallel. See #562.
+                    .ambiguous_with(systems::integration_system::<astrodyn::Earth>)
                     .before(systems::sync_body_to_frame_system::<astrodyn::Earth>)
                     .before(systems::frame_switch_system::<astrodyn::Earth>),
                 systems::aero_drag_system::<astrodyn::Earth>.in_set(AstrodynSet::Interaction),
@@ -860,7 +902,37 @@ impl Plugin for AstrodynPlugin {
                 systems::earth_lighting_system::<astrodyn::Earth>.in_set(AstrodynSet::DerivedState),
             ),
         );
+
+        install_schedule_audit(app);
     }
+}
+
+/// Promote Bevy schedule ambiguity detection to `LogLevel::Error` on
+/// every schedule the plugin has populated so far. No-op unless the
+/// `schedule_audit` Cargo feature is on. See the feature comment in
+/// `crates/astrodyn_bevy/Cargo.toml` and issue #562 for the rationale.
+///
+/// Called at the end of `AstrodynPlugin::build` and at the end of
+/// `register_planet_systems::<P>` so the settings apply after every
+/// `add_systems` call this crate makes. `Schedules::configure_schedules`
+/// mutates schedules already present; the persistence of the settings
+/// across subsequent `add_systems` calls (which only mutate the
+/// schedule's system list, not its build settings) makes "configure at
+/// the end of each entry point" sufficient coverage.
+fn install_schedule_audit(app: &mut App) {
+    #[cfg(feature = "schedule_audit")]
+    {
+        use bevy::ecs::schedule::{LogLevel, ScheduleBuildSettings};
+        app.world_mut()
+            .resource_mut::<bevy::ecs::schedule::Schedules>()
+            .configure_schedules(ScheduleBuildSettings {
+                ambiguity_detection: LogLevel::Error,
+                ..Default::default()
+            });
+    }
+    // Silence the `unused_variables` warning when the feature is off:
+    // the parameter exists only to gate the cfg block above.
+    let _ = app;
 }
 
 /// Register the planet-generic system instantiations needed for a
@@ -957,14 +1029,26 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
             // `AstrodynSet::EphemerisUpdate` so any gravity-control
             // misconfiguration trips the validator's panic before the
             // first ephemeris/gravity evaluation runs.
+            // See the Earth-block sibling for the rationale; mirrored
+            // here so non-Earth planets get the same ordering guarantees.
             validation::validate_jeod_invariants::<P>
                 .after(systems::register_body_frames_system::<P>)
+                .after(body_action::body_action_system::<P>)
+                .after(systems::mass_update_system)
+                .after(mass_tree::composite_mass_system)
                 .before(AstrodynSet::EphemerisUpdate),
             systems::sync_source_to_frame_system::<P>
                 .in_set(AstrodynSet::EphemerisUpdate)
                 .after(systems::ephemeris_update_system::<P>)
                 .after(systems::planet_fixed_rotation_system::<P>),
-            systems::planet_fixed_rotation_system::<P>.in_set(AstrodynSet::EphemerisUpdate),
+            // See the Earth-block sibling for the structural-disjointness
+            // rationale.
+            systems::planet_fixed_rotation_system::<P>
+                .in_set(AstrodynSet::EphemerisUpdate)
+                .ambiguous_with(systems::joint_kinematics_system)
+                .ambiguous_with(systems::sinusoidal_joint_kinematics_system)
+                .ambiguous_with(systems::closure_joint_kinematics_system)
+                .ambiguous_with(systems::multi_dof_joint_kinematics_system),
             systems::ephemeris_update_system::<P>.in_set(AstrodynSet::EphemerisUpdate),
             systems::tidal_update_system::<P>
                 .in_set(AstrodynSet::EphemerisUpdate)
@@ -976,6 +1060,8 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
                 .before(AstrodynSet::Interaction),
             systems::step_detached_system::<P>
                 .in_set(AstrodynSet::Integration)
+                // See Earth-block sibling for structural-disjointness rationale.
+                .ambiguous_with(systems::integration_system::<P>)
                 .before(systems::sync_body_to_frame_system::<P>)
                 .before(systems::frame_switch_system::<P>),
             systems::aero_drag_system::<P>.in_set(AstrodynSet::Interaction),
@@ -1039,6 +1125,8 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
             systems::earth_lighting_system::<P>.in_set(AstrodynSet::DerivedState),
         ),
     );
+
+    install_schedule_audit(app);
 }
 
 // ── Bevy spawn helpers for the typestate VehicleBuilder ──

--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -397,11 +397,14 @@ impl Plugin for AstrodynPlugin {
         app.add_systems(
             Startup,
             (
-                systems::register_source_frames_system::<astrodyn::Earth>,
+                systems::register_source_frames_system::<astrodyn::Earth>
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::register_pfix_frames_system::<astrodyn::Earth>
-                    .after(systems::register_source_frames_system::<astrodyn::Earth>),
+                    .after(systems::register_source_frames_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::register_body_frames_system::<astrodyn::Earth>
-                    .after(systems::register_pfix_frames_system::<astrodyn::Earth>),
+                    .after(systems::register_pfix_frames_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Maintain `MassPointRef` ↔ `MassPropertiesC` invariant
                 // for bodies that gain or lose mass after the one-time
                 // body-frame registration pass.
@@ -463,11 +466,14 @@ impl Plugin for AstrodynPlugin {
         app.add_systems(
             PreUpdate,
             (
-                systems::register_source_frames_system::<astrodyn::Earth>,
+                systems::register_source_frames_system::<astrodyn::Earth>
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::register_pfix_frames_system::<astrodyn::Earth>
-                    .after(systems::register_source_frames_system::<astrodyn::Earth>),
+                    .after(systems::register_source_frames_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::register_body_frames_system::<astrodyn::Earth>
-                    .after(systems::register_pfix_frames_system::<astrodyn::Earth>),
+                    .after(systems::register_pfix_frames_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::sync_body_mass_point_ref_system
                     .after(systems::register_body_frames_system::<astrodyn::Earth>),
             ),
@@ -492,17 +498,20 @@ impl Plugin for AstrodynPlugin {
                 // Catch dynamically-spawned sources before they hit
                 // `planet_fixed_rotation_system` / `ephemeris_update_system`.
                 systems::register_source_frames_system::<astrodyn::Earth>
-                    .before(AstrodynSet::EphemerisUpdate),
+                    .before(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Late-attached `PlanetFixedRotationC` → pfix child node
                 // (see `register_pfix_frames_system` doc).
                 systems::register_pfix_frames_system::<astrodyn::Earth>
                     .after(systems::register_source_frames_system::<astrodyn::Earth>)
-                    .before(AstrodynSet::EphemerisUpdate),
+                    .before(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Catch dynamically-spawned bodies (after source registration so
                 // any IntegSourceC reference resolves to a registered source).
                 systems::register_body_frames_system::<astrodyn::Earth>
                     .after(systems::register_pfix_frames_system::<astrodyn::Earth>)
-                    .before(AstrodynSet::EphemerisUpdate),
+                    .before(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Late-acquired / late-lost `MassPropertiesC` →
                 // insert / remove `MassPointRef` for bodies that have
                 // already passed through `register_body_frames_system`.
@@ -539,7 +548,8 @@ impl Plugin for AstrodynPlugin {
                     .after(body_action::body_action_system::<astrodyn::Earth>)
                     .after(systems::mass_update_system)
                     .after(mass_tree::composite_mass_system)
-                    .before(AstrodynSet::EphemerisUpdate),
+                    .before(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // After ephemeris_update_system writes new source
                 // position / velocity, mirror the values into the
                 // source's frame entity so frame-tree consumers
@@ -547,6 +557,7 @@ impl Plugin for AstrodynPlugin {
                 // frame-switch evaluation) see the latest state.
                 systems::sync_source_to_frame_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>())
                     .after(systems::ephemeris_update_system::<astrodyn::Earth>)
                     .after(systems::planet_fixed_rotation_system::<astrodyn::Earth>),
                 // Planet-fixed rotation (RNP).
@@ -567,16 +578,19 @@ impl Plugin for AstrodynPlugin {
                 // the physics does not require. See #562.
                 systems::planet_fixed_rotation_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>())
                     .ambiguous_with(systems::joint_kinematics_system)
                     .ambiguous_with(systems::sinusoidal_joint_kinematics_system)
                     .ambiguous_with(systems::closure_joint_kinematics_system)
                     .ambiguous_with(systems::multi_dof_joint_kinematics_system),
                 // Ephemeris position updates (DE4xx)
                 systems::ephemeris_update_system::<astrodyn::Earth>
-                    .in_set(AstrodynSet::EphemerisUpdate),
+                    .in_set(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Tidal ΔC20 (must run after planet-fixed rotation)
                 systems::tidal_update_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>())
                     .after(systems::planet_fixed_rotation_system::<astrodyn::Earth>),
                 // Mass update: recompute inverse_mass/inverse_inertia each step.
                 systems::mass_update_system
@@ -597,16 +611,19 @@ impl Plugin for AstrodynPlugin {
                     .before(AstrodynSet::EphemerisUpdate),
                 // Gravity pre-computation
                 systems::gravity_computation_system::<astrodyn::Earth>
-                    .in_set(AstrodynSet::Environment),
+                    .in_set(AstrodynSet::Environment)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Atmosphere evaluation
                 systems::atmosphere_update_system::<astrodyn::Earth>
-                    .in_set(AstrodynSet::Environment),
+                    .in_set(AstrodynSet::Environment)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Interactions
                 // Mass tree staging (attach/detach) — runs before interactions
                 // so mass changes affect the current step's forces and integration.
                 systems::staging_system::<astrodyn::Earth>
                     .after(AstrodynSet::Environment)
-                    .before(AstrodynSet::Interaction),
+                    .before(AstrodynSet::Interaction)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Detached-subtree ballistic propagation: advance every
                 // entity carrying `DetachedSubtreeStateC` by `dt` under
                 // free-flight kinematics (no force, no torque). Runs in
@@ -637,11 +654,18 @@ impl Plugin for AstrodynPlugin {
                     // above) is that the two can run in parallel. See #562.
                     .ambiguous_with(systems::integration_system::<astrodyn::Earth>)
                     .before(systems::sync_body_to_frame_system::<astrodyn::Earth>)
-                    .before(systems::frame_switch_system::<astrodyn::Earth>),
-                systems::aero_drag_system::<astrodyn::Earth>.in_set(AstrodynSet::Interaction),
+                    .before(systems::frame_switch_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
+                systems::aero_drag_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::Interaction)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::gravity_torque_system.in_set(AstrodynSet::Interaction),
-                systems::flat_plate_srp_system::<astrodyn::Earth>.in_set(AstrodynSet::Interaction),
-                systems::cannonball_srp_system::<astrodyn::Earth>.in_set(AstrodynSet::Interaction),
+                systems::flat_plate_srp_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::Interaction)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
+                systems::cannonball_srp_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::Interaction)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
             ),
         );
         app.add_systems(
@@ -701,7 +725,8 @@ impl Plugin for AstrodynPlugin {
                 // `Simulation::step_internal`.
                 frame_attach_system::frame_attach_system::<astrodyn::Earth>
                     .after(AstrodynSet::EphemerisUpdate)
-                    .before(AstrodynSet::Environment),
+                    .before(AstrodynSet::Environment)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Frame-attached body kinematic propagation. Derives
                 // every `FrameAttachedC` body's `TranslationalStateC`
                 // / `RotationalStateC` from its parent frame entity's
@@ -719,7 +744,8 @@ impl Plugin for AstrodynPlugin {
                 // tick they were attached.
                 frame_attach_system::propagate_frame_attached_state_system::<astrodyn::Earth>
                     .after(frame_attach_system::frame_attach_system::<astrodyn::Earth>)
-                    .before(AstrodynSet::Environment),
+                    .before(AstrodynSet::Environment)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Body-action lifecycle: drain `BodyActionEvent`
                 // (`Add` / `Remove` variants) into `BodyActionsR`,
                 // then apply every ready action. Runs before
@@ -753,7 +779,8 @@ impl Plugin for AstrodynPlugin {
                     .after(AstrodynSet::TimeUpdate)
                     .after(systems::sync_body_mass_point_ref_system)
                     .before(systems::mass_update_system)
-                    .before(AstrodynSet::EphemerisUpdate),
+                    .before(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Fail-loud fence on unregistered-planet adds. Runs
                 // after the Earth intake (so the well-formed Earth
                 // adds have already been claimed) and before any
@@ -786,7 +813,8 @@ impl Plugin for AstrodynPlugin {
                     .after(body_action::body_action_intake_system::<astrodyn::Earth>)
                     .after(body_action::body_action_unregistered_planet_fence_system)
                     .before(systems::mass_update_system)
-                    .before(AstrodynSet::EphemerisUpdate),
+                    .before(AstrodynSet::EphemerisUpdate)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Pre-integration kinematic state propagation: walks
                 // MassChildOf chains pre-order from each root and
                 // overwrites every kinematic child's `RotationalStateC`
@@ -809,7 +837,8 @@ impl Plugin for AstrodynPlugin {
                     .after(
                         frame_attach_system::propagate_frame_attached_state_system::<astrodyn::Earth>,
                     )
-                    .before(AstrodynSet::Environment),
+                    .before(AstrodynSet::Environment)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Force collection and integration
                 systems::force_collection_system.in_set(AstrodynSet::ForceCollection),
                 // Composite-rigid-body wrench aggregation: walk
@@ -826,20 +855,24 @@ impl Plugin for AstrodynPlugin {
                 wrench::wrench_aggregation_system
                     .in_set(AstrodynSet::ForceCollection)
                     .after(systems::force_collection_system),
-                systems::integration_system::<astrodyn::Earth>.in_set(AstrodynSet::Integration),
+                systems::integration_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::Integration)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // After integration, sync the body's typed state into
                 // its frame entity's `FrameTransC` so frame-switch
                 // evaluation and downstream `RelativeFrameState` /
                 // `FrameOrigin` queries see current distances.
                 systems::sync_body_to_frame_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::Integration)
-                    .after(systems::integration_system::<astrodyn::Earth>),
+                    .after(systems::integration_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Evaluate distance-based frame switches and reparent
                 // the body's frame entity in the ECS hierarchy on
                 // trigger.
                 systems::frame_switch_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::Integration)
-                    .after(systems::sync_body_to_frame_system::<astrodyn::Earth>),
+                    .after(systems::sync_body_to_frame_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Post-integration frame-attached body propagation.
                 // Symmetric to the pre-integration sweep above: the
                 // integrator just produced fresh source-body state and
@@ -866,7 +899,8 @@ impl Plugin for AstrodynPlugin {
                     astrodyn::Earth,
                 >
                     .in_set(AstrodynSet::Integration)
-                    .after(systems::frame_switch_system::<astrodyn::Earth>),
+                    .after(systems::frame_switch_system::<astrodyn::Earth>)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 // Post-integration kinematic state propagation
                 // (root → leaves). The integrator just produced fresh
                 // root-body state; rerun the kinematic walk so every
@@ -882,7 +916,8 @@ impl Plugin for AstrodynPlugin {
                     .in_set(AstrodynSet::Integration)
                     .after(
                         frame_attach_system::propagate_frame_attached_state_post_integration_system::<astrodyn::Earth>,
-                    ),
+                    )
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
             ),
         );
         // Third `add_systems` call: derived-state systems live here only
@@ -894,12 +929,21 @@ impl Plugin for AstrodynPlugin {
             (
                 // Derived states
                 systems::orbital_elements_system::<astrodyn::Earth>
-                    .in_set(AstrodynSet::DerivedState),
+                    .in_set(AstrodynSet::DerivedState)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::euler_angles_system.in_set(AstrodynSet::DerivedState),
-                systems::lvlh_system::<astrodyn::Earth>.in_set(AstrodynSet::DerivedState),
-                systems::geodetic_system::<astrodyn::Earth>.in_set(AstrodynSet::DerivedState),
-                systems::solar_beta_system::<astrodyn::Earth>.in_set(AstrodynSet::DerivedState),
-                systems::earth_lighting_system::<astrodyn::Earth>.in_set(AstrodynSet::DerivedState),
+                systems::lvlh_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::DerivedState)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
+                systems::geodetic_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::DerivedState)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
+                systems::solar_beta_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::DerivedState)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
+                systems::earth_lighting_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::DerivedState)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
             ),
         );
 
@@ -978,6 +1022,45 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
     // (already wired by `AstrodynPlugin::build`) does not double-init the
     // queue.
     app.init_resource::<body_action::BodyActionsR<P>>();
+    // Cross-planet ambiguity: declare `PerPlanetSet::of::<P>()`
+    // structurally disjoint from every previously-registered planet's
+    // set in all three schedules `register_planet_systems` writes to
+    // (Startup, PreUpdate, FixedUpdate). The cross-planet pairs of
+    // per-planet systems (e.g. `body_action_system<Earth>` vs
+    // `body_action_system<Mars>`) share read/write access on
+    // non-generic components (`RotationalStateC`, `FrameTransC`, …)
+    // but operate on disjoint entity populations via `<P>`-typed
+    // witnesses (`TranslationalStateC<P>`, etc.). Bevy's static
+    // ambiguity analysis can't see the witness-based filter, so
+    // every cross-planet system pair would otherwise panic the
+    // `schedule_audit` gate. Each pair gets a structurally-justified
+    // `.ambiguous_with` here.
+    //
+    // Runs *before* the `RegisteredPlanetsR::register::<P>()` call
+    // below so the registry-walk reflects pre-self planets only.
+    // The filter on `tid != TypeId::of::<P>()` guards against an
+    // idempotent re-registration where Earth's `register::<Earth>`
+    // already inserted Earth into the registry (see
+    // `AstrodynPlugin::build` at lib.rs:359-361, and the doc
+    // comment at lib.rs:1021-1023 that documents idempotency).
+    // See #562 Option B.
+    {
+        let existing: Vec<std::any::TypeId> = app
+            .world()
+            .resource::<body_action::RegisteredPlanetsR>()
+            .planets
+            .iter()
+            .copied()
+            .filter(|tid| *tid != std::any::TypeId::of::<P>())
+            .collect();
+        let this = PerPlanetSet::of::<P>();
+        for old in existing {
+            let other = PerPlanetSet(old);
+            app.configure_sets(Startup, this.clone().ambiguous_with(other.clone()));
+            app.configure_sets(PreUpdate, this.clone().ambiguous_with(other.clone()));
+            app.configure_sets(FixedUpdate, this.clone().ambiguous_with(other));
+        }
+    }
     // Track this planet in the registry consulted by the
     // `BodyActionEvent::Add` writer surfaces (the
     // `BodyActionCommandsExt::add_body_action_for::<P>` call-site
@@ -994,33 +1077,53 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
     app.add_systems(
         Startup,
         (
-            systems::register_source_frames_system::<P>,
+            systems::register_source_frames_system::<P>.in_set(PerPlanetSet::of::<P>()),
             systems::register_pfix_frames_system::<P>
-                .after(systems::register_source_frames_system::<P>),
+                .after(systems::register_source_frames_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::register_body_frames_system::<P>
-                .after(systems::register_pfix_frames_system::<P>),
+                .after(systems::register_pfix_frames_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
         ),
     );
     app.add_systems(
         PreUpdate,
         (
-            systems::register_source_frames_system::<P>,
+            systems::register_source_frames_system::<P>.in_set(PerPlanetSet::of::<P>()),
             systems::register_pfix_frames_system::<P>
-                .after(systems::register_source_frames_system::<P>),
+                .after(systems::register_source_frames_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
+            // `.before(sync_body_mass_point_ref_system)` mirrors the
+            // Earth-block's `.after(register_body_frames_system::<Earth>)`
+            // edge on the shared `sync_body_mass_point_ref_system`
+            // (at lib.rs:471-477). The Earth edge is hardcoded to
+            // `<astrodyn::Earth>`, so non-Earth `<P>` instantiations
+            // would otherwise sit unordered against the downstream
+            // `body_action_intake_system::<P>` /
+            // `body_action_system::<P>` chain. See #562 Option B fix.
             systems::register_body_frames_system::<P>
-                .after(systems::register_pfix_frames_system::<P>),
+                .after(systems::register_pfix_frames_system::<P>)
+                .before(systems::sync_body_mass_point_ref_system)
+                .in_set(PerPlanetSet::of::<P>()),
         ),
     );
     app.add_systems(
         FixedUpdate,
         (
-            systems::register_source_frames_system::<P>.before(AstrodynSet::EphemerisUpdate),
+            systems::register_source_frames_system::<P>
+                .before(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::register_pfix_frames_system::<P>
                 .after(systems::register_source_frames_system::<P>)
-                .before(AstrodynSet::EphemerisUpdate),
+                .before(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
+            // `.before(sync_body_mass_point_ref_system)` — see the
+            // PreUpdate block above for the rationale. #562 Option B fix.
             systems::register_body_frames_system::<P>
                 .after(systems::register_pfix_frames_system::<P>)
-                .before(AstrodynSet::EphemerisUpdate),
+                .before(systems::sync_body_mass_point_ref_system)
+                .before(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
             // Per-planet validator instantiation. Mirrors the schedule
             // slot of the Earth registration in `AstrodynPlugin::build`:
             // after `register_body_frames_system::<P>` so the body's
@@ -1036,37 +1139,55 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
                 .after(body_action::body_action_system::<P>)
                 .after(systems::mass_update_system)
                 .after(mass_tree::composite_mass_system)
-                .before(AstrodynSet::EphemerisUpdate),
+                .before(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::sync_source_to_frame_system::<P>
                 .in_set(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>())
                 .after(systems::ephemeris_update_system::<P>)
                 .after(systems::planet_fixed_rotation_system::<P>),
             // See the Earth-block sibling for the structural-disjointness
             // rationale.
             systems::planet_fixed_rotation_system::<P>
                 .in_set(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>())
                 .ambiguous_with(systems::joint_kinematics_system)
                 .ambiguous_with(systems::sinusoidal_joint_kinematics_system)
                 .ambiguous_with(systems::closure_joint_kinematics_system)
                 .ambiguous_with(systems::multi_dof_joint_kinematics_system),
-            systems::ephemeris_update_system::<P>.in_set(AstrodynSet::EphemerisUpdate),
+            systems::ephemeris_update_system::<P>
+                .in_set(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::tidal_update_system::<P>
                 .in_set(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>())
                 .after(systems::planet_fixed_rotation_system::<P>),
-            systems::gravity_computation_system::<P>.in_set(AstrodynSet::Environment),
-            systems::atmosphere_update_system::<P>.in_set(AstrodynSet::Environment),
+            systems::gravity_computation_system::<P>
+                .in_set(AstrodynSet::Environment)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::atmosphere_update_system::<P>
+                .in_set(AstrodynSet::Environment)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::staging_system::<P>
                 .after(AstrodynSet::Environment)
-                .before(AstrodynSet::Interaction),
+                .before(AstrodynSet::Interaction)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::step_detached_system::<P>
                 .in_set(AstrodynSet::Integration)
                 // See Earth-block sibling for structural-disjointness rationale.
                 .ambiguous_with(systems::integration_system::<P>)
                 .before(systems::sync_body_to_frame_system::<P>)
-                .before(systems::frame_switch_system::<P>),
-            systems::aero_drag_system::<P>.in_set(AstrodynSet::Interaction),
-            systems::flat_plate_srp_system::<P>.in_set(AstrodynSet::Interaction),
-            systems::cannonball_srp_system::<P>.in_set(AstrodynSet::Interaction),
+                .before(systems::frame_switch_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::aero_drag_system::<P>
+                .in_set(AstrodynSet::Interaction)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::flat_plate_srp_system::<P>
+                .in_set(AstrodynSet::Interaction)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::cannonball_srp_system::<P>
+                .in_set(AstrodynSet::Interaction)
+                .in_set(PerPlanetSet::of::<P>()),
         ),
     );
     app.add_systems(
@@ -1087,42 +1208,63 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
                 .after(systems::sync_body_mass_point_ref_system)
                 .before(body_action::body_action_unregistered_planet_fence_system)
                 .before(systems::mass_update_system)
-                .before(AstrodynSet::EphemerisUpdate),
+                .before(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
             body_action::body_action_system::<P>
                 .after(AstrodynSet::TimeUpdate)
                 .after(body_action::body_action_intake_system::<P>)
                 .after(body_action::body_action_unregistered_planet_fence_system)
                 .before(systems::mass_update_system)
-                .before(AstrodynSet::EphemerisUpdate),
+                .before(AstrodynSet::EphemerisUpdate)
+                .in_set(PerPlanetSet::of::<P>()),
             frame_attach_system::frame_attach_system::<P>
                 .after(AstrodynSet::EphemerisUpdate)
-                .before(AstrodynSet::Environment),
+                .before(AstrodynSet::Environment)
+                .in_set(PerPlanetSet::of::<P>()),
             frame_attach_system::propagate_frame_attached_state_system::<P>
                 .after(frame_attach_system::frame_attach_system::<P>)
-                .before(AstrodynSet::Environment),
+                .before(AstrodynSet::Environment)
+                .in_set(PerPlanetSet::of::<P>()),
             kinematic_propagation::propagate_state_from_root_system::<P>
                 .after(frame_attach_system::propagate_frame_attached_state_system::<P>)
-                .before(AstrodynSet::Environment),
-            systems::integration_system::<P>.in_set(AstrodynSet::Integration),
+                .before(AstrodynSet::Environment)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::integration_system::<P>
+                .in_set(AstrodynSet::Integration)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::sync_body_to_frame_system::<P>
                 .in_set(AstrodynSet::Integration)
-                .after(systems::integration_system::<P>),
+                .after(systems::integration_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::frame_switch_system::<P>
                 .in_set(AstrodynSet::Integration)
-                .after(systems::sync_body_to_frame_system::<P>),
+                .after(systems::sync_body_to_frame_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
             frame_attach_system::propagate_frame_attached_state_post_integration_system::<P>
                 .in_set(AstrodynSet::Integration)
-                .after(systems::frame_switch_system::<P>),
+                .after(systems::frame_switch_system::<P>)
+                .in_set(PerPlanetSet::of::<P>()),
             kinematic_propagation::propagate_state_from_root_post_integration_system::<P>
                 .in_set(AstrodynSet::Integration)
                 .after(
                     frame_attach_system::propagate_frame_attached_state_post_integration_system::<P>,
-                ),
-            systems::orbital_elements_system::<P>.in_set(AstrodynSet::DerivedState),
-            systems::lvlh_system::<P>.in_set(AstrodynSet::DerivedState),
-            systems::geodetic_system::<P>.in_set(AstrodynSet::DerivedState),
-            systems::solar_beta_system::<P>.in_set(AstrodynSet::DerivedState),
-            systems::earth_lighting_system::<P>.in_set(AstrodynSet::DerivedState),
+                )
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::orbital_elements_system::<P>
+                .in_set(AstrodynSet::DerivedState)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::lvlh_system::<P>
+                .in_set(AstrodynSet::DerivedState)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::geodetic_system::<P>
+                .in_set(AstrodynSet::DerivedState)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::solar_beta_system::<P>
+                .in_set(AstrodynSet::DerivedState)
+                .in_set(PerPlanetSet::of::<P>()),
+            systems::earth_lighting_system::<P>
+                .in_set(AstrodynSet::DerivedState)
+                .in_set(PerPlanetSet::of::<P>()),
         ),
     );
 

--- a/crates/astrodyn_bevy/src/sets.rs
+++ b/crates/astrodyn_bevy/src/sets.rs
@@ -31,7 +31,50 @@
 //! a JEOD-specific construct, and no current scenario in this workspace
 //! uses it; the single-`FixedUpdate` model covers every shipped sim.
 
+use std::any::TypeId;
+
 use bevy::prelude::*;
+
+/// One per-planet `SystemSet` per registered [`astrodyn::Planet`] type,
+/// keyed by [`TypeId`].
+///
+/// Every `<P>`-typed system in `AstrodynPlugin::build` (Earth) and in
+/// [`crate::register_planet_systems::<P>`] (every other planet) is added
+/// to its planet's `PerPlanetSet`. Cross-planet sets are declared
+/// `.ambiguous_with` each other inside `register_planet_systems`,
+/// which walks [`crate::body_action::RegisteredPlanetsR`] to find every
+/// prior planet and marks the cross-set pair safe.
+///
+/// `TypeId` keying (rather than a generic
+/// `PerPlanetSet<P>(PhantomData<P>)`) is what makes the cross-planet
+/// walk expressible. Reading a `TypeId` out of `RegisteredPlanetsR`
+/// does not give us the concrete planet type back, so a generic
+/// `PerPlanetSet<P>` would not be constructible from runtime data.
+/// `TypeId` is `Send + Sync + 'static + Debug + Clone + Eq + Hash`, so
+/// the `SystemSet` derive accepts the newtype.
+///
+/// Intra-planet ordering inside one `PerPlanetSet` continues to be
+/// expressed with the existing `.before` / `.after` edges — set
+/// membership is solely a cross-planet structural-disjointness
+/// declaration, not an ordering construct.
+///
+/// See issue #562 / PR #565 for the motivation: the multi-planet unit
+/// tests in `astrodyn_bevy` register both Earth and Mars and the static
+/// schedule audit (under the `schedule_audit` Cargo feature) flagged
+/// cross-planet pairs of per-planet systems racing on shared
+/// non-generic component types (`RotationalStateC`, `FrameTransC`,
+/// …). Those pairs are filter-disjoint by entity (a body carries
+/// `TranslationalStateC<Earth>` *or* `TranslationalStateC<Mars>`, never
+/// both), and `PerPlanetSet` is how we communicate that to Bevy.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PerPlanetSet(pub TypeId);
+
+impl PerPlanetSet {
+    /// Construct the set for planet `P`.
+    pub fn of<P: 'static>() -> Self {
+        Self(TypeId::of::<P>())
+    }
+}
 
 /// Bevy system-set partition mirroring JEOD's per-step pipeline. Stages
 /// run in declaration order; `AstrodynPlugin::build` configures the ordering

--- a/crates/astrodyn_bevy/src/sets.rs
+++ b/crates/astrodyn_bevy/src/sets.rs
@@ -63,9 +63,41 @@ use bevy::prelude::*;
 /// schedule audit (under the `schedule_audit` Cargo feature) flagged
 /// cross-planet pairs of per-planet systems racing on shared
 /// non-generic component types (`RotationalStateC`, `FrameTransC`,
-/// …). Those pairs are filter-disjoint by entity (a body carries
-/// `TranslationalStateC<Earth>` *or* `TranslationalStateC<Mars>`, never
-/// both), and `PerPlanetSet` is how we communicate that to Bevy.
+/// `MassPropertiesC`, …). The cross-planet pairs are runtime-disjoint
+/// by entity, but the *mechanism* of disjointness varies by system,
+/// and `PerPlanetSet` is how we communicate either route to Bevy:
+///
+/// 1. **Required-query-item filtering.** Systems like
+///    [`crate::systems::integration_system::<P>`] and
+///    [`crate::systems::flat_plate_srp_system::<P>`] take
+///    `&mut TranslationalStateC<P>` as a required query item. Their
+///    query only matches entities that carry the `<P>`-tagged
+///    storage, which by construction is a single planet's. Bodies
+///    carry `TranslationalStateC<Earth>` *or*
+///    `TranslationalStateC<Mars>`, never both, so the `<Earth>` and
+///    `<Mars>` instantiations of these systems iterate disjoint
+///    entity subsets.
+///
+/// 2. **Queue partitioning.** Systems like
+///    [`crate::body_action::body_action_system::<P>`] take
+///    `Option<&mut TranslationalStateC<P>>` and filter only by
+///    `With<DynamicsConfigC>`, so the query itself *could* match a
+///    body of either planet. The runtime disjointness comes from the
+///    per-planet `BodyActionsR<P>` queue: actions are routed to
+///    `<P>`'s queue at submit time via
+///    `BodyActionCommandsExt::add_body_action_for::<P>` and the
+///    `body_action_unregistered_planet_fence_system` panics on a
+///    `<P>` whose `TypeId` isn't in `RegisteredPlanetsR`. The
+///    `<Mars>` apply pass walks `BodyActionsR<Mars>` and reaches
+///    only Mars-tagged bodies — Earth-tagged bodies are reached
+///    only via `BodyActionsR<Earth>` from the `<Earth>` apply pass.
+///
+/// Both routes produce the same runtime invariant (no two
+/// per-planet `<P>` systems write the same entity in the same tick)
+/// but Bevy's static analysis sees only the shared mutable component
+/// access. `.ambiguous_with` is the right mechanism for both
+/// because the structural justification is symmetric: we know
+/// runtime-disjoint, Bevy doesn't.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PerPlanetSet(pub TypeId);
 

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_ref_attach.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_ref_attach.rs
@@ -59,23 +59,34 @@ use astrodyn_verif_parity::VerificationCaseParityExt;
 /// JEOD ≈ Bevy transitivity holds within tolerance even though the
 /// strict bit-identity gate doesn't.
 ///
-/// Closing this gap is a Bevy-side schedule investigation: the
-/// 3-record-out-of-50 pattern points at a non-deterministic
-/// ordering between systems that don't have explicit
-/// `.before/.after` constraints (most likely candidates: the
-/// post-integration kinematic walk vs. the post-integration
-/// frame-attach propagation, or the order in which `FrameTransC` /
-/// `FrameRotC` writes land on the pfix entity at those records).
+/// Investigation done under issue #562 ruled out a Bevy schedule
+/// ambiguity as the cause. The `astrodyn_bevy/schedule_audit` Cargo
+/// feature configures every `AstrodynPlugin`-built schedule with
+/// `ambiguity_detection: LogLevel::Error`; running this test under
+/// the feature surfaces zero ambiguous pairs after the eight ordering
+/// edges that #562 landed (validator-vs-action / mass writers,
+/// `planet_fixed_rotation_system` vs each of the four
+/// joint-kinematics systems, and `integration_system` vs
+/// `step_detached_system`). The audit gate is clean yet the drift
+/// persists deterministically at the same three records — so the
+/// remaining cause is *not* parallel-system ordering. Likely
+/// suspects, to dig into next: an algorithmic delta between the
+/// runner's `propagate_frame_attached_state` call site and the
+/// Bevy adapter's `propagate_frame_attached_state_system`, or a
+/// difference in how `FrameTransC`/`FrameRotC` for Earth.pfix is
+/// composed via `RelativeFrameState` at certain time samples (the
+/// failing records are not adjacent — they fall at t=70, 73, 82 —
+/// so the trigger is time-state-dependent, not lattice-aligned).
 /// The presence of this wrapper file (with `#[ignore]`) is itself
 /// the structural marker that `parity_coverage.rs` uses to satisfy
 /// the superset invariant, so no `KNOWN_PARITY_GAPS` entry is
-/// needed — re-enable the test once the Bevy schedule order is
-/// pinned to produce bit-identical pfix state at every record the
-/// runner observes.
+/// needed — re-enable the test once the residual drift closes.
 #[test]
 #[ignore = "Bevy adapter produces sub-ULP drift (~30 ULPs on unitless \
             matrix elements of magnitude ~1.0) in Earth.pfix at 3-of-50 \
-            post-attach records; Bevy-side schedule investigation pending"]
+            post-attach records; ruled out as a schedule ambiguity in \
+            #562 (audit gate clean under astrodyn_bevy/schedule_audit), \
+            cause now suspected algorithmic / frame-composition"]
 fn bevy_parity_ref_attach_matrix() {
     sim_ref_attach::run_matrix().run_and_assert_parity::<astrodyn::Earth>();
 }


### PR DESCRIPTION
## Summary

Lands the **`astrodyn_bevy/schedule_audit`** Cargo feature plus the structural infrastructure to keep it a true regression fence: 8 Earth-block ordering edges, a `PerPlanetSet(TypeId)` `SystemSet` that declares cross-planet structural disjointness, the registry-walk plumbing in `register_planet_systems::<P>` that wires it up, and one class-2 intra-planet ordering edge in the generic block that the multi-planet path was missing.

A new **`schedule-audit` CI job** runs the three examples plus `cargo nextest -p astrodyn_bevy` with the feature on. The job already paid for itself on this PR — its first run caught 37 multi-planet ambiguity pairs that single-planet smoke testing missed.

## Why this is valuable on its own

- **Regression fence with proven coverage.** The schedule shape is now a checked invariant of the codebase. The audit gate caught 37 cases on its first multi-planet run; resolving them required structurally declaring per-planet disjointness rather than silencing the warnings. Future PRs that add a system without an ordering edge or set membership fail the `schedule-audit` job loudly.
- **8 latent Earth-block ambiguities resolved.** The audit caught real cases of indeterminate ordering on the single-planet (Earth-only) path that happened to produce correct trajectories in current tests but weren't structurally guaranteed to:
  - `validate_jeod_invariants<P>` racing the three writers it inspects — resolved with `.after()` edges so the validator sees post-update state.
  - `planet_fixed_rotation_system<P>` unordered against the four `*_joint_kinematics_system`s. Entity-disjoint (pfix target vs joint-tagged frames) — `.ambiguous_with` markers document the disjointness.
  - `integration_system<P>` unordered against `step_detached_system<P>`. Filter-disjoint — `.ambiguous_with`.
- **`PerPlanetSet(TypeId)` for cross-planet disjointness.** Multi-planet missions (Earth + Mars + …) hit 37 cross-planet ambiguity pairs of per-planet systems writing shared non-generic components (`RotationalStateC`, `FrameTransC`, `MassPropertiesC`, …). The pairs are runtime-disjoint via either required-query-item filtering (`integration_system<P>` requires `&mut TranslationalStateC<P>`) or queue partitioning (`body_action_system<P>` reaches only `BodyActionsR<P>`-tagged bodies). Both routes documented in the `PerPlanetSet` docstring. The TypeId-keyed set (rather than a generic `PerPlanetSet<P>(PhantomData<P>)`) is what makes the cross-planet ambiguity walk expressible — reading a TypeId out of `RegisteredPlanetsR` doesn't give us the concrete planet type back, but `PerPlanetSet(TypeId)` is constructible from raw runtime data.
- **Class-2 intra-planet ordering fix.** Mars's `register_body_frames_system<Mars>` was unordered against `body_action_system<Mars>` because the implicit Earth-block chain through `sync_body_mass_point_ref_system` is hardcoded to `<astrodyn::Earth>`. Mirrored generically via `.before(sync_body_mass_point_ref_system)` on the per-planet `register_body_frames_system::<P>` registration.
- **Diagnosis on #562 sharpened.** The original issue body hypothesised non-deterministic schedule order as the cause of the post-attach ~30 ULP drift in `bevy_parity_ref_attach_matrix`. With the audit gate clean and the drift still deterministically present at the same 3-of-50 records, that hypothesis is now ruled out — the cause lies in the frame-composition path (`propagate_frame_attached_state_system` vs the runner's `propagate_frame_attached_state`, or how `RelativeFrameState` reads Earth.pfix at certain time samples). The next investigator skips the schedule-ordering rabbit hole.

## How `.ambiguous_with` preserves audit coverage

The cross-planet `.ambiguous_with` declarations are a static-analysis hint, not a runtime change — Bevy still serializes systems with conflicting mutable access. The hint suppresses the ambiguity report **only** for pairs declared as structurally disjoint via `PerPlanetSet`. The gate continues to fire on:

- Intra-planet races (same `<P>`, no ordering edge).
- New `<P>`-typed systems that drop the `.in_set(PerPlanetSet::of::<P>())` annotation — the missing tag means cross-planet pairs aren't declared disjoint, so the audit complains. Self-documenting failure mode: the engineer adds the tag and moves on.
- Any genuine ambiguity touching the shared component types where the systems are not per-planet variants.

## What this PR does not do

`bevy_parity_ref_attach_matrix` remains `#[ignore]`'d. The `#[ignore]` reason string is updated to record that #562's schedule-ordering hypothesis was ruled out and to redirect future work to frame composition. #389's `DEFERRED_GAPS` entry for `dyncomp_run_attach_to_ref_frame` stays in place — it's blocked on the same drift.

## Test plan

- [x] `cargo build --workspace` clean (feature off — production schedule).
- [x] `cargo build -p astrodyn_bevy --features schedule_audit` clean (feature on — audit gate active).
- [x] `cargo run -p astrodyn_bevy --features schedule_audit --example {kepler_orbit,typed_mission,multi_body_scenario} -- --steps 3` — no ambiguity panic.
- [x] `cargo nextest run -p astrodyn_bevy --features schedule_audit` — **149/149 passed**, including the canonical multi-planet target `body_action_for_mars_writes_through_mars_tagged_storage`.
- [x] `cargo nextest run --workspace -E 'test(bevy_parity) and not test(bevy_parity_ref_attach_matrix)'` — **319/319 passed**, bit-identical parity preserved.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --tests -- -D warnings` clean (feature off and on).
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p astrodyn_bevy --no-deps --document-private-items` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)