### PR TITLE
Port DRAG_OPT_CONST aero option + close SIM_VER_DRAG (#99)

### DIFF
--- a/crates/astrodyn_interactions/src/aero_drag.rs
+++ b/crates/astrodyn_interactions/src/aero_drag.rs
@@ -23,20 +23,44 @@ use uom::si::f64::{Area, MassDensity, Ratio};
 // concrete `<P>` so the wind frame and the vehicle's planet-inertial
 // velocity must agree at the type level.
 
+/// Drag-magnitude option (JEOD `DefaultAero::DragOption`). Selects how the
+/// scalar drag magnitude applied along the relative-velocity direction is
+/// computed.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum DragOption {
+    /// Coefficient-of-drag model: `drag = −q·A·Cd` (JEOD `DRAG_OPT_CD`,
+    /// the default). Uses `cd`, `area`, and the atmospheric (or constant)
+    /// density.
+    #[default]
+    CoefficientOfDrag,
+    /// User-specified constant drag magnitude in newtons, applied directly
+    /// along the relative-velocity unit vector (JEOD `DRAG_OPT_CONST`). The
+    /// value is signed and used verbatim — `cd`, `area`, and density are
+    /// ignored. (JEOD's `RUN_aero_drag_const` uses a positive value, i.e.
+    /// force *along* the relative velocity, as an option-exercise.)
+    Constant(f64),
+}
+
 /// Vehicle drag configuration for the ballistic (default) model.
 ///
-/// Port of JEOD `DefaultAero` with `DRAG_OPT_CD` option.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// Port of JEOD `DefaultAero`. The `option` field selects the
+/// coefficient-of-drag (default) or constant-magnitude model.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct DragConfig {
     /// Coefficient of drag (dimensionless). Typically 2.0-2.5 for LEO.
+    /// Used only by [`DragOption::CoefficientOfDrag`].
     pub cd: f64,
-    /// Cross-sectional area in m^2.
+    /// Cross-sectional area in m^2. Used only by
+    /// [`DragOption::CoefficientOfDrag`].
     pub area: f64,
     /// Override atmospheric density with a constant value (kg/m³).
     /// When `Some`, the atmosphere model's density is ignored and this
     /// value is used instead. Wind is still taken from the atmosphere.
     /// Port of JEOD `AerodynamicDrag::constant_density` + `density`.
     pub constant_density: Option<f64>,
+    /// Drag-magnitude model (CD vs constant). Defaults to
+    /// [`DragOption::CoefficientOfDrag`].
+    pub option: DragOption,
 }
 
 /// Aerodynamic force and torque on a vehicle.
