### PR TITLE
[#570] Macro-ify phantom-only Copy/Clone/Debug/PartialEq impls

### DIFF
--- a/crates/astrodyn_quantities/src/derive_utils.rs
+++ b/crates/astrodyn_quantities/src/derive_utils.rs
@@ -1,0 +1,124 @@
+//! Declarative-macro helpers for phantom-only generic wrappers.
+//!
+//! Several typed-quantity wrappers in this crate parameterise on a phantom
+//! generic (`Position<F: Frame>`, `GravParam<P: Planet>`, `Qty3<D, F>`,
+//! `InertiaTensor<F>`, `PlanetFixed<P>`, …). The phantom is zero-sized
+//! `PhantomData<G>`, so the storage is structurally `Copy + Clone + Debug +
+//! PartialEq` whenever the *non-phantom* payload is. `#[derive(Copy)]` etc.
+//! disagree: they unconditionally synthesize `where G: Copy + Clone + Debug +
+//! PartialEq`, which is wrong for a phantom-only generic — the wrapper would
+//! refuse to compile for any tag that does not opt into those derives, even
+//! though the runtime storage never touches a `G` value.
+//!
+//! Hand-rolling the impls works, but at four sites the boilerplate becomes
+//! a maintenance smell. The macros below consolidate it:
+//!
+//! - [`impl_copy_phantom!`] emits a trivial `impl Copy`.
+//! - [`impl_clone_phantom!`] emits `impl Clone` whose `clone` is `*self`
+//!   (free because the wrapper is `Copy`).
+//! - [`impl_partial_eq_phantom!`] emits `impl PartialEq` whose `eq` is the
+//!   caller-supplied boolean expression. The caller names the bound
+//!   identifiers (typically `self, other`) so macro-hygiene keeps them
+//!   reachable inside the body expression.
+//! - [`impl_debug_phantom!`] emits `impl core::fmt::Debug` whose `fmt`
+//!   evaluates the caller-supplied expression. The caller names the
+//!   `&Self` and `&mut Formatter` identifiers (typically `self, f`) for
+//!   the same hygiene reason.
+//!
+//! Both the generics-and-bounds list and the type-argument list are passed
+//! in **square brackets** to keep `macro_rules!`'s `tt`-greedy matcher
+//! unambiguous when the generics include `?Sized` or `+`-joined bounds. The
+//! shape is `impl_*_phantom!([<generics>] Ty [<args>] $extras?)`.
+
+/// Emit `impl Copy` for a phantom-only generic.
+///
+/// ```ignore
+/// impl_copy_phantom!([P: Planet] GravParam[P]);
+/// impl_copy_phantom!([D: ?Sized + Dimension, F: Frame] Qty3[D, F]);
+/// ```
+macro_rules! impl_copy_phantom {
+    ([$($g:tt)*] $ty:ident [$($a:tt)*]) => {
+        impl<$($g)*> Copy for $ty<$($a)*> {}
+    };
+}
+
+/// Emit `impl Clone` whose `clone` returns `*self` (free because the
+/// wrapper is `Copy`).
+///
+/// ```ignore
+/// impl_clone_phantom!([P: Planet] GravParam[P]);
+/// ```
+macro_rules! impl_clone_phantom {
+    ([$($g:tt)*] $ty:ident [$($a:tt)*]) => {
+        impl<$($g)*> Clone for $ty<$($a)*> {
+            #[inline]
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+    };
+}
+
+/// Emit `impl PartialEq` whose `eq` is `$body`. The caller names the two
+/// `&Self` parameters so they survive macro hygiene.
+///
+/// ```ignore
+/// impl_partial_eq_phantom!(
+///     [P: Planet] GravParam[P],
+///     |this, other| this.value == other.value
+/// );
+/// impl_partial_eq_phantom!(
+///     [D: ?Sized + Dimension, F: Frame] Qty3[D, F],
+///     |this, other| this.x.value == other.x.value
+///         && this.y.value == other.y.value
+///         && this.z.value == other.z.value
+/// );
+/// ```
+macro_rules! impl_partial_eq_phantom {
+    (
+        [$($g:tt)*] $ty:ident [$($a:tt)*],
+        |$this:ident, $other:ident| $body:expr
+    ) => {
+        impl<$($g)*> PartialEq for $ty<$($a)*> {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                let $this: &Self = self;
+                let $other: &Self = other;
+                $body
+            }
+        }
+    };
+}
+
+/// Emit `impl core::fmt::Debug` whose `fmt` evaluates `$body`. The caller
+/// names the `&Self` receiver and the `&mut Formatter` so they survive
+/// macro hygiene.
+///
+/// The caller-supplied body keeps the per-site format string (which often
+/// names the phantom tag via `T::NAME` or `core::any::type_name::<T>()`)
+/// visible at the call site rather than hidden in a macro.
+///
+/// ```ignore
+/// impl_debug_phantom!(
+///     [P: Planet] GravParam[P],
+///     |this, f| write!(f, "GravParam<{}>({} m^3/s^2)", P::NAME, this.value)
+/// );
+/// ```
+macro_rules! impl_debug_phantom {
+    (
+        [$($g:tt)*] $ty:ident [$($a:tt)*],
+        |$this:ident, $f:ident| $body:expr
+    ) => {
+        impl<$($g)*> core::fmt::Debug for $ty<$($a)*> {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let $this: &Self = self;
+                let $f: &mut core::fmt::Formatter<'_> = f;
+                $body
+            }
+        }
+    };
+}
+
+pub(crate) use {
+    impl_clone_phantom, impl_copy_phantom, impl_debug_phantom, impl_partial_eq_phantom,
+};

