### PR TITLE
Strip drift-prone observed-value numbers from tier3 test comments

### DIFF
--- a/crates/astrodyn_verif_jeod/tests/rnp_j2000_crossval.rs
+++ b/crates/astrodyn_verif_jeod/tests/rnp_j2000_crossval.rs
@@ -264,8 +264,8 @@ fn rnp_j2000_transform_crossval() {
         CalendarDate::new(1991, 4, 6, 7, 51, 28.386_009),
         26.0,
         0.402_521 - 26.0,
-        // Observed: prec/nut/NP ~1e-18, rot 8.5e-12 (GMST-conversion FP floor);
-        // GAST angle 1.13e-11. Tolerances 1.05× observed max (CLAUDE.md).
+        // The rot residual sits at the GMST-conversion FP floor.
+        // Tolerances 1.05× observed max (CLAUDE.md).
         9.0e-12,
         1.2e-11,
     );
@@ -282,7 +282,7 @@ fn rnp_j2000_init_crossval() {
         CalendarDate::new(1999, 3, 4, 0, 0, 0.0),
         32.0,
         0.649_32 - 32.0,
-        // Observed: matrices ≤ 4.74e-12, GAST angle 4.85e-12. 1.05× observed.
+        // Tolerances 1.05× observed max.
         5.0e-12,
         5.1e-12,
     );
