### PR TITLE
fix(ci): resolve semver-checks baseline as origin/main for PR events

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -91,7 +91,13 @@ jobs:
           # incompatible nalgebra majors via its hyperdual edge. A published
           # manifest can't be patched; `main` can, so the git baseline stays
           # buildable. (Also a better regression fence for a pre-1.0 crate.)
-          baseline-rev: main
+          #
+          # Use the remote-tracking ref, not the bare branch name: on
+          # `pull_request` runs `actions/checkout` lands in detached HEAD and
+          # creates no local `main` ref, so `--baseline-rev main` fails with
+          # "couldn't parse revision: main^{tree}". `origin/main` exists after
+          # `fetch-depth: 0` on both push and pull_request events.
+          baseline-rev: origin/main
 
   cargo-hack:
     # Feature-matrix fence on `astrodyn_ephemeris`. `README.md` documents


### PR DESCRIPTION
## Summary

The `cargo-semver-checks` job has been failing on **every PR** since #632 — including PRs that change no public API — with:

```
cargo semver-checks check-release --package astrodyn --baseline-rev main
error: couldn't parse revision: main^{tree}
```

#632 switched the baseline from the (unbuildable) crates.io release to `baseline-rev: main`. That resolves on **push-to-`main`** runs, where `actions/checkout` leaves a local `main` branch — which is why the gate shows green on `main` and the breakage went unnoticed. But on **`pull_request`** runs, checkout lands in detached HEAD and creates no local `main` ref; only the remote-tracking `origin/main` exists. gix/git can't resolve the revision `main`, so the job dies before analyzing anything.

## Fix

```yaml
baseline-rev: origin/main   # was: main
```

`origin/main` is present after `fetch-depth: 0` on both push and pull_request events, so the gate now actually runs on PRs (and still works on `main`).

## Verification

This PR is its own test: if the `cargo-semver-checks` job goes green here (a no-public-API-change PR), the baseline resolves correctly on a `pull_request` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)