### PR TITLE
[#99] Tier 3: SIM_orbinit direct-Cartesian variants (3 RUNs, Bucket B)

### DIFF
--- a/crates/astrodyn_verif_jeod/src/bin/extract_body_init.rs
+++ b/crates/astrodyn_verif_jeod/src/bin/extract_body_init.rs
@@ -41,7 +41,8 @@
 //!   `trans_Orbit_pfix_body_set06.py`           — pfix orbit (sma/inc/raan/arg-latitude/orb-radius/radial-vel)
 //!   `trans_Orbit_pfix_body_set10.py`           — pfix orbit (sma/ecc + true anomaly)
 //!   `trans_Orbit_pfix_body_set11.py`           — pfix orbit (apo/peri altitudes + true anomaly; same as set04)
-//!   `trans_TransState_inertial_body.py`        — direct Cartesian (STS_114 only)
+//!   `trans_TransState_inertial_body.py`        — direct Cartesian state in `Earth.inertial`
+//!   `trans_TransState_pfix_body.py`            — direct Cartesian state in `Earth.pfix`
 //!
 //! Scenarios extracted: `ISS`, `STS_114`. Each scenario writes a single
 //! `test_data/body_init/<vehicle>.json`. The `reference_inertial` and
@@ -90,7 +91,10 @@ const SCENARIOS: &[Scenario] = &[
             "trans_Orbit_pfix_body_set10",
             "trans_Orbit_pfix_body_set11",
         ],
-        trans_states: &[],
+        trans_states: &[
+            "trans_TransState_inertial_body",
+            "trans_TransState_pfix_body",
+        ],
     },
     Scenario {
         vehicle: "STS_114",
@@ -113,7 +117,10 @@ const SCENARIOS: &[Scenario] = &[
             "trans_Orbit_pfix_body_set10",
             "trans_Orbit_pfix_body_set11",
         ],
-        trans_states: &["trans_TransState_inertial_body"],
+        trans_states: &[
+            "trans_TransState_inertial_body",
+            "trans_TransState_pfix_body",
+        ],
     },
 ];
 

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_docker.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_docker.rs
@@ -46,7 +46,10 @@
 //!   * RUN_0310 — STS-114 orbital elements (set10, sma/ecc + true anomaly) in `Earth.pfix`;
 //!   * RUN_0211 — ISS orbital elements (set11, apo/peri altitudes + true anomaly) in `Earth.pfix`;
 //!   * RUN_0311 — STS-114 orbital elements (set11, apo/peri altitudes + true anomaly) in `Earth.pfix`;
-//!   * RUN_0401 — STS-114 direct Cartesian state in `Earth.inertial`.
+//!   * RUN_0401 — STS-114 direct Cartesian state in `Earth.inertial`;
+//!   * RUN_0400 — ISS direct Cartesian state in `Earth.inertial`;
+//!   * RUN_0410 — ISS direct Cartesian state in `Earth.pfix`;
+//!   * RUN_0411 — STS-114 direct Cartesian state in `Earth.pfix`.
 //!
 //! set01 and set02 resolve to [`init_from_mean_anomaly`]; set01 derives
 //! `M = t_peri·√(μ/a³)` from the fixture's `time_periapsis`, while set02
@@ -431,14 +434,45 @@ fn true_anomaly_sma_state(vehicle: &str, init_name: &str, mu_earth: f64) -> Tran
     resolve_reference_frame(vehicle, init_name, &init.reference_frame, state_ref)
 }
 