@@ -496,8 +496,8 @@ fn rnp_j2000_polar_off_crossval() {
         CalendarDate::new(1999, 3, 4, 0, 0, 0.0),
         32.0,
         false,
-        // Observed: prec/nut/NP ~1e-20, rot 4.40e-12, T_parent_this 4.40e-12,
-        // GAST angle 4.56e-12 (GMST-conversion FP floor). 1.05× observed max.
+        // The rot / T_parent_this residuals sit at the GMST-conversion
+        // FP floor. Tolerances 1.05× observed max.
         4.7e-12,
         4.7e-12,
         4.8e-12,
@@ -517,8 +517,8 @@ fn rnp_j2000_prop_off_crossval() {
         CalendarDate::new(1999, 3, 4, 0, 0, 0.0),
         32.0,
         true,
-        // Observed: prec/nut/NP ~1e-20, rot 4.74e-12, T_parent_this 4.74e-12
-        // (polar fold-in is FP-exact vs JEOD), GAST 5.02e-12. 1.05× observed.
+        // Polar fold-in is FP-exact vs JEOD; residuals sit at the FP
+        // floor. Tolerances 1.05× observed max.
         5.0e-12,
         5.0e-12,
         5.3e-12,
@@ -537,10 +537,10 @@ fn rnp_j2000_prop_crossval() {
         CalendarDate::new(1999, 3, 3, 0, 0, 0.0),
         32.0,
         true,
-        // Observed: prec/nut/NP ~1e-20, rot 6.94e-8, T_parent_this 6.94e-8,
-        // GAST 7.32e-8. The 24 h GMST/UT1 accumulation at t=86400 dominates
-        // (T_parent_this tracks the rot error, so the polar interpolation
-        // across the daily-table bracket is itself consistent). 1.05× observed.
+        // The 24 h GMST/UT1 accumulation at t=86400 dominates the
+        // residual (T_parent_this tracks the rot error, so the polar
+        // interpolation across the daily-table bracket is itself
+        // consistent). Tolerances 1.05× observed max.
         7.3e-8,
         7.3e-8,
         7.7e-8,

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_attach_detach_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_attach_detach_trajectory.rs
@@ -378,9 +378,7 @@ const PRE_ATTACH_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
 // drift; the quaternion residuals are JEOD's `%g`-formatted CSV
 // print precision (~3e-8 rad on a non-trivially rotated body).
 //
-// Observed (JSON report, this test):
-//   veh1: pos=1.667e-9, vel=3.065e-11, quat=2.980e-8, ω=5.55e-17
-//   veh2: pos=5.555e-10, vel=0, quat=2.980e-8, ω=2.08e-17
+// Tolerances 1.05× observed max (CLAUDE.md), per-body.
 const ATTACHED_VEH1_POSITION_TOL_M: f64 = 1.75e-9;
 const ATTACHED_VEH1_VELOCITY_TOL_MPS: f64 = 3.22e-11;
 const ATTACHED_VEH1_QUAT_ANGLE_TOL_RAD: f64 = 3.13e-8;
@@ -397,9 +395,7 @@ const ATTACHED_VEH2_ANG_VEL_TOL_RAD_PER_S: f64 = 2.19e-17;
 // independently integrated again. Same dominant-error story as the
 // attached window — f64 round-off + JEOD CSV print precision.
 //
-// Observed (JSON report, this test):
-//   veh1: pos=1.651e-9, vel=3.065e-11, quat=2.980e-8, ω=2.08e-17
-//   veh2: pos=2.976e-10, vel=1.532e-11, quat=2.980e-8, ω=2.08e-17
+// Tolerances 1.05× observed max (CLAUDE.md), per-body.
 const POST_DETACH_VEH1_POSITION_TOL_M: f64 = 1.74e-9;
 const POST_DETACH_VEH1_VELOCITY_TOL_MPS: f64 = 3.22e-11;
 const POST_DETACH_VEH1_QUAT_ANGLE_TOL_RAD: f64 = 3.13e-8;

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_contact.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_contact.rs
@@ -279,24 +279,24 @@ fn line_mass_props() -> MassProperties {
 // regression guard on the stage-equivalence invariant.
 
 // `CONTACT_FORCE_TOL` covers the loosest observed stage-4 force error
-// across the five inter-body tests (off-center oblique at 9.089e-9 N
-// — see `tier3_contact_point_off_center_stage4_probe`). Head-on tests
-// sit ~3 orders of magnitude tighter (~1.7e-12 N). The literal is
-// ~1.1× the off-center observed for cross-platform FP headroom, which
-// is generous on head-on but still ~7 orders of magnitude tighter
-// than the pre-#460 `POINT_OFF_CENTER_FORCE_TOL` of 0.0375 N — any
-// real per-stage force regression trips this bar with room to spare.
+// across the five inter-body tests (off-center oblique — see
+// `tier3_contact_point_off_center_stage4_probe`). Head-on tests sit
+// several orders of magnitude tighter. The literal is ~1.1× the
+// off-center observed for cross-platform FP headroom, which is
+// generous on head-on but still many orders of magnitude tighter than
+// the pre-#460 `POINT_OFF_CENTER_FORCE_TOL` of 0.0375 N — any real
+// per-stage force regression trips this bar with room to spare.
 const CONTACT_FORCE_TOL: f64 = 1.0e-8;
 
 // `CONTACT_TORQUE_TOL` is the noise-floor tolerance, set above the
-// loosest observed stage-4 torque error: off-center oblique at
-// 2.025e-13 N·m (head-on rotated tops out at 1.191e-13). FP round-off
-// on torque arms of order 1 m crossed with forces of order 1 N sits
-// at ~1e-13 N·m; a strict 1.05× literal would false-fail on platforms
-// whose FP rounding paths differ by a few ULPs. `3.0e-13` is ~1.5×
-// the off-center observed and ~2.5× the head-on rotated observed —
-// large enough to absorb cross-platform FP variance, still ~10 orders
-// of magnitude tighter than the pre-#460 `POINT_OFF_CENTER_TORQUE_TOL`
+// loosest observed stage-4 torque error (off-center oblique, with
+// head-on rotated tighter still). FP round-off on torque arms of
+// order 1 m crossed with forces of order 1 N sits at ~1e-13 N·m; a
+// strict 1.05× literal would false-fail on platforms whose FP
+// rounding paths differ by a few ULPs. `3.0e-13` is ~1.5× the
+// off-center observed and ~2.5× the head-on rotated observed — large
+// enough to absorb cross-platform FP variance, still many orders of
+// magnitude tighter than the pre-#460 `POINT_OFF_CENTER_TORQUE_TOL`
 // of 3.1e-3 N·m.
 const CONTACT_TORQUE_TOL: f64 = 3.0e-13;
 
@@ -1443,12 +1443,12 @@ fn ground_steel() -> ContactMaterial {
 /// `Δv ≈ (1/6) × F × dt / m = 93 081 m/s`, exactly matching the t=0.05 CSV
 /// velocity.
 ///
-/// Tolerances per CLAUDE.md "5% above observed max" policy. Observed:
-/// position 2.79 nm, velocity 4.4e-11 m/s — essentially bit-for-bit
-/// agreement with JEOD's CSV (residual is f64 roundoff in the
-/// gravity-coupled RK4). The constants below are 1.05× observed maxima.
-const GROUND_POS_TOL: f64 = 3.0e-9; // m (observed 2.794 nm)
-const GROUND_VEL_TOL: f64 = 5.0e-11; // m/s (observed 4.366e-11 m/s)
+/// Tolerances per CLAUDE.md "5% above observed max" policy. The
+/// residuals show essentially bit-for-bit agreement with JEOD's CSV
+/// (f64 roundoff in the gravity-coupled RK4). The constants below are
+/// 1.05× observed maxima.
+const GROUND_POS_TOL: f64 = 3.0e-9; // m
+const GROUND_VEL_TOL: f64 = 5.0e-11; // m/s
 
 #[test]
 fn tier3_contact_ground() {

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_csr_compare.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_csr_compare.rs
@@ -166,8 +166,7 @@ fn tier3_csr_compare_gravity_octants() {
 }
 
 // Our GGM05C 70×70 gravity kernel reproduces JEOD's logged `grav_accel`
-// to machine precision (observed per-component max: x = 0, y ≈ 3.5e-18,
-// z ≈ 4.4e-16 m/s² — i.e. ~15 significant figures on a ~7 m/s² signal).
+// to machine precision (~15 significant figures on a ~7 m/s² signal).
 // 1.05× observed would be a sub-ULP / zero tolerance, so these use a
 // uniform 1e-14 m/s² machine-epsilon floor that proves bit-level
 // agreement while absorbing last-ULP variation in the 70×70 harmonic sum.

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_analytical.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_analytical.rs
@@ -399,8 +399,8 @@ fn tier3_drag_no_drag_at_zero_density() {
     println!("  Energy conservation error: {de:.6e} J/kg");
     println!("  Angular momentum conservation error: {dh:.6e} m^2/s");
 
-    // RK4 at dt=10s conserves energy to ~1e-3 J/kg over one orbit (observed 9.5e-4)
-    // and angular momentum to ~1 m^2/s (observed 0.84).
+    // RK4 at dt=10s conserves energy to ~1e-3 J/kg over one orbit and
+    // angular momentum to ~1 m^2/s.
     assert!(
         de < 1e-3,
         "Energy should be conserved with zero density: |dE|={de:.6e} J/kg"

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
@@ -1293,8 +1293,7 @@ fn tier3_sim_dyncomp_run_attach_to_ref_frame() {
 // absorbing into the quaternion residual (the LVLH initial attitude is
 // sourced from the CSV t=0 quaternion; the recurring trajectory's quat
 // drift over 1000 s tracks the JEOD/our composite-body sample timing
-// offset). With matched RNP cadence — observed maxes: pos=1.240e-4 m,
-// vel=3.115e-7 m/s, quat=2.550e-3 rad, ang_vel=6.130e-6 rad/s.
+// offset). Tolerances 1.05× observed max with matched RNP cadence.
 const PRE_ATTACH_POS_TOL_M: f64 = 1.30e-4;
 const PRE_ATTACH_VEL_TOL_MPS: f64 = 3.27e-7;
 const PRE_ATTACH_QUAT_TOL_RAD: f64 = 2.68e-3;
@@ -1303,8 +1302,7 @@ const PRE_ATTACH_ANG_VEL_TOL_RAD_PER_S: f64 = 6.44e-6;
 // attached_first (t=1000..1400): body glued to Earth.pfix matrix-attach
 // at the body's current pfix-relative pose. With matched RNP cadence
 // the position residual collapses to the rigid-composition f64 floor.
-// Observed maxes: pos=1.771e-4 m, vel=1.119e-8 m/s, quat=2.766e-3 rad,
-// ang_vel=1.290e-7 rad/s.
+// Tolerances 1.05× observed max.
 const ATTACHED_FIRST_POS_TOL_M: f64 = 1.86e-4;
 const ATTACHED_FIRST_VEL_TOL_MPS: f64 = 1.18e-8;
 const ATTACHED_FIRST_QUAT_TOL_RAD: f64 = 2.91e-3;
@@ -1313,9 +1311,8 @@ const ATTACHED_FIRST_ANG_VEL_TOL_RAD_PER_S: f64 = 1.36e-7;
 // burn_free_flight (t=1400..1800 + t=2200..2600 + t=2050..2200 inner):
 // post-detach free-flight (with the velocity-only rewind) and the
 // post-burn free-flight after the maneuver finishes. Errors accumulate
-// from the same RK4 floor plus the rewind round-trip. Matched RNP
-// cadence — observed maxes: pos=3.330e-4 m, vel=3.895e-7 m/s,
-// quat=3.819e-3 rad, ang_vel=3.368e-6 rad/s.
+// from the same RK4 floor plus the rewind round-trip. Tolerances 1.05×
+// observed max with matched RNP cadence.
 const FREE_FLIGHT_POS_TOL_M: f64 = 3.50e-4;
 const FREE_FLIGHT_VEL_TOL_MPS: f64 = 4.10e-7;
 const FREE_FLIGHT_QUAT_TOL_RAD: f64 = 4.01e-3;
@@ -1326,9 +1323,8 @@ const FREE_FLIGHT_ANG_VEL_TOL_RAD_PER_S: f64 = 3.54e-6;
 // force is collected through the runner's `set_body_external_force`,
 // but the body is frame-attached so the force has no effect on the
 // derived state — exactly mirroring JEOD's `frame_attach.isAttached()`
-// gate that bypasses integration. Matched RNP cadence — observed
-// maxes: pos=3.233e-4 m, vel=1.739e-7 m/s, quat=3.336e-3 rad,
-// ang_vel=3.951e-6 rad/s.
+// gate that bypasses integration. Tolerances 1.05× observed max with
+// matched RNP cadence.
 const ATTACHED_BURN_POS_TOL_M: f64 = 3.40e-4;
 const ATTACHED_BURN_VEL_TOL_MPS: f64 = 1.83e-7;
 const ATTACHED_BURN_QUAT_TOL_RAD: f64 = 3.51e-3;
@@ -1344,8 +1340,7 @@ const ATTACHED_BURN_ANG_VEL_TOL_RAD_PER_S: f64 = 4.15e-6;
 // drift that floors the `attached_first` window's quat residual.
 // Rotated through the (-3, -1.5, 4) CoM offset that becomes a
 // sub-cm position contribution.
-// Matched RNP cadence — observed maxes: pos=9.616e-3 m,
-// vel=5.529e-7 m/s, quat=3.870e-3 rad, ang_vel=1.802e-7 rad/s.
+// Tolerances 1.05× observed max with matched RNP cadence.
 const ATTACHED_SURFACE_PT_POS_TOL_M: f64 = 1.01e-2;
 const ATTACHED_SURFACE_PT_VEL_TOL_MPS: f64 = 5.81e-7;
 const ATTACHED_SURFACE_PT_QUAT_TOL_RAD: f64 = 4.07e-3;
@@ -1364,8 +1359,7 @@ const ATTACHED_SURFACE_PT_ANG_VEL_TOL_RAD_PER_S: f64 = 1.90e-7;
 // captures `t_inertial_struct`. The drift, rotated through
 // `(-3, -1.5, 4)`, dominates the position residual. The quat
 // residual itself reflects that same accumulated drift.
-// Matched RNP cadence — observed maxes: pos=2.720e-1 m,
-// vel=9.903e-6 m/s, quat=6.349e-2 rad, ang_vel=1.074e-7 rad/s.
+// Tolerances 1.05× observed max with matched RNP cadence.
 const ATTACHED_SURFACE_MATRIX_POS_TOL_M: f64 = 2.86e-1;
 const ATTACHED_SURFACE_MATRIX_VEL_TOL_MPS: f64 = 1.04e-5;
 const ATTACHED_SURFACE_MATRIX_QUAT_TOL_RAD: f64 = 6.67e-2;
@@ -1381,9 +1375,7 @@ const ATTACHED_SURFACE_MATRIX_ANG_VEL_TOL_RAD_PER_S: f64 = 1.13e-7;
 // before the run ends. The quat-angle tolerance is therefore the
 // largest dimensionless tolerance in this test, but it is still set
 // to ~5 % above the observed max so a regression that doubled the
-// drift to ~30° would still trip the gate. Matched RNP cadence —
-// observed maxes: pos=1.738e-1 m, vel=1.873e-4 m/s, quat=2.686e-1
-// rad, ang_vel=2.120e-4 rad/s.
+// drift to ~30° would still trip the gate. Matched RNP cadence.
 const POST_FINAL_DETACH_POS_TOL_M: f64 = 1.83e-1;
 const POST_FINAL_DETACH_VEL_TOL_MPS: f64 = 1.97e-4;
 const POST_FINAL_DETACH_QUAT_TOL_RAD: f64 = 2.82e-1;

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_gj_orders.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_gj_orders.rs
@@ -137,8 +137,8 @@ fn tier3_integ_gj_order4() {
     let (err, _, _) = gj_order_errors();
     println!("GJ order 4 max relative energy error (10 orbits, dt=1s): {err:.6e}");
     // GJ-4 with dt=1s over 10 orbits: bootstrap priming (5 RK4 steps) produces
-    // a transient energy spike; operational mode is much better. Tolerance at 5%
-    // above observed 3.86e-7.
+    // a transient energy spike; operational mode is much better. Tolerance
+    // 5% above observed max.
     assert!(
         err < 4.1e-7,
         "GJ-4 energy conservation: {err:.6e} >= 4.1e-7"
@@ -149,8 +149,8 @@ fn tier3_integ_gj_order4() {
 fn tier3_integ_gj_order8() {
     let (_, err, _) = gj_order_errors();
     println!("GJ order 8 max relative energy error (10 orbits, dt=1s): {err:.6e}");
-    // GJ-8: 9 RK4 priming steps -> larger bootstrap spike. Tolerance at 5%
-    // above observed 1.67e-6.
+    // GJ-8: 9 RK4 priming steps -> larger bootstrap spike. Tolerance
+    // 5% above observed max.
     assert!(
         err < 1.76e-6,
         "GJ-8 energy conservation: {err:.6e} >= 1.76e-6"
@@ -161,8 +161,8 @@ fn tier3_integ_gj_order8() {
 fn tier3_integ_gj_order12() {
     let (_, _, err) = gj_order_errors();
     println!("GJ order 12 max relative energy error (10 orbits, dt=1s): {err:.6e}");
-    // GJ-12: 13 RK4 priming steps -> largest bootstrap spike. Tolerance at 5%
-    // above observed 1.24e-5.
+    // GJ-12: 13 RK4 priming steps -> largest bootstrap spike. Tolerance
+    // 5% above observed max.
     assert!(
         err < 1.31e-5,
         "GJ-12 energy conservation: {err:.6e} >= 1.31e-5"

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_kinematic_propagation.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_kinematic_propagation.rs
@@ -362,12 +362,11 @@ fn simple_attach_offset_and_rotation() -> (DVec3, DMat3) {
 // Tolerances are set to ~5% above observed max error per project
 // policy (CLAUDE.md "Cross-validation tolerances"). Observed values
 // come from `target/tier3_crossval/tier3_sim_kinematic_propagation_
-// simple.json` and are documented inline below.
+// simple.json`.
 
 /// Free-flying veh3 across the full run: no force, no torque, RK4 on
 /// rigid-body kinematics. Error floor is rounding from JEOD's CSV
-/// (~17 sig figures) plus integrator round-off. Observed:
-/// pos=1.28e-12, vel=0, quat=0, ang_vel=0.
+/// (~17 sig figures) plus integrator round-off.
 const VEH3_POSITION_TOL_M: f64 = 1.5e-12;
 const VEH3_VELOCITY_TOL_MPS: f64 = 1e-15;
 const VEH3_QUAT_ANGLE_TOL_RAD: f64 = 1e-15;
@@ -378,8 +377,7 @@ const VEH3_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
 /// absorbs JEOD's scalar-first quaternion CSV print precision —
 /// the recorder writes `Q_parent_this.{scalar,vector}` as separate
 /// %g-formatted f64 fields and the round-trip drifts ~4e-8 rad on a
-/// non-trivially-rotated body. Observed: pos=1.4e-13, vel=0,
-/// quat=4.2e-8, ang_vel=0.
+/// non-trivially-rotated body.
 const PRE_ATTACH_POSITION_TOL_M: f64 = 1.5e-13;
 const PRE_ATTACH_VELOCITY_TOL_MPS: f64 = 1e-15;
 const PRE_ATTACH_QUAT_ANGLE_TOL_RAD: f64 = 4.5e-8;
@@ -389,7 +387,6 @@ const PRE_ATTACH_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
 /// `kernel(veh2_csv, link) ≈ veh1_csv`. The CSV samples are JEOD's
 /// own `composite_body` recorder; the residual reflects rounding
 /// from JEOD's printf format plus the kernel's f64 round-off.
-/// Observed: pos=8.9e-15, vel=1.1e-16, quat=3.0e-8.
 const ATTACH_INVARIANT_POSITION_TOL_M: f64 = 1e-14;
 const ATTACH_INVARIANT_VELOCITY_TOL_MPS: f64 = 1.5e-16;
 const ATTACH_INVARIANT_QUAT_ANGLE_TOL_RAD: f64 = 3.5e-8;
@@ -401,8 +398,7 @@ const ATTACH_INVARIANT_QUAT_ANGLE_TOL_RAD: f64 = 3.5e-8;
 /// absorbs the same `2 · acos(|q · q'|)` ULP residual that pins the
 /// kernel-vs-CSV invariant — when both quaternions are unit-norm but
 /// differ by a few ULPs, the angle test reports ~1e-7–1e-8 rad even
-/// though the underlying components agree to 1 ULP. Observed:
-/// pos=0, vel=0, quat=4.2e-8, ang_vel=0.
+/// though the underlying components agree to 1 ULP.
 const RUNNER_PROP_POSITION_TOL_M: f64 = 1e-15;
 const RUNNER_PROP_VELOCITY_TOL_MPS: f64 = 1e-15;
 const RUNNER_PROP_QUAT_ANGLE_TOL_RAD: f64 = 4.5e-8;
@@ -414,11 +410,9 @@ const RUNNER_PROP_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
 /// kinematic child derived from veh2 by `propagate_state_via_storage`
 /// each tick. Position / velocity residual is dominated by the
 /// momentum-conservation kernel's f64 round-off propagating through
-/// the 10-second integrated window (f64 angular-momentum solve at
-/// 1.7e-9 m / 3.1e-11 m/s on veh1, half that on veh2). Quaternion
-/// tolerance absorbs the same JEOD-recorder %g print rounding that
-/// pins the pre-attach window. Observed: pos=1.67e-9, vel=3.07e-11,
-/// quat=2.98e-8, ang_vel≈0.
+/// the 10-second integrated window (the f64 angular-momentum solve on
+/// veh1, half that on veh2). Quaternion tolerance absorbs the same
+/// JEOD-recorder %g print rounding that pins the pre-attach window.
 const ATTACHED_POSITION_TOL_M: f64 = 1.75e-9;
 const ATTACHED_VELOCITY_TOL_MPS: f64 = 3.25e-11;
 const ATTACHED_QUAT_ANGLE_TOL_RAD: f64 = 3.5e-8;
@@ -429,8 +423,7 @@ const ATTACHED_ANG_VEL_TOL_RAD_PER_S: f64 = 1e-15;
 /// the inverse-split inertial states `Simulation::detach` derives.
 /// The error floor mirrors the attached-window residual since both
 /// bodies have just resumed independent RK4 integration from JEOD-
-/// equivalent initial conditions. Observed: pos=1.65e-9,
-/// vel=3.06e-11, quat=2.98e-8, ang_vel≈0.
+/// equivalent initial conditions.
 const POST_DETACH_POSITION_TOL_M: f64 = 1.75e-9;
 const POST_DETACH_VELOCITY_TOL_MPS: f64 = 3.25e-11;
 const POST_DETACH_QUAT_ANGLE_TOL_RAD: f64 = 3.5e-8;

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs
@@ -262,10 +262,9 @@ fn run_integ_test(
 // preset; cross-validation math is owned by `CrossvalReport`.
 #[test]
 fn tier3_simulation_lsode_abm4() {
-    // Observed max-component errors over 14 orbits (80000 s sim time):
-    //   position [3.406e-4, 3.260e-4, 2.152e-4] m
-    //   velocity [3.870e-7, 3.553e-7, 2.362e-7] m/s
-    // Tolerances set to 5% above observed (CLAUDE.md tolerance policy).
+    // Max-component errors over 14 orbits (80000 s sim time) sit at the
+    // FP-noise floor. Tolerances set to 5% above observed (CLAUDE.md
+    // tolerance policy).
     run_integ_test(
         "tier3_simulation_lsode_abm4",
         "integ_abm4",
@@ -289,10 +288,9 @@ fn tier3_simulation_lsode_abm4() {
 // non-recipe: same derived μ + CSV-rotated IC as `tier3_simulation_lsode_abm4`.
 #[test]
 fn tier3_simulation_lsode_default() {
-    // Observed max-component errors (our LSODE vs JEOD LSODE, 14 orbits):
-    //   position [9.160e-4, 8.721e-4, 5.785e-4] m
-    //   velocity [1.038e-6, 9.572e-7, 6.385e-7] m/s
-    // Tolerances set to 1.05× observed (CLAUDE.md tolerance policy).
+    // Max-component errors (our LSODE vs JEOD LSODE, 14 orbits) sit at
+    // the FP-noise floor. Tolerances set to 1.05× observed (CLAUDE.md
+    // tolerance policy).
     let cfg = astrodyn::LsodeConfig::non_stiff_adams().with_tolerances(2.3e-16, 0.0);
     run_integ_test(
         "tier3_simulation_lsode_default",

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_docker.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_docker.rs
@@ -185,7 +185,7 @@ fn assert_orbinit_match(
 fn tier3_orbinit_docker_run0001_iss_inertial() {
     // RUN_0001: ISS, SmaEccIncAscnodeArgperTimeperi, reference=Earth.inertial.
     // No frame rotation required — recipe output is already in inertial.
-    // Observed: pos=6.25e-9 m, vel=6.19e-12 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0001(),
         "orbinit_0001_orbinit.csv",
@@ -201,7 +201,7 @@ fn tier3_orbinit_docker_run0001_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0101_sts_inertial() {
-    // Observed: pos=1.04e-9 m, vel=2.27e-13 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0101(),
         "orbinit_0101_orbinit.csv",
@@ -219,7 +219,7 @@ fn tier3_orbinit_docker_run0101_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0002_iss_inertial() {
-    // Observed: pos=3.26e-9 m, vel=3.40e-12 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0002(),
         "orbinit_0002_orbinit.csv",
@@ -231,7 +231,7 @@ fn tier3_orbinit_docker_run0002_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0102_sts_inertial() {
-    // Observed: pos=1.68e-9 m, vel=2.33e-12 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0102(),
         "orbinit_0102_orbinit.csv",
@@ -250,7 +250,7 @@ fn tier3_orbinit_docker_run0102_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0003_iss_inertial() {
-    // Observed: pos=5.21e-10 m, vel=2.27e-13 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0003(),
         "orbinit_0003_orbinit.csv",
@@ -262,7 +262,7 @@ fn tier3_orbinit_docker_run0003_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0103_sts_inertial() {
-    // Observed: pos=1.40e-9 m, vel=9.37e-13 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0103(),
         "orbinit_0103_orbinit.csv",
@@ -282,8 +282,8 @@ fn tier3_orbinit_docker_run0103_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0004_iss_inertial() {
-    // Observed: pos=4.66e-10 m, vel=0 m/s (5% above → listed; vel floored at
-    // 1e-13 m/s since the exact-zero observed residual leaves no headroom).
+    // Tolerances 1.05× observed max; vel floored at 1e-13 m/s since the
+    // exact-zero observed residual leaves no headroom.
     assert_orbinit_match(
         sim_orbinit_docker::run_0004(),
         "orbinit_0004_orbinit.csv",
@@ -295,7 +295,7 @@ fn tier3_orbinit_docker_run0004_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0104_sts_inertial() {
-    // Observed: pos=2.13e-9 m, vel=2.27e-13 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0104(),
         "orbinit_0104_orbinit.csv",
@@ -314,7 +314,7 @@ fn tier3_orbinit_docker_run0104_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0005_iss_inertial() {
-    // Observed: pos=5.35e-9 m, vel=5.57e-12 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0005(),
         "orbinit_0005_orbinit.csv",
@@ -326,7 +326,7 @@ fn tier3_orbinit_docker_run0005_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0105_sts_inertial() {
-    // Observed: pos=4.01e-9 m, vel=4.51e-12 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0105(),
         "orbinit_0105_orbinit.csv",
@@ -346,7 +346,7 @@ fn tier3_orbinit_docker_run0105_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0006_iss_inertial() {
-    // Observed: pos=4.66e-10 m, vel=2.27e-13 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0006(),
         "orbinit_0006_orbinit.csv",
@@ -358,8 +358,8 @@ fn tier3_orbinit_docker_run0006_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0106_sts_inertial() {
-    // Observed: pos=6.59e-10 m, vel=0 m/s (5% above → listed; vel floored at
-    // 1e-13 m/s since the exact-zero observed residual leaves no headroom).
+    // Tolerances 1.05× observed max; vel floored at 1e-13 m/s since the
+    // exact-zero observed residual leaves no headroom.
     assert_orbinit_match(
         sim_orbinit_docker::run_0106(),
         "orbinit_0106_orbinit.csv",
@@ -378,7 +378,7 @@ fn tier3_orbinit_docker_run0106_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0010_iss_inertial() {
-    // Observed: pos=6.59e-10 m, vel=4.55e-13 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0010(),
         "orbinit_0010_orbinit.csv",
@@ -390,8 +390,8 @@ fn tier3_orbinit_docker_run0010_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0110_sts_inertial() {
-    // Observed: pos=1.14e-9 m, vel=0 m/s (5% above → listed; vel floored at
-    // 1e-13 m/s since the exact-zero observed residual leaves no headroom).
+    // Tolerances 1.05× observed max; vel floored at 1e-13 m/s since the
+    // exact-zero observed residual leaves no headroom.
     assert_orbinit_match(
         sim_orbinit_docker::run_0110(),
         "orbinit_0110_orbinit.csv",
@@ -409,9 +409,9 @@ fn tier3_orbinit_docker_run0110_sts_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0011_iss_inertial() {
-    // Observed: pos=4.66e-10 m, vel=0 m/s (5% above → listed; vel floored at
-    // 1e-13 m/s). Matches RUN_0004 exactly — set11 (CaseEleven) is the same
-    // JEOD option as set04 with the same ISS elements.
+    // Tolerances 1.05× observed max; vel floored at 1e-13 m/s. Matches
+    // RUN_0004 exactly — set11 (CaseEleven) is the same JEOD option as
+    // set04 with the same ISS elements.
     assert_orbinit_match(
         sim_orbinit_docker::run_0011(),
         "orbinit_0011_orbinit.csv",
@@ -423,9 +423,9 @@ fn tier3_orbinit_docker_run0011_iss_inertial() {
 
 #[test]
 fn tier3_orbinit_docker_run0111_sts_inertial() {
-    // Observed: pos=2.13e-9 m, vel=2.27e-13 m/s (5% above → listed). Matches
-    // RUN_0104 exactly — set11 (CaseEleven) is the same JEOD option as set04
-    // with the same STS-114 elements.
+    // Tolerances 1.05× observed max. Matches RUN_0104 exactly — set11
+    // (CaseEleven) is the same JEOD option as set04 with the same
+    // STS-114 elements.
     assert_orbinit_match(
         sim_orbinit_docker::run_0111(),
         "orbinit_0111_orbinit.csv",
@@ -442,10 +442,9 @@ fn tier3_orbinit_docker_run0111_sts_inertial() {
 #[test]
 fn tier3_orbinit_docker_run0201_iss_pfix() {
     // RUN_0201: ISS pfix set01. Requires RNP rotation at the SIM epoch
-    // (handled inside the recipe). Observed: pos=1.51e-5 m, vel=1.17e-8 m/s
-    // (5% above → listed). The residual reflects tiny differences
-    // between our RNP series and JEOD's over the ~11 000 km Earth
-    // rotation arm from 2005-07-28.
+    // (handled inside the recipe). Tolerances 1.05× observed max. The
+    // residual reflects tiny differences between our RNP series and
+    // JEOD's over the ~11 000 km Earth rotation arm from 2005-07-28.
     assert_orbinit_match(
         sim_orbinit_docker::run_0201(),
         "orbinit_0201_orbinit.csv",
@@ -461,7 +460,7 @@ fn tier3_orbinit_docker_run0201_iss_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0301_sts_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0301(),
         "orbinit_0301_orbinit.csv",
@@ -480,8 +479,8 @@ fn tier3_orbinit_docker_run0301_sts_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0202_iss_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed). The
-    // residual reflects RNP-series drift over the Earth-rotation arm.
+    // Tolerances 1.05× observed max. The residual reflects RNP-series
+    // drift over the Earth-rotation arm.
     assert_orbinit_match(
         sim_orbinit_docker::run_0202(),
         "orbinit_0202_orbinit.csv",
@@ -493,7 +492,7 @@ fn tier3_orbinit_docker_run0202_iss_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0302_sts_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0302(),
         "orbinit_0302_orbinit.csv",
@@ -510,7 +509,7 @@ fn tier3_orbinit_docker_run0302_sts_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0203_iss_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0203(),
         "orbinit_0203_orbinit.csv",
@@ -522,7 +521,7 @@ fn tier3_orbinit_docker_run0203_iss_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0303_sts_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0303(),
         "orbinit_0303_orbinit.csv",
@@ -539,7 +538,7 @@ fn tier3_orbinit_docker_run0303_sts_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0204_iss_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0204(),
         "orbinit_0204_orbinit.csv",
@@ -551,7 +550,7 @@ fn tier3_orbinit_docker_run0204_iss_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0304_sts_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0304(),
         "orbinit_0304_orbinit.csv",
@@ -568,7 +567,7 @@ fn tier3_orbinit_docker_run0304_sts_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0205_iss_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0205(),
         "orbinit_0205_orbinit.csv",
@@ -580,7 +579,7 @@ fn tier3_orbinit_docker_run0205_iss_pfix() {
 
 #[test]
 fn tier3_orbinit_docker_run0305_sts_pfix() {
-    // Observed: pos=1.51e-5 m, vel=1.17e-8 m/s (5% above → listed).
+    // Tolerances 1.05× observed max (CLAUDE.md).
     assert_orbinit_match(
         sim_orbinit_docker::run_0305(),
         "orbinit_0305_orbinit.csv",

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_ref_attach.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_ref_attach.rs
@@ -439,11 +439,10 @@ fn tier3_sim_ref_attach_pt2pt() {
     // attachment to Earth.pfix at offset = (10, 0, 0) with rotation
     // diag(-1, -1, 1).
     //
-    // Tolerances per CLAUDE.md "5% above observed max" policy.
-    // Observed (this PR's regen): post_pos ≈ 15.08 m,
-    // post_vel ≈ 1.10e-3 m/s — same magnitudes as the matrix run
-    // (the named-point algebra is exactly the inverse of the matrix
-    // form for our mass-point geometry).
+    // Tolerances per CLAUDE.md "5% above observed max" policy. The
+    // residuals are the same magnitudes as the matrix run (the
+    // named-point algebra is exactly the inverse of the matrix form
+    // for our mass-point geometry).
     assert!(
         max_post_pos_err < 16.0,
         "post-attach position error too large: {max_post_pos_err:.3} m"


### PR DESCRIPTION
## Summary

Tier3/crossval test comments carried specific observed residual values baked in as prose — `// Observed: pos=1.51e-5 m, vel=1.17e-8 m/s`, `// observed maxes: pos=…, vel=…`, per-component error tables, inline `(observed 2.794 nm)`, etc. Nothing tests that these stay accurate, so they silently drift out of sync whenever code or reference CSVs change. The load-bearing number is the **tolerance literal** in each `assert` (set to 1.05× observed per the CLAUDE.md "Cross-validation tolerances" policy), which *is* enforced — the comment is not.

This removes the measured values across **11 files** while keeping all qualitative rationale.

## What's removed vs kept

**Removed** (drift-prone measured residuals):
- Per-RUN `Observed: pos=…/vel=…` headers
- `observed maxes:` per-component listings
- Max-component error tables (lsode, kinematic, attach/detach)
- Inline `(observed N)` trailing comments

**Kept** (stable, not drift-prone):
- The `1.05× observed max` / `5% above observed` derivation notes themselves
- FP-floor characterizations (`~1e-13 N·m`, machine-precision sig-figs)
- `vel floored at 1e-13 m/s` floor explanations
- `Matched RNP cadence` config notes, `Matches RUN_XXXX exactly` cross-refs
- Coarse ratios/multipliers (`~1.1×`, `~2.5×`, `roughly 10×`)
- Former tolerance-constant values (`0.0375 N`, `3.1e-3 N·m`) and config times (`t=86400`)

## Scope

Comments-only — no logic changes. The only non-comment edits are two inline trailing comments on `GROUND_POS_TOL` / `GROUND_VEL_TOL` consts (values unchanged).

Files: `rnp_j2000_crossval`, `tier3_sim_orbinit_docker`, `tier3_sim_kinematic_propagation`, `tier3_sim_contact`, `tier3_sim_dyncomp_run_attach_to_ref_frame`, `tier3_sim_attach_detach_trajectory`, `tier3_sim_lsode`, `tier3_sim_integ_gj_orders`, `tier3_sim_drag_analytical`, `tier3_sim_csr_compare`, `tier3_sim_ref_attach`.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p astrodyn_verif_jeod --tests -- -D warnings` — clean
- `cargo nextest run -p astrodyn_verif_jeod -E 'test(tier3_) or …'` — 241 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)