### PR TITLE
[#645] PR-D (2/6): Jupiter + Saturn shape presets (#2)

### DIFF
--- a/crates/astrodyn_planet/src/planet.rs
+++ b/crates/astrodyn_planet/src/planet.rs
@@ -72,6 +72,11 @@ impl PlanetShape {
     /// - `r_pol` is finite and `> 0`,
     /// - `r_pol <= r_eq` (oblate or spherical).
     ///
+    /// Triaxial bodies (three distinct semi-axes, e.g. small irregular moons
+    /// and asteroids) are **not** representable — this is a biaxial
+    /// (oblate/spherical) ellipsoid only. A triaxial variant would be a
+    /// separate type, not a relaxation of this one.
+    ///
     /// Violations panic with a fail-loud diagnostic naming the offending
     /// field and the violated invariant. This is a `const fn` so that the
     /// canonical preset constants in [`crate::presets`] (and any future
@@ -223,7 +228,7 @@ mod tests {
 
     #[test]
     fn polar_radius_consistent_with_flattening() {
-        for planet in [EARTH, MOON, SUN, MARS] {
+        for planet in [EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             let expected_r_pol = planet.r_eq() * (1.0 - planet.flat_coeff);
             let err = (planet.r_pol() - expected_r_pol).abs();
             assert!(
@@ -239,7 +244,7 @@ mod tests {
 
     #[test]
     fn all_values_positive() {
-        for planet in [EARTH, MOON, SUN, MARS] {
+        for planet in [EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             assert!(planet.mu > 0.0, "{}: mu must be positive", planet.name);
             assert!(
                 planet.r_eq() > 0.0,
@@ -281,7 +286,7 @@ mod tests {
 
     #[test]
     fn eccentricity_positive() {
-        for planet in [EARTH, MOON, SUN, MARS] {
+        for planet in [EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             let e = planet.e_ellipsoid();
             assert!(e > 0.0 && e < 1.0, "{}: e={}", planet.name, e);
         }
@@ -324,7 +329,7 @@ mod tests {
         // preset and our hand-built shape. We reach for the values via
         // a non-const accessor expression so clippy doesn't fold the
         // comparison to a literal.
-        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS] {
+        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             assert!(
                 planet.r_eq() > planet.r_pol(),
                 "{}: r_eq={} not > r_pol={}",
@@ -358,7 +363,7 @@ mod tests {
     fn mu_accessor_matches_typed_and_preserves_value() {
         // The typed getter must round-trip the raw f64 mu without loss.
         // GravParam stores its value in base SI (m³/s²).
-        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS] {
+        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             assert_eq!(planet.mu_typed().value, planet.mu);
         }
     }
@@ -366,7 +371,7 @@ mod tests {
     #[test]
     fn eccentricity_squared_matches_definition() {
         // e_ellip_sq = 2f - f^2; e_ellipsoid is its sqrt.
-        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS] {
+        for planet in [TEST_SHAPE, EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             let f = planet.flat_coeff;
             let expected = 2.0 * f - f * f;
             assert!((planet.e_ellip_sq() - expected).abs() < 1e-15);

--- a/crates/astrodyn_planet/src/presets.rs
+++ b/crates/astrodyn_planet/src/presets.rs
@@ -13,9 +13,10 @@
 //! depending on `astrodyn_planet`.
 
 use astrodyn_quantities::body_constants::{
-    EARTH_FLAT_COEFF, EARTH_MU, EARTH_R_EQ, EARTH_R_POL, MARS_FLAT_COEFF, MARS_MU, MARS_R_EQ,
-    MARS_R_POL, MOON_FLAT_COEFF, MOON_MU, MOON_R_EQ, MOON_R_POL, SUN_FLAT_COEFF, SUN_MU, SUN_R_EQ,
-    SUN_R_POL,
+    EARTH_FLAT_COEFF, EARTH_MU, EARTH_R_EQ, EARTH_R_POL, JUPITER_FLAT_COEFF, JUPITER_MU,
+    JUPITER_R_EQ, JUPITER_R_POL, MARS_FLAT_COEFF, MARS_MU, MARS_R_EQ, MARS_R_POL, MOON_FLAT_COEFF,
+    MOON_MU, MOON_R_EQ, MOON_R_POL, SATURN_FLAT_COEFF, SATURN_MU, SATURN_R_EQ, SATURN_R_POL,
+    SUN_FLAT_COEFF, SUN_MU, SUN_R_EQ, SUN_R_POL,
 };
 
 use crate::planet::PlanetShape;
@@ -39,3 +40,29 @@ pub const SUN: PlanetShape = PlanetShape::new("Sun", SUN_MU, SUN_R_EQ, SUN_R_POL
 /// values live in [`astrodyn_quantities::body_constants`].
 pub const MARS: PlanetShape =
     PlanetShape::new("Mars", MARS_MU, MARS_R_EQ, MARS_R_POL, MARS_FLAT_COEFF);
+
+/// Jupiter (1-bar oblate ellipsoid). Constants from JEOD
+/// `planet/data/src/jupiter.cc` and `gravity/data/src/jupiter_spherical.cc`;
+/// numeric values live in [`astrodyn_quantities::body_constants`].
+///
+/// Like all [`PlanetShape`] presets this is an oblate ellipsoid (r_pol ≤ r_eq);
+/// see [`PlanetShape::new`] for the oblate-only restriction.
+pub const JUPITER: PlanetShape = PlanetShape::new(
+    "Jupiter",
+    JUPITER_MU,
+    JUPITER_R_EQ,
+    JUPITER_R_POL,
+    JUPITER_FLAT_COEFF,
+);
+
+/// Saturn (1-bar oblate ellipsoid). Constants from JEOD
+/// `ephemerides/verif/SIM_prop_planet/data/src/saturn_planet.cc` and
+/// `saturn_spherical_gravity.cc`; numeric values live in
+/// [`astrodyn_quantities::body_constants`].
+pub const SATURN: PlanetShape = PlanetShape::new(
+    "Saturn",
+    SATURN_MU,
+    SATURN_R_EQ,
+    SATURN_R_POL,
+    SATURN_FLAT_COEFF,
+);

--- a/crates/astrodyn_quantities/src/body_constants.rs
+++ b/crates/astrodyn_quantities/src/body_constants.rs
@@ -76,3 +76,35 @@ pub const MARS_FLAT_COEFF: f64 = 0.005186;
 
 /// Mars polar radius (m), derived as `MARS_R_EQ * (1 - MARS_FLAT_COEFF)`.
 pub const MARS_R_POL: f64 = MARS_R_EQ * (1.0 - MARS_FLAT_COEFF);
+
+// ── Jupiter ────────────────────────────────────────────────────────────
+
+/// Jupiter gravitational parameter (m³/s²) — JEOD
+/// `gravity/data/src/jupiter_spherical.cc:42`.
+pub const JUPITER_MU: f64 = 1.267_312_29e17;
+
+/// Jupiter equatorial (1-bar) radius (m) — JEOD `planet/data/src/jupiter.cc:37`.
+pub const JUPITER_R_EQ: f64 = 1000.0 * 71_492.0;
+
+/// Jupiter flattening coefficient — JEOD `planet/data/src/jupiter.cc:36`.
+pub const JUPITER_FLAT_COEFF: f64 = 0.06487;
+
+/// Jupiter polar radius (m), derived as `JUPITER_R_EQ * (1 - JUPITER_FLAT_COEFF)`.
+pub const JUPITER_R_POL: f64 = JUPITER_R_EQ * (1.0 - JUPITER_FLAT_COEFF);
+
+// ── Saturn ─────────────────────────────────────────────────────────────
+
+/// Saturn gravitational parameter (m³/s²) — JEOD
+/// `ephemerides/verif/SIM_prop_planet/data/src/saturn_spherical_gravity.cc:36`.
+pub const SATURN_MU: f64 = 3.793_118_7e16;
+
+/// Saturn equatorial (1-bar) radius (m) — JEOD
+/// `ephemerides/verif/SIM_prop_planet/data/src/saturn_planet.cc:36`.
+pub const SATURN_R_EQ: f64 = 1000.0 * 60_268.0;
+
+/// Saturn flattening coefficient — JEOD
+/// `ephemerides/verif/SIM_prop_planet/data/src/saturn_planet.cc:35`.
+pub const SATURN_FLAT_COEFF: f64 = 0.09796;
+
+/// Saturn polar radius (m), derived as `SATURN_R_EQ * (1 - SATURN_FLAT_COEFF)`.
+pub const SATURN_R_POL: f64 = SATURN_R_EQ * (1.0 - SATURN_FLAT_COEFF);

--- a/crates/astrodyn_quantities/src/frame.rs
+++ b/crates/astrodyn_quantities/src/frame.rs
@@ -111,6 +111,8 @@ planet_marker!(Earth, "Earth");
 planet_marker!(Moon, "Moon");
 planet_marker!(Sun, "Sun");
 planet_marker!(Mars, "Mars");
+planet_marker!(Jupiter, "Jupiter");
+planet_marker!(Saturn, "Saturn");
 
 /// Phantom marker for "this entity's own planet" — used by ECS adapters
 /// whose per-entity components carry `PlanetFixed<P>` phantoms but whose

--- a/crates/astrodyn_quantities/src/prelude.rs
+++ b/crates/astrodyn_quantities/src/prelude.rs
@@ -7,8 +7,9 @@ pub use crate::body_attitude::BodyAttitude;
 pub use crate::dims::{GravParam, MassFlowRate, SpecificAngMom, SpecificEnergy};
 pub use crate::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use crate::frame::{
-    BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Lvlh, Mars, MassNode, Moon, Ned, Planet,
-    PlanetFixed, PlanetInertial, RootInertial, SelfPlanet, SelfRef, StructuralFrame, Sun, Vehicle,
+    BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Jupiter, Lvlh, Mars, MassNode, Moon, Ned,
+    Planet, PlanetFixed, PlanetInertial, RootInertial, Saturn, SelfPlanet, SelfRef,
+    StructuralFrame, Sun, Vehicle,
 };
 pub use crate::frame_transform::FrameTransform;
 pub use crate::integ_origin::IntegOrigin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub use interactions::{
 };
 pub use kinematic_propagation::{propagate_state_via_storage, KinematicEdge, KinematicNodeState};
 pub use pipeline::{PipelineStage, PIPELINE_ORDER};
-pub use planet_config::{PlanetConfig, EARTH, MARS, MOON, SUN};
+pub use planet_config::{PlanetConfig, EARTH, JUPITER, MARS, MOON, SATURN, SUN};
 pub use rotation_model::RotationModel;
 pub use simulation_builder::{MassTreeAttachment, SimulationBuilder};
 pub use source_frames::SourceFrameIds;
@@ -339,8 +339,9 @@ pub use astrodyn_quantities::diagnostics::CompatibleVehiclePair;
 pub use astrodyn_quantities::dims::GravParam;
 pub use astrodyn_quantities::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use astrodyn_quantities::frame::{
-    BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Lvlh, Mars, MassNode, Moon, Ned, Planet,
-    PlanetFixed, PlanetInertial, RootInertial, SelfPlanet, SelfRef, StructuralFrame, Sun, Vehicle,
+    BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Jupiter, Lvlh, Mars, MassNode, Moon, Ned,
+    Planet, PlanetFixed, PlanetInertial, RootInertial, Saturn, SelfPlanet, SelfRef,
+    StructuralFrame, Sun, Vehicle,
 };
 pub use astrodyn_quantities::integ_origin::IntegOrigin;
 // Macros that mint downstream `Vehicle`/`Planet` markers. Re-exported so

--- a/src/planet_config.rs
+++ b/src/planet_config.rs
@@ -122,6 +122,37 @@ pub const MARS: PlanetConfig = PlanetConfig {
     shadow_radius: 3_396_000.0,
 };
 
+/// Jupiter — shape preset for rendering / sizing an outer planet.
+///
+/// Constants from JEOD source:
+/// - Geometry: `planet/data/src/jupiter.cc` (1-bar oblate ellipsoid)
+/// - Gravity: `gravity/data/src/jupiter_spherical.cc` (mu = 1.26731229e17 m³/s²)
+///
+/// No spin model is wired ([`RotationModel::None`], `omega = 0`): astrodyn does
+/// not propagate or spin Jupiter, so this preset carries geometry + μ only,
+/// for sizing and placement. A body-fixed orientation, when one is needed,
+/// comes from the ephemeris IAU rotation — never from this config's `omega`.
+pub const JUPITER: PlanetConfig = PlanetConfig {
+    shape: astrodyn_planet::presets::JUPITER,
+    rotation_model: RotationModel::None,
+    omega: 0.0,
+    shadow_radius: 71_492_000.0,
+};
+
+/// Saturn — shape preset for rendering / sizing an outer planet.
+///
+/// Constants from JEOD source:
+/// - Geometry: `ephemerides/verif/SIM_prop_planet/data/src/saturn_planet.cc`
+/// - Gravity: `saturn_spherical_gravity.cc` (mu = 3.7931187e16 m³/s²)
+///
+/// As with [`JUPITER`], no spin model is wired — geometry + μ only.
+pub const SATURN: PlanetConfig = PlanetConfig {
+    shape: astrodyn_planet::presets::SATURN,
+    rotation_model: RotationModel::None,
+    omega: 0.0,
+    shadow_radius: 60_268_000.0,
+};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,7 +169,7 @@ mod tests {
 
     #[test]
     fn all_configs_positive_radii() {
-        for config in [EARTH, MOON, SUN, MARS] {
+        for config in [EARTH, MOON, SUN, MARS, JUPITER, SATURN] {
             assert!(
                 config.shadow_radius > 0.0,
                 "{}: shadow_radius must be positive",
@@ -149,6 +180,38 @@ mod tests {
                 "{}: omega must be non-negative",
                 config.shape.name
             );
+            // PlanetShape::new already enforces r_pol ≤ r_eq (oblate/spherical);
+            // re-assert at the config level so a fat-fingered preset trips here.
+            assert!(
+                config.shape.r_pol() <= config.shape.r_eq(),
+                "{}: r_pol must not exceed r_eq (oblate only)",
+                config.shape.name
+            );
         }
+    }
+
+    // Spot-check the JEOD-sourced outer-planet geometry so a transcription
+    // error in the body constants is caught here rather than downstream.
+    // Bit-exact comparison (`to_bits`) keeps the denied `clippy::float_cmp`
+    // lint quiet while still pinning the exact JEOD values.
+    #[test]
+    fn jupiter_saturn_geometry_matches_jeod() {
+        // Full geometry (r_eq, flattening, derived r_pol) plus μ, pinned to the
+        // exact JEOD source values. Jupiter: jupiter.cc / jupiter_spherical.cc.
+        assert_eq!(JUPITER.shape.r_eq().to_bits(), 71_492_000.0_f64.to_bits());
+        assert_eq!(JUPITER.shape.flat_coeff.to_bits(), 0.06487_f64.to_bits());
+        assert_eq!(
+            JUPITER.shape.r_pol().to_bits(),
+            (71_492_000.0_f64 * (1.0 - 0.06487)).to_bits()
+        );
+        assert_eq!(JUPITER.shape.mu.to_bits(), 1.267_312_29e17_f64.to_bits());
+        // Saturn: saturn_planet.cc / saturn_spherical_gravity.cc.
+        assert_eq!(SATURN.shape.r_eq().to_bits(), 60_268_000.0_f64.to_bits());
+        assert_eq!(SATURN.shape.flat_coeff.to_bits(), 0.09796_f64.to_bits());
+        assert_eq!(
+            SATURN.shape.r_pol().to_bits(),
+            (60_268_000.0_f64 * (1.0 - 0.09796)).to_bits()
+        );
+        assert_eq!(SATURN.shape.mu.to_bits(), 3.793_118_7e16_f64.to_bits());
     }
 }


### PR DESCRIPTION
Part 2 of 6 for #645. **Stacked on \`645-a-typed-rotation\`** (PR-A); shows only this gap's diff.

JEOD-sourced `PlanetShape`/`PlanetConfig` presets for Jupiter + Saturn (the two outer planets JEOD ships constants for). Venus/Mercury/Uranus/Neptune intentionally excluded — no JEOD source.

Stack: A → **D** → E → F → B → C.