-/// Materialize a JEOD direct-Cartesian fixture (RUN_0401 only) into an
-/// inertial-frame translational state. The fixture is a pass-through:
-/// `position`/`velocity` arrays are taken verbatim.
+/// Materialize a JEOD direct-Cartesian (`DynBodyInitTransState`) fixture
+/// into an inertial-frame translational state.
+///
+/// `Earth.inertial` fixtures are a pass-through: `position`/`velocity` are
+/// taken verbatim. `Earth.pfix` fixtures are expressed in the rotating
+/// planet-fixed frame and composed into inertial through the full
+/// reference-frame relation JEOD applies for a direct trans-state init
+/// (`DynBodyInit::apply_user_inputs` → `RefFrameState` composition).
+///
+/// Unlike the orbital-element pfix path — which rotates the elements'
+/// Cartesian image as pure 3-vectors (JEOD `dyn_body_init_orbit.cc`
+/// overrides the composition) — the direct trans-state path goes through
+/// `compute_relative_state`, so the velocity carries the planet-rotation
+/// `ω × r` term. With A = inertial, B = pfix, C = vehicle and the pfix
+/// frame's `ang_vel_this = [0, 0, planet_omega]` (JEOD `planet_rnp.cc`),
+/// JEOD's `RefFrameState::incr_left` reduces (zero parent-frame
+/// translation) to:
+///   r_inertial = T_pfix_inertial · r_pfix
+///   v_inertial = T_pfix_inertial · (v_pfix + ω_pfix × r_pfix)
+/// where the `ω × r` cross product is evaluated in the pfix frame before
+/// the rotation, matching JEOD's order of operations. Any other frame
+/// fails loudly.
 fn trans_state(vehicle: &str, init_name: &str) -> TranslationalState {
     let trans = load_trans_state(vehicle, init_name);
-    TranslationalState {
-        position: DVec3::from_array(trans.position),
-        velocity: DVec3::from_array(trans.velocity),
+    let position = DVec3::from_array(trans.position);
+    let velocity = DVec3::from_array(trans.velocity);
+    match trans.reference_frame.as_str() {
+        "Earth.inertial" => TranslationalState { position, velocity },
+        "Earth.pfix" => {
+            let t_inertial_pfix = t_inertial_pfix_at_epoch();
+            let t_pfix_inertial = t_inertial_pfix.transpose();
+            let omega_pfix = DVec3::new(0.0, 0.0, EARTH.omega);
+            let velocity_in_pfix = velocity + omega_pfix.cross(position);
+            TranslationalState {
+                position: t_pfix_inertial * position,
+                velocity: t_pfix_inertial * velocity_in_pfix,
+            }
+        }
+        other => panic!("{vehicle}/{init_name}: unsupported reference_frame '{other}'"),
     }
 }
 
@@ -518,6 +552,29 @@ fn build_run_0301(_init: &InitialConditions) -> SimulationBuilder {
 fn build_run_0401(_init: &InitialConditions) -> SimulationBuilder {
     let mu = load_mu_earth();
     let state = trans_state("STS_114", "trans_TransState_inertial_body");
+    build_orbinit_docker(mu, state)
+}
+
+/// RUN_0400: ISS direct Cartesian state in `Earth.inertial` (pass-through).
+fn build_run_0400(_init: &InitialConditions) -> SimulationBuilder {
+    let mu = load_mu_earth();
+    let state = trans_state("ISS", "trans_TransState_inertial_body");
+    build_orbinit_docker(mu, state)
+}
+
+/// RUN_0410: ISS direct Cartesian state in `Earth.pfix`. The pfix branch
+/// composes the planet-fixed state into inertial including the planet
+/// rotation `ω × r` velocity term.
+fn build_run_0410(_init: &InitialConditions) -> SimulationBuilder {
+    let mu = load_mu_earth();
+    let state = trans_state("ISS", "trans_TransState_pfix_body");
+    build_orbinit_docker(mu, state)
+}
+
+/// RUN_0411: STS-114 direct Cartesian state in `Earth.pfix`.
+fn build_run_0411(_init: &InitialConditions) -> SimulationBuilder {
+    let mu = load_mu_earth();
+    let state = trans_state("STS_114", "trans_TransState_pfix_body");
     build_orbinit_docker(mu, state)
 }
 
@@ -1293,6 +1350,59 @@ pub fn run_0401() -> VerificationCase {
     VerificationCase {
         name: "tier3_orbinit_docker_run_0401",
         scenario: build_run_0401,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// RUN_0400: ISS direct Cartesian state (`DynBodyInitTransState`) in
+/// `Earth.inertial`. Pass-through of the literal position/velocity from
+/// `trans_TransState_inertial_body`.
+pub fn run_0400() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_docker_run_0400",
+        scenario: build_run_0400,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// RUN_0410: ISS direct Cartesian state (`DynBodyInitTransState`) in
+/// `Earth.pfix`. The pfix branch composes the planet-fixed state into
+/// inertial with the planet-rotation velocity term.
+pub fn run_0410() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_docker_run_0410",
+        scenario: build_run_0410,
+        reference: CsvReference::SyntheticTimes {
+            dt: DT_S,
+            num_steps: NUM_STEPS,
+        },
+        duration: Time::new::<second>(0.0),
+        tolerances: synthetic_tolerances(),
+        extras: None,
+        pre_step: None,
+    }
+}
+
+/// RUN_0411: STS-114 direct Cartesian state (`DynBodyInitTransState`) in
+/// `Earth.pfix`.
+pub fn run_0411() -> VerificationCase {
+    VerificationCase {
+        name: "tier3_orbinit_docker_run_0411",
+        scenario: build_run_0411,
         reference: CsvReference::SyntheticTimes {
             dt: DT_S,
             num_steps: NUM_STEPS,

--- a/crates/astrodyn_verif_jeod/test_data/body_init/iss.json
+++ b/crates/astrodyn_verif_jeod/test_data/body_init/iss.json
@@ -4,7 +4,7 @@
   "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/ISS/",
   "jeod_version": "5.4",
   "jeod_commit": "27893108bbde8bb162b3213a30d57af89acd1c76",
-  "generated_utc": "2026-05-29T04:20:12Z",
+  "generated_utc": "2026-05-29T05:59:53Z",
   "note": "Body initialization vectors. Regenerate with: cargo run -p astrodyn_verif_jeod --bin extract_body_init -- --jeod-home $JEOD_HOME",
   "reference_inertial": {"position": [1244540.53, 5655938.85, 3425643.22], "velocity": [-6003.833051, -1469.496044, 4590.511776]},
   "orbital_inits": [
@@ -314,5 +314,17 @@
     }
   ],
   "trans_states": [
+    {
+      "name": "trans_TransState_inertial_body",
+      "position": [1244540.53, 5655938.85, 3425643.22],
+      "velocity": [-6003.833051, -1469.496044, 4590.511776],
+      "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "trans_TransState_pfix_body",
+      "position": [5406298.57, -2074684.56, 3426540.03],
+      "velocity": [-706.065581, 5764.307162, 4587.246163],
+      "reference_frame": "Earth.pfix"
+    }
   ]
 }

--- a/crates/astrodyn_verif_jeod/test_data/body_init/sts_114.json
+++ b/crates/astrodyn_verif_jeod/test_data/body_init/sts_114.json
@@ -4,7 +4,7 @@
   "source": "models/dynamics/body_action/verif/SIM_orbinit/Modified_data/STS_114/",
   "jeod_version": "5.4",
   "jeod_commit": "27893108bbde8bb162b3213a30d57af89acd1c76",
-  "generated_utc": "2026-05-29T04:20:12Z",
+  "generated_utc": "2026-05-29T05:59:53Z",
   "note": "Body initialization vectors. Regenerate with: cargo run -p astrodyn_verif_jeod --bin extract_body_init -- --jeod-home $JEOD_HOME",
   "reference_inertial": {"position": [1244471.94, 5655811.8, 3425518.88], "velocity": [-6003.553468, -1469.321965, 4590.57723]},
   "orbital_inits": [
@@ -319,6 +319,12 @@
       "position": [1244471.94, 5655811.8, 3425518.88],
       "velocity": [-6003.553468, -1469.321965, 4590.57723],
       "reference_frame": "Earth.inertial"
+    },
+    {
+      "name": "trans_TransState_pfix_body",
+      "position": [5406183.21, -2074597.8, 3426415.65],
+      "velocity": [-705.92895, 5764.013134, 4587.311774],
+      "reference_frame": "Earth.pfix"
     }
   ]
 }

--- a/crates/astrodyn_verif_jeod/test_data/orbinit_0400_orbinit.csv
+++ b/crates/astrodyn_verif_jeod/test_data/orbinit_0400_orbinit.csv
@@ -1,0 +1,2 @@
+sys.exec.out.time {s},target.dyn_body.composite_body.state.trans.position[0] {m},target.dyn_body.composite_body.state.trans.position[1] {m},target.dyn_body.composite_body.state.trans.position[2] {m},target.dyn_body.composite_body.state.trans.velocity[0] {m/s},target.dyn_body.composite_body.state.trans.velocity[1] {m/s},target.dyn_body.composite_body.state.trans.velocity[2] {m/s}
+                   0,          1244540.53,          5655938.85,          3425643.22,        -6003.833051,        -1469.496044,         4590.511776

--- a/crates/astrodyn_verif_jeod/test_data/orbinit_0410_orbinit.csv
+++ b/crates/astrodyn_verif_jeod/test_data/orbinit_0410_orbinit.csv
@@ -1,0 +1,2 @@
+sys.exec.out.time {s},target.dyn_body.composite_body.state.trans.position[0] {m},target.dyn_body.composite_body.state.trans.position[1] {m},target.dyn_body.composite_body.state.trans.position[2] {m},target.dyn_body.composite_body.state.trans.velocity[0] {m/s},target.dyn_body.composite_body.state.trans.velocity[1] {m/s},target.dyn_body.composite_body.state.trans.velocity[2] {m/s}
+                   0,   1244540.526327741,    5655938.84916914,   3425643.215728393,  -6003.833058925691,  -1469.496045057633,   4590.511775679918

--- a/crates/astrodyn_verif_jeod/test_data/orbinit_0411_orbinit.csv
+++ b/crates/astrodyn_verif_jeod/test_data/orbinit_0411_orbinit.csv
@@ -1,0 +1,2 @@
+sys.exec.out.time {s},target.dyn_body.composite_body.state.trans.position[0] {m},target.dyn_body.composite_body.state.trans.position[1] {m},target.dyn_body.composite_body.state.trans.position[2] {m},target.dyn_body.composite_body.state.trans.velocity[0] {m/s},target.dyn_body.composite_body.state.trans.velocity[1] {m/s},target.dyn_body.composite_body.state.trans.velocity[2] {m/s}
+                   0,   1244471.930630903,   5655811.804841856,    3425518.87755694,  -6003.553475948745,  -1469.321967066438,   4590.577230295433

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_docker.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_orbinit_docker.rs
@@ -64,6 +64,9 @@
 //!   RUN_0211: ISS orbital elements in pfix frame (set11, altitudes + true anomaly)
 //!   RUN_0311: STS-114 orbital elements in pfix frame (set11, altitudes + true anomaly)
 //!   RUN_0401: STS-114 direct Cartesian state in inertial frame
+//!   RUN_0400: ISS direct Cartesian state in inertial frame
+//!   RUN_0410: ISS direct Cartesian state in planet-fixed (pfix) frame
+//!   RUN_0411: STS-114 direct Cartesian state in planet-fixed (pfix) frame
 //!
 //! All scenarios share the same JEOD epoch: 2005-07-28 10:09:59 UT1.
 //! The SIM disables polar motion (`earth.rnp.enable_polar = False`).
@@ -709,5 +712,57 @@ fn tier3_orbinit_docker_run0401_sts_trans_state() {
         "RUN_0401 (STS-114 inertial cart)",
         1.0e-6,
         1.0e-9,
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// RUN_0400: ISS direct Cartesian state in inertial frame
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn tier3_orbinit_docker_run0400_iss_trans_state() {
+    // RUN_0400 uses DynBodyInitTransState (direct Cartesian input in
+    // inertial). Recipe initialization is a pass-through to the body
+    // state and the JEOD CSV logs the input to full precision, so the
+    // residual is exactly zero; both tolerances are floored at 1e-13.
+    assert_orbinit_match(
+        sim_orbinit_docker::run_0400(),
+        "orbinit_0400_orbinit.csv",
+        "RUN_0400 (ISS inertial cart)",
+        1.0e-13,
+        1.0e-13,
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// RUN_0410 / RUN_0411: direct Cartesian state in planet-fixed (pfix) frame.
+// Unlike the orbital-element pfix RUNs, the direct trans-state path composes
+// the planet-fixed state into inertial through the full reference-frame
+// relation (including the planet-rotation `ω × r` velocity term). The residual
+// reflects RNP-series drift over the Earth-rotation arm plus the ~10-char CSV
+// input precision. Tolerances 1.05× observed max (CLAUDE.md).
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn tier3_orbinit_docker_run0410_iss_pfix_trans_state() {
+    // Tolerances 1.05× observed max (CLAUDE.md).
+    assert_orbinit_match(
+        sim_orbinit_docker::run_0410(),
+        "orbinit_0410_orbinit.csv",
+        "RUN_0410 (ISS pfix cart)",
+        1.589e-5,
+        1.225e-8,
+    );
+}
+
+#[test]
+fn tier3_orbinit_docker_run0411_sts_pfix_trans_state() {
+    // Tolerances 1.05× observed max (CLAUDE.md).
+    assert_orbinit_match(
+        sim_orbinit_docker::run_0411(),
+        "orbinit_0411_orbinit.csv",
+        "RUN_0411 (STS-114 pfix cart)",
+        1.589e-5,
+        1.225e-8,
     );
 }

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_orbinit_docker.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_orbinit_docker.rs
@@ -182,3 +182,18 @@ fn bevy_parity_orbinit_docker_run_0311() {
 fn bevy_parity_orbinit_docker_run_0401() {
     sim_orbinit_docker::run_0401().run_and_assert_parity::<astrodyn::Earth>();
 }
+
+#[test]
+fn bevy_parity_orbinit_docker_run_0400() {
+    sim_orbinit_docker::run_0400().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_docker_run_0410() {
+    sim_orbinit_docker::run_0410().run_and_assert_parity::<astrodyn::Earth>();
+}
+
+#[test]
+fn bevy_parity_orbinit_docker_run_0411() {
+    sim_orbinit_docker::run_0411().run_and_assert_parity::<astrodyn::Earth>();
+}

--- a/trick/generate_references.sh
+++ b/trick/generate_references.sh
@@ -738,6 +738,10 @@ run_orbinit_group() {
         # set11 apo/peri-altitude + true-anomaly parameterization (CaseEleven == set04; ISS + STS, planet-fixed)
         "SET_test/RUN_0211:orbinit_0211:orbinit_0211_orbinit.csv"
         "SET_test/RUN_0311:orbinit_0311:orbinit_0311_orbinit.csv"
+        # direct-Cartesian (DynBodyInitTransState) variants
+        "SET_test/RUN_0400:orbinit_0400:orbinit_0400_orbinit.csv"
+        "SET_test/RUN_0410:orbinit_0410:orbinit_0410_orbinit.csv"
+        "SET_test/RUN_0411:orbinit_0411:orbinit_0411_orbinit.csv"
     )
     local needs_build=0
     for entry in "${RUNS[@]}"; do


### PR DESCRIPTION
## Summary

Closes 3 Tier 3 RUNs under #99 (Bucket B): the `DynBodyInitTransState` direct-Cartesian variants for SIM_orbinit. Generalizes the `trans_state` converter to handle the planet-fixed frame, then adds recipes, tier3 tests, and parity wrappers.

**orbinit coverage: 33/46 → 36/46.**

## RUNs covered

| RUN | Vehicle / frame | form |
|---|---|---|
| RUN_0400 | ISS / Earth.inertial | direct Cartesian pass-through |
| RUN_0410 | ISS / Earth.pfix | direct Cartesian in planet-fixed |
| RUN_0411 | STS-114 / Earth.pfix | direct Cartesian in planet-fixed |

## Physics note — pfix Cartesian init includes the ω×r velocity term

The two JEOD initialization paths rotate pfix→inertial **differently**, and matching JEOD required honoring the distinction (JEOD Convention Rule — verified against source, not assumed):

- **Orbital-element pfix init** (`dyn_body_init_orbit.cc:331`) rotates position and velocity as **pure 3-vectors** (`transform_transpose`, no ω×r). This is the existing `resolve_reference_frame` path — unchanged.
- **Direct trans-state pfix init** (`dyn_body_init_trans_state.cc` → `dyn_body_init.cc::apply_user_inputs` → `ref_frame_state.cc::incr_left`) goes through full `compute_relative_state`, which **includes the planet-rotation ω×r term**.

So `trans_state` gets its own pfix branch:
```
r_inertial = T_pfix_inertial · r_pfix
v_inertial = T_pfix_inertial · (v_pfix + ω_pfix × r_pfix),   ω_pfix = [0, 0, EARTH.omega]
```
Validated numerically: the ISS inertial deck (RUN_0400) and ISS pfix deck (RUN_0410) describe the same physical orbit, and the recovered ECI velocity magnitude (7699.236 m/s) matches **only** with ω×r included (pure rotation would give 7400.58). The pfix residuals land at the ~1.5e-5 m RNP-series-difference floor, same as the other pfix RUNs — confirming correct recovery.

## Computational independence

ICs come only from JEOD `Modified_data/*.py` (via `extract_body_init`); JEOD CSV output is used solely as the t=0 comparison target.

## Tolerances (1.05× observed)

- RUN_0400: 1e-13 / 1e-13 (residual exactly 0 — full-precision pass-through — floored)
- RUN_0410 / RUN_0411: 1.589e-5 m / 1.225e-8 m/s (RNP-drift floor)

## Verification

- `cargo fmt --check` / `cargo clippy --workspace --tests -- -D warnings` — clean
- `cargo nextest run --workspace -E 'test(tier3_orbinit)'` — pass (3 new verified)
- `cargo nextest run --workspace -E 'test(bevy_parity_orbinit)'` — pass
- `parity_coverage` — pass
- `cargo nextest run --workspace` — green (2113 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)