--- a/crates/astrodyn_quantities/src/dims.rs
+++ b/crates/astrodyn_quantities/src/dims.rs
@@ -24,6 +24,9 @@ use core::marker::PhantomData;
 use typenum::{N1, N2, P1, P2, P3, Z0};
 use uom::si::{Quantity, ISQ, SI};
 
+use crate::derive_utils::{
+    impl_clone_phantom, impl_copy_phantom, impl_debug_phantom, impl_partial_eq_phantom,
+};
 use crate::frame::{Planet, SelfPlanet};
 
 /// Gravitational parameter μ = GM (L³T⁻²). Base SI unit: m³/s².
@@ -193,34 +196,24 @@ impl GravParam<SelfPlanet> {
     }
 }
 
-// Manual impls — the derive macros would demand `P: Default`/`P: Copy`/...
-// which is wrong for a phantom-only type parameter.
-impl<P: Planet> Copy for GravParam<P> {}
-
-impl<P: Planet> Clone for GravParam<P> {
-    #[inline]
-    fn clone(&self) -> Self {
-        *self
-    }
-}
+// Phantom-only generic: `#[derive]` would wrongly demand `P: Copy + Clone +
+// PartialEq + Debug`. `Default` is hand-rolled because the zero μ delegates
+// to `Self::from_si`.
+impl_copy_phantom!([P: Planet] GravParam[P]);
+impl_clone_phantom!([P: Planet] GravParam[P]);
+impl_partial_eq_phantom!(
+    [P: Planet] GravParam[P],
+    |this, other| this.value == other.value
+);
+// `Planet::NAME` carries the per-planet identifier (e.g. "Earth").
+impl_debug_phantom!(
+    [P: Planet] GravParam[P],
+    |this, f| write!(f, "GravParam<{}>({} m^3/s^2)", P::NAME, this.value)
+);
 
 impl<P: Planet> Default for GravParam<P> {
     #[inline]
     fn default() -> Self {
         Self::from_si(0.0)
-    }
-}
-
-impl<P: Planet> PartialEq for GravParam<P> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
-}
-
-impl<P: Planet> core::fmt::Debug for GravParam<P> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // `Planet::NAME` carries the per-planet identifier (e.g. "Earth").
-        write!(f, "GravParam<{}>({} m^3/s^2)", P::NAME, self.value)
     }
 }

