### PR TITLE
[#654] CI: add --noplot to perf-microbench-smoke to stop criterion plot flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,12 @@ jobs:
         # those flaky. The job catches "I broke the bench harness"
         # regressions cheaply.
         #
+        # `--noplot` disables criterion's HTML/plot report generation.
+        # The smoke job only needs build/run/exit-0, and the plot renderer
+        # (plotters PDF/KDE) panics on certain degenerate sample
+        # distributions that --quick's ~10 samples can produce — a flake
+        # unrelated to the code under test. See #654.
+        #
         # `--workspace -- --quick` doesn't work because cargo also
         # invokes the default cargo-test bench harness on every lib /
         # bin target, and those reject criterion's `--quick` flag. We
@@ -350,7 +356,7 @@ jobs:
         run: |
           cargo bench -p astrodyn_gravity --bench accumulate \
                       -p astrodyn_gravity --bench integration \
-                      -p astrodyn_verif_jeod --bench step -- --quick
+                      -p astrodyn_verif_jeod --bench step -- --quick --noplot
 
   perf-baseline-track:
     name: Perf baseline (main-only)


### PR DESCRIPTION
Fixes #654.

The `Perf microbench smoke` job intermittently panics inside criterion's plot/HTML report generation:

```
error: bench failed, to rerun pass `-p astrodyn_verif_jeod --bench step`
  3: <criterion::plot::plotters_backend::PlottersBackend as criterion::plot::Plotter>::pdf
  4: <criterion::html::Html as criterion::report::Report>::measurement_complete
```

The bench *measures* fine; it panics afterward rendering the KDE/PDF plot. With `--quick` (~10 samples) certain degenerate sample distributions (near-zero spread → zero KDE bandwidth, or an outlier) trip the plotter. It's data-dependent on the runner's timings, not a code defect — the identical bench passed on a sibling PR in the same stack.

The job asserts only build/run/exit-0 (no timing thresholds), so plot rendering is pure liability. This adds criterion's `--noplot` flag (verified present in criterion 0.5) to skip report/plot generation. One-line change; the main-only `Perf baseline` track is separate and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)