### PR TITLE
Reframe astrodyn docs/metadata as an engine-agnostic framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,23 @@
 
 ## Project
 
-Rust port of [NASA JEOD](https://github.com/nasa/jeod) v5.4 using Bevy ECS instead of
-NASA's Trick. Phases 1–7 closed April 2026; ongoing work is tracked as GitHub issues.
+Pure-Rust port of [NASA JEOD](https://github.com/nasa/jeod) v5.4 — the JSC Engineering
+Orbital Dynamics physics — as an **engine-agnostic** library. Ongoing work is tracked
+as GitHub issues.
+
+**Engine independence is a design goal, not an accident.** JEOD's physics carried a
+dependence on NASA's Trick sim framework (Trick-generated `S_define` wiring, logging,
+job scheduling threaded into the physics); that coupling is the mistake we are
+deliberately avoiding. astrodyn's physics has *zero* dependence on any sim engine: it
+is plain borrow-based Rust that a host drives. Bevy ECS (`astrodyn_bevy`) and the
+standalone arena runner (`astrodyn_runner`) are two interchangeable drivers, and a
+third-party host can drive the same pipeline with its own storage and scheduling.
+Treat the engine as a removable consumer at the top of the stack — never let engine
+concerns (ECS components, Bevy systems, schedules, async) leak into `astrodyn` or the
+`astrodyn_*` physics crates.
 
 **Read before refactoring**:
-- [Strategy](https://github.com/simnaut/astrodyn/wiki/Strategy) — architecture and phase history.
+- [Strategy](https://github.com/simnaut/astrodyn/wiki/Strategy) — architecture and project history.
 - [Audit-2026-05](https://github.com/simnaut/astrodyn/wiki/Audit-2026-05) — load-bearing guardrails
   (CI, parity-superset invariant, typed-quantity facade, JEOD invariant catalog).
 
@@ -38,7 +50,7 @@ against `// JEOD_INV: XX.YY` source tags by `tests/invariant_coverage.rs`. Per-c
   test reveals missing physics, port the JEOD code — don't approximate it or read JEOD's
   output.
 
-- **Tier 3 cross-validation is definition of done**. When a phase delivers new physics,
+- **Tier 3 cross-validation is definition of done**. When new physics is delivered,
   a `tier3_*` test exercising it via the full `Simulation::step()` pipeline must
   accompany it. Initial conditions may come from JEOD source files (`Modified_data/*.py`,
   `S_define`, gravity coefficient files) or the t=0 row of a JEOD reference CSV — both

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrodyn"
-description = "Pipeline orchestration, VehicleBuilder, and recipes — single API surface for ECS adapters"
-keywords = ["orbital-mechanics", "simulation", "aerospace", "ecs", "physics"]
+description = "Gateway to the astrodyn orbital-dynamics framework — a pure-Rust, engine-agnostic port of NASA JEOD (spherical-harmonics gravity, RNP Earth rotation, atmosphere, drag/SRP, multi-body dynamics) composing the astrodyn_* physics crates into one pipeline API any host can drive"
+keywords = ["orbital-mechanics", "simulation", "aerospace", "propagator", "physics"]
 categories = ["science", "aerospace", "simulation"]
 readme = "README.md"
 version.workspace = true

--- a/README.md
+++ b/README.md
@@ -1,29 +1,90 @@
 # astrodyn
 
-Pipeline orchestration, the typestate `VehicleBuilder`, and the
-recipes module — the single API surface that any consumer (the Bevy
-adapter or a non-Bevy runner) depends on.
+A pure-Rust orbital-dynamics simulation framework — a port of the physics in
+[NASA JEOD](https://github.com/nasa/jeod) v5.4 (the JSC Engineering Orbital
+Dynamics package). It models what a high-fidelity space-mission propagator
+needs: spherical-harmonics gravity, Earth rotation (RNP precession/nutation),
+multiple time scales, reference-frame trees, atmosphere and drag, solar
+radiation pressure, third-body and gravity-gradient effects, and multi-body
+rigid-body dynamics with a family of integrators.
 
-`astrodyn` composes the
-[`astrodyn_*`](https://github.com/simnaut/astrodyn/tree/main/crates) physics
-crates into pipeline stages and re-exports their types so a downstream
-crate only needs `astrodyn` to access the entire physics surface.
-Pure Rust, zero Bevy dependency.
+The framework is **engine-agnostic**: the physics is plain Rust with no game
+engine, ECS, or async runtime baked in, so it can be driven from a batch
+propagator, a custom integrator loop, an ECS, or any other host. It is split
+into a stack of small, single-responsibility `astrodyn_*` physics crates (each
+independently publishable), an orchestration **gateway** crate (`astrodyn`,
+this crate) that any host depends on, and optional reference consumers. See
+[The astrodyn workspace](#the-astrodyn-workspace) below for the full crate map.
+
+## This crate (`astrodyn`)
+
+`astrodyn` is the orchestration gateway: it composes the `astrodyn_*` physics
+crates into pipeline stages and re-exports their types, so a host needs only
+`astrodyn` to reach the entire physics surface. It also provides the typestate
+`VehicleBuilder` and the `recipes` module of mission presets. The per-stage
+pipeline functions are borrow-based and storage-agnostic — the host owns state
+and decides how to store it. No game-engine or runtime dependency.
 
 **Status:** pre-1.0. Tier 3 cross-validated against JEOD Trick simulations
 (see the [Tier3-Regeneration wiki page](https://github.com/simnaut/astrodyn/wiki/Tier3-Regeneration)).
 API may change before 1.0.
 
+## The astrodyn workspace
+
+The framework is organized into architectural layers. Every consumer of
+physics reads through `astrodyn` and only `astrodyn`; the `astrodyn_*` crates
+below it are plain Rust and can also be used à la carte.
+
+**Foundations**
+
+| Crate | Responsibility |
+| --- | --- |
+| [`astrodyn_quantities`](https://docs.rs/astrodyn_quantities) | Phantom-tagged typed quantities (`Position<F>`, `Velocity<F>`, `Quat<L,T>`, …) — frame/unit safety at API boundaries |
+| [`astrodyn_math`](https://docs.rs/astrodyn_math) | Quaternion, Euler, geodetic, orbital-element, and LVLH math kernels |
+| [`astrodyn_time`](https://docs.rs/astrodyn_time) | Time scales (TAI/UTC/UT1/TDB/TT/GMST) and converters |
+
+**Environment & physics**
+
+| Crate | Responsibility |
+| --- | --- |
+| [`astrodyn_frames`](https://docs.rs/astrodyn_frames) | Reference-frame tree and Earth rotation (RNP, nutation, precession) |
+| [`astrodyn_planet`](https://docs.rs/astrodyn_planet) | Planet definitions and presets (Earth, Moon, Sun, Mars) |
+| [`astrodyn_ephemeris`](https://docs.rs/astrodyn_ephemeris) | DE4xx (SPICE) binary ephemeris reader |
+| [`astrodyn_gravity`](https://docs.rs/astrodyn_gravity) | Spherical-harmonics gravity (Gottlieb), tides, and third-body |
+| [`astrodyn_atmosphere`](https://docs.rs/astrodyn_atmosphere) | Atmospheric density models (exponential, MET) |
+| [`astrodyn_interactions`](https://docs.rs/astrodyn_interactions) | Aerodynamic drag, SRP, gravity-gradient torque, shadow, and contact |
+| [`astrodyn_dynamics`](https://docs.rs/astrodyn_dynamics) | Rigid-body dynamics, integrators (RK4, RKF45, GJ, ABM4), mass tree, body initialization |
+
+**Orchestration & consumers**
+
+| Crate | Responsibility |
+| --- | --- |
+| [`astrodyn`](https://docs.rs/astrodyn) | **This crate.** Pipeline orchestration, `VehicleBuilder`, recipes — the single API surface every host depends on |
+| [`astrodyn_runner`](https://docs.rs/astrodyn_runner) | Standalone arena-state harness that owns all state and drives the pipeline — batch propagation and the Tier 3 test harness |
+| [`astrodyn_bevy`](https://docs.rs/astrodyn_bevy) | Optional adapter for hosts built on the [Bevy](https://bevyengine.org/) ECS: component derives, systems, plugin registration |
+
+`astrodyn_runner` and `astrodyn_bevy` are the two reference consumers shipped
+in this workspace; a host with different storage or scheduling needs depends on
+`astrodyn` directly and supplies its own state container.
+
+**Verification** (not published to crates.io). The `astrodyn_verif_jeod`,
+`astrodyn_verif_jeod_fixtures`, `astrodyn_verif_nesc`, and
+`astrodyn_verif_parity` crates hold the JEOD Tier 3 cross-validation rigs, the
+NESC GN&C Lunar Check Cases track, and the parity tests asserting the two
+reference consumers stay bit-identical. They live in the
+[workspace](https://github.com/simnaut/astrodyn/tree/main/crates) but stay
+in-tree as `publish = false`.
+
 ## Quick start
 
-Most users want one of the consumer crates rather than this orchestration
-layer directly:
+Many users want one of the reference consumer crates rather than this
+orchestration layer directly:
 
-- `astrodyn_bevy` for the Bevy-ECS production runtime,
-- `astrodyn_runner` for plain-Rust batch propagation and Tier 3 tests.
+- `astrodyn_runner` for plain-Rust batch propagation and Tier 3 tests,
+- `astrodyn_bevy` if your host is built on the Bevy ECS.
 
-If you are building a custom adapter on top of the pipeline, depend on
-`astrodyn` directly:
+If you are wiring the pipeline into your own host (a batch tool, an integrator
+loop, a different ECS, …), depend on `astrodyn` directly:
 
 ```toml
 [dependencies]
@@ -43,9 +104,9 @@ let cfg = VehicleBuilder::new()
     .rk4()
     .gravity(GravityControl::new_spherical(0_usize, false))
     .build();
-// `cfg` is a `VehicleConfig` ready to hand to either
-// `astrodyn_bevy::spawn_bevy::<Earth>(...)` or
-// `astrodyn_runner::Simulation::add_vehicle(...)`.
+// `cfg` is a `VehicleConfig` ready to hand to any host — e.g.
+// `astrodyn_runner::Simulation::add_vehicle(...)` for batch propagation,
+// or `astrodyn_bevy::spawn_bevy::<Earth>(...)` for a Bevy host.
 # let _ = cfg;
 ```
 
@@ -55,19 +116,19 @@ The typestate `VehicleBuilder` rejects misuse at compile time
 ## Layered architecture
 
 ```
-astrodyn_bevy        (Bevy ECS adapter)
+host  (astrodyn_runner, astrodyn_bevy, or your own)
    ↓
-astrodyn         ←  this crate (pure Rust, zero Bevy)
+astrodyn         ←  this crate (the single gateway, no engine dependency)
    ↓
 astrodyn_dynamics, astrodyn_gravity, astrodyn_time, astrodyn_frames,
 astrodyn_atmosphere, astrodyn_interactions, astrodyn_ephemeris,
 astrodyn_planet, astrodyn_math, astrodyn_quantities
 ```
 
-`astrodyn` (this crate) sits at the workspace root. The Bevy-ECS
-adapter is `astrodyn_bevy` (`crates/astrodyn_bevy/`), and `astrodyn` is
-also exercised directly by the standalone `astrodyn_runner` Tier 3
-harness; both consumers share the same API surface. See the
+`astrodyn` (this crate) sits at the workspace root and is the only physics
+dependency a host needs. `astrodyn_runner` is the standalone arena-state host
+used by the Tier 3 harness; `astrodyn_bevy` is the optional Bevy-ECS adapter.
+Any host shares the same API surface. See the
 [Strategy wiki page](https://github.com/simnaut/astrodyn/wiki/Strategy)
 for the layered-architecture rules.
 
@@ -79,10 +140,11 @@ for the layered-architecture rules.
   `vehicle`, `scenarios`. Mission-facing only; the JEOD-source-backed
   Tier 3 verification scaffolding lives in `astrodyn_verif_jeod`.
 - Per-stage pipeline functions (`accumulate_gravity`,
-  `validate_body`, …) that mirror the `AstrodynSet` schedule slot the
-  Bevy adapter exposes.
-- Frame-tree orchestration helpers shared by `astrodyn_bevy` and
-  `astrodyn_runner`: `SourceFrameIds` (root + per-source frame IDs),
+  `validate_body`, …), one per stage of the per-step pipeline, that a host
+  schedules in order. (The Bevy adapter maps these onto its `AstrodynSet`
+  schedule slots; a batch host just calls them in sequence.)
+- Frame-tree orchestration helpers shared by the reference consumers:
+  `SourceFrameIds` (root + per-source frame IDs),
   `sync_pfix_rotation` (writes a planet-fixed child's rotation +
   angular velocity into a `FrameTree`),
   `evaluate_and_apply_frame_switch::<SourceId, F>` (generic
@@ -130,12 +192,14 @@ inherits it; users on older toolchains get a clean
 `error: package <name> requires Rust 1.89` from cargo rather than a
 deep dependency-tree compile error.
 
-The binding constraint is `bevy = "0.18"` (0.18.1 declares its own
-`rust-version = "1.89"`, which MSRV-aware resolution in cargo 1.85+
-enforces transitively). Our own direct usage of recent stdlib features
-(`u{32,usize}::is_multiple_of`, stabilized in 1.87; `#[diagnostic::
-on_unimplemented]`; recent const generics) sits comfortably below this
-floor.
+The binding constraint is the workspace's `bevy = "0.18"` dependency (used
+only by the optional `astrodyn_bevy` adapter — `astrodyn` and the `astrodyn_*`
+physics crates do not depend on it): bevy 0.18.1 declares its own
+`rust-version = "1.89"`, which MSRV-aware resolution in cargo 1.85+ enforces
+transitively, and the floor is shared workspace-wide via `[workspace.package]`.
+Our own direct usage of recent stdlib features (`u{32,usize}::is_multiple_of`,
+stabilized in 1.87; `#[diagnostic::on_unimplemented]`; recent const generics)
+sits comfortably below this floor.
 
 **Bump policy.** Raising the MSRV is treated as a minor-version event,
 not a patch. The project tracks the last two to three stable Rust
@@ -167,7 +231,9 @@ distinction (astrodyn is an independent reimplementation, not a JEOD fork).
 
 - [Project README](https://github.com/simnaut/astrodyn/blob/main/README.md) and
   [`CLAUDE.md`](https://github.com/simnaut/astrodyn/blob/main/CLAUDE.md) — workspace-level architecture.
+- [`crates/astrodyn_runner/examples/batch_propagation.rs`](https://github.com/simnaut/astrodyn/blob/main/crates/astrodyn_runner/examples/batch_propagation.rs)
+  — engine-agnostic worked example (plain-Rust host).
 - [`crates/astrodyn_bevy/examples/typed_mission.rs`](https://github.com/simnaut/astrodyn/blob/main/crates/astrodyn_bevy/examples/typed_mission.rs)
-  — canonical worked example.
+  — the same pipeline driven from a Bevy ECS host.
 - Rendered rustdoc:
   <https://docs.rs/astrodyn>

--- a/crates/astrodyn_runner/Cargo.toml
+++ b/crates/astrodyn_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astrodyn_runner"
-description = "Standalone arena-state simulation harness driving the astrodyn pipeline without Bevy ECS"
+description = "Standalone arena-state simulation harness that owns all state and drives the astrodyn pipeline — batch propagation and the Tier 3 test harness"
 readme = "README.md"
 keywords = ["orbital-mechanics", "simulation", "propagator", "aerospace"]
 categories = ["science", "aerospace", "simulation"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,18 @@
 // JEOD_INV: TS.01 — `<SelfRef>` / `<SelfPlanet>` are runtime-resolved storage-boundary wildcards; see `docs/JEOD_invariants.md` row TS.01 and the lint at `tests/self_ref_self_planet_discipline.rs`.
-//! ECS-agnostic orchestration layer for JEOD physics.
+//! Engine-agnostic orchestration layer for JEOD physics.
 //!
-//! This crate is the **single dependency** for ECS adapters and mission
-//! crates. It re-exports the types from the `astrodyn_*` physics crates that
-//! such consumers need, plus orchestration functions that compose them
-//! into pipeline stages.
+//! This crate is the **single physics dependency** for any host — a batch
+//! propagator, a custom integrator loop, an ECS adapter, or mission crates.
+//! It re-exports the types from the `astrodyn_*` physics crates that such
+//! consumers need, plus orchestration functions that compose them into
+//! pipeline stages. The pipeline carries no game-engine, ECS, or async-runtime
+//! dependency of its own.
 //!
-//! ## Per-body functions (primary API for ECS integration)
+//! ## Per-body functions (primary API for host integration)
 //!
-//! Composable, borrow-based functions that any ECS adapter can call from
-//! its system functions. The ECS world remains the single source of truth.
+//! Composable, borrow-based functions that any host can call from its update
+//! loop. The host's own storage remains the single source of truth — the
+//! pipeline never owns state.
 //!
 //! - [`accumulate_gravity`] — gravity accumulation across sources
 //! - [`evaluate_atmosphere`] — atmosphere evaluation pipeline
@@ -28,10 +31,11 @@
 //!
 //! For batch propagation and Tier 3 tests, see the `astrodyn_runner` crate which
 //! provides a standalone `Simulation` struct that owns all state and drives the
-//! pipeline. ECS adapters should **not** use `astrodyn_runner` — use the per-body
-//! functions from this crate instead. `astrodyn_runner` is a parallel non-Bevy
-//! consumer that, like `astrodyn_bevy` and mission code, depends on `astrodyn`
-//! and only `astrodyn` for physics.
+//! pipeline. A host that embeds the pipeline into its own storage should call
+//! the per-body functions from this crate directly rather than depending on
+//! `astrodyn_runner`. `astrodyn_runner` and `astrodyn_bevy` are the two
+//! reference consumers shipped in the workspace; like mission code, each
+//! depends on `astrodyn` and only `astrodyn` for physics.
 //!
 //! ## Re-export discipline
 //!
@@ -46,7 +50,7 @@
 //! ## Pipeline ordering
 //!
 //! See [`PipelineStage`] and [`PIPELINE_ORDER`] for the canonical stage
-//! execution order that any adapter must respect.
+//! execution order that any host must respect.
 //!
 //! ## Quick start
 //!
@@ -230,7 +234,7 @@ pub use astrodyn_dynamics::body_init::{
 // already-exposed `compute_kinematic_child_state`.
 pub use astrodyn_dynamics::kinematic_propagation::KinematicChildInputs;
 
-// astrodyn_dynamics typed siblings: ECS components built on the typed
+// astrodyn_dynamics typed siblings: host storage types built on the typed
 // state primitives so storage carries frame phantoms rather than
 // re-lifting raw `DVec3` every step.
 pub use astrodyn_dynamics::forces::{
@@ -273,15 +277,15 @@ pub use astrodyn_interactions::{
 // `RefFrameTrans`, `RefFrameState`) are needed by mission code that
 // constructs or reads frame nodes; `frame_compute_relative_state_via_storage`
 // drives cross-frame state queries. `FrameTree` (concrete arena) is the
-// non-Bevy storage implementation — used by `astrodyn_runner`'s
+// reference arena-storage implementation — used by `astrodyn_runner`'s
 // `Simulation` state container.
 pub use astrodyn_frames::{
     compute_relative_state as frame_compute_relative_state_via_storage, FrameId, FrameStorage,
     FrameTree, RefFrameKind, RefFrameRot, RefFrameState, RefFrameTrans,
 };
 
-// astrodyn_time: simulation-time + leap-second + epoch surface that the
-// Bevy adapter and mission code consume through `SimulationTime` /
+// astrodyn_time: simulation-time + leap-second + epoch surface that
+// hosts and mission code consume through `SimulationTime` /
 // `default_leap_second_table()`. `SimulationTime` + `TimeScaleId` are the
 // multi-scale time API (mirrors JEOD's `TimeManager` aggregate);
 // `time_utc::{calendar_to_tjt, tjt_to_calendar, CalendarDate}` are the
@@ -324,8 +328,8 @@ pub use astrodyn_gravity::relativistic;
 // astrodyn_planet: planet shape
 pub use astrodyn_planet::PlanetShape;
 
-// astrodyn_quantities: typed-quantity foundation. ECS adapters (e.g. the
-// `astrodyn_bevy` root crate) consume these types via `astrodyn` to
+// astrodyn_quantities: typed-quantity foundation. Hosts (e.g. the
+// `astrodyn_bevy` adapter) consume these types via `astrodyn` to
 // preserve the "single dependency" invariant.
 pub use astrodyn_quantities::aliases::{
     Acceleration, AngularAcceleration, AngularVelocity, Force, InertiaTensor, Position, Torque,
@@ -349,8 +353,8 @@ pub use astrodyn_quantities::frame_transform::FrameTransform;
 pub use astrodyn_quantities::qty3::Qty3;
 pub use astrodyn_quantities::{define_planet, define_vehicle};
 
-// uom scalar quantities used directly by the Bevy adapter for typed
-// component fields (`Angle` for Euler angles, `Ratio` for tidal ΔC20).
+// uom scalar quantities used directly by hosts for typed storage
+// fields (`Angle` for Euler angles, `Ratio` for tidal ΔC20).
 pub use uom::si::f64::{Angle, Mass, Ratio};
 
 /// Re-export of [`uom::si::mass::kilogram`] for typed-quantity callers
@@ -363,7 +367,7 @@ pub use uom::si::mass::kilogram;
 /// [`Angle`].
 ///
 /// Mirrors `astrodyn_quantities::ext::F64Ext::rad(f)` but exists at the
-/// `astrodyn` boundary so ECS adapters don't need to import
+/// `astrodyn` boundary so hosts don't need to import
 /// `astrodyn_quantities` (or `uom::si::angle::radian`) directly.
 #[inline]
 pub fn radians(value: f64) -> Angle {


### PR DESCRIPTION
## Summary

Broaden the published `astrodyn` README and crate metadata to describe the whole orbital-dynamics framework (all `astrodyn_*` subcrates), and decouple the public framing from any sim engine. ECS/Bevy references are confined to the `astrodyn_bevy` crate; Bevy and the standalone arena runner are presented as two interchangeable **drivers** a host can swap, not the framework the physics is built into.

Motivation: avoid repeating JEOD's coupling to Trick. JEOD's physics carried a dependence on the Trick sim framework; astrodyn's physics is plain borrow-based Rust with zero engine dependency, and the docs should say so.

## Changes

- **README.md** — New project-scope intro + a layered **workspace crate map** (docs.rs links for every published subcrate). Engine-agnostic framing throughout; quick-start and "See also" now lead with the plain-Rust host path.
- **Cargo.toml** — Broaden the `astrodyn` package `description` to cover the framework; swap the `ecs` keyword for `propagator`.
- **src/lib.rs** — Crate-doc header "ECS-agnostic" → "engine-agnostic"; "single dependency for ECS adapters" → "for any host"; soften internal consumer comments from ECS-specific to host-neutral wording. (Concrete `astrodyn_bevy`/`astrodyn_runner` references that name the real consumer crates are kept.)
- **crates/astrodyn_runner/Cargo.toml** — Describe positively (batch + Tier 3 harness) rather than "without Bevy ECS".
- **CLAUDE.md** — State engine-independence as an explicit design goal and name the JEOD↔Trick physics coupling as the mistake being avoided; remove implementation-phase references.

## Companion wiki changes (already pushed, not part of this PR)

The Strategy/Architecture wiki pages were reframed around engine independence, and the implementation-phase narrative was stripped wiki-wide (Strategy §8 deleted). Wikis don't take PRs; those landed directly on the wiki repo.

## Verification

- `cargo metadata --no-deps` parses cleanly.
- `cargo doc -p astrodyn --no-deps` builds with no broken intra-doc links.

Docs/metadata only — no code-path or physics changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)