@@ -77,12 +101,6 @@ pub fn compute_ballistic_drag(
     inertial_velocity: DVec3,
     t_inertial_struct: &DMat3,
 ) -> AerodynamicForce {
-    // JEOD aero_drag.cc line 128: if(constant_density == false) { density = atmos_ptr->density; }
-    let density = config.constant_density.unwrap_or(atmos.density);
-    if density <= 0.0 {
-        return AerodynamicForce::default();
-    }
-
     // Relative velocity = vehicle velocity - atmospheric wind (in inertial frame)
     // JEOD aero_drag.cc line 111: Vector3::diff(inertial_velocity, atmos_ptr->wind, relative_vel_cm)
     let relative_vel_cm = inertial_velocity - atmos.wind.raw_si();
@@ -98,13 +116,23 @@ pub fn compute_ballistic_drag(
 
     let rel_vel_struct_hat = rel_vel_cm_struct / rel_vel_mag;
 
-    // Dynamic pressure: 0.5 · ρ · v²
-    // JEOD aero_drag.cc line 132: param.dynamic_pressure = 0.5 * density * rel_vel_mag * rel_vel_mag
-    let dynamic_pressure = 0.5 * density * rel_vel_mag * rel_vel_mag;
-
-    // Drag force magnitude (negative = opposing motion)
-    // JEOD default_aero.cc line 70: drag = -dynamic_pressure * area * Cd
-    let drag = -dynamic_pressure * config.area * config.cd;
+    // Drag magnitude (JEOD default_aero.cc `aerodrag_force` switch on `option`).
+    let drag = match config.option {
+        // DRAG_OPT_CONST: the user-set magnitude is used verbatim; density,
+        // area, and Cd are not consulted (JEOD default_aero.cc case
+        // DRAG_OPT_CONST leaves `drag` at its preset value).
+        DragOption::Constant(mag) => mag,
+        // DRAG_OPT_CD: drag = -q·A·Cd, q = ½·ρ·v². Density ≤ 0 ⇒ no force.
+        // JEOD aero_drag.cc line 128 / default_aero.cc line 70.
+        DragOption::CoefficientOfDrag => {
+            let density = config.constant_density.unwrap_or(atmos.density);
+            if density <= 0.0 {
+                return AerodynamicForce::default();
+            }
+            let dynamic_pressure = 0.5 * density * rel_vel_mag * rel_vel_mag;
+            -dynamic_pressure * config.area * config.cd
+        }
+    };
 
     // Force in structural frame: drag along relative velocity direction
     // JEOD default_aero.cc line 106: Vector3::scale(rel_vel_hat, drag, force)
@@ -144,6 +172,10 @@ impl DragConfigTyped {
             cd: self.cd.value,
             area: self.area.value,
             constant_density: self.constant_density.map(|d| d.value),
+            // The typed sibling is the coefficient-of-drag path; the
+            // constant-magnitude option (`DRAG_OPT_CONST`) is set on the
+            // untyped `DragConfig` directly.
+            option: DragOption::CoefficientOfDrag,
         }
     }
 
@@ -275,6 +307,7 @@ mod typed_tests {
             cd: 2.2,
             area: 4.5,
             constant_density: Some(1e-12),
+            ..Default::default()
         };
         let typed = DragConfigTyped::from_untyped_unchecked(&untyped);
         let back = typed.to_untyped();
@@ -289,6 +322,7 @@ mod typed_tests {
             cd: 2.0,
             area: 1.0,
             constant_density: None,
+            ..Default::default()
         };
         let typed = DragConfigTyped::from_untyped_unchecked(&untyped);
         assert!(typed.constant_density.is_none());
@@ -319,6 +353,7 @@ mod typed_tests {
             cd: 2.2,
             area: 4.5,
             constant_density: None,
+            ..Default::default()
         };
         let atmos =
             AtmosphereState::<SelfPlanet>::from_raw(1e-12, 0.0, 0.0, DVec3::new(0.0, 50.0, 0.0));
@@ -381,6 +416,7 @@ mod tests {
             cd: 2.2,
             area: 10.0, // m^2
             constant_density: None,
+            ..Default::default()
         };
         let density = 1e-12; // kg/m^3 (typical at 400 km)
         let velocity = 7600.0; // m/s (LEO orbital speed)
@@ -416,6 +452,7 @@ mod tests {
             cd: 2.2,
             area: 10.0,
             constant_density: None,
+            ..Default::default()
         };
         let atmos = AtmosphereState::<SelfPlanet>::default(); // density = 0
         let vel = DVec3::new(7600.0, 0.0, 0.0);
@@ -431,6 +468,7 @@ mod tests {
             cd: 2.0,
             area: 1.0,
             constant_density: None,
+            ..Default::default()
         };
         let atmos = AtmosphereState::<SelfPlanet>::from_raw(
             1e-12,
@@ -468,6 +506,7 @@ mod tests {
             cd: 2.2,
             area: 10.0,
             constant_density: None,
+            ..Default::default()
         };
         let atmos = AtmosphereState::<SelfPlanet>::from_raw(1e-12, 0.0, 0.0, DVec3::ZERO);
         let vel = DVec3::new(7600.0, 0.0, 0.0);
@@ -483,6 +522,7 @@ mod tests {
             cd: 2.0,
             area: 1.0,
             constant_density: None,
+            ..Default::default()
         };
         let atmos = AtmosphereState::<SelfPlanet>::from_raw(1e-12, 0.0, 0.0, DVec3::ZERO);
 
@@ -521,6 +561,7 @@ mod tests {
             cd: 2.2,
             area: 1900.0, // m^2 (Cd*A/m ≈ 2.2*1900/420000 ≈ 0.01)
             constant_density: None,
+            ..Default::default()
         };
 
         // Typical density at 400 km during solar mean
@@ -576,6 +617,7 @@ mod tests {
                 cd,
                 area,
                 constant_density,
+                option: DragOption::CoefficientOfDrag,
             })
     }
 

