### PR TITLE
[#569] Document SH iteration bound discipline; no helper substitution

### DIFF
--- a/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
+++ b/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
@@ -11,12 +11,25 @@
 //! inner bound that is dictated by the specific Gottlieb equation the
 //! loop evaluates:
 //!
-//! - `for jj in 2..=(ii - 2)` — Pnm recursion fill below the
-//!   tridiagonal band, equation (7-12), in the per-step kernel.
-//! - `for jj in 1..=order.min(ii)` — the main m-sum that accumulates
-//!   the gravitational potential and gradient terms, equation (3-18).
+//! - `for jj in 2..=ii.saturating_sub(2)` — Pnm recursion fill below
+//!   the tridiagonal band, equation (7-12), in the per-step kernel.
+//!   The `saturating_sub` is load-bearing: the loop is *intentionally
+//!   empty* for `ii < 4` (at `ii = 2` and `ii = 3` the tridiagonal-band
+//!   entries already cover every `jj`, so there is nothing below the
+//!   band to fill). Replacing it with the unchecked `ii - 2` form
+//!   underflows `usize` at `ii = 0`/`ii = 1` and is wrong by
+//!   construction; replacing it with a wider lower bound fabricates
+//!   off-band Pnm terms.
+//! - `let jj_max = order.min(ii); for jj in 1..=jj_max` — the main
+//!   m-sum that accumulates the gravitational potential and gradient
+//!   terms, equation (3-18). The bound is the smaller of the field's
+//!   order and the current degree row, gated by `if order > 0` one
+//!   level up (so `order == 0` skips the whole branch rather than
+//!   entering with an empty range).
 //! - `for jj in 0..=(ii - 1)` — `xi`/`eta` precompute, equation (7-10),
-//!   in [`SphericalHarmonicsData`]'s `initialize_body`.
+//!   in [`SphericalHarmonicsData`]'s `initialize_body`. The plain
+//!   `ii - 1` is safe here because the enclosing `for ii in 2..=degree`
+//!   guarantees `ii >= 2`.
 //! - `for jj in 0..=ii` — `zeta`/`upsilon` precompute, equations
 //!   (7-19) and (7-22), in the same `initialize_body` body.
 //!

--- a/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
+++ b/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
@@ -3,6 +3,29 @@
 //! Direct port of JEOD `spherical_harmonics_calc_nonspherical.cc`.
 //! The caller must provide position in planet-fixed coordinates and
 //! rotate the result back to inertial.
+//!
+//! ## SH iteration bound discipline
+//!
+//! Each `for ii in 2..=degree { for jj in … }` nest in this module and
+//! in [`crate::spherical_harmonics_gravity_source`] carries a *distinct*
+//! inner bound that is dictated by the specific Gottlieb equation the
+//! loop evaluates:
+//!
+//! - `for jj in 2..=(ii - 2)` — Pnm recursion fill below the
+//!   tridiagonal band, equation (7-12), in the per-step kernel.
+//! - `for jj in 1..=order.min(ii)` — the main m-sum that accumulates
+//!   the gravitational potential and gradient terms, equation (3-18).
+//! - `for jj in 0..=(ii - 1)` — `xi`/`eta` precompute, equation (7-10),
+//!   in [`SphericalHarmonicsData`]'s `initialize_body`.
+//! - `for jj in 0..=ii` — `zeta`/`upsilon` precompute, equations
+//!   (7-19) and (7-22), in the same `initialize_body` body.
+//!
+//! Because these bounds are equation-specific, a single
+//! `for_each_sh_coefficient(degree, order, …)`-style helper covering
+//! more than one of them silently drops or fabricates terms and so
+//! produces wrong physics. Future refactors that wish to collapse the
+//! scaffolding must keep the inner bound attached to the per-equation
+//! recursion, not to a generic "SH iteration" abstraction.
 
 use astrodyn_dynamics::forces::GravityAccelerationTyped;
 use astrodyn_dynamics::GravityAcceleration;

--- a/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
+++ b/crates/astrodyn_gravity/src/spherical_harmonics_calc_nonspherical.rs
@@ -13,13 +13,17 @@
 //!
 //! - `for jj in 2..=ii.saturating_sub(2)` — Pnm recursion fill below
 //!   the tridiagonal band, equation (7-12), in the per-step kernel.
-//!   The `saturating_sub` is load-bearing: the loop is *intentionally
-//!   empty* for `ii < 4` (at `ii = 2` and `ii = 3` the tridiagonal-band
-//!   entries already cover every `jj`, so there is nothing below the
-//!   band to fill). Replacing it with the unchecked `ii - 2` form
-//!   underflows `usize` at `ii = 0`/`ii = 1` and is wrong by
-//!   construction; replacing it with a wider lower bound fabricates
-//!   off-band Pnm terms.
+//!   The bound is *intentionally empty* for `ii < 4` (at `ii = 2` and
+//!   `ii = 3` the tridiagonal-band entries already cover every `jj`, so
+//!   there is nothing below the band to fill), and replacing it with a
+//!   wider lower bound fabricates off-band Pnm terms. The
+//!   `saturating_sub` itself is defensive rather than load-bearing
+//!   today: the enclosing `for ii in 2..=degree` already restricts
+//!   `ii >= 2`, so plain `ii - 2` would not underflow in this loop as
+//!   written and would yield the same empty range for `ii ∈ {2, 3}`.
+//!   The `saturating_sub` is retained so the inner expression stays
+//!   safe under any future widening of the outer loop bound that
+//!   admits `ii < 2`.
 //! - `let jj_max = order.min(ii); for jj in 1..=jj_max` — the main
 //!   m-sum that accumulates the gravitational potential and gradient
 //!   terms, equation (3-18). The bound is the smaller of the field's


### PR DESCRIPTION
## Summary

A bound-by-bound audit of every `for ii in 2..=degree { for jj in … }`
nest in `crates/astrodyn_gravity/src/` finds that the inner range is
*distinct at every site*. Substituting the helper bound proposed in the
issue (`1..=ii.saturating_sub(2).min(order)`) at any of these sites
silently drops or fabricates gravitational terms, which is a physics
bug, so this PR adds **no helper and substitutes no call site**.

Instead it lands a `## SH iteration bound discipline` block in the
module docstring of `spherical_harmonics_calc_nonspherical` that
enumerates every existing bound with its JEOD/Gottlieb equation
reference and warns future contributors / refactor-scrub bots that any
generic `for_each_sh_coefficient(degree, order, …)` helper covering
more than one bound is unsafe.

Closes #569.

## Bound audit

| Site | Inner-loop bound | JEOD equation | Notes |
|------|------------------|---------------|-------|
| `spherical_harmonics_calc_nonspherical.rs:413` | `for jj in 2..=(ii - 2)` | (7-12) Pnm recursion fill | Body sets `scratch.pnm(ii, jj)` from `pnm(ii-1, jj)` and `pnm(ii-2, jj)` — both undefined for `jj < 2`. Substituting the issue's `1..=…` helper would write `pnm(ii, 1)` a second time after the explicit eq. (7-12) at jj=1 site three lines above. |
| `spherical_harmonics_calc_nonspherical.rs:459` | `for jj in 1..=order.min(ii)` (`jj_max = order.min(ii)`) | (3-18) main m-sum | No `-2` truncation. Substituting the issue's helper would chop two terms off the SH potential / gradient series. Body shares 25+ mutable accumulators with the outer `ii` loop, so even a bound-correct helper would not collapse cleanly. |
| `spherical_harmonics_gravity_source.rs:227` | `for jj in 0..=(ii - 1)` | (7-10) `xi` / `eta` precompute | Distinct from every other site; only appears here. |
| `spherical_harmonics_gravity_source.rs:244` | `for jj in 0..=ii` | (7-19) / (7-22) `zeta` / `upsilon` precompute | Distinct from every other site; only appears here. |
| `spherical_harmonics_calc_nonspherical.rs:324` | (no inner loop) | (7-8) Pnm diagonal | Single-level `for ii in 2..=degree`; the issue's double-loop helper does not apply. |

There is no production-site pair that shares an inner bound: each of
the four real `(degree, jj)` bounds appears exactly once, so adding
four single-use bound-specific helpers would be net-zero LOC and a
readability regression. The dominant *outer* bound (`for ii in
2..=degree`) is shared across three sites, but wrapping it in
`for_each_degree(degree, |ii| { … })` replaces the language's native
`for ii in range` with a closure call without simplifying the
multi-field `&mut self` / `&mut scratch` plumbing in any inner body —
also net-zero benefit. The issue's stated savings (~70 LOC) is not
achievable without changing the iteration bounds (i.e., changing the
physics).

## Sites deliberately left alone (with bound-mismatch notes)

All four production double-loops are left alone, because none of their
inner bounds matches the issue's helper. The single-loop site at
`spherical_harmonics_calc_nonspherical.rs:324` is also left alone
because the issue's helper is a *double* loop. The four bound tags in
the new docstring block are the durable artifact of this audit.

## Helper signature(s) chosen

None. The audit conclusion is that the issue's proposed
`for_each_sh_coefficient(degree: usize, order: usize, f: impl FnMut(usize, usize))`
helper is unsafe to apply at every existing site, and no other helper
shape collapses ≥2 sites without rewriting the underlying physics.
The bound-discipline docstring documents that conclusion at the source
where a future refactor pass would propose the same change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run -p astrodyn_gravity` (76 passed, primary risk surface)
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` (1393 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [ ] PR CI: tier 3 + bevy_parity (skipped locally per task instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)