--- a/crates/astrodyn_quantities/src/frame.rs
+++ b/crates/astrodyn_quantities/src/frame.rs
@@ -24,6 +24,7 @@
 
 use core::marker::PhantomData;
 
+use crate::derive_utils::{impl_clone_phantom, impl_copy_phantom};
 use crate::sealed::{FrameSealed, PlanetSealed, VehicleSealed};
 
 /// Compile-time reference frame tag.
@@ -286,16 +287,11 @@ impl Frame for MassNode {
 /// Planet-fixed frame for any planet `P`. Rotates with that planet.
 #[derive(Debug)]
 pub struct PlanetFixed<P: Planet>(PhantomData<P>);
-// Manual `Clone` / `Copy` impls so `FrameTransform<_, PlanetFixed<P>>` can
-// be cloned/copied even when `P` itself doesn't bound `Clone` / `Copy`.
-// `PlanetFixed<P>` is just `PhantomData<P>` — zero-sized — so both impls
-// are trivially correct.
-impl<P: Planet> Clone for PlanetFixed<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<P: Planet> Copy for PlanetFixed<P> {}
+// Phantom-only generic: `#[derive(Clone, Copy)]` would wrongly demand
+// `P: Clone + Copy` even though `PhantomData<P>` is zero-sized. Hand-rolled
+// so `FrameTransform<_, PlanetFixed<P>>` clones/copies for any planet tag.
+impl_clone_phantom!([P: Planet] PlanetFixed[P]);
+impl_copy_phantom!([P: Planet] PlanetFixed[P]);
 impl<P: Planet> FrameSealed for PlanetFixed<P> {}
 impl<P: Planet> Frame for PlanetFixed<P> {
     const NAME: &'static str = "PlanetFixed";

--- a/crates/astrodyn_quantities/src/inertia.rs
+++ b/crates/astrodyn_quantities/src/inertia.rs
@@ -23,6 +23,9 @@ use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 use glam::DMat3;
 
+use crate::derive_utils::{
+    impl_clone_phantom, impl_copy_phantom, impl_debug_phantom, impl_partial_eq_phantom,
+};
 use crate::frame::Frame;
 
 /// Mass moment of inertia tensor (`kg·m²`) expressed in frame `F`.
@@ -121,36 +124,24 @@ impl<F: Frame> InertiaTensor<F> {
     }
 }
 
-// Manual Copy/Clone/Debug/PartialEq mirroring `Qty3` style — derives would
-// otherwise demand `F: Copy + Debug + PartialEq` even though `PhantomData<F>`
-// is zero-sized regardless.
-
-impl<F: Frame> Copy for InertiaTensor<F> {}
-
-impl<F: Frame> Clone for InertiaTensor<F> {
-    #[inline]
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<F: Frame> core::fmt::Debug for InertiaTensor<F> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "InertiaTensor<{}>({:?})",
-            core::any::type_name::<F>(),
-            self.value
-        )
-    }
-}
-
-impl<F: Frame> PartialEq for InertiaTensor<F> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
-}
+// Phantom-only generic mirroring `Qty3` style — `#[derive]` would wrongly
+// demand `F: Copy + Debug + PartialEq` even though `PhantomData<F>` is
+// zero-sized regardless.
+impl_copy_phantom!([F: Frame] InertiaTensor[F]);
+impl_clone_phantom!([F: Frame] InertiaTensor[F]);
+impl_debug_phantom!(
+    [F: Frame] InertiaTensor[F],
+    |this, f| write!(
+        f,
+        "InertiaTensor<{}>({:?})",
+        core::any::type_name::<F>(),
+        this.value
+    )
+);
+impl_partial_eq_phantom!(
+    [F: Frame] InertiaTensor[F],
+    |this, other| this.value == other.value
+);
 
 impl<F: Frame> Default for InertiaTensor<F> {
     #[inline]

--- a/crates/astrodyn_quantities/src/lib.rs
+++ b/crates/astrodyn_quantities/src/lib.rs
@@ -163,6 +163,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+mod derive_utils;
 mod sealed;
 
 pub mod aliases;

--- a/crates/astrodyn_quantities/src/qty3.rs
+++ b/crates/astrodyn_quantities/src/qty3.rs
@@ -5,6 +5,9 @@ use core::marker::PhantomData;
 use glam::DVec3;
 use uom::si::{Dimension, Quantity, SI};
 
+use crate::derive_utils::{
+    impl_clone_phantom, impl_copy_phantom, impl_debug_phantom, impl_partial_eq_phantom,
+};
 use crate::frame::Frame;
 
 /// Componentwise 3-vector: each of `x`, `y`, `z` carries the dimension `D`,
@@ -114,42 +117,31 @@ impl<D: ?Sized + Dimension, F: Frame> Qty3<D, F> {
     }
 }
 
