### PR TITLE
Wire LSODE Bevy adapter + parity test (#200 Phase 6B)

### DIFF
--- a/crates/astrodyn_bevy/src/body_action.rs
+++ b/crates/astrodyn_bevy/src/body_action.rs
@@ -124,8 +124,8 @@ use bevy::ecs::message::MessageWriter;
 use bevy::prelude::*;
 
 use crate::components::{
-    Abm4StateC, DynamicsConfigC, GaussJacksonStateC, LsodeStateC, MassPropertiesC, RotationalStateC,
-    TranslationalStateC,
+    Abm4StateC, DynamicsConfigC, GaussJacksonStateC, LsodeStateC, MassPropertiesC,
+    RotationalStateC, TranslationalStateC,
 };
 
 /// Set of planet `TypeId`s for which a per-planet body-action pipeline

--- a/crates/astrodyn_bevy/src/body_action.rs
+++ b/crates/astrodyn_bevy/src/body_action.rs
@@ -124,7 +124,7 @@ use bevy::ecs::message::MessageWriter;
 use bevy::prelude::*;
 
 use crate::components::{
-    Abm4StateC, DynamicsConfigC, GaussJacksonStateC, MassPropertiesC, RotationalStateC,
+    Abm4StateC, DynamicsConfigC, GaussJacksonStateC, LsodeStateC, MassPropertiesC, RotationalStateC,
     TranslationalStateC,
 };
 
@@ -554,6 +554,7 @@ pub fn body_action_system<P: Planet>(
             Option<&mut MassPropertiesC>,
             Option<&mut GaussJacksonStateC>,
             Option<&mut Abm4StateC>,
+            Option<&mut LsodeStateC>,
         ),
         // JEOD_INV: BA.01 — subject must be a DynBody-equivalent entity. `DynamicsConfigC`
         // is required on every dynamic body; gating the query on it both narrows
@@ -578,7 +579,7 @@ pub fn body_action_system<P: Planet>(
         // entry stripped, so a recovered World won't replay the
         // bad action on the next tick.
         let action = queue.pending.remove(idx);
-        let (mut trans, mut rot, mut mass, mut gj, mut abm) = bodies
+        let (mut trans, mut rot, mut mass, mut gj, mut abm, mut lsode) = bodies
             .get_mut(action.entity)
             .unwrap_or_else(|err| {
                 panic!(
@@ -688,7 +689,7 @@ pub fn body_action_system<P: Planet>(
             astrodyn::reset_integrators(
                 gj.as_deref_mut().map(|c| c.0.inner_mut()),
                 abm.as_deref_mut().map(|c| c.0.inner_mut()),
-                None, // no Bevy LsodeStateC yet (#200 Phase 6B)
+                lsode.as_deref_mut().map(|c| c.0.inner_mut()),
             );
         }
         // Do not advance idx: the queue shifted left by one when we

--- a/crates/astrodyn_bevy/src/components/state.rs
+++ b/crates/astrodyn_bevy/src/components/state.rs
@@ -307,6 +307,19 @@ pub struct GaussJacksonStateC(pub astrodyn::GaussJacksonState);
 #[derive(Component, Debug, Clone, Default, Deref, DerefMut)]
 pub struct Abm4StateC(pub astrodyn::Abm4State);
 
+/// Persistent LSODE (Livermore Solver) integrator state.
+///
+/// Required on entities using `IntegratorType::Lsode`. Created once with
+/// `LsodeState::new(config)` — using the same `LsodeConfig` carried by the
+/// `IntegratorTypeC` — and maintained across steps. When absent,
+/// `integration_system` will panic if `IntegratorTypeC` is `Lsode`.
+///
+/// Unlike `Abm4StateC`, this has no `Default`: the Nordsieck history is
+/// sized and primed from the config, so the state cannot be constructed
+/// without one (mirrors `GaussJacksonStateC`).
+#[derive(Component, Debug, Clone, Deref, DerefMut)]
+pub struct LsodeStateC(pub astrodyn::LsodeState);
+
 /// Typed structural→body rotation for a vehicle entity.
 ///
 /// Stores the rotation that maps structural-frame vectors into body-frame

--- a/crates/astrodyn_bevy/src/prelude.rs
+++ b/crates/astrodyn_bevy/src/prelude.rs
@@ -32,7 +32,7 @@ pub use crate::{
     ExternalForceStructC, ExternalTorqueC, ExternalTorqueStructC, FrameAngVelC, FrameDerivativesC,
     FrameEntityC, FrameRotC, FrameTransC, GaussJacksonStateC, GravityAccelerationC,
     GravityControlsC, GravitySourceC, GravityTorqueC, InertialFrameMarker, IntegrationDtR,
-    IntegrationFrameMarker, IntegratorTypeC, JointKinematicsC, MassPropertiesC,
+    IntegrationFrameMarker, IntegratorTypeC, JointKinematicsC, LsodeStateC, MassPropertiesC,
     MultiDofJointKinematicsC, PfixFrameEntityC, PlanetFixedFrameMarker, PlanetFixedRotationC,
     RadiationForceC, RootFrameEntityR, RotationalStateC, ScenarioHandles, SimulationBuilderBevyExt,
     SimulationTimeR, SinusoidalJointKinematicsC, SourceInertialPositionC, SourceInertialVelocityC,

--- a/crates/astrodyn_bevy/src/scenario.rs
+++ b/crates/astrodyn_bevy/src/scenario.rs
@@ -60,7 +60,7 @@
 //! source_ephem_bodies[i]    →  EphemerisBodyC on the source entity
 //! sun_source / moon_source  →  SunMarker / MoonMarker on the source entity
 //! bodies[i]                 →  cfg.spawn_bevy::<P>(commands, &source_entities)
-//! integrator (GJ / ABM4)    →  GaussJacksonStateC / Abm4StateC inserted
+//! integrator (GJ/ABM4/LSODE)→  GaussJacksonStateC / Abm4StateC / LsodeStateC inserted
 //! mass_tree_names[i]        →  pre-allocated MassBodyIdC(id) on the body
 //! mass_tree_attachments     →  MassTreeR.attach() + MassChildOf on child
 //! ```
@@ -93,15 +93,15 @@ use bevy::prelude::*;
 use glam::DVec3;
 
 use astrodyn::{
-    Abm4State, FrameTransform, GaussJacksonState, IntegratorType, MassBodyId, MassTree,
+    Abm4State, FrameTransform, GaussJacksonState, IntegratorType, LsodeState, MassBodyId, MassTree,
     MassTreeAttachment, Planet, PlanetFixed, RootInertial, RotationModel, SimulationBuilder,
     ValidationError, VehicleConfig,
 };
 
 use crate::components::{
-    Abm4StateC, EphemerisBodyC, GaussJacksonStateC, GravitySourceC, MassBodyIdC, MassChildOf,
-    MoonMarker, PlanetFixedRotationC, PlanetOmegaC, RotationModelC, SourceInertialPositionC,
-    SourceInertialVelocityC, SunMarker, TidalConfigC, TranslationalStateC,
+    Abm4StateC, EphemerisBodyC, GaussJacksonStateC, GravitySourceC, LsodeStateC, MassBodyIdC,
+    MassChildOf, MoonMarker, PlanetFixedRotationC, PlanetOmegaC, RotationModelC,
+    SourceInertialPositionC, SourceInertialVelocityC, SunMarker, TidalConfigC, TranslationalStateC,
 };
 use crate::{
     AstrodynPlugin, AtmosphereModelR, EphemerisR, IntegrationDtR, MassTreeR, PolarMotionR,
@@ -460,6 +460,11 @@ impl SimulationBuilderBevyExt for SimulationBuilder {
                     app.world_mut()
                         .entity_mut(entity)
                         .insert(Abm4StateC(Abm4State::new()));
+                }
+                IntegratorType::Lsode(config) => {
+                    app.world_mut()
+                        .entity_mut(entity)
+                        .insert(LsodeStateC(LsodeState::new(config)));
                 }
                 _ => {}
             }

--- a/crates/astrodyn_bevy/src/systems/integration.rs
+++ b/crates/astrodyn_bevy/src/systems/integration.rs
@@ -1,7 +1,7 @@
 // JEOD_INV: TS.01 — `<SelfRef>` / `<SelfPlanet>` are runtime-resolved storage-boundary wildcards; see `docs/JEOD_invariants.md` row TS.01 and the lint at `tests/self_ref_self_planet_discipline.rs`.
 //! Bevy systems for [`AstrodynSet::Integration`](crate::AstrodynSet::Integration).
 //!
-//! State integration (RK4 / Gauss-Jackson / ABM4), mass-tree staging
+//! State integration (RK4 / Gauss-Jackson / ABM4 / LSODE), mass-tree staging
 //! (attach / detach), detached-subtree free-flight propagation, and
 //! distance-based frame switching.
 
@@ -248,8 +248,9 @@ pub fn frame_switch_system<P: Planet>(
 /// for proper multi-stage accuracy.
 ///
 /// The integration method is determined by the optional `IntegratorTypeC`
-/// component (RK4, RKF45, GaussJackson, Abm4). When absent, RK4 is used.
-/// GaussJackson requires `GaussJacksonStateC`; ABM4 requires `Abm4StateC`.
+/// component (RK4, RKF45, GaussJackson, Abm4, Lsode). When absent, RK4 is
+/// used. GaussJackson requires `GaussJacksonStateC`; ABM4 requires
+/// `Abm4StateC`; LSODE requires `LsodeStateC`.
 ///
 /// Per-body integration-frame origins (relative to root) are queried via
 /// the [`FrameOrigin`] SystemParam, which walks the ECS frame hierarchy

--- a/crates/astrodyn_bevy/src/systems/integration.rs
+++ b/crates/astrodyn_bevy/src/systems/integration.rs
@@ -294,8 +294,15 @@ pub fn integration_system<P: Planet>(
             &GravityControlsC,
             &mut TotalForceC,
             Option<&IntegratorTypeC>,
-            Option<&mut GaussJacksonStateC>,
-            Option<&mut Abm4StateC>,
+            // Persistent multistep integrator states, nested in one
+            // sub-tuple to keep the outer query within Bevy's QueryData
+            // tuple-arity limit. At most one is present per body (the
+            // one matching `IntegratorTypeC`); RK4/RKF45 bodies carry none.
+            (
+                Option<&mut GaussJacksonStateC>,
+                Option<&mut Abm4StateC>,
+                Option<&mut LsodeStateC>,
+            ),
             Option<&mut FlatPlateConfigC>,
             Option<&StructuralTransformC>,
             Option<&mut RadiationForceC>,
@@ -490,8 +497,7 @@ pub fn integration_system<P: Planet>(
         controls,
         mut total_force,
         integrator,
-        mut gj_state,
-        mut abm4_state,
+        (mut gj_state, mut abm4_state, mut lsode_state),
         mut flat_config,
         struct_xform,
         mut srp_force,
@@ -534,6 +540,15 @@ pub fn integration_system<P: Planet>(
                 "Entity {entity:?}: IntegratorTypeC is Abm4 but \
                  Abm4StateC component is missing. Add \
                  Abm4StateC(Abm4State::new()) to the entity."
+            );
+        }
+        if matches!(integrator_type, astrodyn::IntegratorType::Lsode(..)) {
+            assert!(
+                lsode_state.is_some(),
+                "Entity {entity:?}: IntegratorTypeC is Lsode but \
+                 LsodeStateC component is missing. Create the state from \
+                 the same config used in IntegratorTypeC, e.g.: \
+                 LsodeStateC(LsodeState::new(config))"
             );
         }
 
@@ -784,11 +799,7 @@ pub fn integration_system<P: Planet>(
             integrator_type,
             gj_state.as_mut().map(|g| g.0.inner_mut()),
             abm4_state.as_mut().map(|a| a.0.inner_mut()),
-            // LSODE Bevy support (an `LsodeStateC` component, mirroring
-            // `Abm4StateC`) is a follow-on (#200 Phase 6B); no Bevy body
-            // selects `IntegratorType::Lsode` yet, and the runner-side
-            // `integrate_body` panics loudly if one does without state.
-            None,
+            lsode_state.as_mut().map(|l| l.0.inner_mut()),
         );
         // Re-wrap kernel-mutated state back into typed components;
         // integrate_body signature is untyped, so re-wrapping is the
@@ -1227,6 +1238,7 @@ pub fn staging_system<P: Planet>(
         &crate::MassBodyIdC,
         Option<&mut GaussJacksonStateC>,
         Option<&mut Abm4StateC>,
+        Option<&mut LsodeStateC>,
     )>,
     // `frame_origin` performs the per-body root-inertial lift required by
     // the cross-integration-frame attach path. The merge kernel composes
@@ -3119,13 +3131,16 @@ pub fn staging_system<P: Planet>(
     // JEOD_INV: IG.37 — kept strictly before Site B so a regression
     // that drops Site B leaves the dirty flag set and panics on next
     // integrate.
-    for (body_id, mut gj_opt, mut abm_opt) in &mut integrators {
+    for (body_id, mut gj_opt, mut abm_opt, mut lsode_opt) in &mut integrators {
         if affected_ids.binary_search(&body_id.0).is_ok() {
             if let Some(ref mut gj) = gj_opt {
                 gj.0.mark_topology_dirty();
             }
             if let Some(ref mut abm) = abm_opt {
                 abm.0.mark_topology_dirty();
+            }
+            if let Some(ref mut lsode) = lsode_opt {
+                lsode.0.mark_topology_dirty();
             }
         }
     }
@@ -3134,12 +3149,12 @@ pub fn staging_system<P: Planet>(
     // `dyn_body_attach.cc::reset_integrators()` (lines 860, 871) and
     // `dyn_body_detach.cc:271-273`.
     // JEOD_INV: IG.37 — multi-step integrator history must be reset on topology change
-    for (body_id, mut gj_opt, mut abm_opt) in &mut integrators {
+    for (body_id, mut gj_opt, mut abm_opt, mut lsode_opt) in &mut integrators {
         if affected_ids.binary_search(&body_id.0).is_ok() {
             astrodyn::reset_integrators(
                 gj_opt.as_mut().map(|c| c.0.inner_mut()),
                 abm_opt.as_mut().map(|c| c.0.inner_mut()),
-                None, // no Bevy LsodeStateC yet (#200 Phase 6B)
+                lsode_opt.as_mut().map(|c| c.0.inner_mut()),
             );
         }
     }

--- a/crates/astrodyn_bevy/src/wrench.rs
+++ b/crates/astrodyn_bevy/src/wrench.rs
@@ -97,12 +97,12 @@ use astrodyn::{aggregate_wrenches_via_storage, EdgeGeometry, MassStorage, Vec3Ex
 
 use crate::components::{
     Abm4StateC, DynamicsConfigC, FrameDerivativesC, GaussJacksonStateC, GravityAccelerationC,
-    KinematicChildC, MassChildOf, MassPropertiesC, RotationalStateC, StructuralTransformC,
-    TotalForceC,
+    KinematicChildC, LsodeStateC, MassChildOf, MassPropertiesC, RotationalStateC,
+    StructuralTransformC, TotalForceC,
 };
 use crate::mass_tree::MassTreeView;
 
-/// Clear multi-step integrator (Gauss-Jackson, ABM4) predictor /
+/// Clear multi-step integrator (Gauss-Jackson, ABM4, LSODE) predictor /
 /// corrector history for an entity that's about to resume root-side
 /// integration after being a kinematic child of a `MassChildOf`
 /// chain. Single-step integrators (RK4, RKF4(5)) carry no per-step
@@ -116,13 +116,15 @@ fn reset_multi_step_history(
     entity: Entity,
     gj_q: &mut Query<&mut GaussJacksonStateC>,
     abm_q: &mut Query<&mut Abm4StateC>,
+    lsode_q: &mut Query<&mut LsodeStateC>,
 ) {
     let mut gj = gj_q.get_mut(entity).ok();
     let mut abm = abm_q.get_mut(entity).ok();
+    let mut lsode = lsode_q.get_mut(entity).ok();
     astrodyn::reset_integrators(
         gj.as_mut().map(|g| g.0.inner_mut()),
         abm.as_mut().map(|a| a.0.inner_mut()),
-        None, // no Bevy LsodeStateC yet (#200 Phase 6B)
+        lsode.as_mut().map(|l| l.0.inner_mut()),
     );
 }
 
@@ -194,6 +196,7 @@ pub fn wrench_aggregation_system(
     // be reset on topology change.
     mut gj_q: Query<&mut GaussJacksonStateC>,
     mut abm_q: Query<&mut Abm4StateC>,
+    mut lsode_q: Query<&mut LsodeStateC>,
 ) {
     // Fast path: no MassChildOf edges in the world means no chains —
     // every entity is its own root and the existing per-entity
@@ -214,7 +217,7 @@ pub fn wrench_aggregation_system(
     // JEOD_INV: IG.37 — multi-step integrator history must be reset on topology change
     if parents_q.is_empty() {
         for entity in kinematic_q.iter() {
-            reset_multi_step_history(entity, &mut gj_q, &mut abm_q);
+            reset_multi_step_history(entity, &mut gj_q, &mut abm_q, &mut lsode_q);
             commands.entity(entity).remove::<KinematicChildC>();
         }
         return;
@@ -456,7 +459,7 @@ pub fn wrench_aggregation_system(
     // JEOD_INV: IG.37 — multi-step integrator history must be reset on topology change
     for entity in kinematic_q.iter() {
         if !should_be_kinematic.contains(&entity) {
-            reset_multi_step_history(entity, &mut gj_q, &mut abm_q);
+            reset_multi_step_history(entity, &mut gj_q, &mut abm_q, &mut lsode_q);
             commands.entity(entity).remove::<KinematicChildC>();
         }
     }

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lsode.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lsode.rs
@@ -1,37 +1,35 @@
-//! Bevy ↔ runner parity for the `RUN_abm4` portion of JEOD's `SIM_integ_test`.
+//! Bevy ↔ runner parity for the `RUN_lsode` portion of JEOD's
+//! `SIM_integ_test` — the variable-order/variable-step LSODE method.
 //!
 //! The runner-side oracle is
-//! `crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs::tier3_simulation_lsode_abm4`,
-//! which cross-validates our ABM4 implementation against JEOD's ABM4 on a
-//! Kepler orbit using Trick's `TimeDyn::scale_factor` (≈ 15.54 dyn-seconds
-//! per sim-second, one degree of orbital phase per sim step). The parity
-//! wrapper carries the `bevy ≡ runner` half of the
-//! `bevy ≡ runner ≈ JEOD` transitivity argument for the ABM4 method:
-//! both runtimes integrate the same Kepler orbit with the same ABM4
-//! configuration and the same `time_scale_factor`; bit-identity at every
-//! checkpoint over the full 80 000 s window is the contract.
+//! `crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs::tier3_simulation_lsode_default`,
+//! which cross-validates our ported LSODE (`ImplicitAdamsNonStiff`,
+//! `rtol = 2.3e-16`, `atol = 0`) against JEOD's LSODE on a Kepler orbit
+//! using Trick's `TimeDyn::scale_factor` (≈ 15.54 dyn-seconds per
+//! sim-second, one degree of orbital phase per sim step).
 //!
-//! The companion `RUN_lsode` case in `tier3_sim_lsode.rs` is mirrored by
-//! the sibling `bevy_parity_lsode.rs` wrapper, not here. When this file
-//! was written our integrator set did not include LSODE, so there was no
-//! Bevy-side LSODE to assert parity against; the LSODE non-stiff Adams
-//! family has since landed (#200) along with the `LsodeStateC` Bevy
-//! component, and `bevy_parity_lsode.rs` now carries the runner≡Bevy
-//! bit-identity contract for the variable-order method. This file remains
-//! the ABM4-flavor half; both prefix-match the `lsode` tier3 topic in
-//! `parity_coverage.rs`.
+//! This wrapper carries the `bevy ≡ runner` half of the
+//! `bevy ≡ runner ≈ JEOD` transitivity argument for the LSODE method:
+//! both runtimes integrate the same Kepler orbit with the same
+//! `LsodeConfig` and the same `time_scale_factor`, and bit-identity at
+//! every checkpoint over the full 80 000 s window is the contract.
+//! Unlike the companion `bevy_parity_lsode_abm4.rs` (which mirrors
+//! `RUN_abm4` only — LSODE was unported when it was written), this file
+//! exercises the `LsodeStateC` Bevy component path landed in #200 Phase
+//! 6B: the integrator's persistent Nordsieck history must thread through
+//! the ECS exactly as it does through the runner's `SimBody::lsode_state`.
 //!
 //! ## Why not a recipe?
 //!
 //! `SIM_integ_test` derives μ from `sma`/`mean_motion`, takes initial
 //! conditions from the deterministically-rotated `prop_integ_state` row
-//! (the t=0 line of the reference CSV — a JEOD source value), and
-//! applies a `time_scale_factor`. None of these match a recipe preset;
-//! the runner-side test in `tier3_sim_lsode.rs` is annotated
-//! `non-recipe:` for the same reason. This wrapper mirrors the bootstrap
-//! pattern in `bevy_parity_gj.rs`: build identical
-//! `SimulationBuilder`s for both runtimes and assert bit-identity at
-//! every checkpoint, with no `VerificationCase` factory in between.
+//! (the t=0 line of the reference CSV — a JEOD source value), and applies
+//! a `time_scale_factor`. None of these match a recipe preset; the
+//! runner-side test in `tier3_sim_lsode.rs` is annotated `non-recipe:`
+//! for the same reason. This wrapper mirrors the bootstrap pattern in
+//! `bevy_parity_lsode_abm4.rs`: build identical `SimulationBuilder`s for
+//! both runtimes and assert bit-identity at every checkpoint, with no
+//! `VerificationCase` factory in between.
 
 #![allow(
     clippy::float_cmp,
@@ -48,8 +46,8 @@ use std::time::Duration;
 
 use astrodyn::{
     default_leap_second_table, GravityControl, GravityControls, GravityGradient, GravityModel,
-    GravitySource, GravitySourceEntry, IntegratorType, Position, RootInertial, SimulationBuilder,
-    SimulationTime, TranslationalState, VehicleConfig, Velocity,
+    GravitySource, GravitySourceEntry, IntegratorType, LsodeConfig, Position, RootInertial,
+    SimulationBuilder, SimulationTime, TranslationalState, VehicleConfig, Velocity,
 };
 use astrodyn_bevy::{SimulationBuilderBevyExt, TranslationalStateC};
 use astrodyn_runner::builder::SimulationBuilderExt;
@@ -81,7 +79,7 @@ fn compute_mu() -> f64 {
     SMA * SMA * SMA * MDOT * MDOT
 }
 
-/// Load the t=0 `prop_integ_state` row from JEOD's `integ_abm4_integ.csv`.
+/// Load the t=0 `prop_integ_state` row from JEOD's `integ_lsode_integ.csv`.
 ///
 /// The integrator frame is deterministically rotated from the canonical
 /// Kepler solution (`IntegrationTest` uses a regression-mode RNG), so the
@@ -98,18 +96,18 @@ fn load_t0_initial_state(path: &Path) -> TranslationalState {
     let first_data_line = content
         .lines()
         .nth(1)
-        .expect("integ_abm4_integ.csv must have at least one data row after the header");
+        .expect("integ_lsode_integ.csv must have at least one data row after the header");
     let f: Vec<&str> = first_data_line.split(',').collect();
     assert!(
         f.len() >= 7,
-        "integ_abm4_integ.csv t=0 row expected >=7 columns (time + pos[3] + vel[3]), got {}",
+        "integ_lsode_integ.csv t=0 row expected >=7 columns (time + pos[3] + vel[3]), got {}",
         f.len()
     );
     let parse = |idx: usize| -> f64 { f[idx].trim().parse().unwrap() };
     let t0: f64 = parse(0);
     assert!(
         t0 == 0.0,
-        "first data row of integ_abm4_integ.csv must be t=0 (got t={t0})",
+        "first data row of integ_lsode_integ.csv must be t=0 (got t={t0})",
     );
     TranslationalState {
         position: DVec3::new(parse(1), parse(2), parse(3)),
@@ -117,11 +115,13 @@ fn load_t0_initial_state(path: &Path) -> TranslationalState {
     }
 }
 
-/// Build the SIM_integ_test ABM4 scenario as a fresh `SimulationBuilder`.
+/// Build the SIM_integ_test LSODE scenario as a fresh `SimulationBuilder`.
 /// Both runtime sides consume an independently-constructed builder from
 /// this factory so neither builder is moved twice. The returned builder
-/// carries the matched `time_scale_factor`, derived μ, and the same IC.
-fn build_abm4_scenario(initial_state: TranslationalState) -> SimulationBuilder {
+/// carries the matched `time_scale_factor`, derived μ, the same IC, and
+/// the `RUN_lsode` configuration (`ImplicitAdamsNonStiff`, rtol = 2.3e-16,
+/// atol = 0 — JEOD `integ_option_int = 140`).
+fn build_lsode_scenario(initial_state: TranslationalState) -> SimulationBuilder {
     let mu = compute_mu();
     let time_scale = compute_time_scale();
 
@@ -146,9 +146,10 @@ fn build_abm4_scenario(initial_state: TranslationalState) -> SimulationBuilder {
     };
     let earth_idx = b.add_source("Earth", earth);
 
+    let cfg = LsodeConfig::non_stiff_adams().with_tolerances(2.3e-16, 0.0);
     b.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&initial_state),
-        integrator: IntegratorType::Abm4,
+        integrator: IntegratorType::Lsode(cfg),
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(
                 earth_idx,
@@ -171,8 +172,8 @@ const CHECKPOINT_CADENCE_S: f64 = 200.0;
 const PARITY_WINDOW_S: f64 = 80_000.0;
 
 #[test]
-fn bevy_parity_lsode_abm4() {
-    let csv_path = test_data_path("integ_abm4_integ.csv");
+fn bevy_parity_lsode() {
+    let csv_path = test_data_path("integ_lsode_integ.csv");
     assert!(
         csv_path.exists(),
         "JEOD SIM_integ_test reference CSV not found at {}.\n\
@@ -183,19 +184,20 @@ fn bevy_parity_lsode_abm4() {
     let initial_state = load_t0_initial_state(&csv_path);
 
     // Runner side — own builder instance.
-    let runner_builder = build_abm4_scenario(initial_state);
+    let runner_builder = build_lsode_scenario(initial_state);
     let dt = runner_builder.dt;
     let mut runner = runner_builder
         .build()
-        .expect("runner build for SIM_integ_test ABM4");
+        .expect("runner build for SIM_integ_test LSODE");
 
     // Bevy side — independent builder instance from the same factory,
     // materialized into a fresh App under `<Earth>`. `populate_app`
     // honors the builder's `SimulationTime.time_scale_factor` via the
-    // `SimulationTimeR` insertion in `scenario.rs`.
+    // `SimulationTimeR` insertion in `scenario.rs`, and inserts the
+    // `LsodeStateC` component (scenario.rs auto-init arm).
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
-    let handles = build_abm4_scenario(initial_state)
+    let handles = build_lsode_scenario(initial_state)
         .populate_app::<astrodyn::Earth>(&mut app)
         .expect("bevy populate_app under <Earth>");
     let vehicle = handles.body_entities[0];
@@ -215,7 +217,7 @@ fn bevy_parity_lsode_abm4() {
     while t + CHECKPOINT_CADENCE_S <= PARITY_WINDOW_S {
         runner
             .step_n(steps_per_checkpoint)
-            .expect("runner step_n during SIM_integ_test ABM4 parity loop");
+            .expect("runner step_n during SIM_integ_test LSODE parity loop");
         for _ in 0..steps_per_checkpoint {
             app.world_mut()
                 .resource_mut::<Time<Fixed>>()
@@ -237,14 +239,14 @@ fn bevy_parity_lsode_abm4() {
         for i in 0..3 {
             assert!(
                 r_pos[i].to_bits() == b_pos[i].to_bits(),
-                "SIM_integ_test ABM4 translational bit-parity broke at t={t} on position[{i}]: \
+                "SIM_integ_test LSODE translational bit-parity broke at t={t} on position[{i}]: \
                  runner={} bevy={}",
                 r_pos[i],
                 b_pos[i],
             );
             assert!(
                 r_vel[i].to_bits() == b_vel[i].to_bits(),
-                "SIM_integ_test ABM4 translational bit-parity broke at t={t} on velocity[{i}]: \
+                "SIM_integ_test LSODE translational bit-parity broke at t={t} on velocity[{i}]: \
                  runner={} bevy={}",
                 r_vel[i],
                 b_vel[i],

--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -116,18 +116,18 @@ const DEFERRED_GAPS: &[(&str, &str)] = &[
         "pre-recipe sibling — drag-family recipe factory not yet defined \
          (#389 follow-up)",
     ),
-    // `lsode` (tier3_sim_lsode.rs) covered by
-    // `bevy_parity_lsode_abm4.rs`: the `RUN_abm4` half of the tier3
-    // file (the half whose JEOD reference uses our ABM4 implementation
-    // on both sides) runs lockstep through both runtimes and asserts
-    // bit-identical state at every checkpoint. The `RUN_lsode` half
-    // documents the drift between our fixed-order ABM4 and JEOD's
-    // adaptive LSODE — there is no Bevy-side LSODE to assert parity
-    // against until LSODE itself is ported (see
-    // `crates/astrodyn_dynamics/src/abm4.rs` doc rationale for the
-    // future-work scoping). The prefix-match in `is_covered_by_parity`
-    // satisfies this entry implicitly, so the topic is not listed
-    // here.
+    // `lsode` (tier3_sim_lsode.rs) covered by two parity wrappers, both
+    // satisfying this topic implicitly via the prefix-match in
+    // `is_covered_by_parity` (so neither is listed in a gap array):
+    //   * `bevy_parity_lsode_abm4.rs` — the `RUN_abm4` half (our ABM4 on
+    //     both sides) runs lockstep through both runtimes.
+    //   * `bevy_parity_lsode.rs` — the `RUN_lsode` half. Since the LSODE
+    //     non-stiff Adams family landed (#200), the Bevy `LsodeStateC`
+    //     component path threads the Nordsieck history through the ECS,
+    //     and this wrapper asserts bit-identical runner≡Bevy state at
+    //     every checkpoint over the full 80 000 s window — closing the
+    //     "no Bevy-side LSODE to assert parity against" gap the older
+    //     `bevy_parity_lsode_abm4.rs` doc described.
     //
     // `time_docker` (tier3_sim_time_docker.rs) covered by
     // `bevy_parity_time_docker.rs`: all six SIM_1..6 cases run as a


### PR DESCRIPTION
## Summary

LSODE Phase 6B: gives the ported LSODE integrator (#615) a real Bevy ECS path. Before this PR, `integration_system` passed `None` for the LSODE state and a Bevy body selecting `IntegratorType::Lsode` would panic in the kernel — LSODE was only covered transitively.

- **`LsodeStateC` component** — wraps `astrodyn::LsodeState`. No `Default` (the Nordsieck history is sized/primed from the config), mirroring `GaussJacksonStateC`.
- **Scenario auto-init** — `SimulationBuilder::populate_app` inserts `LsodeStateC(LsodeState::new(config))` for `IntegratorType::Lsode`, matching the runner's `Simulation::validate`.
- **`integration_system` wiring** — the three multistep integrator-state `Option`s (GJ/ABM4/LSODE) are nested into one sub-tuple in the `bodies` query to stay within Bevy 0.18's `QueryData` tuple-arity limit (the outer tuple was already at 15). Added the `Lsode`-requires-`LsodeStateC` panic guard, threaded `lsode_state` into `integrate_body`, and extended the topology-change reset path (mark-dirty + `reset_integrators`).
- **`bevy_parity_lsode.rs`** — asserts bit-identical runner≡Bevy translational state at every 200 s checkpoint across the full 80 000 s (~14-orbit) RUN_lsode window, exercising the new component's history threading end-to-end.

## Doc/coverage updates
- `parity_coverage.rs` and `bevy_parity_lsode_abm4.rs` notes updated — LSODE parity is no longer "unbacked until LSODE is ported." Both wrappers prefix-match the `lsode` tier3 topic.

## Verification
- `bevy_parity_lsode` passes (full 80 000 s bit-identity).
- All 14 GJ (orders 4/8/12) + ABM4 + attach/detach topology-reset parity tests pass — the query restructure is behavior-preserving.
- `cargo fmt --check` and `cargo clippy --tests -- -D warnings` clean on `astrodyn_bevy` + `astrodyn_verif_parity`.

Part of #200 / #99 Bucket A. Remaining: Phase 6C (BDF/stiff Newton family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)