### PR TITLE
[#571] Document one-binary-per-topic as load-bearing on parity coverage + CI split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,13 +176,13 @@ jobs:
       # coupling". If `tests/bevy_parity_*.rs` were ever collapsed under
       # one umbrella binary named `bevy_parity` (e.g. mod-based
       # restructure), the four binary selectors below (two
-      # `binary(/^bevy_parity_…/)` regex + two exact
-      # `binary(=bevy_parity_…)`) would each match zero binaries — both
-      # forms require the trailing `_<topic>` suffix that the umbrella
-      # target name lacks, so nothing gets excluded and the PR lane
-      # silently runs every heavy parity scenario. The
-      # `parity_coverage.rs` module doc enumerates the parallel guard
-      # fence.
+      # `binary(/^bevy_parity_…/)` regexes plus two exact-match
+      # `binary(=bevy_parity_…)` selectors) would each match zero
+      # binaries — both forms require the trailing `_<topic>` suffix
+      # that the umbrella target name lacks, so nothing gets excluded
+      # and the PR lane silently runs every heavy parity scenario.
+      # The `parity_coverage.rs` module doc enumerates the parallel
+      # guard fence.
       - name: Run fast bevy_parity_* tests (exclude heavy binaries)
         run: |
           cargo nextest run --workspace -E '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,14 @@ jobs:
       # extend both this exclusion and the
       # `test-parity-trajectory-full` job's matching comment so the
       # full-coverage invariant stays explicit.
+      #
+      # Note: the `binary(...)` selectors below read the cargo target
+      # name (one binary per `tests/bevy_parity_*.rs` file). This is the
+      # second of the two structural fences cataloged in
+      # `crates/astrodyn_verif_parity/tests/parity_coverage.rs` §"Structural
+      # coupling" — collapsing the parity tests into a single umbrella
+      # integration-test binary would silently collapse all four
+      # selectors below to one, undoing the heavy/fast split.
       - name: Run fast bevy_parity_* tests (exclude heavy binaries)
         run: |
           cargo nextest run --workspace -E '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,16 @@ jobs:
       # name (one binary per `tests/bevy_parity_*.rs` file). This is the
       # second of the two structural fences cataloged in
       # `crates/astrodyn_verif_parity/tests/parity_coverage.rs` §"Structural
-      # coupling" — collapsing the parity tests into a single umbrella
-      # integration-test binary would silently collapse all four
-      # selectors below to one, undoing the heavy/fast split.
+      # coupling". If `tests/bevy_parity_*.rs` were ever collapsed under
+      # one umbrella binary named `bevy_parity` (e.g. mod-based
+      # restructure), the four binary selectors below (two
+      # `binary(/^bevy_parity_…/)` regex + two exact
+      # `binary(=bevy_parity_…)`) would each match zero binaries — both
+      # forms require the trailing `_<topic>` suffix that the umbrella
+      # target name lacks, so nothing gets excluded and the PR lane
+      # silently runs every heavy parity scenario. The
+      # `parity_coverage.rs` module doc enumerates the parallel guard
+      # fence.
       - name: Run fast bevy_parity_* tests (exclude heavy binaries)
         run: |
           cargo nextest run --workspace -E '

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -20,6 +20,43 @@
 //! with a `#[ignore = "parity-gap: <reason>"]` on the wrapper test (or
 //! omit the wrapper entirely). The intent is that *every* gap is
 //! either solved or named explicitly.
+//!
+//! ## Structural coupling: one-binary-per-topic is load-bearing
+//!
+//! The `bevy_parity_<topic>.rs` *file stem* is the topic identifier on
+//! two structural fences, not a convention:
+//!
+//! 1. **Parity-superset coverage (this file).** [`collect_topics`]
+//!    enumerates by `read_dir` + `file_stem` + `strip_prefix("bevy_parity_")`.
+//!    There is no inspection of test function names anywhere in the
+//!    crate. Collapsing N integration-test files into a single
+//!    `tests/bevy_parity.rs` umbrella binary that `mod`s each former
+//!    file would empty this scan (a single file stem of `bevy_parity`
+//!    leaves no topic after the prefix strip), and every Tier 3 topic
+//!    would immediately report "uncovered". The coverage gate would
+//!    have to be rewritten to scan test function names from compiled
+//!    binary metadata before the umbrella restructure is safe.
+//!
+//! 2. **CI heavy/fast split** (`.github/workflows/ci.yml`,
+//!    `test-parity-trajectory` job). The PR-lane exclusion filter uses
+//!    `binary(/^bevy_parity_dyncomp_run/)`,
+//!    `binary(/^bevy_parity_solar_beta/)`,
+//!    `binary(=bevy_parity_torque_simple)`,
+//!    `binary(=bevy_parity_srp_1st_order)`. Each parity wrapper today
+//!    is its own cargo integration-test target (one binary per file),
+//!    and the `binary(...)` nextest selector reads cargo's target name.
+//!    Collapsing into one umbrella binary collapses these four
+//!    selectors to a single `binary(=bevy_parity)`; the heavy subset
+//!    would have to be re-expressed via `test(...)` selectors against
+//!    function names, which requires every heavy test function to
+//!    carry the same `bevy_parity_<topic>` prefix the file stem
+//!    carries today.
+//!
+//! Both fences depend on the **file stem** identifying the topic.
+//! Refactors that hoist `#![allow]` blocks (or anything else) into a
+//! single umbrella integration-test binary must coincide with
+//! structural updates to both fences in the same PR — half-baked
+//! consolidations are unsafe.
 
 use std::collections::BTreeSet;
 use std::path::Path;

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -31,16 +31,19 @@
 //!    There is no inspection of test function names anywhere in the
 //!    crate. Collapsing N integration-test files into a single
 //!    `tests/bevy_parity.rs` umbrella binary that `mod`s each former
-//!    file would empty this scan (a single file stem of `bevy_parity`
-//!    leaves no topic after the prefix strip). The coverage loop then
-//!    skips any topic listed in [`DEFERRED_GAPS`] or [`PERMANENT_GAPS`]
-//!    before pushing to `uncovered`, so the resulting failure mode is
-//!    "every Tier 3 topic *not already gap-listed* fires uncovered" —
-//!    with today's gap lists that's the bulk of the parity matrix,
-//!    a substantial but per-topic-aware failure rather than a total
-//!    one. The coverage gate would still have to be rewritten to scan
-//!    test function names from compiled binary metadata before the
-//!    umbrella restructure is safe.
+//!    file would empty this scan: the file stem `bevy_parity` (no
+//!    trailing underscore) fails the `strip_prefix("bevy_parity_")`
+//!    call entirely and the file is skipped — it does *not* contribute
+//!    an empty-string topic. With no parity wrappers discovered, the
+//!    `parity_topics` set is empty; the coverage loop then skips any
+//!    topic listed in [`DEFERRED_GAPS`] or [`PERMANENT_GAPS`] before
+//!    pushing to `uncovered`, so the resulting failure mode is "every
+//!    Tier 3 topic *not already gap-listed* fires uncovered" — with
+//!    today's gap lists that's the bulk of the parity matrix, a
+//!    substantial but per-topic-aware failure rather than a total one.
+//!    The coverage gate would still have to be rewritten to scan test
+//!    function names from compiled binary metadata before the umbrella
+//!    restructure is safe.
 //!
 //! 2. **CI heavy/fast split** (`.github/workflows/ci.yml`,
 //!    `test-parity-trajectory` job). The PR-lane exclusion filter uses
@@ -50,12 +53,18 @@
 //!    `binary(=bevy_parity_srp_1st_order)`. Each parity wrapper today
 //!    is its own cargo integration-test target (one binary per file),
 //!    and the `binary(...)` nextest selector reads cargo's target name.
-//!    Collapsing into one umbrella binary collapses these four
-//!    selectors to a single `binary(=bevy_parity)`; the heavy subset
-//!    would have to be re-expressed via `test(...)` selectors against
-//!    function names, which requires every heavy test function to
-//!    carry the same `bevy_parity_<topic>` prefix the file stem
-//!    carries today.
+//!    Collapsing into one umbrella binary (target name `bevy_parity`)
+//!    leaves these four selectors matching **no** binaries — both the
+//!    `^bevy_parity_dyncomp_run` / `^bevy_parity_solar_beta` regexes
+//!    and the exact `=bevy_parity_torque_simple` /
+//!    `=bevy_parity_srp_1st_order` names require the trailing
+//!    `_<topic>` suffix, which the umbrella target name lacks. The
+//!    heavy/fast split silently breaks at the selector level: nothing
+//!    gets excluded, and the PR lane runs every heavy parity scenario.
+//!    To restore the split, the heavy subset would have to be
+//!    re-expressed via `test(...)` selectors against function names,
+//!    which requires every heavy test function to carry the same
+//!    `bevy_parity_<topic>` prefix the file stem carries today.
 //!
 //! Both fences depend on the **file stem** identifying the topic.
 //! Refactors that hoist `#![allow]` blocks (or anything else) into a

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -32,10 +32,15 @@
 //!    crate. Collapsing N integration-test files into a single
 //!    `tests/bevy_parity.rs` umbrella binary that `mod`s each former
 //!    file would empty this scan (a single file stem of `bevy_parity`
-//!    leaves no topic after the prefix strip), and every Tier 3 topic
-//!    would immediately report "uncovered". The coverage gate would
-//!    have to be rewritten to scan test function names from compiled
-//!    binary metadata before the umbrella restructure is safe.
+//!    leaves no topic after the prefix strip). The coverage loop then
+//!    skips any topic listed in [`DEFERRED_GAPS`] or [`PERMANENT_GAPS`]
+//!    before pushing to `uncovered`, so the resulting failure mode is
+//!    "every Tier 3 topic *not already gap-listed* fires uncovered" —
+//!    with today's gap lists that's the bulk of the parity matrix,
+//!    a substantial but per-topic-aware failure rather than a total
+//!    one. The coverage gate would still have to be rewritten to scan
+//!    test function names from compiled binary metadata before the
+//!    umbrella restructure is safe.
 //!
 //! 2. **CI heavy/fast split** (`.github/workflows/ci.yml`,
 //!    `test-parity-trajectory` job). The PR-lane exclusion filter uses


### PR DESCRIPTION
## Feasibility-gate outcome: verify-and-close (no `#![allow]` consolidation)

Issue #571 proposes collapsing the ~26 (actually 14 of 81) `bevy_parity_*.rs`
integration-test files into a single umbrella `tests/bevy_parity.rs` that
`mod`s each former file and carries one `#![allow]` block. The task spec
required answering three feasibility questions before writing any code.

### Q1: Does `parity_coverage.rs` enumerate by file stem or by test function name?

**By file stem.** `collect_topics()` in
`crates/astrodyn_verif_parity/tests/parity_coverage.rs` calls
`read_dir` + `file_stem` + `strip_prefix("bevy_parity_")`. No
function-name introspection exists anywhere in the crate. With a
single umbrella file named `tests/bevy_parity.rs`, the file stem
`bevy_parity` (no trailing underscore) fails the
`strip_prefix("bevy_parity_")` check entirely and is silently skipped
by the scanner, leaving `parity_topics` empty. Every Tier 3 topic
would then report "uncovered" and the parity-superset CI guard from
#389 would fail on the next run.

### Q2: Does the CI exclusion list reference binary names or test function names?

**Binary names.** `.github/workflows/ci.yml` `test-parity-trajectory`
job:
```
binary(/^bevy_parity_dyncomp_run/)
binary(/^bevy_parity_solar_beta/)
binary(=bevy_parity_torque_simple)
binary(=bevy_parity_srp_1st_order)
```

These read the cargo *target name* (one binary per
`tests/bevy_parity_*.rs` file today). Collapsing into a single
integration-test target collapses all four selectors to one
`binary(=bevy_parity)`. The heavy/fast PR-lane split would either
admit every heavy parity test to PR CI (45–60 min, well past the
~10–12 min budget the comment explicitly cites) or exclude all of
them. Migrating to `test(...)` selectors against function names is
*technically possible* — function names use the same
`bevy_parity_<topic>_` prefix — but requires auditing every
function-name in the suite for cross-topic collisions before the
filter can be re-expressed.

### Q3: Does collapsing 80+ binaries into 1 materially change PR CI runtime?

Compile cost: link cost drops (one binary instead of 81), but the
heavy/fast split's structural prerequisite collapses with it. Runtime
is similar (nextest parallelism is per-test). So the win the issue
cites is real, but only after Q1 and Q2 are addressed in coincident
PRs.

### Additional findings vs the issue body

- Issue cites "~26 files" with the `#![allow]` block; the actual
  count is **14 of 81** parity wrapper files
  (`grep -l '#!\[allow(' tests/bevy_parity_*.rs | wc -l`). The
  claimed ~50 LOC savings is in the right order of magnitude
  (~70–100 LOC, 5–8 lines × 14 files).
- `tests/bevy_parity.rs` **already exists today** as a separate
  cargo-target containing two `bevy_parity_*_bit_identical` tests
  — collapsing wouldn't be naming-conflict-free either.

## Pivot rationale

Per the task spec: "If question 1's answer is 'file stem' and the
restructure would break the coverage check, OR question 2's answer
is 'binary names' and the restructure breaks the CI exclusion filter
→ pivot to verify-and-close". **Both** answers trigger the pivot.

This PR mirrors the **#569 → #581** verify-and-close pattern: ship
an audit-as-doc at the structurally-coupled sites so a future
refactor-scrub pass (or human re-derivation) sees the constraint
immediately. No file restructure, no `#![allow]` consolidation.

## Changes

- `crates/astrodyn_verif_parity/tests/parity_coverage.rs`: adds a
  "Structural coupling: one-binary-per-topic is load-bearing"
  section to the module docstring, enumerating both fences (file-stem
  scanner here + `binary(...)` selectors in CI) that depend on the
  one-file-per-topic invariant.
- `.github/workflows/ci.yml`: adds a back-reference comment in the
  `test-parity-trajectory` job pointing to the new section, so a
  future contributor editing the heavy-binary exclusion list sees
  the same fence is documented.

## Recommended split if a future PR pursues the consolidation

The task spec recommended splitting into 3 dependent issues; the
recommendation lands implicitly in the new docstring: the coverage
gate has to scan compiled binary metadata (test names) before the
umbrella restructure is safe, and the CI heavy/fast filter has to
move from `binary(...)` to `test(...)` selectors. A future PR can
either:

1. Refactor `parity_coverage.rs` to use cargo's `--list` machinery
   or a build-time `inventory!`-style registration so test function
   names become the topic identifier; then refactor CI; then
   consolidate.
2. Accept the LOC overhead (14 × 5–8 lines) as the price of the
   two file-stem fences this PR documents.

Either way, this PR keeps the next reader's path clear.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests --examples -- -D warnings -D deprecated`
- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` (1393 passed)
- [x] `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` (still green)
- [x] `cargo doc --workspace --no-deps`
- [x] `scripts/check_no_escape_hatches.sh`
- [x] `scripts/check_no_bypass_deps.sh`
- [x] `scripts/check_no_silent_warn.sh`
- [x] `cargo test -p astrodyn --test invariant_coverage`
- [ ] PR CI: tier 3 + bevy_parity heavy/fast split (skipped locally per task instructions)

Closes #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
