### PR TITLE
[#510] Remove H4 raw-return escape hatches; type-extend body external loads

### DIFF
--- a/crates/astrodyn_bevy/src/body_mutator.rs
+++ b/crates/astrodyn_bevy/src/body_mutator.rs
@@ -1,0 +1,507 @@
+// JEOD_INV: TS.01 — `<SelfRef>` wildcards on this file's `BodyReader` /
+// `BodyMutator` SystemParam returns and inputs are the storage-boundary
+// surface for per-entity body identity (mirrors the `<SelfRef>` use in
+// `crate::components::state` for the underlying body components). The
+// wildcard is resolved by the entity passed to the accessor at call
+// time; system code paths that consume the returned typed values pin
+// `<V: Vehicle>` themselves.
+//! Body-state read/write API for Bevy missions.
+//!
+//! `astrodyn_runner::Simulation` exposes `body()` / `body_state()` for
+//! reads and `set_body_external_force` / `set_body_external_torque` /
+//! `set_body_external_force_struct` / `set_body_external_torque_struct`
+//! (each with a `_typed` sibling) for time-scheduled external loads.
+//!
+//! The Bevy adapter mirrors that surface as two `SystemParam`s:
+//!
+//! - [`BodyReader`] — read-only per-field accessors over a body entity's
+//!   translational / rotational / mass / per-step acceleration / external
+//!   load components. All accessors return *typed* values (`Force<…>`,
+//!   `Acceleration<RootInertial>`, etc.); the raw-`DVec3` reader is not
+//!   exposed because the underlying components are already typed end-to-end.
+//! - [`BodyMutator`] — read+write API for the four external-load setters,
+//!   typed-first with raw `// ESCAPE_HATCH:` siblings retained for parity
+//!   with the runner's raw [`Simulation::set_body_external_force`] entry
+//!   points.
+//!
+//! Both filter on [`DynamicsConfigC`] (the universally-present body
+//! component — every body spawned via [`crate::lib::VehicleConfigBevyExt::spawn_bevy`]
+//! carries one). Passing a non-body entity (e.g. a gravity source) panics
+//! with a diagnostic naming the misuse — the same fail-loud pattern
+//! [`crate::source_mutator::SourceMutator`] applies for source-targeted
+//! queries.
+//!
+//! The struct-frame variants ([`ExternalForceStructC`] /
+//! [`ExternalTorqueStructC`]) default to zero on bodies that don't carry
+//! them; the mutator's typed setters auto-insert the component on the
+//! zero-to-non-zero transition — mirroring the runner's
+//! `SimBody::from_config` zero-init pattern and the
+//! `SourceMutator::set_source_state` auto-insert precedent.
+
+use astrodyn::{
+    Acceleration, AngularAcceleration, BodyFrame, Force, Planet, PlanetInertial, RootInertial,
+    RotationalStateTyped, SelfRef, StructuralFrame, Torque, TranslationalStateTyped,
+};
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use glam::DVec3;
+
+use crate::components::{
+    DynamicsConfigC, ExternalForceC, ExternalForceStructC, ExternalTorqueC, ExternalTorqueStructC,
+    FrameDerivativesC, MassPropertiesC, RotationalStateC, TranslationalStateC,
+};
+
+/// Bevy `SystemParam` exposing the **read-only** half of the
+/// `astrodyn_runner::Simulation::body*` API on entities carrying
+/// [`DynamicsConfigC`] (which `spawn_bevy` always inserts).
+///
+/// All queries are immutable, so this composes inside one system with
+/// other read-only SystemParams (e.g. [`crate::frame_param::FrameOrigin`]).
+/// Mission code that only inspects body state should pick
+/// [`BodyReader`]; reach for [`BodyMutator`] only when also writing
+/// external loads.
+///
+/// Per-field accessors rather than a monolithic `body() -> VehicleOutput`
+/// — the runner's `VehicleOutput` mixes a dozen+ optional fields most
+/// readers don't need, and the per-field shape keeps Bevy queries narrow
+/// (avoids holding `&'static` views of components the consumer never
+/// reads).
+#[derive(SystemParam)]
+pub struct BodyReader<'w, 's, P: Planet> {
+    body_filter: Query<'w, 's, (), With<DynamicsConfigC>>,
+    trans: Query<'w, 's, &'static TranslationalStateC<P>>,
+    rot: Query<'w, 's, &'static RotationalStateC>,
+    mass: Query<'w, 's, &'static MassPropertiesC>,
+    frame_derivs: Query<'w, 's, &'static FrameDerivativesC>,
+    ext_force: Query<'w, 's, &'static ExternalForceC>,
+    ext_torque: Query<'w, 's, &'static ExternalTorqueC>,
+    ext_force_struct: Query<'w, 's, &'static ExternalForceStructC>,
+    ext_torque_struct: Query<'w, 's, &'static ExternalTorqueStructC>,
+    names: Query<'w, 's, &'static Name>,
+}
+
+impl<P: Planet> BodyReader<'_, '_, P> {
+    /// Typed translational state of `body` in `P`'s planet-inertial
+    /// frame. Mirrors `VehicleOutput.trans` after the
+    /// `TranslationalStateC<P>` storage convention (the component
+    /// already carries `<PlanetInertial<P>>`, so this is a direct
+    /// projection — no relabel, no arithmetic).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body (missing
+    /// [`DynamicsConfigC`]) or lacks [`TranslationalStateC<P>`].
+    pub fn body_translational_state(
+        &self,
+        body: Entity,
+    ) -> TranslationalStateTyped<PlanetInertial<P>> {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "body_translational_state",
+        );
+        self.trans
+            .get(body)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "BodyReader::body_translational_state: {label} is a registered \
+                     dynamic body but lacks TranslationalStateC<P> ({err:?}). \
+                     Spawn the body via VehicleConfig::spawn_bevy (which inserts \
+                     TranslationalStateC), or attach the component directly.",
+                    label = _entity_label(&self.names, body),
+                )
+            })
+            .0
+    }
+
+    /// Typed rotational state of `body`, or `None` for 3-DOF bodies
+    /// (those spawned without a `RotationalStateC`). Mirrors
+    /// `VehicleOutput.rot`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_rotational_state(&self, body: Entity) -> Option<RotationalStateTyped<SelfRef>> {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "body_rotational_state",
+        );
+        self.rot.get(body).ok().map(|c| c.0)
+    }
+
+    /// Typed mass properties of `body`, or `None` for 3-DOF bodies
+    /// spawned without a `MassPropertiesC`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_mass(&self, body: Entity) -> Option<astrodyn::MassPropertiesTyped<SelfRef>> {
+        _assert_is_body(&self.body_filter, &self.names, body, "body_mass");
+        self.mass.get(body).ok().map(|c| c.0)
+    }
+
+    /// Typed translational acceleration of `body` (`Acceleration<RootInertial>`)
+    /// from the last `Update` cycle. Mirrors `VehicleOutput.trans_accel`;
+    /// reads directly from [`FrameDerivativesC`] (which has carried the
+    /// typed value since #397 — the runner's `VehicleOutput.trans_accel`
+    /// is the laggard tightened in this PR).
+    ///
+    /// Returns the typed zero if the body has no `FrameDerivativesC`
+    /// (which the `#[require(FrameDerivativesC)]` attribute on
+    /// `DynamicsConfigC` prevents in practice — but the fallback keeps
+    /// the accessor `Option`-free for ergonomics).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_trans_accel(&self, body: Entity) -> Acceleration<RootInertial> {
+        _assert_is_body(&self.body_filter, &self.names, body, "body_trans_accel");
+        self.frame_derivs
+            .get(body)
+            .map(|c| c.0.trans_accel)
+            .unwrap_or_default()
+    }
+
+    /// Typed rotational acceleration of `body`
+    /// (`AngularAcceleration<BodyFrame<SelfRef>>`). Mirrors
+    /// `VehicleOutput.rot_accel`; returns `None` for 3-DOF bodies
+    /// (those without a `RotationalStateC`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_rot_accel(&self, body: Entity) -> Option<AngularAcceleration<BodyFrame<SelfRef>>> {
+        _assert_is_body(&self.body_filter, &self.names, body, "body_rot_accel");
+        // Match the runner's `VehicleOutput::rot_accel` gating: `None` for
+        // 3-DOF bodies (no rotational state), `Some(typed)` for 6-DOF.
+        self.rot.get(body).ok().map(|_| {
+            self.frame_derivs
+                .get(body)
+                .map(|c| c.0.rot_accel)
+                .unwrap_or_default()
+        })
+    }
+
+    /// Typed external inertial-frame force scheduled for collection on
+    /// `body`. Returns the typed zero if the body has no
+    /// [`ExternalForceC`] — matching the runner's "uninstalled = 0"
+    /// convention.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_external_force(&self, body: Entity) -> Force<RootInertial> {
+        _assert_is_body(&self.body_filter, &self.names, body, "body_external_force");
+        self.ext_force.get(body).map(|c| c.0).unwrap_or_default()
+    }
+
+    /// Typed external body-frame torque scheduled for collection on
+    /// `body`. Returns the typed zero if the body has no
+    /// [`ExternalTorqueC`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_external_torque(&self, body: Entity) -> Torque<BodyFrame<SelfRef>> {
+        _assert_is_body(&self.body_filter, &self.names, body, "body_external_torque");
+        self.ext_torque.get(body).map(|c| c.0).unwrap_or_default()
+    }
+
+    /// Typed external structural-frame force scheduled for collection
+    /// on `body`. Returns the typed zero if the body has no
+    /// [`ExternalForceStructC`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_external_force_struct(&self, body: Entity) -> Force<StructuralFrame<SelfRef>> {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "body_external_force_struct",
+        );
+        self.ext_force_struct
+            .get(body)
+            .map(|c| c.0)
+            .unwrap_or_default()
+    }
+
+    /// Typed external structural-frame torque scheduled for collection
+    /// on `body`. Returns the typed zero if the body has no
+    /// [`ExternalTorqueStructC`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `body` is not a registered dynamic body.
+    pub fn body_external_torque_struct(&self, body: Entity) -> Torque<StructuralFrame<SelfRef>> {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "body_external_torque_struct",
+        );
+        self.ext_torque_struct
+            .get(body)
+            .map(|c| c.0)
+            .unwrap_or_default()
+    }
+}
+
+/// Bevy `SystemParam` exposing the **read+write** body-load API on
+/// entities carrying [`DynamicsConfigC`]. Mirrors
+/// `astrodyn_runner::Simulation`'s four `set_body_external_*` setters
+/// (with `_typed` siblings) plus the read accessors mission code needs
+/// to inspect state while writing back forces.
+///
+/// The typed setters auto-insert the load component when transitioning
+/// from absent (or zero) — the same pattern
+/// [`crate::source_mutator::SourceMutator::set_source_state`] uses for
+/// `SourceInertialVelocityC`. The raw setters are `// ESCAPE_HATCH:`
+/// annotated parity shims for the runner's raw `DVec3` entry points;
+/// callers should prefer the typed siblings.
+///
+/// Bodies have no analogue of [`crate::components::CentralSourceMarker`]
+/// (the central-body convention applies to gravity sources only), so no
+/// "central body protection" panic exists here — the
+/// `With<DynamicsConfigC>` filter is the only fail-loud check.
+#[derive(SystemParam)]
+pub struct BodyMutator<'w, 's, P: Planet> {
+    commands: Commands<'w, 's>,
+    body_filter: Query<'w, 's, (), With<DynamicsConfigC>>,
+    ext_force: Query<'w, 's, &'static mut ExternalForceC, With<DynamicsConfigC>>,
+    ext_torque: Query<'w, 's, &'static mut ExternalTorqueC, With<DynamicsConfigC>>,
+    ext_force_struct: Query<'w, 's, &'static mut ExternalForceStructC, With<DynamicsConfigC>>,
+    ext_torque_struct: Query<'w, 's, &'static mut ExternalTorqueStructC, With<DynamicsConfigC>>,
+    // Read-only siblings — let one mutator read+write within one system.
+    trans_read: Query<'w, 's, &'static TranslationalStateC<P>>,
+    rot_read: Query<'w, 's, &'static RotationalStateC>,
+    frame_derivs_read: Query<'w, 's, &'static FrameDerivativesC>,
+    names: Query<'w, 's, &'static Name>,
+}
+
+impl<P: Planet> BodyMutator<'_, '_, P> {
+    // ── Read-only accessors (composition with mutating systems) ──
+
+    /// See [`BodyReader::body_translational_state`].
+    pub fn body_translational_state(
+        &self,
+        body: Entity,
+    ) -> TranslationalStateTyped<PlanetInertial<P>> {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "body_translational_state",
+        );
+        self.trans_read
+            .get(body)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "BodyMutator::body_translational_state: {label} is a registered \
+                     dynamic body but lacks TranslationalStateC<P> ({err:?}).",
+                    label = _entity_label(&self.names, body),
+                )
+            })
+            .0
+    }
+
+    /// See [`BodyReader::body_rotational_state`].
+    pub fn body_rotational_state(&self, body: Entity) -> Option<RotationalStateTyped<SelfRef>> {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "body_rotational_state",
+        );
+        self.rot_read.get(body).ok().map(|c| c.0)
+    }
+
+    /// See [`BodyReader::body_trans_accel`].
+    pub fn body_trans_accel(&self, body: Entity) -> Acceleration<RootInertial> {
+        _assert_is_body(&self.body_filter, &self.names, body, "body_trans_accel");
+        self.frame_derivs_read
+            .get(body)
+            .map(|c| c.0.trans_accel)
+            .unwrap_or_default()
+    }
+
+    // ── Typed setters (primary surface) ──
+
+    /// Typed sibling of [`set_body_external_force`](Self::set_body_external_force).
+    /// The `Force<RootInertial>` argument's phantom enforces at compile
+    /// time that the value is in the root-inertial frame, matching the
+    /// runner's [`Simulation::set_body_external_force_typed`].
+    ///
+    /// Auto-inserts [`ExternalForceC`] if the body doesn't carry one yet
+    /// (i.e. was spawned with a zero `VehicleConfig.external_force`, the
+    /// runner's `SimBody::from_config:373-374` zero-init equivalent).
+    pub fn set_body_external_force_typed(&mut self, body: Entity, force: Force<RootInertial>) {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "set_body_external_force_typed",
+        );
+        if let Ok(mut c) = self.ext_force.get_mut(body) {
+            c.0 = force;
+        } else {
+            self.commands.entity(body).insert(ExternalForceC(force));
+        }
+    }
+
+    /// Typed sibling of [`set_body_external_torque`](Self::set_body_external_torque).
+    /// The `Torque<BodyFrame<SelfRef>>` argument's phantom enforces at
+    /// compile time that the value is expressed in the body frame.
+    pub fn set_body_external_torque_typed(
+        &mut self,
+        body: Entity,
+        torque: Torque<BodyFrame<SelfRef>>,
+    ) {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "set_body_external_torque_typed",
+        );
+        if let Ok(mut c) = self.ext_torque.get_mut(body) {
+            c.0 = torque;
+        } else {
+            self.commands.entity(body).insert(ExternalTorqueC(torque));
+        }
+    }
+
+    /// Typed sibling of [`set_body_external_force_struct`](Self::set_body_external_force_struct).
+    /// The `Force<StructuralFrame<SelfRef>>` argument's phantom enforces
+    /// at compile time that the value is in the body's structural frame.
+    ///
+    /// Auto-inserts [`ExternalForceStructC`] when the body doesn't carry
+    /// one — `VehicleConfig` has no `external_force_struct` field today
+    /// (matching the runner's `SimBody::from_config` zero-init), so the
+    /// component is absent until first set.
+    pub fn set_body_external_force_struct_typed(
+        &mut self,
+        body: Entity,
+        force: Force<StructuralFrame<SelfRef>>,
+    ) {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "set_body_external_force_struct_typed",
+        );
+        if let Ok(mut c) = self.ext_force_struct.get_mut(body) {
+            c.0 = force;
+        } else {
+            self.commands
+                .entity(body)
+                .insert(ExternalForceStructC(force));
+        }
+    }
+
+    /// Typed sibling of [`set_body_external_torque_struct`](Self::set_body_external_torque_struct).
+    /// The `Torque<StructuralFrame<SelfRef>>` argument's phantom enforces
+    /// at compile time that the value is in the body's structural frame.
+    pub fn set_body_external_torque_struct_typed(
+        &mut self,
+        body: Entity,
+        torque: Torque<StructuralFrame<SelfRef>>,
+    ) {
+        _assert_is_body(
+            &self.body_filter,
+            &self.names,
+            body,
+            "set_body_external_torque_struct_typed",
+        );
+        if let Ok(mut c) = self.ext_torque_struct.get_mut(body) {
+            c.0 = torque;
+        } else {
+            self.commands
+                .entity(body)
+                .insert(ExternalTorqueStructC(torque));
+        }
+    }
+
+    // ── Raw setters (parity shims for the runner's raw entry points) ──
+
+    /// Raw-`DVec3` parity shim for the runner's
+    /// `Simulation::set_body_external_force`. Prefer
+    /// [`set_body_external_force_typed`](Self::set_body_external_force_typed).
+    // ESCAPE_HATCH: parity with raw runner setter `Simulation::set_body_external_force`.
+    // Closes once the runner's raw entry point is itself retired.
+    pub fn set_body_external_force(&mut self, body: Entity, force: DVec3) {
+        // allowed: raw-DVec3 escape-hatch boundary mirroring the runner's
+        // raw `Simulation::set_body_external_force` input.
+        self.set_body_external_force_typed(body, Force::<RootInertial>::from_raw_si(force));
+    }
+
+    /// Raw-`DVec3` parity shim for the runner's
+    /// `Simulation::set_body_external_torque`. Prefer
+    /// [`set_body_external_torque_typed`](Self::set_body_external_torque_typed).
+    // ESCAPE_HATCH: parity with raw runner setter `Simulation::set_body_external_torque`.
+    pub fn set_body_external_torque(&mut self, body: Entity, torque: DVec3) {
+        // allowed: raw-DVec3 escape-hatch boundary mirroring the runner's raw input.
+        let typed = Torque::<BodyFrame<SelfRef>>::from_raw_si(torque);
+        self.set_body_external_torque_typed(body, typed);
+    }
+
+    /// Raw-`DVec3` parity shim for the runner's
+    /// `Simulation::set_body_external_force_struct`. Prefer
+    /// [`set_body_external_force_struct_typed`](Self::set_body_external_force_struct_typed).
+    // ESCAPE_HATCH: parity with raw runner setter `Simulation::set_body_external_force_struct`.
+    pub fn set_body_external_force_struct(&mut self, body: Entity, force: DVec3) {
+        // allowed: raw-DVec3 escape-hatch boundary mirroring the runner's raw input.
+        let typed = Force::<StructuralFrame<SelfRef>>::from_raw_si(force);
+        self.set_body_external_force_struct_typed(body, typed);
+    }
+
+    /// Raw-`DVec3` parity shim for the runner's
+    /// `Simulation::set_body_external_torque_struct`. Prefer
+    /// [`set_body_external_torque_struct_typed`](Self::set_body_external_torque_struct_typed).
+    // ESCAPE_HATCH: parity with raw runner setter `Simulation::set_body_external_torque_struct`.
+    pub fn set_body_external_torque_struct(&mut self, body: Entity, torque: DVec3) {
+        // allowed: raw-DVec3 escape-hatch boundary mirroring the runner's raw input.
+        let typed = Torque::<StructuralFrame<SelfRef>>::from_raw_si(torque);
+        self.set_body_external_torque_struct_typed(body, typed);
+    }
+}
+
+// ---------------------------------------------------------------------
+// Shared helpers (mirror `source_mutator::_entity_label` / `_fetch_*`).
+
+/// Format a user-facing label for `entity`. Mirrors
+/// `source_mutator::_entity_label`.
+fn _entity_label(names: &Query<&'static Name>, entity: Entity) -> String {
+    match names.get(entity) {
+        Ok(name) => format!("{name} ({entity:?})"),
+        Err(_) => format!("{entity:?}"),
+    }
+}
+
+/// Assert that `body` is a registered dynamic body (carries
+/// [`DynamicsConfigC`]). The same misuse → fail-loud pattern
+/// [`source_mutator::_fetch_frame_entity`] applies for source-targeted
+/// queries — passing a non-body entity (e.g. a gravity source) panics
+/// here with a diagnostic naming the misuse.
+fn _assert_is_body(
+    body_filter: &Query<(), With<DynamicsConfigC>>,
+    names: &Query<&'static Name>,
+    body: Entity,
+    method: &str,
+) {
+    if body_filter.get(body).is_err() {
+        panic!(
+            "BodyReader/BodyMutator::{method}: {label} is not a registered dynamic body \
+             — it is missing DynamicsConfigC. Spawn the body via \
+             `VehicleConfig::spawn_bevy(...)` (which inserts DynamicsConfigC + the \
+             per-stage state / load components) before reading or writing its loads. \
+             If the entity is a gravity source (planet), pass it to SourceReader / \
+             SourceMutator instead — bodies and sources occupy disjoint entity \
+             slots and the SystemParam filter is the demarcation.",
+            label = _entity_label(names, body),
+        );
+    }
+}

