### PR TITLE
[#535] Close IN.09 negative-test gap and promote gate to hard assertion

### DIFF
--- a/crates/astrodyn_bevy/src/systems/derived_state.rs
+++ b/crates/astrodyn_bevy/src/systems/derived_state.rs
@@ -567,6 +567,10 @@ mod tests {
         // Deliberately no SunMarker / SunBundle in the world; the
         // `Without<SunMarker>` body still appears in the system's
         // query, and the missing-Sun branch panics naming it.
+        // JEOD_INV: IN.09 — body carrying SolarBetaC without a
+        // SunMarker in the World; per-step safety net inside
+        // solar_beta_system (the startup `validation` pass is the
+        // first line, this is the fallback for bodies that bypass it).
         app.add_systems(Update, solar_beta_system::<Earth>);
         app.update();
     }

--- a/crates/astrodyn_bevy/tests/in_09_solar_beta_requires_sun_marker.rs
+++ b/crates/astrodyn_bevy/tests/in_09_solar_beta_requires_sun_marker.rs
@@ -1,0 +1,136 @@
+//! Negative test for IN.09: a body carrying `SolarBetaC` must not
+//! survive into the per-tick pipeline without a matching `SunMarker`
+//! entity in the world.
+//!
+//! Catalogued in `docs/JEOD_invariants.md` row IN.09. Two enforcement
+//! sites cover this invariant:
+//! - The startup-pass `validate_jeod_invariants::<P>` panics with
+//!   `"Entity {entity:?}: SolarBetaC present but no SunMarker entity
+//!   exists."` for bodies that pass through the validator
+//!   (`crates/astrodyn_bevy/src/validation.rs`).
+//! - The per-step `solar_beta_system` panics with
+//!   `"{entity:?} solar beta: no SunMarker entity exists in the
+//!   World"` as a fallback for bodies that bypass validation (e.g. a
+//!   body with `SolarBetaC` but no `GravityControlsC`, or a
+//!   `SolarBetaC` inserted after the body's spawn tick)
+//!   (`crates/astrodyn_bevy/src/systems/derived_state.rs`).
+//!
+//! This integration test drives the validator site by going through
+//! the public `VehicleBuilder` API + the full `AstrodynPlugin`
+//! schedule — mirroring the AT.03 negative test's shape. The
+//! in-module unit test
+//! `derived_state::tests::solar_beta_missing_sun_marker_panics_with_caller_fix`
+//! drives the per-step site in isolation. Both messages share the
+//! `"no SunMarker entity exists"` substring so this test is robust
+//! to a future refactor that reorders the two sites.
+//!
+//! The pre-#535 silent fallback was `SolarBeta::default() = 0.0` —
+//! the geometrically-plausible "perfectly noon" value that downstream
+//! thermal / power / pointing budgets cannot distinguish from a real
+//! computation.
+
+use std::time::Duration;
+
+use astrodyn::{
+    F64Ext, GravityControl, GravityGradient, RootInertial, TranslationalStateTyped, Vec3Ext,
+    VehicleBuilder, EARTH,
+};
+use astrodyn_bevy::{AstrodynPlugin, IntegrationDtR, PlanetBundle, VehicleConfigBevyExt};
+use bevy::prelude::*;
+use glam::DVec3;
+
+const DT: f64 = 60.0;
+
+fn iss_trans() -> TranslationalStateTyped<RootInertial> {
+    TranslationalStateTyped::<RootInertial> {
+        position: DVec3::new(6_778_137.0, 0.0, 0.0).m_at::<RootInertial>(),
+        velocity: DVec3::new(0.0, 7668.56, 0.0).m_per_s_at::<RootInertial>(),
+    }
+}
+
+fn iss_mass_kg() -> uom::si::f64::Mass {
+    400_000.0.kg()
+}
+
+fn step(app: &mut App) {
+    app.world_mut().run_schedule(Startup);
+    app.world_mut()
+        .resource_mut::<Time<Fixed>>()
+        .advance_by(Duration::from_secs_f64(DT));
+    app.world_mut().run_schedule(FixedUpdate);
+}
+
+#[test]
+#[should_panic(expected = "no SunMarker entity exists")]
+fn in_09_panics_on_solar_beta_without_sun_marker() {
+    // JEOD_INV: IN.09 — a body requesting solar-beta derived state
+    // (SolarBetaC) in a world that has zero SunMarker entities must
+    // fail loudly rather than silently writing SolarBeta = 0.0. The
+    // validator catches the misconfiguration on the first FixedUpdate
+    // tick; the per-step solar_beta_system is the second-line safety
+    // net for bodies that bypass validation (covered by the in-module
+    // unit test in derived_state::tests).
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .insert_resource(Time::<Fixed>::from_seconds(DT))
+        .insert_resource(IntegrationDtR(DT))
+        .add_plugins(AstrodynPlugin);
+
+    // Spawn an Earth gravity source. Deliberately no `SunBundle` /
+    // `SunMarker` in the world — that is the misconfiguration this
+    // test drives.
+    let earth = app
+        .world_mut()
+        .spawn(PlanetBundle::<astrodyn::Earth>::point_mass_only(
+            "Earth",
+            astrodyn::GravitySource {
+                mu: EARTH.shape.mu,
+                model: astrodyn::GravityModel::PointMass,
+            },
+        ))
+        .id();
+
+    // Build a vehicle that requests solar-beta derived state. The
+    // builder's `.solar_beta()` flips `derived.solar_beta = true`;
+    // `spawn_bevy` then inserts `SolarBetaC::default()` on the body
+    // (per `crates/astrodyn_bevy/src/lib.rs::spawn_bevy_inner` —
+    // see the `derived.solar_beta` row in the rustdoc enumeration).
+    let cfg = VehicleBuilder::new()
+        .with_translational(iss_trans())
+        .three_dof_point_mass(iss_mass_kg())
+        .rk4()
+        .gravity(GravityControl::new_spherical(
+            0_usize,
+            GravityGradient::Skip,
+        ))
+        .solar_beta()
+        .build();
+
+    {
+        let mut commands = app.world_mut().commands();
+        let _vehicle = cfg.spawn_bevy::<astrodyn::Earth>(&mut commands, &[earth]);
+    }
+    app.world_mut().flush();
+
+    // Sanity precondition: the misconfiguration is actually wired —
+    // the world has a body carrying SolarBetaC and zero SunMarker
+    // entities. If either assertion fails the test is no longer
+    // driving the IN.09 enforcement sites.
+    {
+        let world = app.world_mut();
+        let mut solar_beta_q = world.query::<&astrodyn_bevy::SolarBetaC>();
+        let solar_beta_count = solar_beta_q.iter(world).count();
+        assert_eq!(
+            solar_beta_count, 1,
+            "test precondition: exactly one body must carry SolarBetaC for IN.09 to fire"
+        );
+        let mut sun_q = world.query::<&astrodyn_bevy::SunMarker>();
+        let sun_count = sun_q.iter(world).count();
+        assert_eq!(
+            sun_count, 0,
+            "test precondition: zero SunMarker entities must exist for IN.09 to fire"
+        );
+    }
+
+    step(&mut app);
+}

--- a/tests/invariant_coverage.rs
+++ b/tests/invariant_coverage.rs
@@ -612,11 +612,15 @@ fn every_enforced_row_has_a_negative_test() {
         missing_enforced
     );
 
-    // Defensive sanity guard: if the scanner ever silently returns
-    // zero matches the assertion above would trivially pass on an
-    // empty `missing_enforced` vec only when the catalog itself is
-    // empty (already false today). This assert documents the implicit
-    // dependency and surfaces scanner breakage as a distinct failure.
+    // Defensive sanity guard with a dedicated error message for
+    // scanner breakage. If the scanner ever silently returns zero
+    // matches, every `enforced` row lands in `missing_enforced` and
+    // the assertion above already fails — but the failure message
+    // would name all 75 rows and read as "the entire catalog regressed
+    // overnight." This second assert fires on the same condition
+    // (`covered_enforced.is_empty()` ↔ scanner returned nothing) and
+    // points the reader at the scanner (window, brace-counting, root
+    // set) instead.
     assert!(
         !covered_enforced.is_empty(),
         "Negative-test scanner found zero covered `enforced` rows — the scanner \

--- a/tests/invariant_coverage.rs
+++ b/tests/invariant_coverage.rs
@@ -507,23 +507,25 @@ fn find_test_fn_body_end(lines: &[&str], attr_idx: usize) -> Option<usize> {
     None
 }
 
-/// Direction 6 (informational seed from #531): every `enforced`
-/// catalog row should have at least one negative test driving the
-/// misconfiguration. Emits a `::warning::`-style coverage report and
-/// PASSES regardless — the bidirectional gate is staged in chunks
-/// (this PR seeds the matcher + a handful of tests; subsequent PRs
-/// fill in the per-section bodies; the final PR in the chain promotes
-/// this to a hard `assert!`).
+/// Direction 6 (promoted in #535): every `enforced` catalog row
+/// must have at least one `#[should_panic(expected = "…")]` negative
+/// test driving the misconfiguration. The matcher is grep-based
+/// (see `find_negative_tests` above): a `// JEOD_INV: XX.YY` token
+/// inside the test function body OR on the 6 lines immediately
+/// preceding the `#[should_panic]` attribute counts.
 ///
-/// Rationale: today the bidirectional `tag ↔ catalog` checks above
-/// only prove the tag *exists* at the enforcement site. They do not
-/// prove the `assert!` actually fires under misconfiguration — an
+/// Rationale: the bidirectional `tag ↔ catalog` checks above only
+/// prove the tag *exists* at the enforcement site. They do not prove
+/// the `assert!` actually fires under misconfiguration — an
 /// AI-authored refactor could neuter a panic site to a silent
 /// `if … return` and CI would stay green. A `#[should_panic(expected
 /// = "…")]` negative test that drives the failure and pins the panic
 /// message text closes that gap.
+///
+/// `partial` rows are reported but not required (best-effort per the
+/// #535 acceptance criteria).
 #[test]
-fn enforced_rows_have_negative_tests_or_warn() {
+fn every_enforced_row_has_a_negative_test() {
     let catalog = parse_catalog();
     let neg_tests = find_negative_tests();
 
@@ -556,7 +558,7 @@ fn enforced_rows_have_negative_tests_or_warn() {
     let partial_total = covered_partial.len() + missing_partial.len();
 
     eprintln!();
-    eprintln!("=== Negative-test coverage (#531 seed gate, informational) ===");
+    eprintln!("=== Negative-test coverage (#535 promoted gate) ===");
     eprintln!(
         "enforced: {}/{} rows have a #[should_panic] negative test",
         covered_enforced.len(),
@@ -596,22 +598,29 @@ fn enforced_rows_have_negative_tests_or_warn() {
     eprintln!("================================================================");
     eprintln!();
 
-    // Pass unconditionally this round. The gate is promoted to an
-    // assertion once the catalog body lands (tracked as follow-up
-    // sub-issues of #517 / #531).
-    //
-    // Sanity check: the matcher must locate at least the seed tests
-    // landed alongside this gate; if zero rows are covered, the
-    // scanner is broken and the informational-mode escape hatch is
-    // hiding the breakage.
+    // Promoted gate (#535): every `enforced` row in the catalog must
+    // carry a tagged `#[should_panic]` negative test. The eprintln
+    // report above lists any missing rows so CI failure output names
+    // them; this assertion is the actual fail-loud guarantee.
+    assert!(
+        missing_enforced.is_empty(),
+        "Invariants marked `enforced` in `docs/JEOD_invariants.md` but lacking a \
+         #[should_panic] negative test: {:?}. Add a `#[should_panic(expected = \"<substring>\")]` \
+         test that drives the misconfiguration near the enforcement site, tagged with \
+         `// JEOD_INV: XX.YY` inside the test body or within the 6 lines preceding the \
+         attribute.",
+        missing_enforced
+    );
+
+    // Defensive sanity guard: if the scanner ever silently returns
+    // zero matches the assertion above would trivially pass on an
+    // empty `missing_enforced` vec only when the catalog itself is
+    // empty (already false today). This assert documents the implicit
+    // dependency and surfaces scanner breakage as a distinct failure.
     assert!(
         !covered_enforced.is_empty(),
-        "Negative-test scanner found zero covered `enforced` rows. \
-         The seed tests in `gravity_controls.rs`, `mass.rs`, and \
-         `crates/astrodyn_quantities/tests/quat_normalize_panic.rs` \
-         should each contribute coverage; if all of them are missing \
-         the scanner has regressed (window, brace-counting, or root \
-         set), not the test suite."
+        "Negative-test scanner found zero covered `enforced` rows — the scanner \
+         has regressed (window, brace-counting, or root set), not the test suite."
     );
 }
 


### PR DESCRIPTION
## Summary

- Adds the `// JEOD_INV: IN.09` tag to the existing `solar_beta_missing_sun_marker_panics_with_caller_fix` unit test in `derived_state.rs` (the test already drove the per-step panic but was invisible to the scanner because it lacked a tag in the matching window).
- Adds a parallel integration test `crates/astrodyn_bevy/tests/in_09_solar_beta_requires_sun_marker.rs` that drives the **validator** site through the full `AstrodynPlugin` + `VehicleBuilder::solar_beta()` public API (mirroring AT.03's pattern). Asserts the shared panic substring `"no SunMarker entity exists"` so the test is robust to a future refactor that reorders the validator and per-step sites.
- Promotes `tests/invariant_coverage.rs` from informational `eprintln!` warning to a hard `assert!(missing_enforced.is_empty(), …)` (75/75 enforced rows now covered) and renames `enforced_rows_have_negative_tests_or_warn` → `every_enforced_row_has_a_negative_test` to reflect the new contract.

Closes #535.

## Context

This is the final follow-up to #531 + the 13 per-section sweep PRs (#536–#549). The deferral note in #549 claimed IN.09 needed a new Bevy-App-scaffolded test fixture; in fact the unit test already existed and just needed a tag — see `derived_state.rs:556`. The integration test in this PR is the AT.03-style sibling, added so IN.09 has both Placement A (in-module unit test exercising the per-step site in isolation) and Placement B (integration test exercising the validator site through the public scenario API).

After this PR, a future refactor that neuters an `assert!` at any enforced JEOD invariant enforcement site fails CI rather than silently passing.

## Test plan

- [x] `cargo test --test invariant_coverage` — all 7 tests pass; the promoted gate reports `enforced: 75/75`
- [x] `cargo nextest run -p astrodyn_bevy --test in_09_solar_beta_requires_sun_marker` — new integration test passes; panic substring matches
- [x] `cargo nextest run -p astrodyn_bevy --lib systems::derived_state` — existing unit tests still pass (Edit 1 was a comment-only change)
- [x] **Negative-fire sanity check**: temporarily disabled both IN.09 tags; the promoted gate correctly fails with `missing_enforced = ["IN.09"]`. Tags restored.
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)