--- a/crates/astrodyn_interactions/src/lib.rs
+++ b/crates/astrodyn_interactions/src/lib.rs
@@ -49,7 +49,7 @@
 //! use astrodyn_quantities::frame::SelfPlanet;
 //! use glam::{DMat3, DVec3};
 //!
-//! let cfg = DragConfig { cd: 2.2, area: 1.0, constant_density: None };
+//! let cfg = DragConfig { cd: 2.2, area: 1.0, constant_density: None, ..Default::default() };
 //! // 1e-12 kg/m^3 is roughly 400 km altitude.
 //! let atmos = AtmosphereState::<SelfPlanet>::from_raw(1.0e-12, 0.0, 0.0, DVec3::ZERO);
 //! // Velocity along +X at 7.5 km/s; identity rotation (inertial == body).

--- a/crates/astrodyn_interactions/tests/integration_physics.rs
+++ b/crates/astrodyn_interactions/tests/integration_physics.rs
@@ -72,6 +72,7 @@ fn drag_causes_altitude_decay() {
         cd: 2.2,
         area: 1900.0, // ISS-like
         constant_density: None,
+        ..Default::default()
     };
 
     let atmos = met::SOLAR_MEAN;

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
@@ -168,6 +168,7 @@ fn build_drag_6dof(
             cd: CD,
             area: AREA_M2,
             constant_density: Some(DENSITY),
+            ..Default::default()
         }),
         ..Default::default()
     });

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp.rs
@@ -916,6 +916,7 @@ fn build_run7(
             cd: 0.02,
             area: 1.0,
             constant_density: None,
+            ..Default::default()
         })
     } else {
         None
@@ -1195,6 +1196,7 @@ fn build_run6a(init: &InitialConditions) -> SimulationBuilder {
             cd: 0.02,
             area: 1.0,
             constant_density: Some(1.4e-12),
+            ..Default::default()
         },
     )
 }
@@ -1207,6 +1209,7 @@ fn build_run6b(init: &InitialConditions) -> SimulationBuilder {
             cd: 0.02,
             area: 1.0,
             constant_density: None,
+            ..Default::default()
         },
     )
 }
@@ -1650,6 +1653,7 @@ fn build_run6b_aero_traj(init: &InitialConditions, t_struct_body: DMat3) -> Simu
             cd: 0.02,
             area: 1.0,
             constant_density: None,
+            ..Default::default()
         }),
         t_struct_body,
         ..Default::default()

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp_combinations.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp_combinations.rs
@@ -444,6 +444,7 @@ fn build_drag_point_mass_monotonic_decay(_init: &InitialConditions) -> Simulatio
             cd: 2.2,
             area: 20.0,
             constant_density: Some(TEST3_DENSITY),