--- a/crates/astrodyn_bevy/src/body_mutator.rs
+++ b/crates/astrodyn_bevy/src/body_mutator.rs
@@ -483,7 +483,7 @@ fn _entity_label(names: &Query<&'static Name>, entity: Entity) -> String {
 
 /// Assert that `body` is a registered dynamic body (carries
 /// [`DynamicsConfigC`]). The same misuse → fail-loud pattern
-/// [`source_mutator::_fetch_frame_entity`] applies for source-targeted
+/// `source_mutator::_fetch_frame_entity` applies for source-targeted
 /// queries — passing a non-body entity (e.g. a gravity source) panics
 /// here with a diagnostic naming the misuse.
 fn _assert_is_body(

--- a/crates/astrodyn_bevy/src/body_mutator.rs
+++ b/crates/astrodyn_bevy/src/body_mutator.rs
@@ -21,11 +21,11 @@
 //!   exposed because the underlying components are already typed end-to-end.
 //! - [`BodyMutator`] — read+write API for the four external-load setters,
 //!   typed-first with raw `// ESCAPE_HATCH:` siblings retained for parity
-//!   with the runner's raw [`Simulation::set_body_external_force`] entry
+//!   with the runner's raw `Simulation::set_body_external_force` entry
 //!   points.
 //!
 //! Both filter on [`DynamicsConfigC`] (the universally-present body
-//! component — every body spawned via [`crate::lib::VehicleConfigBevyExt::spawn_bevy`]
+//! component — every body spawned via [`crate::VehicleConfigBevyExt::spawn_bevy`]
 //! carries one). Passing a non-body entity (e.g. a gravity source) panics
 //! with a diagnostic naming the misuse — the same fail-loud pattern
 //! [`crate::source_mutator::SourceMutator`] applies for source-targeted
@@ -334,7 +334,7 @@ impl<P: Planet> BodyMutator<'_, '_, P> {
     /// Typed sibling of [`set_body_external_force`](Self::set_body_external_force).
     /// The `Force<RootInertial>` argument's phantom enforces at compile
     /// time that the value is in the root-inertial frame, matching the
-    /// runner's [`Simulation::set_body_external_force_typed`].
+    /// runner's `Simulation::set_body_external_force_typed`.
     ///
     /// Auto-inserts [`ExternalForceC`] if the body doesn't carry one yet
     /// (i.e. was spawned with a zero `VehicleConfig.external_force`, the

--- a/crates/astrodyn_bevy/src/components/state.rs
+++ b/crates/astrodyn_bevy/src/components/state.rs
@@ -6,7 +6,7 @@
 //! external-force / external-torque injection slots.
 
 use astrodyn::{
-    BodyFrame, DynamicsConfig, FrameDerivatives, FrameDerivativesTyped, FrameTransform,
+    BodyFrame, DynamicsConfig, Force, FrameDerivatives, FrameDerivativesTyped, FrameTransform,
     GravityAcceleration, GravityAccelerationTyped, MassPropertiesTyped, Planet, PlanetInertial,
     Position, RootInertial, RotationalStateTyped, SelfRef, StructuralFrame, Torque, TotalForce,
     TotalForceTyped, TranslationalState, TranslationalStateTyped, Velocity,
@@ -352,3 +352,31 @@ pub struct ExternalForceC(pub astrodyn::Force<RootInertial>);
 /// Mutate between steps to implement time-scheduled torque injection.
 #[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
 pub struct ExternalTorqueC(pub Torque<BodyFrame<SelfRef>>);
+
+/// External force in the body's **structural** frame (N).
+///
+/// Mirrors JEOD's `Force` model
+/// (`models/dynamics/dyn_body/include/force.hh`): the force vector is
+/// expressed in the body's structural frame, then rotated to inertial at
+/// force-collection time via `T_inertial_struct = T_struct_body^T *
+/// T_inertial_body`. The companion [`ExternalForceC`] (inertial frame)
+/// remains available for callers that produce inertial-frame
+/// contributions directly; the two contribute additively at collection.
+///
+/// Matches `SimBody.external_force_struct` in `astrodyn::Simulation` —
+/// the parity-lockstep invariant requires both adapters to expose the
+/// same surface.
+// JEOD_INV: DB.28 — forces collected in structural frame, rotated to inertial at root
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+pub struct ExternalForceStructC(pub Force<StructuralFrame<SelfRef>>);
+
+/// External torque in the body's **structural** frame (N·m).
+///
+/// Companion to [`ExternalForceStructC`]; rotated to body frame at
+/// force-collection time via the body's `t_struct_body` (the matrix
+/// stored on [`StructuralTransformC`]).
+///
+/// Matches `SimBody.external_torque_struct` in `astrodyn::Simulation`.
+// JEOD_INV: DB.29 — torques collected in structural frame, rotated to body at root
+#[derive(Component, Debug, Clone, Copy, Default, Deref, DerefMut)]
+pub struct ExternalTorqueStructC(pub Torque<StructuralFrame<SelfRef>>);

--- a/crates/astrodyn_bevy/src/frame_attach_system.rs
+++ b/crates/astrodyn_bevy/src/frame_attach_system.rs
@@ -535,7 +535,10 @@ pub fn propagate_frame_attached_state_system<P: Planet>(
                 .ok()
                 .and_then(|fe| parents.get(fe.0).ok().map(|child_of| child_of.parent()));
             let (integ_origin_pos, integ_origin_vel) = match integ_frame_entity {
-                Some(integ_e) if integ_e != root => rel.position_velocity(root, integ_e),
+                Some(integ_e) if integ_e != root => {
+                    let trans = rel.relative_state(root, integ_e).trans;
+                    (trans.position, trans.velocity)
+                }
                 _ => (DVec3::ZERO, DVec3::ZERO),
             };
 

--- a/crates/astrodyn_bevy/src/frame_param.rs
+++ b/crates/astrodyn_bevy/src/frame_param.rs
@@ -79,55 +79,38 @@ pub struct RelativeFrameState<'w, 's> {
 }
 
 impl<'w, 's> RelativeFrameState<'w, 's> {
-    /// `(position, velocity)` of `to` relative to `from`, both in
-    /// `from`-frame coordinates.
+    /// Typed `(Position<F>, Velocity<F>)` of `to` relative to `from`,
+    /// both in `from`-frame coordinates. The caller asserts via the
+    /// turbofish that `from`'s frame marker is `F` — phantom-attachment
+    /// is unchecked at runtime, matching [`FrameOrigin::origin_in_typed`].
     ///
-    /// Prefer [`position_velocity_typed`](Self::position_velocity_typed)
-    /// when `from`'s frame marker is statically known.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up (see #485 task 18).
-    pub fn position_velocity(&self, from: Entity, to: Entity) -> (DVec3, DVec3) {
-        let rel = self.relative_state(from, to);
-        (rel.trans.position, rel.trans.velocity)
-    }
-
-    /// Typed sibling of [`position_velocity`](Self::position_velocity).
-    /// The caller asserts via the turbofish that `from`'s frame marker is
-    /// `F` — phantom-attachment is unchecked at runtime, matching
-    /// [`FrameOrigin::origin_in_typed`].
+    /// Callers whose `from`'s marker isn't known at compile time should
+    /// read [`relative_state`](Self::relative_state) and project the
+    /// `.trans.position` / `.trans.velocity` fields directly.
     pub fn position_velocity_typed<F: astrodyn::Frame>(
         &self,
         from: Entity,
         to: Entity,
     ) -> (astrodyn::Position<F>, astrodyn::Velocity<F>) {
-        let (pos, vel) = self.position_velocity(from, to);
+        let trans = self.relative_state(from, to).trans;
         (
             // allowed: typed-sibling accessor boundary; phantom attached unchecked.
-            astrodyn::Position::<F>::from_raw_si(pos),
+            astrodyn::Position::<F>::from_raw_si(trans.position),
             // allowed: typed-sibling accessor boundary; phantom attached unchecked.
-            astrodyn::Velocity::<F>::from_raw_si(vel),
+            astrodyn::Velocity::<F>::from_raw_si(trans.velocity),
         )
     }
 
-    /// Position of `to` relative to `from`, in `from`-frame
-    /// coordinates.
-    ///
-    /// Prefer [`position_typed`](Self::position_typed) when `from`'s frame
-    /// marker is statically known.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up (see #485 task 18).
-    pub fn position(&self, from: Entity, to: Entity) -> DVec3 {
-        self.relative_state(from, to).trans.position
-    }
-
-    /// Typed sibling of [`position`](Self::position). See
-    /// [`position_velocity_typed`](Self::position_velocity_typed) for
-    /// the phantom-attachment semantics.
+    /// Typed `Position<F>` of `to` relative to `from`, in `from`-frame
+    /// coordinates. See [`position_velocity_typed`](Self::position_velocity_typed)
+    /// for the phantom-attachment semantics.
     pub fn position_typed<F: astrodyn::Frame>(
         &self,
         from: Entity,
         to: Entity,
     ) -> astrodyn::Position<F> {
         // allowed: typed-sibling accessor boundary; phantom attached unchecked.
-        astrodyn::Position::<F>::from_raw_si(self.position(from, to))
+        astrodyn::Position::<F>::from_raw_si(self.relative_state(from, to).trans.position)
     }
 
     /// Full [`RefFrameState`] of `to` relative to `from`. Delegates
@@ -253,7 +236,8 @@ impl<'w, 's> FrameOrigin<'w, 's> {
     // the typed siblings origin_in_root / origin_in_typed handle the
     // static-marker majority of callers. See #485 H4 / T2.
     pub fn origin_in(&self, ancestor: Entity, frame: Entity) -> (DVec3, DVec3) {
-        self.rel.position_velocity(ancestor, frame)
+        let trans = self.rel.relative_state(ancestor, frame).trans;
+        (trans.position, trans.velocity)
     }
 
     /// Typed `(Position<RootInertial>, Velocity<RootInertial>)` for the

--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod app_ext;
 pub mod body_action;
+pub mod body_mutator;
 pub mod bundles;
 pub mod components;
 pub mod frame_attach_system;
@@ -35,6 +36,7 @@ pub use body_action::{
     body_action_unregistered_planet_fence_system, BodyActionCommandsExt, BodyActionEvent,
     BodyActionsR, RegisteredPlanetsR,
 };
+pub use body_mutator::{BodyMutator, BodyReader};
 pub use bundles::*;
 pub use components::*;
 pub use frame_attach_system::{

--- a/crates/astrodyn_bevy/src/prelude.rs
+++ b/crates/astrodyn_bevy/src/prelude.rs
@@ -27,14 +27,15 @@
 
 pub use crate::{
     Abm4StateC, AerodynamicForceC, AstrodynAppExt, AstrodynPlugin, AstrodynSet, AtmosphericStateC,
-    BodyActionCommandsExt, BodyActionEvent, BodyActionsR, BodyFrameMarker, ClosureJointKinematicsC,
-    DetachedSubtreeStateC, DynamicsConfigC, FrameAngVelC, FrameDerivativesC, FrameEntityC,
-    FrameRotC, FrameTransC, GaussJacksonStateC, GravityAccelerationC, GravityControlsC,
-    GravitySourceC, GravityTorqueC, InertialFrameMarker, IntegrationDtR, IntegrationFrameMarker,
-    IntegratorTypeC, JointKinematicsC, MassPropertiesC, MultiDofJointKinematicsC, PfixFrameEntityC,
-    PlanetFixedFrameMarker, PlanetFixedRotationC, RadiationForceC, RootFrameEntityR,
-    RotationalStateC, ScenarioHandles, SimulationBuilderBevyExt, SimulationTimeR,
-    SinusoidalJointKinematicsC, SourceInertialPositionC, SourceInertialVelocityC,
+    BodyActionCommandsExt, BodyActionEvent, BodyActionsR, BodyFrameMarker, BodyMutator, BodyReader,
+    ClosureJointKinematicsC, DetachedSubtreeStateC, DynamicsConfigC, ExternalForceC,
+    ExternalForceStructC, ExternalTorqueC, ExternalTorqueStructC, FrameAngVelC, FrameDerivativesC,
+    FrameEntityC, FrameRotC, FrameTransC, GaussJacksonStateC, GravityAccelerationC,
+    GravityControlsC, GravitySourceC, GravityTorqueC, InertialFrameMarker, IntegrationDtR,
+    IntegrationFrameMarker, IntegratorTypeC, JointKinematicsC, MassPropertiesC,
+    MultiDofJointKinematicsC, PfixFrameEntityC, PlanetFixedFrameMarker, PlanetFixedRotationC,
+    RadiationForceC, RootFrameEntityR, RotationalStateC, ScenarioHandles, SimulationBuilderBevyExt,
+    SimulationTimeR, SinusoidalJointKinematicsC, SourceInertialPositionC, SourceInertialVelocityC,
     StructuralTransformC, TotalForceC, TranslationalStateC, VehicleConfigBevyExt,
 };
 // ECS-native frame-tree mission-code surface.

--- a/crates/astrodyn_bevy/src/source_mutator.rs
+++ b/crates/astrodyn_bevy/src/source_mutator.rs
@@ -49,7 +49,7 @@
 use astrodyn::{Planet, Vec3Ext};
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
-use glam::{DMat3, DVec3};
+use glam::DVec3;
 
 use crate::components::{
     CentralSourceMarker, FrameEntityC, FrameRotC, FrameTransC, GravitySourceC, PfixFrameEntityC,
@@ -100,81 +100,72 @@ impl SourceReader<'_, '_> {
     }
 
     /// Get the inertial-frame position of `source` relative to the
-    /// root inertial frame, in root-frame coordinates. Mirrors
-    /// `astrodyn::source_state::source_position`.
+    /// root inertial frame, already wrapped in `Position<F>`. The frame
+    /// phantom is asserted by the caller via turbofish (e.g.
+    /// `source_position_typed::<RootInertial>` for the production-path
+    /// central convention) — no runtime check is performed, mirroring
+    /// `astrodyn::Position::<F>::from_raw_si`.
     ///
     /// Reads the source's frame entity's [`FrameTransC`] directly —
     /// the same storage [`crate::frame_param::FrameOrigin`] and
-    /// [`crate::frame_param::RelativeFrameState`] consume.
-    ///
-    /// Prefer [`source_position_typed`](Self::source_position_typed) for the
-    /// typed-result path.
+    /// [`crate::frame_param::RelativeFrameState`] consume. Mirrors
+    /// `astrodyn::source_state::source_position` with the typed phantom
+    /// attached at the boundary.
     ///
     /// # Panics
     ///
     /// Panics if `source` is not a registered gravity source.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up — typed sibling
-    // `source_position_typed` is the preferred consumer; this raw variant
-    // is kept for backwards compatibility until the parity-lockstep
-    // follow-on PR removes it (see #485 task 18).
-    pub fn source_position(&self, source: Entity) -> DVec3 {
+    pub fn source_position_typed<F: astrodyn::Frame>(
+        &self,
+        source: Entity,
+    ) -> astrodyn::Position<F> {
         let fe = self.source_frame_entity(source);
-        self.frame_trans
+        let raw = self
+            .frame_trans
             .get(fe)
             .map(|t| t.position)
             .unwrap_or_else(|err| {
                 panic!(
-                    "SourceReader::source_position: {label} has \
+                    "SourceReader::source_position_typed: {label} has \
                      FrameEntityC({fe:?}) but that entity has no \
                      FrameTransC ({err:?}). The source's frame entity \
                      must be alive with FrameTransC attached (spawned \
                      by register_source_frames_system).",
                     label = _entity_label(&self.names, source),
                 )
-            })
-    }
-
-    /// Typed sibling of [`source_position`](Self::source_position). Returns
-    /// the source's inertial-frame position already wrapped in
-    /// `Position<F>`. The frame phantom is asserted by the caller via
-    /// turbofish (e.g. `source_position_typed::<RootInertial>` for the
-    /// production-path central convention) — no runtime check is
-    /// performed, mirroring `astrodyn::Position::<F>::from_raw_si`.
-    pub fn source_position_typed<F: astrodyn::Frame>(
-        &self,
-        source: Entity,
-    ) -> astrodyn::Position<F> {
+            });
         // allowed: typed-sibling accessor boundary. The phantom is the
         // caller's pinned-frame convention attached unchecked, matching
         // the `Simulation::source_position_typed` shape.
-        astrodyn::Position::<F>::from_raw_si(self.source_position(source))
+        astrodyn::Position::<F>::from_raw_si(raw)
     }
 
-    /// Get the planet-fixed rotation matrix for `source` (the
-    /// `t_parent_this` of the source's pfix frame entity). Returns
-    /// `None` if the source has no pfix frame entity (i.e. no
+    /// Get the planet-fixed rotation for `source` as
+    /// `FrameTransform<RootInertial, PlanetFixed<P>>` (the `t_parent_this`
+    /// of the source's pfix frame entity wrapped with the typed phantom),
+    /// matching the canonical shape used by `PlanetFixedRotationC<P>`. The
+    /// caller asserts via the turbofish that `source` resolves to planet
+    /// `P`'s pfix frame.
+    ///
+    /// Returns `None` if the source has no pfix frame entity (i.e. no
     /// [`PfixFrameEntityC`] — non-rotating source). Mirrors
     /// `astrodyn::source_state::source_pfix_rotation`.
-    ///
-    /// Prefer [`source_pfix_rotation_typed`](Self::source_pfix_rotation_typed)
-    /// for typed `FrameTransform<RootInertial, PlanetFixed<P>>`.
     ///
     /// # Panics
     ///
     /// Panics if `source` is not a registered gravity source. Returns
     /// `None` (not panic) when the source is registered but has no
     /// pfix child — same contract as the arena helper.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up — typed sibling
-    // `source_pfix_rotation_typed::<P>` is the preferred consumer; this
-    // raw variant is kept for backwards compatibility until the
-    // parity-lockstep follow-on PR removes it (see #485 task 18).
-    pub fn source_pfix_rotation(&self, source: Entity) -> Option<DMat3> {
+    pub fn source_pfix_rotation_typed<P: astrodyn::Planet>(
+        &self,
+        source: Entity,
+    ) -> Option<astrodyn::FrameTransform<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>> {
         // Verify the entity is a registered gravity source first.
         let _ = self.source_frame_entity(source);
         let pfix_fe = self.pfix_frame_entities.get(source).ok()?;
         let rot = self.frame_rots.get(pfix_fe.0).unwrap_or_else(|err| {
             panic!(
-                "SourceReader::source_pfix_rotation: {label} has \
+                "SourceReader::source_pfix_rotation_typed: {label} has \
                  PfixFrameEntityC({fe:?}) but that entity has no \
                  FrameRotC ({err:?}). The pfix frame entity must be \
                  alive with FrameRotC attached (spawned by \
@@ -183,22 +174,12 @@ impl SourceReader<'_, '_> {
                 label = _entity_label(&self.names, source),
             )
         });
-        Some(rot.t_parent_this)
-    }
-
-    /// Typed sibling of [`source_pfix_rotation`](Self::source_pfix_rotation).
-    /// Returns the planet-fixed rotation as
-    /// `FrameTransform<RootInertial, PlanetFixed<P>>`, matching the canonical
-    /// shape used by `PlanetFixedRotationC<P>`. The caller asserts via the
-    /// turbofish that `source` resolves to planet `P`'s pfix frame.
-    pub fn source_pfix_rotation_typed<P: astrodyn::Planet>(
-        &self,
-        source: Entity,
-    ) -> Option<astrodyn::FrameTransform<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>> {
-        let raw = self.source_pfix_rotation(source);
         // allowed: typed-sibling accessor boundary. The phantom is the
         // caller's pinned-planet convention attached unchecked.
-        raw.map(astrodyn::FrameTransform::<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>::from_matrix)
+        Some(astrodyn::FrameTransform::<
+            astrodyn::RootInertial,
+            astrodyn::PlanetFixed<P>,
+        >::from_matrix(rot.t_parent_this))
     }
 }
 
@@ -287,67 +268,62 @@ impl<P: Planet> SourceMutator<'_, '_, P> {
     }
 
     /// Get the inertial-frame position of `source` relative to the
-    /// root inertial frame, in root-frame coordinates. Mirrors
-    /// `astrodyn::source_state::source_position`.
+    /// root inertial frame, already wrapped in `Position<F>`. See
+    /// [`SourceReader::source_position_typed`] for semantics.
     ///
     /// Reads the source's frame entity's [`FrameTransC`] directly —
     /// the same storage [`crate::frame_param::FrameOrigin`] and
     /// [`crate::frame_param::RelativeFrameState`] consume.
     ///
-    /// Prefer [`source_position_typed`](Self::source_position_typed).
-    ///
     /// # Panics
     ///
     /// Panics if `source` is not a registered gravity source.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up (see #485 task 18).
-    pub fn source_position(&self, source: Entity) -> DVec3 {
+    pub fn source_position_typed<F: astrodyn::Frame>(
+        &self,
+        source: Entity,
+    ) -> astrodyn::Position<F> {
         let fe = self.source_frame_entity(source);
-        self.frame_trans
+        let raw = self
+            .frame_trans
             .get(fe)
             .map(|t| t.position)
             .unwrap_or_else(|err| {
                 panic!(
-                    "SourceMutator::source_position: {label} has \
+                    "SourceMutator::source_position_typed: {label} has \
                      FrameEntityC({fe:?}) but that entity has no \
                      FrameTransC ({err:?}). The source's frame entity \
                      must be alive with FrameTransC attached (spawned \
                      by register_source_frames_system).",
                     label = _entity_label(&self.names, source),
                 )
-            })
-    }
-
-    /// Typed sibling of [`source_position`](Self::source_position).
-    /// See [`SourceReader::source_position_typed`] for semantics.
-    pub fn source_position_typed<F: astrodyn::Frame>(
-        &self,
-        source: Entity,
-    ) -> astrodyn::Position<F> {
+            });
         // allowed: typed-sibling accessor boundary; phantom attached unchecked.
-        astrodyn::Position::<F>::from_raw_si(self.source_position(source))
+        astrodyn::Position::<F>::from_raw_si(raw)
     }
 
-    /// Get the planet-fixed rotation matrix for `source` (the
-    /// `t_parent_this` of the source's pfix frame entity). Returns
-    /// `None` if the source has no pfix frame entity (i.e. no
-    /// [`PfixFrameEntityC`] — non-rotating source). Mirrors
-    /// `astrodyn::source_state::source_pfix_rotation`.
+    /// Get the planet-fixed rotation for `source` tagged with the
+    /// `SourceMutator`'s `<P: Planet>` phantom — the mutator is already
+    /// pinned to one planet at instantiation, so no per-call turbofish
+    /// is needed. Mirrors `astrodyn::source_state::source_pfix_rotation`.
     ///
-    /// Prefer [`source_pfix_rotation_typed`](Self::source_pfix_rotation_typed).
+    /// Returns `None` if the source has no pfix frame entity (i.e. no
+    /// [`PfixFrameEntityC`] — non-rotating source).
     ///
     /// # Panics
     ///
     /// Panics if `source` is not a registered gravity source. Returns
     /// `None` (not panic) when the source is registered but has no
     /// pfix child — same contract as the arena helper.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up (see #485 task 18).
-    pub fn source_pfix_rotation(&self, source: Entity) -> Option<DMat3> {
+    pub fn source_pfix_rotation_typed(
+        &self,
+        source: Entity,
+    ) -> Option<astrodyn::FrameTransform<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>> {
         // Verify the entity is a registered gravity source first.
         let _ = self.source_frame_entity(source);
         let pfix_fe = self.pfix_frame_entities.get(source).ok()?;
         let rot = self.frame_rots.get(pfix_fe.0).unwrap_or_else(|err| {
             panic!(
-                "SourceMutator::source_pfix_rotation: {label} has \
+                "SourceMutator::source_pfix_rotation_typed: {label} has \
                  PfixFrameEntityC({fe:?}) but that entity has no \
                  FrameRotC ({err:?}). The pfix frame entity must be \
                  alive with FrameRotC attached (spawned by \
@@ -356,20 +332,11 @@ impl<P: Planet> SourceMutator<'_, '_, P> {
                 label = _entity_label(&self.names, source),
             )
         });
-        Some(rot.t_parent_this)
-    }
-
-    /// Typed sibling of [`source_pfix_rotation`](Self::source_pfix_rotation).
-    /// Returns the planet-fixed rotation tagged with the `SourceMutator`'s
-    /// `<P: Planet>` phantom — the mutator is already pinned to one planet
-    /// at instantiation, so no per-call turbofish is needed.
-    pub fn source_pfix_rotation_typed(
-        &self,
-        source: Entity,
-    ) -> Option<astrodyn::FrameTransform<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>> {
-        let raw = self.source_pfix_rotation(source);
         // allowed: typed-sibling accessor boundary; phantom attached unchecked.
-        raw.map(astrodyn::FrameTransform::<astrodyn::RootInertial, astrodyn::PlanetFixed<P>>::from_matrix)
+        Some(astrodyn::FrameTransform::<
+            astrodyn::RootInertial,
+            astrodyn::PlanetFixed<P>,
+        >::from_matrix(rot.t_parent_this))
     }
 
     /// Set the inertial position of `source` and sync to the source's

--- a/crates/astrodyn_bevy/src/systems/force_collection.rs
+++ b/crates/astrodyn_bevy/src/systems/force_collection.rs
@@ -4,7 +4,9 @@
 //! Aggregates per-step force / torque contributions from the interaction
 //! systems into [`TotalForceC`] / [`FrameDerivativesC`] for the integrator.
 
-use astrodyn::{Acceleration, AngularAcceleration, BodyFrame, RootInertial, SelfRef};
+use astrodyn::{
+    Acceleration, AngularAcceleration, BodyFrame, Force, RootInertial, SelfRef, Torque,
+};
 use bevy::prelude::*;
 use glam::DVec3;
 
@@ -40,6 +42,8 @@ pub fn force_collection_system(
             Option<&StructuralTransformC>,
             Option<&ExternalForceC>,
             Option<&ExternalTorqueC>,
+            Option<&ExternalForceStructC>,
+            Option<&ExternalTorqueStructC>,
         ),
         Without<crate::DetachedSubtreeStateC>,
     >,
@@ -56,6 +60,8 @@ pub fn force_collection_system(
         struct_xform,
         ext_force,
         ext_torque,
+        ext_force_struct,
+        ext_torque_struct,
     ) in &mut query
     {
         let t_struct_body = struct_xform.map_or(glam::DMat3::IDENTITY, |s| *s.0.matrix_ref());
@@ -147,6 +153,50 @@ pub fn force_collection_system(
                     frame_derivs.rot_accel +=
                         // allowed: same untyped inverse_inertia boundary as above.
                         AngularAcceleration::<BodyFrame<SelfRef>>::from_raw_si(alpha_contrib);
+                }
+            }
+        }
+
+        // Struct-frame external force/torque: rotate to inertial / body
+        // using the body's current attitude. Mirrors the runner's
+        // `simulation/step/integrate.rs:85-105`, which in turn mirrors
+        // JEOD's `dyn_body_collect.cc:219-221`
+        // (`extern_forc_inrtl = T_inertial_struct^T · extern_forc_struct`).
+        if ext_force_struct.is_some() || ext_torque_struct.is_some() {
+            let ef_struct_raw = ext_force_struct.map_or(DVec3::ZERO, |c| c.0.raw_si());
+            let et_struct_raw = ext_torque_struct.map_or(DVec3::ZERO, |c| c.0.raw_si());
+            if ef_struct_raw != DVec3::ZERO || et_struct_raw != DVec3::ZERO {
+                let t_inertial_body = rot_state.map_or(glam::DMat3::IDENTITY, |r| {
+                    r.0.q_inertial_body
+                        .as_witness()
+                        .left_quat_to_transformation()
+                });
+                let t_inertial_struct =
+                    astrodyn::compute_t_inertial_struct(&t_struct_body, &t_inertial_body);
+                let force_inertial = t_inertial_struct.transpose() * ef_struct_raw;
+                let torque_body = t_struct_body * et_struct_raw;
+                // allowed: typed re-wrap at the totals accumulator —
+                // `force_inertial` is in root-inertial by construction
+                // (computed from a structural-frame load and the body's
+                // attitude), so the phantom is asserted at the boundary.
+                total.0.force += Force::<RootInertial>::from_raw_si(force_inertial);
+                // allowed: typed re-wrap — `torque_body` is in the body
+                // frame by construction (rotated from structural via
+                // `t_struct_body`).
+                total.0.torque += Torque::<BodyFrame<SelfRef>>::from_raw_si(torque_body);
+                if let Some(mass) = mass {
+                    if force_inertial != DVec3::ZERO {
+                        let accel_contrib = force_inertial * mass.0.inverse_mass;
+                        frame_derivs.trans_accel +=
+                            // allowed: scalar inverse_mass is untyped by design; rewrap.
+                            Acceleration::<RootInertial>::from_raw_si(accel_contrib);
+                    }
+                    if torque_body != DVec3::ZERO {
+                        let alpha_contrib = mass.0.inverse_inertia * torque_body;
+                        frame_derivs.rot_accel +=
+                            // allowed: same untyped inverse_inertia boundary as above.
+                            AngularAcceleration::<BodyFrame<SelfRef>>::from_raw_si(alpha_contrib);
+                    }
                 }
             }
         }

--- a/crates/astrodyn_bevy/src/systems/integration.rs
+++ b/crates/astrodyn_bevy/src/systems/integration.rs
@@ -150,7 +150,10 @@ pub fn frame_switch_system<P: Planet>(
             let threshold_sq = sw.switch_distance * sw.switch_distance;
             let triggered = match sw.switch_sense {
                 astrodyn::SwitchSense::OnApproach => {
-                    let pos_in_target = rel.position(target_frame_entity, body_frame_entity.0);
+                    let pos_in_target = rel
+                        .relative_state(target_frame_entity, body_frame_entity.0)
+                        .trans
+                        .position;
                     pos_in_target.length_squared() < threshold_sq
                 }
                 astrodyn::SwitchSense::OnDeparture => {

--- a/crates/astrodyn_bevy/tests/frame_origin_systemparam.rs
+++ b/crates/astrodyn_bevy/tests/frame_origin_systemparam.rs
@@ -157,7 +157,10 @@ fn frame_origin_and_relative_frame_state_agree() {
         .run_system_cached_with(
             |In((ancestor, frame)): In<(Entity, Entity)>,
              rel: RelativeFrameState|
-             -> (DVec3, DVec3) { rel.position_velocity(ancestor, frame) },
+             -> (DVec3, DVec3) {
+                let trans = rel.relative_state(ancestor, frame).trans;
+                (trans.position, trans.velocity)
+            },
             (pfix_frame_e, body_frame_e),
         )
         .expect("run_system_cached_with should succeed");

--- a/crates/astrodyn_runner/examples/apollo.rs
+++ b/crates/astrodyn_runner/examples/apollo.rs
@@ -183,7 +183,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let body = sim.body(0);
             let pos = body.trans.position.raw_si();
             let vel = body.trans.velocity.raw_si();
-            let moon_pos = sim.source_position(apollo::MOON_IDX);
+            let moon_pos = sim.source_position_typed(apollo::MOON_IDX).raw_si();
             let alt_km = (pos.length() - R_EARTH) / 1000.0;
             let dist_moon_km = (pos - moon_pos).length() / 1000.0;
             let speed = vel.length();
@@ -207,8 +207,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let final_body = sim.body(0);
-    let final_moon_dist =
-        (final_body.trans.position.raw_si() - sim.source_position(apollo::MOON_IDX)).length();
+    let final_moon_dist = (final_body.trans.position.raw_si()
+        - sim.source_position_typed(apollo::MOON_IDX).raw_si())
+    .length();
     println!();
     println!(
         "Final distance to Moon: {:.0} km after {elapsed_days:.2} days",

--- a/crates/astrodyn_runner/src/branded.rs
+++ b/crates/astrodyn_runner/src/branded.rs
@@ -1,3 +1,8 @@
+// JEOD_INV: TS.01 — `<SelfRef>` wildcards on the typed body-load setters
+// (`set_body_external_torque_typed`, `set_body_external_*_struct_typed`)
+// are the runner-side storage-boundary surface mirroring
+// `crate::simulation::bodies`'s typed setters; the underlying `BodyIdx`
+// resolves per-entity body identity at call time.
 //! Branded `Simulation<'sim>` wrapper with compile-time index isolation
 //! between concurrent simulations (#152).
 //!
@@ -51,7 +56,7 @@
 //!
 //! `BrandedSimulation` covers the most common index-using methods:
 //! `add_source`, `add_body`, `set_source_position`, `set_source_state`,
-//! `source_position`, `body`, plus `step`, `step_until`, `validate`,
+//! `source_position_typed`, `body`, plus `step`, `step_until`, `validate`,
 //! and `unbranded()` / `unbranded_mut()` escape hatches that expose the
 //! inner `Simulation` for methods not yet branded. Adding more branded
 //! methods later is mechanical.
@@ -166,19 +171,8 @@ impl<'sim> BrandedSimulation<'sim> {
         self.inner.set_source_state(idx.raw, position, velocity);
     }
 
-    /// Read a source's inertial position.
-    ///
-    /// Prefer [`source_position_typed`](Self::source_position_typed) for the
-    /// typed-result path.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up (see #485 task 18).
-    pub fn source_position(&self, idx: SourceIdx<'sim>) -> DVec3 {
-        self.inner.source_position(idx.raw)
-    }
-
-    /// Typed sibling of [`source_position`](Self::source_position). Returns
-    /// the source's inertial-frame position already wrapped in
-    /// `Position<RootInertial>` (the runner-wide convention; mirrors
-    /// `Simulation::source_position_typed`).
+    /// Read a source's inertial position as `Position<RootInertial>` (the
+    /// runner-wide convention; mirrors `Simulation::source_position_typed`).
     pub fn source_position_typed(
         &self,
         idx: SourceIdx<'sim>,
@@ -193,13 +187,81 @@ impl<'sim> BrandedSimulation<'sim> {
     }
 
     /// Set a body's external (non-gravity) force in inertial coordinates.
+    ///
+    /// Prefer [`set_body_external_force_typed`](Self::set_body_external_force_typed)
+    /// for the typed-input path.
     pub fn set_body_external_force(&mut self, idx: BodyIdx<'sim>, force: DVec3) {
         self.inner.set_body_external_force(idx.raw, force);
     }
 
+    /// Typed sibling of [`set_body_external_force`](Self::set_body_external_force).
+    /// Mirrors `Simulation::set_body_external_force_typed`.
+    pub fn set_body_external_force_typed(
+        &mut self,
+        idx: BodyIdx<'sim>,
+        force: astrodyn::Force<astrodyn::RootInertial>,
+    ) {
+        self.inner.set_body_external_force_typed(idx.raw, force);
+    }
+
     /// Set a body's external (non-gravity) torque in body-frame coordinates.
+    ///
+    /// Prefer [`set_body_external_torque_typed`](Self::set_body_external_torque_typed)
+    /// for the typed-input path.
     pub fn set_body_external_torque(&mut self, idx: BodyIdx<'sim>, torque: DVec3) {
         self.inner.set_body_external_torque(idx.raw, torque);
+    }
+
+    /// Typed sibling of [`set_body_external_torque`](Self::set_body_external_torque).
+    /// Mirrors `Simulation::set_body_external_torque_typed`.
+    pub fn set_body_external_torque_typed(
+        &mut self,
+        idx: BodyIdx<'sim>,
+        torque: astrodyn::Torque<astrodyn::BodyFrame<astrodyn::SelfRef>>,
+    ) {
+        self.inner.set_body_external_torque_typed(idx.raw, torque);
+    }
+
+    /// Set a body's external force in the body's structural frame.
+    /// Companion to [`set_body_external_force`](Self::set_body_external_force);
+    /// mirrors `Simulation::set_body_external_force_struct`.
+    ///
+    /// Prefer [`set_body_external_force_struct_typed`](Self::set_body_external_force_struct_typed)
+    /// for the typed-input path.
+    pub fn set_body_external_force_struct(&mut self, idx: BodyIdx<'sim>, force_struct: DVec3) {
+        self.inner
+            .set_body_external_force_struct(idx.raw, force_struct);
+    }
+
+    /// Typed sibling of [`set_body_external_force_struct`](Self::set_body_external_force_struct).
+    pub fn set_body_external_force_struct_typed(
+        &mut self,
+        idx: BodyIdx<'sim>,
+        force_struct: astrodyn::Force<astrodyn::StructuralFrame<astrodyn::SelfRef>>,
+    ) {
+        self.inner
+            .set_body_external_force_struct_typed(idx.raw, force_struct);
+    }
+
+    /// Set a body's external torque in the body's structural frame.
+    /// Companion to [`set_body_external_torque`](Self::set_body_external_torque);
+    /// mirrors `Simulation::set_body_external_torque_struct`.
+    ///
+    /// Prefer [`set_body_external_torque_struct_typed`](Self::set_body_external_torque_struct_typed)
+    /// for the typed-input path.
+    pub fn set_body_external_torque_struct(&mut self, idx: BodyIdx<'sim>, torque_struct: DVec3) {
+        self.inner
+            .set_body_external_torque_struct(idx.raw, torque_struct);
+    }
+
+    /// Typed sibling of [`set_body_external_torque_struct`](Self::set_body_external_torque_struct).
+    pub fn set_body_external_torque_struct_typed(
+        &mut self,
+        idx: BodyIdx<'sim>,
+        torque_struct: astrodyn::Torque<astrodyn::StructuralFrame<astrodyn::SelfRef>>,
+    ) {
+        self.inner
+            .set_body_external_torque_struct_typed(idx.raw, torque_struct);
     }
 
     /// Set a body's inertial position directly (e.g. for fixed-trajectory

--- a/crates/astrodyn_runner/src/simulation/bodies.rs
+++ b/crates/astrodyn_runner/src/simulation/bodies.rs
@@ -589,15 +589,46 @@ impl Simulation {
     /// Set the externally applied force (inertial frame, N) for a body.
     ///
     /// Added to `total_force.force` each step after force collection.
+    ///
+    /// Prefer [`set_body_external_force_typed`](Self::set_body_external_force_typed)
+    /// for the typed-input path; the raw entry point stays for callers
+    /// that have not yet migrated.
     pub fn set_body_external_force(&mut self, idx: usize, force: DVec3) {
         self.bodies[idx].external_force = force;
+    }
+
+    /// Typed sibling of [`set_body_external_force`](Self::set_body_external_force).
+    /// The `Force<RootInertial>` argument's phantom enforces at compile
+    /// time that the value is in the root-inertial frame, matching the
+    /// `external_force` storage convention.
+    pub fn set_body_external_force_typed(
+        &mut self,
+        idx: usize,
+        force: astrodyn::Force<astrodyn::RootInertial>,
+    ) {
+        self.set_body_external_force(idx, force.raw_si());
     }
 
     /// Set the externally applied torque (body frame, N*m) for a body.
     ///
     /// Added to `total_force.torque` each step after force collection.
+    ///
+    /// Prefer [`set_body_external_torque_typed`](Self::set_body_external_torque_typed)
+    /// for the typed-input path; the raw entry point stays for callers
+    /// that have not yet migrated.
     pub fn set_body_external_torque(&mut self, idx: usize, torque: DVec3) {
         self.bodies[idx].external_torque = torque;
+    }
+
+    /// Typed sibling of [`set_body_external_torque`](Self::set_body_external_torque).
+    /// The `Torque<BodyFrame<SelfRef>>` argument's phantom enforces at
+    /// compile time that the value is expressed in the body frame.
+    pub fn set_body_external_torque_typed(
+        &mut self,
+        idx: usize,
+        torque: astrodyn::Torque<astrodyn::BodyFrame<astrodyn::SelfRef>>,
+    ) {
+        self.set_body_external_torque(idx, torque.raw_si());
     }
 
     /// Set the externally applied force in the body's structural frame
@@ -617,8 +648,22 @@ impl Simulation {
     /// point is preserved for callers that already produce
     /// inertial-frame contributions (custom thrusters, debugging, etc.);
     /// the two contribute additively at force collection.
+    ///
+    /// Prefer [`set_body_external_force_struct_typed`](Self::set_body_external_force_struct_typed)
+    /// for the typed-input path.
     pub fn set_body_external_force_struct(&mut self, idx: usize, force_struct: DVec3) {
         self.bodies[idx].external_force_struct = force_struct;
+    }
+
+    /// Typed sibling of [`set_body_external_force_struct`](Self::set_body_external_force_struct).
+    /// The `Force<StructuralFrame<SelfRef>>` argument's phantom enforces
+    /// at compile time that the value is in the body's structural frame.
+    pub fn set_body_external_force_struct_typed(
+        &mut self,
+        idx: usize,
+        force_struct: astrodyn::Force<astrodyn::StructuralFrame<astrodyn::SelfRef>>,
+    ) {
+        self.set_body_external_force_struct(idx, force_struct.raw_si());
     }
 
     /// Set the externally applied torque in the body's structural frame
@@ -627,8 +672,22 @@ impl Simulation {
     /// Mirrors JEOD's `Torque` model. Rotated to body frame at force
     /// collection via the body's structural-to-body transform; companion
     /// to [`set_body_external_force_struct`](Self::set_body_external_force_struct).
+    ///
+    /// Prefer [`set_body_external_torque_struct_typed`](Self::set_body_external_torque_struct_typed)
+    /// for the typed-input path.
     pub fn set_body_external_torque_struct(&mut self, idx: usize, torque_struct: DVec3) {
         self.bodies[idx].external_torque_struct = torque_struct;
+    }
+
+    /// Typed sibling of [`set_body_external_torque_struct`](Self::set_body_external_torque_struct).
+    /// The `Torque<StructuralFrame<SelfRef>>` argument's phantom enforces
+    /// at compile time that the value is in the body's structural frame.
+    pub fn set_body_external_torque_struct_typed(
+        &mut self,
+        idx: usize,
+        torque_struct: astrodyn::Torque<astrodyn::StructuralFrame<astrodyn::SelfRef>>,
+    ) {
+        self.set_body_external_torque_struct(idx, torque_struct.raw_si());
     }
 
     /// Set a body's translational position (inertial frame, m).

--- a/crates/astrodyn_runner/src/simulation/sources.rs
+++ b/crates/astrodyn_runner/src/simulation/sources.rs
@@ -5,7 +5,7 @@
 //! `set_source_state`, `source_pfix_rotation`, `source_tidal_config_mut`,
 //! `source_delta_c20`.
 
-use glam::{DMat3, DVec3};
+use glam::DVec3;
 
 use astrodyn::{
     set_source_position as sim_set_source_position, set_source_state as sim_set_source_state,
@@ -204,29 +204,12 @@ impl Simulation {
     }
 
     /// Get the current position of a gravity source relative to the root
-    /// inertial frame. Returns `DVec3::ZERO` for the root-mapped central source.
-    ///
-    /// Prefer [`source_position_typed`](Self::source_position_typed) for the
-    /// typed-result path.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up. The typed sibling
-    // `source_position_typed` exists; this raw variant is preserved for
-    // backwards compatibility until the parity-lockstep follow-on PR (see
-    // #485 task 18) removes it alongside the Bevy mirrors.
-    pub fn source_position(&self, source_idx: usize) -> DVec3 {
-        sim_source_position(
-            &self.frame_tree,
-            &self.source_frame_ids,
-            self.root_frame_id,
-            source_idx,
-        )
-    }
-
-    /// Typed sibling of [`Self::source_position`] returning the source
-    /// position already wrapped as `Position<RootInertial>`. The
+    /// inertial frame, already wrapped as `Position<RootInertial>`. The
     /// frame phantom matches the runner's root-inertial convention; per-
     /// step pipelines that consume gravity / SRP / shadow inputs in
     /// `RootInertial` should call this rather than re-lifting the raw
-    /// `DVec3` at every body.
+    /// `DVec3` at every body. Returns the typed zero for the root-mapped
+    /// central source.
     pub fn source_position_typed(
         &self,
         source_idx: usize,
@@ -236,7 +219,12 @@ impl Simulation {
         // raw kernel returns a frame-erased `DVec3` and the only source
         // of truth for the phantom is the runner's documented root
         // configuration.
-        astrodyn::Position::<astrodyn::RootInertial>::from_raw_si(self.source_position(source_idx))
+        astrodyn::Position::<astrodyn::RootInertial>::from_raw_si(sim_source_position(
+            &self.frame_tree,
+            &self.source_frame_ids,
+            self.root_frame_id,
+            source_idx,
+        ))
     }
 
     /// Set the position of a gravity source relative to the root inertial frame.
@@ -269,24 +257,10 @@ impl Simulation {
         self.gravity_data[source_idx].velocity = velocity;
     }
 
-    /// Get the planet-fixed rotation matrix for a gravity source. Returns `None`
-    /// if the source has no rotation model (no pfix frame).
-    ///
-    /// Prefer [`source_pfix_rotation_typed`](Self::source_pfix_rotation_typed)
-    /// for typed `FrameTransform<RootInertial, PlanetFixed<P>>`.
-    // ESCAPE_HATCH: pending H4 typed-migration follow-up. Raw `DMat3`
-    // return is deferred to the parity-lockstep follow-on PR (see #485
-    // task 18) to be removed alongside the Bevy mirror in
-    // `SourceReader::source_pfix_rotation`.
-    pub fn source_pfix_rotation(&self, source_idx: usize) -> Option<DMat3> {
-        sim_source_pfix_rotation(&self.frame_tree, &self.source_frame_ids, source_idx)
-    }
-
-    /// Typed sibling of [`source_pfix_rotation`](Self::source_pfix_rotation).
-    ///
-    /// Returns the source's planet-fixed rotation as a typed
+    /// Get the planet-fixed rotation for a gravity source as a typed
     /// `FrameTransform<RootInertial, PlanetFixed<P>>`, matching the canonical
-    /// shape used by `PlanetFixedRotationC<P>` on the Bevy adapter side. The
+    /// shape used by `PlanetFixedRotationC<P>` on the Bevy adapter side. Returns
+    /// `None` if the source has no rotation model (no pfix frame). The
     /// caller asserts via the turbofish that `source_idx` resolves to the
     /// planet `P`'s pfix frame — no runtime check is performed (mirroring
     /// `source_position_typed`'s phantom-attachment boundary).

--- a/crates/astrodyn_runner/src/simulation/types.rs
+++ b/crates/astrodyn_runner/src/simulation/types.rs
@@ -177,11 +177,11 @@ pub struct VehicleOutput {
     /// JEOD's `derivs.trans_accel`. Zero before the first `step()`.
     ///
     /// Typed against `RootInertial` to match the Bevy adapter's
-    /// [`FrameDerivativesC`](astrodyn_bevy::components::FrameDerivativesC)
-    /// phantom (the integ-origin shift on acceleration is zero — only
-    /// positions shift between integration and root frames — so the
-    /// `RootInertial` phantom carries the same numerics whether the body
-    /// integrates in the root frame or a planet-inertial child of root).
+    /// `FrameDerivativesC` phantom (the integ-origin shift on
+    /// acceleration is zero — only positions shift between integration
+    /// and root frames — so the `RootInertial` phantom carries the same
+    /// numerics whether the body integrates in the root frame or a
+    /// planet-inertial child of root).
     pub trans_accel: Acceleration<RootInertial>,
     /// Total rotational acceleration (rad/s²) in the body frame at the
     /// end of the last `step()` — mirrors JEOD's `derivs.rot_accel`.

--- a/crates/astrodyn_runner/src/simulation/types.rs
+++ b/crates/astrodyn_runner/src/simulation/types.rs
@@ -28,11 +28,11 @@
 use glam::{DMat3, DVec3};
 
 use astrodyn::{
-    AerodynamicForce, AtmosphereState, DragConfig, DynamicsConfig, EulerSequence, FrameDerivatives,
-    FrameSwitchConfig, GeodeticState, GravityAccelerationTyped, GravityControls, GravitySource,
-    LvlhFrame, MassPropertiesTyped, OrbitalElements, RadiationForce, RootInertial, RotationModel,
-    RotationalStateTyped, SelfPlanet, SelfRef, SrpModel, TotalForce, TranslationalStateTyped,
-    VehicleConfig,
+    Acceleration, AerodynamicForce, AngularAcceleration, AtmosphereState, BodyFrame, DragConfig,
+    DynamicsConfig, EulerSequence, FrameDerivatives, FrameSwitchConfig, GeodeticState,
+    GravityAccelerationTyped, GravityControls, GravitySource, LvlhFrame, MassPropertiesTyped,
+    OrbitalElements, RadiationForce, RootInertial, RotationModel, RotationalStateTyped, SelfPlanet,
+    SelfRef, SrpModel, TotalForce, TranslationalStateTyped, VehicleConfig,
 };
 use astrodyn::{ContactFacet, FrameId, GroundFacet, IntegrationFrame, MassBodyId, MassPointState};
 
@@ -172,14 +172,21 @@ pub struct VehicleOutput {
     /// Current rotational state (attitude, body-frame angular velocity).
     /// `None` for 3-DOF.
     pub rot: Option<RotationalStateTyped<SelfRef>>,
-    /// Total translational acceleration in the integration frame (m/s²) at the
-    /// end of the last `step()`. Sum of gravity and non-gravity contributions —
-    /// mirrors JEOD's `derivs.trans_accel`. Zero before the first `step()`.
-    pub trans_accel: DVec3,
-    /// Total rotational acceleration in the body frame (rad/s²) at the end of
-    /// the last `step()` — mirrors JEOD's `derivs.rot_accel`. `None` for 3-DOF
-    /// bodies; zero before the first `step()`.
-    pub rot_accel: Option<DVec3>,
+    /// Total translational acceleration (m/s²) at the end of the last
+    /// `step()`. Sum of gravity and non-gravity contributions — mirrors
+    /// JEOD's `derivs.trans_accel`. Zero before the first `step()`.
+    ///
+    /// Typed against `RootInertial` to match the Bevy adapter's
+    /// [`FrameDerivativesC`](astrodyn_bevy::components::FrameDerivativesC)
+    /// phantom (the integ-origin shift on acceleration is zero — only
+    /// positions shift between integration and root frames — so the
+    /// `RootInertial` phantom carries the same numerics whether the body
+    /// integrates in the root frame or a planet-inertial child of root).
+    pub trans_accel: Acceleration<RootInertial>,
+    /// Total rotational acceleration (rad/s²) in the body frame at the
+    /// end of the last `step()` — mirrors JEOD's `derivs.rot_accel`.
+    /// `None` for 3-DOF bodies; the typed zero before the first `step()`.
+    pub rot_accel: Option<AngularAcceleration<BodyFrame<SelfRef>>>,
     /// Orbital elements from the latest step.
     pub orbital_elements: Option<OrbitalElements<SelfPlanet>>,
     /// Euler angles `[phi, theta, psi]` from the latest step.
@@ -418,8 +425,16 @@ impl SimBody {
             trans: self.trans,
             integ_frame_id: self.integ_frame_id,
             rot: self.rot,
-            trans_accel: self.frame_derivs.trans_accel,
-            rot_accel: self.rot.map(|_| self.frame_derivs.rot_accel),
+            // allowed: typed-output boundary at the VehicleOutput
+            // materialization site. `SimBody.frame_derivs` is the raw
+            // `FrameDerivatives` form the kernel populates; the phantom
+            // attached here mirrors the Bevy adapter's
+            // `FrameDerivativesC(FrameDerivativesTyped<RootInertial, SelfRef>)`.
+            trans_accel: Acceleration::<RootInertial>::from_raw_si(self.frame_derivs.trans_accel),
+            rot_accel: self.rot.map(|_| {
+                // allowed: same typed-output boundary as `trans_accel` above.
+                AngularAcceleration::<BodyFrame<SelfRef>>::from_raw_si(self.frame_derivs.rot_accel)
+            }),
             orbital_elements: self.orbital_elements.clone(),
             euler_angles: self.euler_angles,
             lvlh_frame: self.lvlh_frame,

--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -165,6 +165,14 @@ impl SimContext for Simulation {
         Simulation::set_body_external_torque(self, body_idx, torque);
     }
 
+    fn set_body_external_force_struct(&mut self, body_idx: usize, force_struct: DVec3) {
+        Simulation::set_body_external_force_struct(self, body_idx, force_struct);
+    }
+
+    fn set_body_external_torque_struct(&mut self, body_idx: usize, torque_struct: DVec3) {
+        Simulation::set_body_external_torque_struct(self, body_idx, torque_struct);
+    }
+
     fn body_q_inertial_body(&self, body_idx: usize) -> glam::DQuat {
         // `VehicleOutput.rot` is `Option<RotationalStateTyped<SelfRef>>`;
         // panic with a descriptive message rather than returning identity
@@ -619,13 +627,13 @@ fn snapshot_from(body: &VehicleOutput, ref_record: &StateLog) -> StateLog {
         time: ref_record.time,
         position: Some(body.trans.position.raw_si()),
         velocity: Some(body.trans.velocity.raw_si()),
-        acceleration: Some(body.trans_accel),
+        acceleration: Some(body.trans_accel.raw_si()),
         quaternion: body
             .rot
             .as_ref()
             .map(|r| r.q_inertial_body.as_witness().inner().to_glam()),
         ang_vel: body.rot.as_ref().map(|r| r.ang_vel_body.raw_si()),
-        ang_accel: body.rot_accel,
+        ang_accel: body.rot_accel.map(|a| a.raw_si()),
     }
 }
 

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
@@ -450,3 +450,160 @@ pub fn force_symmetric_impulse() -> VerificationCase {
         pre_step: Some((impulse_pre_step, PreStepCadence::PerRecord)),
     }
 }
+
+// ── Test 5: struct-frame external force / torque (issue #510 part 2) ─
+//
+// Exercises the new `SimContext::set_body_external_force_struct` /
+// `set_body_external_torque_struct` surface across both runtimes.
+// The struct-frame interpretation requires three distinct frames at
+// runtime (structural ≠ body ≠ inertial), so both `t_struct_body`
+// and the initial inertial-body attitude are non-trivial. The pre_step
+// fires once at the first record to set the struct-frame load (which
+// `VehicleConfig` has no field for), then the load persists through
+// the rest of the propagation. Parity is asserted at every record.
+
+/// Structural-frame force the struct-frame parity recipe applies for
+/// the entire propagation (N) — set via `pre_step` at record 0 (the
+/// only way today, since `VehicleConfig` has no
+/// `external_force_struct` field).
+fn force_struct_load() -> DVec3 {
+    DVec3::new(10.0, -3.0, 5.0)
+}
+
+/// Structural-frame torque companion for the torque variant (N·m).
+fn torque_struct_load() -> DVec3 {
+    DVec3::new(0.5, 0.0, 2.0)
+}
+
+/// Non-trivial structural-to-body rotation matrix (30° about z) —
+/// distinct from `DMat3::IDENTITY` so the `T_struct_body` factor in
+/// the force-collection chain is exercised.
+fn t_struct_body_nontrivial() -> DMat3 {
+    DMat3::from_rotation_z(std::f64::consts::FRAC_PI_6)
+}
+
+/// Non-trivial initial inertial-body attitude (45° about y) — distinct
+/// from identity so the `T_inertial_body` factor in
+/// `T_inertial_struct = T_struct_body^T * T_inertial_body` is also
+/// exercised.
+fn initial_attitude_nontrivial() -> JeodQuat {
+    JeodQuat::left_quat_from_eigen_rotation(std::f64::consts::FRAC_PI_4, DVec3::new(0.0, 1.0, 0.0))
+}
+
+fn build_force_struct_pre_step(_init: &InitialConditions) -> SimulationBuilder {
+    let time = SimulationTime::at_j2000(default_leap_second_table());
+    let mut sb = SimulationBuilder::new(time, DT_TORQUE_S);
+    add_dummy_central_source(&mut sb);
+    let mass_props = MassProperties::with_inertia(MASS_KG, inertia_uniform(), DVec3::ZERO);
+    sb.add_body(VehicleConfig {
+        trans: super::typed_helpers::trans_typed(&TranslationalState {
+            position: DVec3::ZERO,
+            velocity: DVec3::ZERO,
+        }),
+        rot: Some(super::typed_helpers::rot_typed(&RotationalState {
+            quaternion: initial_attitude_nontrivial(),
+            ang_vel_body: DVec3::ZERO,
+        })),
+        mass: Some(super::typed_helpers::mass_typed(&mass_props)),
+        gravity_controls: GravityControls { controls: vec![] },
+        compute_gravity_gradient: false,
+        t_struct_body: t_struct_body_nontrivial(),
+        ..Default::default()
+    });
+    sb
+}
+
+fn force_struct_pre_step(_init: &InitialConditions) -> PreStepClosure {
+    Box::new(move |sim, time_s: f64| {
+        // Fire on the first record only (time_s ≈ DT). The setter is
+        // idempotent in principle, but firing once mirrors how a real
+        // mission would schedule a one-shot struct-frame load and
+        // tests the auto-insert path on the Bevy adapter (component
+        // is absent before the first set; afterwards force-collection
+        // reads it every step).
+        let half_dt = 0.5 * DT_TORQUE_S;
+        if (time_s - DT_TORQUE_S).abs() < half_dt {
+            sim.set_body_external_force_struct(0, force_struct_load());
+        }
+    })
+}
+
+fn torque_struct_pre_step(_init: &InitialConditions) -> PreStepClosure {
+    Box::new(move |sim, time_s: f64| {
+        let half_dt = 0.5 * DT_TORQUE_S;
+        if (time_s - DT_TORQUE_S).abs() < half_dt {
+            sim.set_body_external_torque_struct(0, torque_struct_load());
+        }
+    })
+}
+
+fn both_struct_pre_step(_init: &InitialConditions) -> PreStepClosure {
+    Box::new(move |sim, time_s: f64| {
+        let half_dt = 0.5 * DT_TORQUE_S;
+        if (time_s - DT_TORQUE_S).abs() < half_dt {
+            sim.set_body_external_force_struct(0, force_struct_load());
+            sim.set_body_external_torque_struct(0, torque_struct_load());
+        }
+    })
+}
+
+/// 6-DOF body with a constant **structural-frame** external force
+/// scheduled via `pre_step` at the first record. The runner mirrors
+/// `Simulation::set_body_external_force_struct`; the Bevy adapter
+/// mirrors `BevySimContext::set_body_external_force_struct` (which
+/// writes / auto-inserts `ExternalForceStructC`). Parity asserts the
+/// two propagate bit-identical trajectories — the lockstep gate for
+/// issue #510 Part 2.
+pub fn force_struct_via_pre_step() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_struct_via_pre_step",
+        scenario: build_force_struct_pre_step,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_DECOUPLE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: Some((force_struct_pre_step, PreStepCadence::PerRecord)),
+    }
+}
+
+/// Companion to [`force_struct_via_pre_step`]: same scenario, but
+/// scheduling a structural-frame torque via `pre_step`. Exercises the
+/// `T_struct_body` rotation in the torque branch of the force-collection
+/// pipeline (mirrors `simulation/step/integrate.rs:94` →
+/// `torque_body = t_struct_body * external_torque_struct`).
+pub fn torque_struct_via_pre_step() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_torque_struct_via_pre_step",
+        scenario: build_force_struct_pre_step,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_DECOUPLE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: Some((torque_struct_pre_step, PreStepCadence::PerRecord)),
+    }
+}
+
+/// Both struct-frame force + torque scheduled simultaneously — drives
+/// the joint code path through the force-collection branch (both
+/// `T_inertial_struct^T * ef_struct` and `t_struct_body * et_struct`
+/// active in the same body's per-step pipeline).
+pub fn force_and_torque_struct_via_pre_step() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_force_and_torque_struct_via_pre_step",
+        scenario: build_force_struct_pre_step,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_TORQUE_S,
+            num_steps: num_steps(DT_TORQUE_S, T_TOTAL_DECOUPLE_S),
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: analytical_tolerances(),
+        extras: None,
+        pre_step: Some((both_struct_pre_step, PreStepCadence::PerRecord)),
+    }
+}

--- a/crates/astrodyn_verif_jeod/src/verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/verification/mod.rs
@@ -184,6 +184,49 @@ pub trait SimContext {
         );
     }
 
+    /// Set body `body_idx`'s **structural-frame** external force,
+    /// replacing any previous value. Mirrors the runner's
+    /// `Simulation::set_body_external_force_struct` — the force is
+    /// expressed in the body's structural frame and rotated to
+    /// inertial at force-collection time using the body's current
+    /// attitude (mirrors JEOD's `dyn_body_collect.cc:219-221`). Use
+    /// this entry point for Tier 3 sims that schedule struct-frame
+    /// force events (`SIM_verif_attach_detach`'s
+    /// `RUN_compute_child_derivative`) so the inertial-frame
+    /// contribution tracks the body's attitude across each
+    /// integration step.
+    ///
+    /// The default implementation panics with an explicit
+    /// "set_body_external_force_struct not supported" message so
+    /// existing `SimContext` implementors stay source-compatible.
+    fn set_body_external_force_struct(&mut self, body_idx: usize, force_struct: DVec3) {
+        let _ = (body_idx, force_struct);
+        panic!(
+            "set_body_external_force_struct not supported by this SimContext implementation; \
+             provide a SimContext impl that mutates the adapter's structural-frame \
+             external-load surface (e.g. ExternalForceStructC on the Bevy body entity)"
+        );
+    }
+
+    /// Set body `body_idx`'s **structural-frame** external torque,
+    /// replacing any previous value. Mirrors the runner's
+    /// `Simulation::set_body_external_torque_struct` — the torque is
+    /// expressed in the body's structural frame and rotated to the
+    /// body frame at force-collection time using the body's
+    /// structural-to-body transform.
+    ///
+    /// The default implementation panics with an explicit
+    /// "set_body_external_torque_struct not supported" message so
+    /// existing `SimContext` implementors stay source-compatible.
+    fn set_body_external_torque_struct(&mut self, body_idx: usize, torque_struct: DVec3) {
+        let _ = (body_idx, torque_struct);
+        panic!(
+            "set_body_external_torque_struct not supported by this SimContext implementation; \
+             provide a SimContext impl that mutates the adapter's structural-frame \
+             external-load surface (e.g. ExternalTorqueStructC on the Bevy body entity)"
+        );
+    }
+
     /// Read body `body_idx`'s current inertial-body left-transformation
     /// quaternion as `glam::DQuat` (xyzw layout). Used by `pre_step`
     /// closures that need to rotate a body-frame load into the inertial

--- a/crates/astrodyn_verif_jeod/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_apollo8_frame_switch.rs
@@ -344,13 +344,13 @@ fn tier3_apollo8_eci_integ() {
                 time: r.time,
                 position: Some(body.trans.position.raw_si()),
                 velocity: Some(body.trans.velocity.raw_si()),
-                acceleration: Some(body.trans_accel),
+                acceleration: Some(body.trans_accel.raw_si()),
                 quaternion: body
                     .rot
                     .as_ref()
                     .map(|rot| rot.q_inertial_body.as_witness().inner().to_glam()),
                 ang_vel: body.rot.as_ref().map(|rot| rot.ang_vel_body.raw_si()),
-                ang_accel: body.rot_accel,
+                ang_accel: body.rot_accel.map(|a| a.raw_si()),
             });
             ref_log.push(StateLog {
                 time: r.time,

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_apollo_trajectory.rs
@@ -268,13 +268,13 @@ fn tier3_sim_apollo_trajectory() {
             time: reference.time,
             position: Some(core_position),
             velocity: Some(core_velocity),
-            acceleration: Some(body.trans_accel),
+            acceleration: Some(body.trans_accel.raw_si()),
             quaternion: body
                 .rot
                 .as_ref()
                 .map(|r| r.q_inertial_body.as_witness().inner().to_glam()),
             ang_vel: body.rot.as_ref().map(|r| r.ang_vel_body.raw_si()),
-            ang_accel: body.rot_accel,
+            ang_accel: body.rot_accel.map(|a| a.raw_si()),
         });
         ref_log.push(StateLog {
             time: reference.time,

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
@@ -459,8 +459,9 @@ fn apply_event(
                 .source_pfix_frame_id(earth_idx)
                 .expect("Earth source has a pfix frame");
             let t_inertial_pfix = sim
-                .source_pfix_rotation(earth_idx)
-                .expect("Earth source has a pfix rotation");
+                .source_pfix_rotation_typed::<astrodyn::Earth>(earth_idx)
+                .expect("Earth source has a pfix rotation")
+                .matrix();
             let rot = body_out
                 .rot
                 .as_ref()
@@ -537,8 +538,9 @@ fn apply_event(
                 .source_pfix_frame_id(earth_idx)
                 .expect("Earth source has a pfix frame");
             let t_inertial_pfix = sim
-                .source_pfix_rotation(earth_idx)
-                .expect("Earth source has a pfix rotation");
+                .source_pfix_rotation_typed::<astrodyn::Earth>(earth_idx)
+                .expect("Earth source has a pfix rotation")
+                .matrix();
             let t_inertial_struct = rot
                 .q_inertial_body
                 .as_witness()
@@ -589,8 +591,9 @@ fn apply_event(
                 .source_pfix_frame_id(earth_idx)
                 .expect("Earth source has a pfix frame");
             let t_inertial_pfix = sim
-                .source_pfix_rotation(earth_idx)
-                .expect("Earth source has a pfix rotation");
+                .source_pfix_rotation_typed::<astrodyn::Earth>(earth_idx)
+                .expect("Earth source has a pfix rotation")
+                .matrix();
             let t_inertial_struct = rot
                 .q_inertial_body
                 .as_witness()
@@ -756,8 +759,9 @@ fn drive_through_csv(
                     .expect("step_until to t-dt must succeed");
                 let body_now = sim.body(body_idx);
                 let t_ip_now = sim
-                    .source_pfix_rotation(earth_idx)
-                    .expect("Earth source has a pfix rotation");
+                    .source_pfix_rotation_typed::<astrodyn::Earth>(earth_idx)
+                    .expect("Earth source has a pfix rotation")
+                    .matrix();
                 Some(t_ip_now * body_now.trans.position.raw_si())
             } else {
                 None

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_earth_moon.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_earth_moon.rs
@@ -108,8 +108,8 @@ fn tier3_simulation_earth_moon_clem() {
             time: record.time,
             position: Some(body.trans.position.raw_si()),
             velocity: Some(body.trans.velocity.raw_si()),
-            acceleration: Some(body.trans_accel),
-            ang_accel: body.rot_accel,
+            acceleration: Some(body.trans_accel.raw_si()),
+            ang_accel: body.rot_accel.map(|a| a.raw_si()),
             ..Default::default()
         });
     }

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs
@@ -223,8 +223,8 @@ fn run_integ_test(
             time: record.time,
             position: Some(body.trans.position.raw_si()),
             velocity: Some(body.trans.velocity.raw_si()),
-            acceleration: Some(body.trans_accel),
-            ang_accel: body.rot_accel,
+            acceleration: Some(body.trans_accel.raw_si()),
+            ang_accel: body.rot_accel.map(|a| a.raw_si()),
             ..Default::default()
         });
     }

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_mars_orbit.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_mars_orbit.rs
@@ -176,8 +176,8 @@ fn tier3_simulation_mars_dawn() {
             time: record.time,
             position: Some(body.trans.position.raw_si()),
             velocity: Some(body.trans.velocity.raw_si()),
-            acceleration: Some(body.trans_accel),
-            ang_accel: body.rot_accel,
+            acceleration: Some(body.trans_accel.raw_si()),
+            ang_accel: body.rot_accel.map(|a| a.raw_si()),
             ..Default::default()
         });
     }

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_shadow_2a.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_shadow_2a.rs
@@ -169,7 +169,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
         sim.set_body_position(0, record.position);
 
         // Compute our shadow fraction at the current Sun position
-        let sun_pos = sim.source_position(sun);
+        let sun_pos = sim.source_position_typed(sun).raw_si();
         let our_frac =
             compute_shadow_fraction(record.position, sun_pos, DVec3::ZERO, R_EARTH, SOLAR_RADIUS);
 

--- a/crates/astrodyn_verif_parity/src/bevy_context.rs
+++ b/crates/astrodyn_verif_parity/src/bevy_context.rs
@@ -58,9 +58,10 @@ use astrodyn::{
     StructuralFrame, Torque, Vec3Ext,
 };
 use astrodyn_bevy::{
-    AttachEvent, DetachEvent, ExternalForceC, ExternalTorqueC, FrameAttachEvent, FrameEntityC,
-    FrameTransC, KinematicChildC, MassChildOf, PfixFrameEntityC, RotationalStateC, SimulationTimeR,
-    SourceInertialPositionC, SourceInertialVelocityC, TidalConfigC, TranslationalStateC,
+    AttachEvent, DetachEvent, ExternalForceC, ExternalForceStructC, ExternalTorqueC,
+    ExternalTorqueStructC, FrameAttachEvent, FrameEntityC, FrameTransC, KinematicChildC,
+    MassChildOf, PfixFrameEntityC, RotationalStateC, SimulationTimeR, SourceInertialPositionC,
+    SourceInertialVelocityC, TidalConfigC, TranslationalStateC,
 };
 use astrodyn_verif_jeod::verification::{SimContext, SourceFrameKind};
 use bevy::ecs::message::Messages;
@@ -466,6 +467,42 @@ impl<P: Planet> SimContext for BevySimContext<'_, P> {
             tc.0 = typed;
         } else {
             self.world.entity_mut(entity).insert(ExternalTorqueC(typed));
+        }
+    }
+
+    fn set_body_external_force_struct(&mut self, body_idx: usize, force_struct: DVec3) {
+        // Mirror the runner's `Simulation::set_body_external_force_struct`:
+        // overwrite the body's structural-frame external-force component.
+        // `force_collection_system` reads it, rotates to inertial via
+        // `T_inertial_struct = T_struct_body^T * T_inertial_body`, and
+        // adds to `TotalForceC` (same logic as the runner's
+        // `simulation/step/integrate.rs:85-105`). Auto-insert when the
+        // component is absent — `VehicleConfig` has no
+        // `external_force_struct` field today, so the component is
+        // absent until the first `set_body_external_force_struct` call.
+        let entity = self.body_entity(body_idx);
+        let typed = Force::<StructuralFrame<SelfRef>>::from_raw_si(force_struct);
+        if let Some(mut fc) = self.world.get_mut::<ExternalForceStructC>(entity) {
+            fc.0 = typed;
+        } else {
+            self.world
+                .entity_mut(entity)
+                .insert(ExternalForceStructC(typed));
+        }
+    }
+
+    fn set_body_external_torque_struct(&mut self, body_idx: usize, torque_struct: DVec3) {
+        // Mirror `set_body_external_force_struct`'s pattern for torque:
+        // `force_collection_system` rotates to body frame via
+        // `t_struct_body` (the body's structural-to-body transform).
+        let entity = self.body_entity(body_idx);
+        let typed = Torque::<StructuralFrame<SelfRef>>::from_raw_si(torque_struct);
+        if let Some(mut tc) = self.world.get_mut::<ExternalTorqueStructC>(entity) {
+            tc.0 = typed;
+        } else {
+            self.world
+                .entity_mut(entity)
+                .insert(ExternalTorqueStructC(typed));
         }
     }
 

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
@@ -1115,7 +1115,7 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_does_not_reparent_child_frame_
         .world_mut()
         .run_system_cached_with(
             |In((from, to)): In<(Entity, Entity)>, rel: RelativeFrameState| -> DVec3 {
-                rel.position(from, to)
+                rel.relative_state(from, to).trans.position
             },
             (root_frame_entity, child_frame_entity),
         )
@@ -1483,7 +1483,7 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_runs_combine
         .world_mut()
         .run_system_cached_with(
             move |In((root, frame)): In<(Entity, Entity)>, rel: RelativeFrameState| {
-                rel.position(root, frame)
+                rel.relative_state(root, frame).trans.position
             },
             (root_e, parent_frame_entity),
         )
@@ -1774,7 +1774,7 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_rewrites_chi
         .world_mut()
         .run_system_cached_with(
             move |In((root, frame)): In<(Entity, Entity)>, rel: RelativeFrameState| {
-                rel.position(root, frame)
+                rel.relative_state(root, frame).trans.position
             },
             (root_e, child_frame_entity),
         )

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
@@ -194,7 +194,7 @@ fn bevy_parity_frame_switch_earth_to_moon_matches_simulation() {
         .world_mut()
         .run_system_cached_with(
             |In((from, to)): In<(Entity, Entity)>, rel: RelativeFrameState| -> glam::DVec3 {
-                rel.position(from, to)
+                rel.relative_state(from, to).trans.position
             },
             (moon_frame_entity, body_frame_entity),
         )

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
@@ -558,7 +558,10 @@ fn bevy_parity_point_mass_mars_rotation_dispatch() {
     sim.validate().unwrap();
     sim.step_n(10).expect("step_n failed");
 
-    let rot = sim.source_pfix_rotation(mars).unwrap();
+    let rot = sim
+        .source_pfix_rotation_typed::<astrodyn::Mars>(mars)
+        .unwrap()
+        .matrix();
     assert!(
         rot != glam::DMat3::IDENTITY,
         "Mars rotation should differ from identity after 10 steps"
@@ -632,8 +635,14 @@ fn bevy_parity_point_mass_multi_source_rotation() {
     sim.validate().unwrap();
     sim.step_n(10).expect("step_n failed");
 
-    let earth_rot = sim.source_pfix_rotation(earth).unwrap();
-    let mars_rot = sim.source_pfix_rotation(mars).unwrap();
+    let earth_rot = sim
+        .source_pfix_rotation_typed::<astrodyn::Earth>(earth)
+        .unwrap()
+        .matrix();
+    let mars_rot = sim
+        .source_pfix_rotation_typed::<astrodyn::Mars>(mars)
+        .unwrap()
+        .matrix();
 
     assert!(earth_rot != glam::DMat3::IDENTITY, "Earth rotation updated");
     assert!(mars_rot != glam::DMat3::IDENTITY, "Mars rotation updated");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_set_body_external_force_struct.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_set_body_external_force_struct.rs
@@ -1,0 +1,49 @@
+//! Bevy ↔ runner parity for the **structural-frame** external load
+//! surface — the lockstep gate for issue #510 Part 2.
+//!
+//! The struct-frame load setters (`Simulation::set_body_external_force_struct`
+//! and `_torque_struct`) feed `SimBody.external_force_struct` /
+//! `external_torque_struct` on the runner side. The Bevy adapter mirrors
+//! them through new `ExternalForceStructC` / `ExternalTorqueStructC`
+//! components and an extended `force_collection_system` branch that
+//! rotates struct → inertial / body using the body's current attitude
+//! (`T_inertial_struct = T_struct_body^T * T_inertial_body`, mirroring
+//! the runner's `simulation/step/integrate.rs:85-105` and JEOD's
+//! `dyn_body_collect.cc:219-221`).
+//!
+//! The recipes paired below ([`force_struct_via_pre_step`],
+//! [`torque_struct_via_pre_step`], [`force_and_torque_struct_via_pre_step`])
+//! build a 6-DOF body with a non-trivial structural-to-body rotation
+//! (30° about z) **and** a non-trivial initial inertial-body attitude
+//! (45° about y), so all three frames are distinct at runtime — the
+//! struct-frame load is exercised through both `T_struct_body` and
+//! `T_inertial_body` non-identity factors, ruling out tests that
+//! short-circuit when either matrix is identity.
+//!
+//! Parity asserts `runner ↔ bevy` bit-identity at every synthetic
+//! record (the `analytical_tolerances()` setting in the recipe is zero
+//! per-component). Any divergence here means the Bevy adapter's
+//! struct-frame branch in `force_collection_system` drifted from the
+//! runner's `integrate.rs` shape — the regression-protection
+//! mechanism the issue specifies.
+
+use astrodyn_verif_jeod::run_verification::sim_force_torque_response;
+use astrodyn_verif_parity::VerificationCaseParityExt;
+
+#[test]
+fn bevy_parity_set_body_external_force_struct_force_only() {
+    sim_force_torque_response::force_struct_via_pre_step()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_set_body_external_force_struct_torque_only() {
+    sim_force_torque_response::torque_struct_via_pre_step()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_set_body_external_force_struct_both() {
+    sim_force_torque_response::force_and_torque_struct_via_pre_step()
+        .run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_source_mutation.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_source_mutation.rs
@@ -157,7 +157,7 @@ fn bevy_parity_source_mutation_source_mutator_set_state_matches_runner() {
     );
     sim.set_source_state(moon_idx, new_pos, new_vel);
 
-    let sim_pos = sim.source_position(moon_idx);
+    let sim_pos = sim.source_position_typed(moon_idx).raw_si();
     let sim_node_vel = sim
         .frame_tree()
         .get(sim.source_frame(moon_idx))


### PR DESCRIPTION
## Summary

Closes [#510](https://github.com/simnaut/astrodyn/issues/510) — the H4 follow-on from PR #511. Two parts in one PR (per the lockstep-policy framing in the issue):

**Part 1: H4 raw-removal + callsite migration.** Deletes the 9 raw-returning public methods #511 left behind `// ESCAPE_HATCH: pending H4 typed-migration follow-up` annotations: `source_position` / `source_pfix_rotation` on `Simulation`, `BrandedSimulation`, `SourceReader`, `SourceMutator`; `position` / `position_velocity` on `RelativeFrameState`. Each typed sibling absorbs the deleted method's body (free-fn call or query logic) so the surface is behavior-preserving. The 2 documented escape hatches (`FrameOrigin::origin_in` non-static-`F` case; `Simulation::frame_origin` runtime-`FrameId` case) are kept.

All in-tree callsites — the apollo example, branded-sim wrappers, the integration system's frame-switch trigger (`systems/integration.rs:153`), `frame_attach_system.rs:538`, the verif_parity + verif_jeod test suites — migrate to typed siblings (or to `relative_state(...).trans` for the non-static-`F` `position_velocity` consumers).

**Part 2: Typed-quantity expansion to non-paralleled surfaces.** Restores the runner ↔ Bevy lockstep invariant (CLAUDE.md "two parallel consumers of astrodyn") for the body-load surface:

- `VehicleOutput.trans_accel` / `rot_accel` re-typed against `Acceleration<RootInertial>` / `Option<AngularAcceleration<BodyFrame<SelfRef>>>` (matches the Bevy adapter's existing `FrameDerivativesC` phantom; the integ-origin shift is zero for accelerations, so the choice is cosmetic in numerics but enforces the convention at the type level).
- Four typed setters on `Simulation` (`set_body_external_*_typed`) + matching `BrandedSimulation` wrappers; raw setters retained as the documented escape hatches.
- Two new Bevy components `ExternalForceStructC` / `ExternalTorqueStructC`, plus a new branch in `force_collection_system` mirroring the runner's `simulation/step/integrate.rs:85-105` (rotate struct → inertial / body via `T_inertial_struct = T_struct_body^T * T_inertial_body`, mirroring JEOD's `dyn_body_collect.cc:219-221`).
- New `BodyReader<P>` / `BodyMutator<P>` SystemParams in `crates/astrodyn_bevy/src/body_mutator.rs`, mirroring the `SourceReader` / `SourceMutator` shape. Typed-first setters auto-insert on zero → non-zero; raw `// ESCAPE_HATCH:` parity shims kept around the runner's raw entry points.
- `SimContext` trait gets `set_body_external_force_struct` / `set_body_external_torque_struct` defaults (panic); runner and Bevy impls override both.

## Test plan

All gates green from a clean checkout:

- [x] `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` → **1419/1419** passed.
- [x] `cargo nextest run --workspace -E 'test(bevy_parity)'` → **329/329** passed (was 326; +3 new `bevy_parity_set_body_external_force_struct_{force_only,torque_only,both}` parity tests covering struct-frame loads with a 6-DOF body whose `t_struct_body` (30° about z) and initial attitude (45° about y) are both non-trivial — all three frames distinct at runtime, no identity short-circuit).
- [x] `cargo nextest run --workspace -E 'test(tier3_)'` → **219/219** passed (incl. heavy `tier3_simulation_earth_moon_clem`).
- [x] `cargo fmt --check && cargo clippy --workspace --tests -- -D warnings`.
- [x] `scripts/check_no_escape_hatches.sh` + `scripts/check_no_bypass_deps.sh`.
- [x] `cargo test --test invariant_coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)