### PR TITLE
[#645] PR-E (3/6): CartesianState<F> + opt-in serde (#4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,8 @@ version = "0.2.0"
 dependencies = [
  "glam 0.30.10",
  "proptest",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "typenum",
  "uom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,13 @@ uom = { workspace = true }
 # fixture has a recorded SHA-256 sidecar matching its bytes).
 sha2 = { workspace = true }
 
+[features]
+# Forward serialization to the typed surface so consumers that read physics
+# through `astrodyn` can `(de)serialize` `CartesianState` without depending on
+# `astrodyn_quantities` directly. OFF by default — the production build stays
+# serde-free.
+serde = ["astrodyn_quantities/serde"]
+
 [workspace]
 resolver = "2"
 members = [
@@ -114,6 +121,14 @@ thiserror = "2"
 uom = { version = "0.38", default-features = false, features = ["f64", "si", "std"] }
 typenum = "1.20"
 sha2 = "0.11"
+
+# Optional serialization. Opted into per-crate behind a non-default `serde`
+# feature (currently only `astrodyn_quantities`, for the `CartesianState`
+# interchange record). `default-features = false` keeps it `no_std`-clean;
+# the `derive` feature is requested at the crate that needs it. `serde_json`
+# is a test-only dev-dependency for round-trip coverage.
+serde = { version = "1", default-features = false }
+serde_json = "1"
 
 # Benchmarking — dev-only deps, opted into per-crate via
 # `[dev-dependencies]` on the crates that own `benches/`. `pprof`

--- a/crates/astrodyn_quantities/Cargo.toml
+++ b/crates/astrodyn_quantities/Cargo.toml
@@ -18,15 +18,21 @@ glam = { workspace = true }
 uom = { workspace = true }
 typenum = { workspace = true }
 thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 proptest = "1"
+serde_json = { workspace = true }
 
 [features]
 # Exposes test-only phantom markers (e.g. `TestVehicle`) so downstream crates
 # can write frame-composition tests without needing to implement sealed
 # marker traits. Never enabled in production builds.
 test-utils = []
+# Opt-in (de)serialization for the typed interchange surface: `Qty3` (raw-SI
+# triple), `SecondsSince`, and the `CartesianState` record. OFF by default so
+# the production dependency graph stays serde-free; kernels never enable it.
+serde = ["dep:serde"]
 
 [lints]
 workspace = true

--- a/crates/astrodyn_quantities/src/cartesian_state.rs
+++ b/crates/astrodyn_quantities/src/cartesian_state.rs
@@ -1,0 +1,159 @@
+//! [`CartesianState`] — a single (de)serializable position + velocity + epoch
+//! record, the natural interchange unit for a replay log or telemetry frame.
+//!
+//! The typed surface keeps [`Position<F>`](crate::aliases::Position),
+//! [`Velocity<F>`](crate::aliases::Velocity), and time as separate values so
+//! the kernels can stay unit-pure. A downstream consumer that logs or streams
+//! state, however, wants one record it can round-trip without inventing a
+//! bespoke schema. `CartesianState<F>` is that record: position, velocity, and
+//! the epoch they are sampled at, all sharing the static frame tag `F`.
+//!
+//! Serialization is gated behind the crate's non-default `serde` feature, so
+//! the production dependency graph stays serde-free. The epoch is stored as a
+//! typed [`SecondsSince<TDB>`] — *not* an external library's `Epoch` type — so
+//! the record carries no dependency on the ephemeris/time backend and the
+//! typed-quantity facade stays intact.
+
+use crate::aliases::{Position, Velocity};
+use crate::frame::Frame;
+use crate::time_scale::{SecondsSince, TDB};
+
+/// A Cartesian state sample: position, velocity, and the epoch they hold at,
+/// all in frame `F`.
+///
+/// All three fields are public; construct directly or via [`Self::new`]. The
+/// epoch is barycentric-dynamical seconds since the TDB epoch
+/// ([`SecondsSince<TDB>`]).
+///
+/// With the crate's `serde` feature enabled this round-trips as
+/// `{ "position": [x, y, z], "velocity": [x, y, z], "epoch": t }` in raw SI
+/// units (metres, m/s, seconds). The frame `F` is encoded by the static type,
+/// not the payload — deserializing into `CartesianState<Ecef>` vs.
+/// `CartesianState<RootInertial>` is a compile-time choice at the call site.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+// Clear serde's auto-generated `F: Serialize`/`F: Deserialize` bound: `F` is a
+// phantom carried inside the field types (which implement serde for *all*
+// frames), so the struct needs no bound on `F` itself.
+#[cfg_attr(feature = "serde", serde(bound = ""))]
+pub struct CartesianState<F: Frame> {
+    /// Position in frame `F` (metres).
+    pub position: Position<F>,
+    /// Velocity in frame `F` (m/s).
+    pub velocity: Velocity<F>,
+    /// Epoch the sample holds at — seconds since the TDB epoch.
+    pub epoch: SecondsSince<TDB>,
+}
+
+impl<F: Frame> CartesianState<F> {
+    /// Bundle a position, velocity, and epoch into a [`CartesianState`].
+    #[inline]
+    pub const fn new(
+        position: Position<F>,
+        velocity: Velocity<F>,
+        epoch: SecondsSince<TDB>,
+    ) -> Self {
+        Self {
+            position,
+            velocity,
+            epoch,
+        }
+    }
+
+    /// Relabel the frame tag from `F` to `F2` without changing any numeric
+    /// values — a caller-asserted phantom swap, mirroring
+    /// [`Qty3::relabel_to`](crate::qty3::Qty3::relabel_to). The caller is
+    /// responsible for the invariant that `F` and `F2` name the same physical
+    /// frame.
+    #[inline]
+    pub fn relabel_to<F2: Frame>(self) -> CartesianState<F2> {
+        CartesianState {
+            position: self.position.relabel_to::<F2>(),
+            velocity: self.velocity.relabel_to::<F2>(),
+            epoch: self.epoch,
+        }
+    }
+}
+
+// Phantom-clean trait impls: `F` only appears inside `Position<F>`/`Velocity<F>`
+// (which are `Copy`/`Clone`/`Debug`/`PartialEq` for every frame), so these are
+// hand-written to avoid `#[derive]` minting a spurious `F: Copy` bound.
+impl<F: Frame> Copy for CartesianState<F> {}
+
+impl<F: Frame> Clone for CartesianState<F> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<F: Frame> core::fmt::Debug for CartesianState<F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CartesianState")
+            .field("position", &self.position)
+            .field("velocity", &self.velocity)
+            .field("epoch_s", &self.epoch.as_seconds())
+            .finish()
+    }
+}
+
+impl<F: Frame> PartialEq for CartesianState<F> {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare the epoch's underlying `uom` `Time` field directly:
+        // `SecondsSince<S>` only derives `PartialEq` when `S: PartialEq`, which
+        // the time-scale markers don't implement. `Time == Time` is a typed
+        // comparison (not a bare-`f64` one), so it also stays clear of the
+        // denied `clippy::float_cmp` lint.
+        self.position == other.position
+            && self.velocity == other.velocity
+            && self.epoch.value == other.epoch.value
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    use super::*;
+    use crate::ext::Vec3Ext;
+    use crate::frame::RootInertial;
+    use glam::DVec3;
+
+    #[test]
+    fn cartesian_state_json_round_trips_bit_exact() {
+        let state = CartesianState::<RootInertial>::new(
+            DVec3::new(7_000_123.5, -42.25, 1_234_567.875).m_at::<RootInertial>(),
+            DVec3::new(-0.5, 7_546.125, 3.0).m_per_s_at::<RootInertial>(),
+            SecondsSince::<TDB>::from_seconds(86_400.5),
+        );
+
+        let json = serde_json::to_string(&state).expect("serialize");
+        let back: CartesianState<RootInertial> = serde_json::from_str(&json).expect("deserialize");
+
+        // Raw-SI values must survive the round trip bit-for-bit.
+        let (p0, p1) = (state.position.raw_si(), back.position.raw_si());
+        let (v0, v1) = (state.velocity.raw_si(), back.velocity.raw_si());
+        assert_eq!(
+            p0.to_array().map(f64::to_bits),
+            p1.to_array().map(f64::to_bits)
+        );
+        assert_eq!(
+            v0.to_array().map(f64::to_bits),
+            v1.to_array().map(f64::to_bits)
+        );
+        assert_eq!(
+            state.epoch.as_seconds().to_bits(),
+            back.epoch.as_seconds().to_bits()
+        );
+    }
+
+    #[test]
+    fn cartesian_state_serializes_as_raw_si_triples() {
+        let state = CartesianState::<RootInertial>::new(
+            DVec3::new(1.0, 2.0, 3.0).m_at::<RootInertial>(),
+            DVec3::new(4.0, 5.0, 6.0).m_per_s_at::<RootInertial>(),
+            SecondsSince::<TDB>::from_seconds(10.0),
+        );
+        let value: serde_json::Value = serde_json::to_value(state).expect("to_value");
+        assert_eq!(value["position"], serde_json::json!([1.0, 2.0, 3.0]));
+        assert_eq!(value["velocity"], serde_json::json!([4.0, 5.0, 6.0]));
+        assert_eq!(value["epoch"], serde_json::json!(10.0));
+    }
+}

--- a/crates/astrodyn_quantities/src/lib.rs
+++ b/crates/astrodyn_quantities/src/lib.rs
@@ -169,6 +169,7 @@ mod sealed;
 pub mod aliases;
 pub mod body_attitude;
 pub mod body_constants;
+pub mod cartesian_state;
 pub mod diagnostics;
 pub mod dims;
 pub mod ext;
@@ -187,6 +188,7 @@ pub mod time_scale;
 
 pub use aliases::*;
 pub use body_attitude::BodyAttitude;
+pub use cartesian_state::CartesianState;
 pub use dims::*;
 pub use frame::*;
 pub use frame_transform::*;

--- a/crates/astrodyn_quantities/src/prelude.rs
+++ b/crates/astrodyn_quantities/src/prelude.rs
@@ -4,6 +4,7 @@
 
 pub use crate::aliases::*;
 pub use crate::body_attitude::BodyAttitude;
+pub use crate::cartesian_state::CartesianState;
 pub use crate::dims::{GravParam, MassFlowRate, SpecificAngMom, SpecificEnergy};
 pub use crate::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use crate::frame::{

--- a/crates/astrodyn_quantities/src/qty3.rs
+++ b/crates/astrodyn_quantities/src/qty3.rs
@@ -152,3 +152,25 @@ impl<D: ?Sized + Dimension, F: Frame> Default for Qty3<D, F> {
         Self::zero()
     }
 }
+
+// `serde` support is hand-written (not derived) for the same reason the other
+// trait impls above are: the `D`/`F` type parameters are phantom and must not
+// leak into the serialized form or generate spurious `D: Serialize` bounds. A
+// `Qty3` round-trips as its raw-SI `[x, y, z]` triple — the dimension and frame
+// are carried by the static type at the deserialization site, so they need no
+// runtime encoding.
+#[cfg(feature = "serde")]
+impl<D: ?Sized + Dimension, F: Frame> serde::Serialize for Qty3<D, F> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let v = self.raw_si();
+        [v.x, v.y, v.z].serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, D: ?Sized + Dimension, F: Frame> serde::Deserialize<'de> for Qty3<D, F> {
+    fn deserialize<De: serde::Deserializer<'de>>(deserializer: De) -> Result<Self, De::Error> {
+        let [x, y, z] = <[f64; 3]>::deserialize(deserializer)?;
+        Ok(Self::from_raw_si(DVec3::new(x, y, z)))
+    }
+}

