### PR TITLE
[#645] PR-F (4/6): site-anchored topocentric (ENU) frame (#6)

### DIFF
--- a/crates/astrodyn_math/src/lib.rs
+++ b/crates/astrodyn_math/src/lib.rs
@@ -86,6 +86,7 @@ pub mod quaternion;
 pub mod solar_beta;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
+pub mod topocentric;
 pub mod types;
 
 pub use astrodyn_quantities::{
@@ -107,4 +108,5 @@ pub use orbital_elements::OrbitalElements;
 pub use solar_beta::{
     compute_body_solar_beta, compute_body_solar_beta_typed, solar_beta_angle_typed,
 };
+pub use topocentric::topocentric_enu_transform;
 pub use types::*;

--- a/crates/astrodyn_math/src/topocentric.rs
+++ b/crates/astrodyn_math/src/topocentric.rs
@@ -1,0 +1,129 @@
+//! Site-anchored topocentric (East-North-Up) frame construction.
+//!
+//! Builds the rotation from a planet's body-fixed (PCPF) frame to a local
+//! East-North-Up frame anchored at a fixed geodetic site — a landing site, a
+//! ground station, a DEM tile origin. The result is a typed
+//! [`FrameTransform<PlanetFixed<P>, Topocentric<P>>`] that composes directly
+//! with the inertial→body-fixed rotation from the ephemeris.
+//!
+//! Convention follows JEOD's `NorthEastDown::build_ned_orientation()`
+//! (`models/utils/planet_fixed/north_east_down/src/north_east_down.cc`), with
+//! the rows permuted/sign-flipped from North-East-Down to East-North-Up:
+//!
+//! - East  = `(-sinλ,        cosλ,        0   )`
+//! - North = `(-sinφ·cosλ,  -sinφ·sinλ,   cosφ)`
+//! - Up    = `( cosφ·cosλ,   cosφ·sinλ,   sinφ)`   (= −Down)
+//!
+//! where φ is geodetic latitude and λ is geodetic longitude. These rows are the
+//! ENU basis axes expressed in PCPF, i.e. the `parent → this` rotation matrix
+//! (PCPF → ENU). `Up` is the outward geodetic ellipsoid normal, so passing a
+//! *geodetic* (not geocentric) latitude makes the local horizon agree with the
+//! reference ellipsoid the DEM is tied to.
+//!
+//! Only the site's latitude/longitude affect the ENU *orientation*; altitude
+//! and the ellipsoid shape shift the frame *origin*, which a rotation-only
+//! [`FrameTransform`] does not carry. The builder accepts a full
+//! [`GeodeticStateTyped`] for ergonomics (callers already have one) but reads
+//! only its latitude and longitude — the `altitude` field is ignored.
+
+use astrodyn_quantities::frame::{Planet, PlanetFixed, Topocentric};
+use astrodyn_quantities::frame_transform::FrameTransform;
+use glam::{DMat3, DVec3};
+use uom::si::angle::radian;
+
+use crate::geodetic::GeodeticStateTyped;
+
+/// Rotation from planet `P`'s body-fixed (PCPF) frame to the East-North-Up
+/// frame anchored at geodetic site `site`.
+///
+/// Apply it to a `Position`/`Velocity`/`Acceleration` in `PlanetFixed<P>` to
+/// get the same quantity in the site-local ENU frame; compose with the
+/// ephemeris `FrameTransform<RootInertial, PlanetFixed<P>>` for an inertial→ENU
+/// chain. The returned transform depends only on the site's geodetic
+/// latitude/longitude (see the module docs).
+pub fn topocentric_enu_transform<P: Planet>(
+    site: &GeodeticStateTyped,
+) -> FrameTransform<PlanetFixed<P>, Topocentric<P>> {
+    let (sinlat, coslat) = site.latitude.get::<radian>().sin_cos();
+    let (sinlon, coslon) = site.longitude.get::<radian>().sin_cos();
+
+    // ENU basis axes expressed in PCPF coordinates (the rows of the PCPF→ENU
+    // rotation). `from_cols(...).transpose()` lays these vectors in as rows.
+    let east = DVec3::new(-sinlon, coslon, 0.0);
+    let north = DVec3::new(-sinlat * coslon, -sinlat * sinlon, coslat);
+    let up = DVec3::new(coslat * coslon, coslat * sinlon, sinlat);
+    let pcpf_to_enu = DMat3::from_cols(east, north, up).transpose();
+
+    FrameTransform::from_matrix(pcpf_to_enu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrodyn_quantities::frame::Earth;
+    use astrodyn_quantities::prelude::{PlanetFixed, Vec3Ext};
+    use uom::si::angle::degree;
+    use uom::si::f64::{Angle, Length};
+    use uom::si::length::meter;
+
+    fn site(lat_deg: f64, lon_deg: f64) -> GeodeticStateTyped {
+        GeodeticStateTyped {
+            latitude: Angle::new::<degree>(lat_deg),
+            longitude: Angle::new::<degree>(lon_deg),
+            altitude: Length::new::<meter>(0.0),
+        }
+    }
+
+    // At the sub-(0°,0°) site on the prime meridian/equator, PCPF axes map to
+    // ENU as: PCPF +X (out through 0°,0°) → Up, PCPF +Y (90°E) → East,
+    // PCPF +Z (north pole) → North.
+    #[test]
+    fn enu_at_lat0_lon0_matches_known_axes() {
+        let t = topocentric_enu_transform::<Earth>(&site(0.0, 0.0));
+        let x = t.apply(DVec3::X.m_at::<PlanetFixed<Earth>>()).raw_si();
+        let y = t.apply(DVec3::Y.m_at::<PlanetFixed<Earth>>()).raw_si();
+        let z = t.apply(DVec3::Z.m_at::<PlanetFixed<Earth>>()).raw_si();
+        // x (PCPF) → Up = +Z_enu; y → East = +X_enu; z → North = +Y_enu.
+        assert!(
+            (x - DVec3::Z).length() < 1e-12,
+            "PCPF X should map to ENU Up, got {x:?}"
+        );
+        assert!(
+            (y - DVec3::X).length() < 1e-12,
+            "PCPF Y should map to ENU East, got {y:?}"
+        );
+        assert!(
+            (z - DVec3::Y).length() < 1e-12,
+            "PCPF Z should map to ENU North, got {z:?}"
+        );
+    }
+
+    // Round-trip a non-trivial PCPF vector through the transform and its
+    // inverse at an off-axis site (not equator, not pole).
+    #[test]
+    fn enu_round_trips_through_inverse() {
+        let t = topocentric_enu_transform::<Earth>(&site(34.5, -118.25));
+        let v = DVec3::new(1_234.5, -6_789.0, 4_242.0);
+        let there = t.apply(v.m_at::<PlanetFixed<Earth>>());
+        let back = t.inverse().apply(there).raw_si();
+        assert!(
+            (back - v).length() < 1e-9,
+            "round trip drifted: {back:?} vs {v:?}"
+        );
+    }
+
+    // The North pole's geodetic Up must be PCPF +Z, and at a non-zero longitude
+    // there the East/North still form a right-handed triad with Up (det = +1 is
+    // already enforced by FrameTransform::from_matrix; this pins the Up axis).
+    #[test]
+    fn enu_up_axis_is_geodetic_normal() {
+        let t = topocentric_enu_transform::<Earth>(&site(90.0, 45.0));
+        // Up is the third row of the PCPF→ENU matrix; apply to the pole normal.
+        let up_image = t.apply(DVec3::Z.m_at::<PlanetFixed<Earth>>()).raw_si();
+        // At the pole, PCPF +Z is the geodetic normal → maps to ENU Up (+Z_enu).
+        assert!(
+            (up_image - DVec3::Z).length() < 1e-12,
+            "pole normal should map to ENU Up, got {up_image:?}"
+        );
+    }
+}

--- a/crates/astrodyn_quantities/src/frame.rs
+++ b/crates/astrodyn_quantities/src/frame.rs
@@ -299,6 +299,28 @@ impl<P: Planet> Frame for PlanetFixed<P> {
     const NAME: &'static str = "PlanetFixed";
 }
 
+/// Site-anchored topocentric (ENU) frame on planet `P`.
+///
+/// East-North-Up axes anchored at a fixed geodetic site (lat/lon/alt) on `P`:
+/// X = East, Y = North, Z = local geodetic Up (outward ellipsoid normal). Unlike
+/// [`Ned<Chief>`] — which is parameterized by a *vehicle* and tracks that
+/// vehicle's sub-point — this frame is pinned to a fixed surface location (a
+/// landing site, a ground station), so it does not require a dummy vehicle.
+///
+/// The anchor itself is runtime data carried by the
+/// `FrameTransform<PlanetFixed<P>, Topocentric<P>>` a builder returns (see
+/// `astrodyn_math::topocentric`); the zero-sized marker only labels the frame
+/// identity, exactly like [`PlanetFixed<P>`]/[`Lvlh`]/[`Ned`].
+#[derive(Debug)]
+pub struct Topocentric<P: Planet>(PhantomData<P>);
+// Phantom-only generic — hand-rolled Clone/Copy, same rationale as `PlanetFixed`.
+impl_clone_phantom!([P: Planet] Topocentric[P]);
+impl_copy_phantom!([P: Planet] Topocentric[P]);
+impl<P: Planet> FrameSealed for Topocentric<P> {}
+impl<P: Planet> Frame for Topocentric<P> {
+    const NAME: &'static str = "Topocentric";
+}
+
 /// Body (CoM-centered) frame of vehicle `V`. Rotates with the vehicle.
 #[derive(Debug, Clone, Copy)]
 pub struct BodyFrame<V: Vehicle>(PhantomData<V>);

--- a/crates/astrodyn_quantities/src/prelude.rs
+++ b/crates/astrodyn_quantities/src/prelude.rs
@@ -10,7 +10,7 @@ pub use crate::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use crate::frame::{
     BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Jupiter, Lvlh, Mars, MassNode, Moon, Ned,
     Planet, PlanetFixed, PlanetInertial, RootInertial, Saturn, SelfPlanet, SelfRef,
-    StructuralFrame, Sun, Vehicle,
+    StructuralFrame, Sun, Topocentric, Vehicle,
 };
 pub use crate::frame_transform::FrameTransform;
 pub use crate::integ_origin::IntegOrigin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ pub use astrodyn_quantities::ext::{Array3Ext, F64Ext, Vec3Ext};
 pub use astrodyn_quantities::frame::{
     BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Jupiter, Lvlh, Mars, MassNode, Moon, Ned,
     Planet, PlanetFixed, PlanetInertial, RootInertial, Saturn, SelfPlanet, SelfRef,
-    StructuralFrame, Sun, Vehicle,
+    StructuralFrame, Sun, Topocentric, Vehicle,
 };
 pub use astrodyn_quantities::integ_origin::IntegOrigin;
 // Macros that mint downstream `Vehicle`/`Planet` markers. Re-exported so
@@ -388,6 +388,15 @@ pub use astrodyn_math::JeodQuat;
 
 // astrodyn_math: derived state types
 pub use astrodyn_math::{EulerSequence, GeodeticState, LvlhFrame, OrbitalElements, OrbitalError};
+// Geodetic conversions + site-anchored topocentric (ENU) frame builder, so a
+// consumer can build a site anchor and a local-horizon frame entirely through
+// the facade (e.g. a landing-site camera over DEM terrain). The ENU builder
+// returns `FrameTransform<PlanetFixed<P>, Topocentric<P>>`, which composes with
+// the ephemeris `FrameTransform<RootInertial, PlanetFixed<P>>`.
+pub use astrodyn_math::{
+    cartesian_to_geodetic_typed, geodetic_to_cartesian_typed, topocentric_enu_transform,
+    GeodeticStateTyped,
+};
 
 // astrodyn_math::euler_angles: typed-quantity Euler-angle helpers
 // paired with the already-exposed `EulerSequence`.


### PR DESCRIPTION
Part 4 of 6 for #645. **Stacked on \`645-e-cartesian-serde\`** (PR-E).

Adds sealed `Topocentric<P>` frame + `topocentric_enu_transform` (ENU convention ported from JEOD `north_east_down.cc`) for a fixed-site local-horizon frame.

Stack: A → D → E → **F** → B → C.