-// Manual Copy/Clone/PartialEq to avoid the derive macro demanding `D: Copy`.
-impl<D: ?Sized + Dimension, F: Frame> Copy for Qty3<D, F> {}
-
-impl<D: ?Sized + Dimension, F: Frame> Clone for Qty3<D, F> {
-    #[inline]
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<D: ?Sized + Dimension, F: Frame> core::fmt::Debug for Qty3<D, F> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // `F::NAME` is the *kind* of the frame (e.g. "BodyFrame"). For
-        // vehicle- or planet-parameterized frames that alone can't
-        // distinguish `BodyFrame<Iss>` from `BodyFrame<Mir>`. Use
-        // `type_name::<F>()` so the output carries the full phantom tag
-        // — the cost is a single opaque string, no allocations.
-        write!(
-            f,
-            "Qty3<{}>({}, {}, {})",
-            core::any::type_name::<F>(),
-            self.x.value,
-            self.y.value,
-            self.z.value
-        )
-    }
-}
-
-impl<D: ?Sized + Dimension, F: Frame> PartialEq for Qty3<D, F> {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.x.value == other.x.value
-            && self.y.value == other.y.value
-            && self.z.value == other.z.value
-    }
-}
+// Phantom-only generic: `#[derive]` would wrongly demand `D: Copy`,
+// `F: Copy + Debug + PartialEq`, etc.
+impl_copy_phantom!([D: ?Sized + Dimension, F: Frame] Qty3[D, F]);
+impl_clone_phantom!([D: ?Sized + Dimension, F: Frame] Qty3[D, F]);
+// `F::NAME` is the *kind* of the frame (e.g. "BodyFrame"). For vehicle- or
+// planet-parameterized frames that alone can't distinguish `BodyFrame<Iss>`
+// from `BodyFrame<Mir>`. Use `type_name::<F>()` so the output carries the
+// full phantom tag — the cost is a single opaque string, no allocations.
+impl_debug_phantom!(
+    [D: ?Sized + Dimension, F: Frame] Qty3[D, F],
+    |this, f| write!(
+        f,
+        "Qty3<{}>({}, {}, {})",
+        core::any::type_name::<F>(),
+        this.x.value,
+        this.y.value,
+        this.z.value
+    )
+);
+impl_partial_eq_phantom!(
+    [D: ?Sized + Dimension, F: Frame] Qty3[D, F],
+    |this, other| this.x.value == other.x.value
+        && this.y.value == other.y.value
+        && this.z.value == other.z.value
+);
 
 /// `Default` returns the zero vector of dimension `D` in frame `F`. Manual
 /// impl rather than derive, because `derive(Default)` would demand