+            ..Default::default()
         }),
         ..Default::default()
     });

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_srp.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_srp.rs
@@ -570,6 +570,7 @@ fn build_full_stack_sixdof(_init: &InitialConditions) -> SimulationBuilder {
         cd: 2.2,
         area: 1000.0,
         constant_density: None,
+        ..Default::default()
     };
     let plate = vec![(
         FlatPlate {

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_analytical.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_analytical.rs
@@ -96,6 +96,7 @@ fn make_drag_sim(
         cd,
         area,
         constant_density: Some(density),
+        ..Default::default()
     };
 
     sim.add_body(VehicleConfig {
@@ -554,6 +555,7 @@ fn make_drag_sim_with_wind(
         cd,
         area,
         constant_density: Some(density),
+        ..Default::default()
     };
 
     sim.add_body(VehicleConfig {

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_ver.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_ver.rs
@@ -25,19 +25,16 @@
 //! - `RUN_aero_drag_BC`: `DefaultAero::DRAG_OPT_BC` with `BC=0.005`, `mass=1`.
 //!   `drag = -dyn_p·mass/BC = -dyn_p·200` — numerically identical to
 //!   `DRAG_OPT_CD` with `Cd·A = 200`, so we configure the same ballistic model.
-//!
-//! Not covered (requires a port of `DefaultAero::DRAG_OPT_CONST`):
-//! - `RUN_aero_drag_const`: user-specified constant force magnitude along
-//!   the relative-velocity direction. Our `DragConfig` exposes only the CD
-//!   path today. Adding CONST/BC as discriminated options is tracked as a
-//!   follow-on task; the reference CSV (`drag_const_drag.csv`) is generated
-//!   and retained for that work.
+//! - `RUN_aero_drag_const`: `DefaultAero::DRAG_OPT_CONST` with a user-set
+//!   constant drag magnitude (`drag = 0.05`), applied verbatim along the
+//!   relative-velocity direction (density/area/Cd ignored), via
+//!   [`astrodyn::DragOption::Constant`].
 
 use astrodyn_verif_jeod::tier3_csv::{load_drag_csv, test_data_path};
 
 use astrodyn::AtmosphereState;
 use astrodyn::SelfPlanet;
-use astrodyn::{compute_ballistic_drag, DragConfig};
+use astrodyn::{compute_ballistic_drag, DragConfig, DragOption};
 use astrodyn_verif_jeod::crossval::CrossvalReport;
 use glam::{DMat3, DVec3};
 
@@ -149,6 +146,7 @@ fn tier3_sim_drag_ver_cd() {
         cd: 2.0,
         area: 100.0,
         constant_density: None,
+        ..Default::default()
     };
 
     let (force_err, torque_err, accel_err) =
@@ -157,6 +155,42 @@ fn tier3_sim_drag_ver_cd() {
     // Tolerances at 5% above observed max error. All values are tiny — this
     // is effectively a bit-exact match modulo floating-point noise between
     // JEOD's C++ (IEEE 754 double ops) and ours.
+    assert!(
+        force_err < 5.0e-17,
+        "force_err {force_err:.3e} N exceeds 5.0e-17 N"
+    );
+    assert!(
+        torque_err < 1.0e-20,
+        "torque_err {torque_err:.3e} N*m exceeds 1.0e-20 N*m"
+    );
+    assert!(
+        accel_err < 5.0e-17,
+        "accel_err {accel_err:.3e} m/s^2 exceeds 5.0e-17 m/s^2"
+    );
+}
+
+/// `RUN_aero_drag_const`: `DRAG_OPT_CONST` with a user-specified constant
+/// drag magnitude of `0.05 N` applied along the relative-velocity direction.
+///
+/// JEOD's `input.py` sets `ballistic_drag.option = DRAG_OPT_CONST` and
+/// `ballistic_drag.drag = 0.05` (positive — force *along* +v̂_rel, an
+/// option-exercise rather than realistic drag). Density / area / Cd are not
+/// consulted, so `|force| = 0.05 N` and `accel_mag = 0.05 m/s²` at every
+/// sample regardless of the velocity magnitude.
+// non-recipe: SIM_VER_DRAG bit-exact match — the constant-drag option is set
+// directly on `DragConfig`, no recipe preset matches the JEOD-injection setup.
+#[test]
+fn tier3_sim_drag_ver_const() {
+    let drag = DragConfig {
+        option: DragOption::Constant(0.05),
+        ..Default::default()
+    };
+
+    let (force_err, torque_err, accel_err) =
+        run_ballistic_case("tier3_sim_drag_ver_const", "drag_const_drag.csv", drag);
+
+    // Constant magnitude along v̂_rel; the only arithmetic is the unit-vector
+    // scale, so the match is bit-exact modulo IEEE-754 noise (1.05× observed).
     assert!(
         force_err < 5.0e-17,
         "force_err {force_err:.3e} N exceeds 5.0e-17 N"
@@ -188,6 +222,7 @@ fn tier3_sim_drag_ver_bc() {
         cd: 2.0,
         area: 100.0,
         constant_density: None,
+        ..Default::default()
     };
 
     let (force_err, torque_err, accel_err) =

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
@@ -358,6 +358,7 @@ fn build_sim(t0: &DyncompRecord) -> (Simulation, usize, usize) {
             cd: 2.0,
             area: 1400.0,
             constant_density: None,
+            ..Default::default()
         }),
         compute_gravity_gradient: true,
         ..Default::default()
@@ -682,6 +683,7 @@ fn enable_atmosphere(sim: &mut Simulation, body_idx: usize) {
             cd: 2.0,
             area: 1400.0,
             constant_density: None,
+            ..Default::default()
         }),
     );
 }

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_time_reversal.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_time_reversal.rs
@@ -603,6 +603,7 @@ fn tier3_sim_time_reversal_run6a() {
                     cd: 0.02,
                     area: 1.0,
                     constant_density: Some(1.4e-12),
+                    ..Default::default()
                 }),
             )
         },

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag.rs
@@ -28,6 +28,7 @@ fn bevy_parity_drag_atmosphere_sixdof() {
         cd: 2.2,
         area: 1000.0,
         constant_density: None,
+        ..Default::default()
     };
     let exp_atmos = ExponentialAtmosphere::default();
 
@@ -140,6 +141,7 @@ fn bevy_parity_drag_constant_density_drag_sixdof() {
         cd: 2.2,
         area: 1000.0,
         constant_density: Some(1.4e-12),
+        ..Default::default()
     };
     let exp_atmos = ExponentialAtmosphere::default();
 
@@ -245,6 +247,7 @@ fn bevy_parity_drag_met_atmosphere_drag_sixdof() {
         cd: 2.2,
         area: 1000.0,
         constant_density: None,
+        ..Default::default()
     };
     let met = MetAtmosphere {
         f10: 128.8,
@@ -400,6 +403,7 @@ fn bevy_parity_drag_met_run5a() {
                 cd: 2.2,
                 area: 1000.0,
                 constant_density: None,
+                ..Default::default()
             }),
         ))
         .id();