--- a/crates/astrodyn_quantities/src/time_scale.rs
+++ b/crates/astrodyn_quantities/src/time_scale.rs
@@ -105,6 +105,26 @@ impl<S: TimeScale> SecondsSince<S> {
     }
 }
 
+// Hand-written serde (gated): a `SecondsSince<S>` round-trips as its raw SI
+// seconds (an `f64`); the time-scale `S` is carried by the static type, not
+// the serialized form, so it generates no spurious `S: Serialize` bound.
+#[cfg(feature = "serde")]
+impl<S: TimeScale> serde::Serialize for SecondsSince<S> {
+    fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        // Read the field rather than `self.as_seconds()`: `as_seconds(self)`
+        // takes `self` by value, but `SecondsSince<S>: Copy` only holds when
+        // `S: Copy` (the derive's bound), which `TimeScale` does not require.
+        self.value.get::<second>().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, S: TimeScale> serde::Deserialize<'de> for SecondsSince<S> {
+    fn deserialize<De: serde::Deserializer<'de>>(deserializer: De) -> Result<Self, De::Error> {
+        Ok(Self::from_seconds(f64::deserialize(deserializer)?))
+    }
+}
+
 /// Explicit converter between two time scales.
 ///
 /// The converters exposed by this crate model the *constant* offsets only

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,7 @@ pub use astrodyn_quantities::aliases::{
     Acceleration, AngularAcceleration, AngularVelocity, Force, InertiaTensor, Position, Torque,
     Velocity,
 };
+pub use astrodyn_quantities::cartesian_state::CartesianState;
 pub use astrodyn_quantities::diagnostics::CompatibleVehiclePair;
 pub use astrodyn_quantities::dims::GravParam;
 pub use astrodyn_quantities::ext::{Array3Ext, F64Ext, Vec3Ext};


### PR DESCRIPTION
Part 3 of 6 for #645. **Stacked on \`645-d-presets\`** (PR-D).

Adds `CartesianState<F>` (position+velocity+epoch interchange record) and a non-default `serde` feature. Epoch is typed `SecondsSince<TDB>`, not `anise::Epoch`; default build stays serde-free.

Stack: A → D → **E** → F → B → C.