### PR DESCRIPTION
Closes #570.

## Summary

Consolidates the hand-written `Copy` / `Clone` / `Debug` / `PartialEq` impls at four phantom-only generic wrappers in `astrodyn_quantities` behind four declarative macros in a new `pub(crate)` module.

`#[derive]` is still the wrong tool: it would synthesize `where G: Copy + Clone + Debug + PartialEq` bounds even though `PhantomData<G>` is zero-sized and the runtime storage never touches a `G` value. The macros emit the same trivial impl shape without those bounds, so a tag that does not opt into `Copy + Debug + ...` can still parameterise the wrapper.

## Macro signatures

All four live in `crates/astrodyn_quantities/src/derive_utils.rs` (re-exported via `pub(crate) use`):

```rust
impl_copy_phantom!([<generics>] Ty[<args>]);
impl_clone_phantom!([<generics>] Ty[<args>]);
impl_partial_eq_phantom!([<generics>] Ty[<args>], |this, other| <bool expr>);
impl_debug_phantom!([<generics>] Ty[<args>], |this, f| <fmt::Result expr>);
```

- Both the bounds list and the type-argument list are enclosed in **square brackets** so `macro_rules!`'s `tt`-greedy matcher stays unambiguous when bounds include `?Sized` or `+`-joined paths.
- `PartialEq` / `Debug` take the receiver / `other` / formatter as caller-named identifiers so macro hygiene keeps them reachable inside the body expression. The per-site `write!(...)` format string stays visible at the call site rather than being hidden inside the macro.

## Substituted sites

| File | Wrapper | Impls substituted |
|---|---|---|
| `crates/astrodyn_quantities/src/dims.rs` | `GravParam<P: Planet>` | Copy, Clone, PartialEq, Debug |
| `crates/astrodyn_quantities/src/qty3.rs` | `Qty3<D: ?Sized + Dimension, F: Frame>` | Copy, Clone, PartialEq, Debug |
| `crates/astrodyn_quantities/src/inertia.rs` | `InertiaTensor<F: Frame>` | Copy, Clone, PartialEq, Debug |
| `crates/astrodyn_quantities/src/frame.rs` | `PlanetFixed<P: Planet>` | Clone, Copy (Debug stays `#[derive]`) |

## Not substituted (deliberately)

- `Default` impls at `GravParam<P>`, `Qty3<D, F>`, `InertiaTensor<F>` are kept hand-rolled because each delegates to the type's own zero constructor (`Self::from_si(0.0)`, `Self::zero()`). A macro wouldn't simplify them.
- The `#[derive(Debug)]` on `PlanetFixed<P>` stays as-is because the autogenerated tuple-struct Debug suffices and matches the pre-PR output.

## Comments preserved

The per-site explanatory comments ("derive would demand `D: Copy` ...", "F::NAME is the kind of the frame ...", etc.) are condensed and moved to the macro invocation block. The module-level doc comment on `derive_utils.rs` carries the centralized rationale for the pattern.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated` clean
- `cargo nextest run -p astrodyn_quantities` -- 149/149 pass
- `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` -- 1393/1393 pass
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` clean
- `scripts/check_no_escape_hatches.sh` clean
- `cargo test -p astrodyn --test invariant_coverage` -- 7/7 pass
- `cargo expand -p astrodyn_quantities --lib dims` inspected: macro expansion is semantically identical to the previous hand-written impls (the only literal difference is a no-op `let this: &Self = self;` rebinding to thread macro hygiene; LLVM elides it).

## Test plan

- [x] All unit + tier-2 tests pass locally
- [x] `Debug` output unchanged (verified by `debug_includes_planet_name` test)
- [x] `PartialEq` behaviour unchanged (verified by `equality_within_planet` test)
- [x] Clippy / fmt / docs / escape-hatch / invariant-coverage checks all clean

PR CI will exercise the parity-trajectory + tier-3 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)