@@ -438,6 +442,7 @@ fn bevy_parity_drag_met_run5a() {
         cd: 2.2,
         area: 1000.0,
         constant_density: None,
+        ..Default::default()
     });
     sim.add_body(body);
     sim.validate().unwrap();
@@ -466,6 +471,7 @@ fn bevy_parity_drag_run6b() {
         cd: 0.02,
         area: 1.0,
         constant_density: None,
+        ..Default::default()
     };
 
     // ── Bevy ──

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,9 +262,8 @@ pub use astrodyn_interactions::{
     compute_flat_plate_srp_thermal, compute_gravity_torque, compute_gravity_torque_typed,
     compute_shadow_fraction, solar_flux_at_distance, AerodynamicForce, ContactFacet,
     ContactMaterial, DragConfig, DragConfigTyped, DragOption, EarthLightingState, FlatPlate,
-    FlatPlateParams,
-    FlatPlateSrpResult, FlatPlateThermal, GroundFacet, LightingBody, LightingParams, Phase,
-    RadiationForce, SphericalTerrain, Terrain, SOLAR_RADIUS,
+    FlatPlateParams, FlatPlateSrpResult, FlatPlateThermal, GroundFacet, LightingBody,
+    LightingParams, Phase, RadiationForce, SphericalTerrain, Terrain, SOLAR_RADIUS,
 };
 
 // astrodyn_frames: reference frame state and arena-based frame tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,8 @@ pub use astrodyn_interactions::{
     compute_cannonball_srp_typed, compute_earth_lighting, compute_earth_lighting_typed,
     compute_flat_plate_srp_thermal, compute_gravity_torque, compute_gravity_torque_typed,
     compute_shadow_fraction, solar_flux_at_distance, AerodynamicForce, ContactFacet,
-    ContactMaterial, DragConfig, DragConfigTyped, EarthLightingState, FlatPlate, FlatPlateParams,
+    ContactMaterial, DragConfig, DragConfigTyped, DragOption, EarthLightingState, FlatPlate,
+    FlatPlateParams,
     FlatPlateSrpResult, FlatPlateThermal, GroundFacet, LightingBody, LightingParams, Phase,
     RadiationForce, SphericalTerrain, Terrain, SOLAR_RADIUS,
 };

--- a/src/recipes/scenarios/iss_leo.rs
+++ b/src/recipes/scenarios/iss_leo.rs
@@ -90,6 +90,7 @@ pub fn iss_leo_drag() -> SimulationBuilder {
             cd: 2.2,
             area: 1900.0,
             constant_density: None,
+            ..Default::default()
         })
         .build();
     sb.add_body(vehicle);

--- a/src/vehicle_builder.rs
+++ b/src/vehicle_builder.rs
@@ -625,6 +625,7 @@ mod tests {
                 cd: 2.2,
                 area: 1.0,
                 constant_density: None,
+                ..Default::default()
             })
             .lvlh()
             .solar_beta()

--- a/tests/vehicle_builder_typestate.rs
+++ b/tests/vehicle_builder_typestate.rs
@@ -68,6 +68,7 @@ fn six_dof_rkf45_with_options() {
         cd: 2.2,
         area: 40.0,
         constant_density: None,
+        ..Default::default()
     };
     let cfg = VehicleBuilder::new()
         .with_translational(iss_trans())


### PR DESCRIPTION
## Summary

Ports JEOD `DefaultAero`'s **constant-drag option** (`DRAG_OPT_CONST`) — the last of the three ballistic-drag modes — and closes **SIM_VER_DRAG** (10/11 → 11/11) by adding the `RUN_aero_drag_const` cross-validation. Resolves the documented follow-on the `tier3_sim_drag_ver` docstring had flagged.

- **`DragConfig` gains a `DragOption` field** (`CoefficientOfDrag` default, or `Constant(f64)`). `compute_ballistic_drag` dispatches on it: `Constant(mag)` applies the user-set magnitude verbatim along `v̂_rel` (density/area/Cd ignored, density gate skipped); the CD path is unchanged. `DragConfig` now derives `Default`, so the ~23 existing construction sites pick up the default option via `..Default::default()` (no per-site `DragOption` import).
- **`tier3_sim_drag_ver_const`** validates against the already-committed `drag_const_drag.csv` — force/torque/accel match JEOD to FP noise (`drag = 0.05 N` along `+v̂_rel`, a positive option-exercise value, so `accel_mag = 0.05` at every sample).

## Verification
- All 3 `tier3_sim_drag_ver` tests pass; **`_cd`/`_bc` remain byte-identical** (the kernel refactor must not perturb them — confirmed).
- 156 `astrodyn_interactions` tests pass; `cargo fmt --check` + `cargo clippy --tests -- -D warnings` clean across the touched crates.

## Note on classification
`SIM_VER_DRAG` is a **non-propagating** force-model cross-check (it evaluates `compute_ballistic_drag` at scheduled velocities, not through `Simulation::step()`), so the const RUN slots into the existing direct-kernel `drag_ver` harness alongside `_cd`/`_bc` — no `Simulation::step` path and no parity-coverage change. The value here is closing the `DRAG_OPT_CONST` physics gap.

Part of #99 Bucket B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)