### PR TITLE
[#660] PR-1: frame identity vocabulary + `Frame::DESCRIPTOR` on the sealed trait

### DIFF
--- a/crates/astrodyn_quantities/src/frame.rs
+++ b/crates/astrodyn_quantities/src/frame.rs
@@ -25,6 +25,9 @@
 use core::marker::PhantomData;
 
 use crate::derive_utils::{impl_clone_phantom, impl_copy_phantom};
+use crate::frame_descriptor::{
+    mint_for_param, FrameClass, FrameDescriptorStatic, FrameRoleStatic, MintPolicy,
+};
 use crate::sealed::{FrameSealed, PlanetSealed, VehicleSealed};
 
 /// Compile-time reference frame tag.
@@ -52,6 +55,14 @@ use crate::sealed::{FrameSealed, PlanetSealed, VehicleSealed};
 pub trait Frame: FrameSealed + 'static {
     /// Human-readable name for error messages and debug output.
     const NAME: &'static str;
+
+    /// Runtime identity descriptor for this frame kind: class, role,
+    /// instance tag, and mint policy. Lowered to an owned
+    /// [`FrameUid`](crate::frame_descriptor::FrameUid) via
+    /// [`FrameUid::of`](crate::frame_descriptor::FrameUid::of). For
+    /// parameterized frames the tag and mint policy are composed from the
+    /// `Planet`/`Vehicle` tag's `NAME` and `IS_WILDCARD` consts.
+    const DESCRIPTOR: FrameDescriptorStatic;
 }
 
 /// Compile-time planet tag used to parameterize planet-fixed frames.
@@ -70,6 +81,14 @@ pub trait Frame: FrameSealed + 'static {
 pub trait Planet: PlanetSealed + Send + Sync + 'static {
     /// Human-readable name for error messages and debug output.
     const NAME: &'static str;
+
+    /// `true` iff this tag is a runtime-resolved storage-boundary wildcard
+    /// (`SelfPlanet`) rather than a concrete planet. Defaulted `false` so
+    /// `define_planet!` call sites and the built-in markers need no change;
+    /// only the wildcard overrides it. Drives the
+    /// [`MintPolicy`](crate::frame_descriptor::MintPolicy) of frames
+    /// parameterized by this tag.
+    const IS_WILDCARD: bool = false;
 }
 
 /// Compile-time vehicle tag used to parameterize vehicle-relative frames.
@@ -91,6 +110,14 @@ pub trait Planet: PlanetSealed + Send + Sync + 'static {
 pub trait Vehicle: VehicleSealed + Send + Sync + 'static {
     /// Human-readable name for error messages and debug output.
     const NAME: &'static str;
+
+    /// `true` iff this tag is a runtime-resolved storage-boundary wildcard
+    /// (`SelfRef`) rather than a concrete vehicle. Defaulted `false` so
+    /// `define_vehicle!` call sites, the built-in markers, and `TestVehicle`
+    /// need no change; only the wildcard overrides it. Drives the
+    /// [`MintPolicy`](crate::frame_descriptor::MintPolicy) of frames
+    /// parameterized by this tag.
+    const IS_WILDCARD: bool = false;
 }
 
 // --- Planet markers -----------------------------------------------------------
@@ -134,6 +161,9 @@ pub struct SelfPlanet;
 impl PlanetSealed for SelfPlanet {}
 impl Planet for SelfPlanet {
     const NAME: &'static str = "SelfPlanet";
+    // JEOD_INV: TS.01 — the wildcard flag marks frames parameterized by this
+    // tag as unmintable runtime identities (FrameUid::of refuses them).
+    const IS_WILDCARD: bool = true;
 }
 
 // --- Frame markers ------------------------------------------------------------
@@ -161,6 +191,12 @@ pub struct RootInertial;
 impl FrameSealed for RootInertial {}
 impl Frame for RootInertial {
     const NAME: &'static str = "RootInertial";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::RootInertial,
+        role: FrameRoleStatic::Primary,
+        tag: None,
+        mint: MintPolicy::Stable,
+    };
 }
 
 /// A particular planet's inertial (non-rotating, J2000-aligned) frame,
@@ -191,6 +227,12 @@ pub struct PlanetInertial<P: Planet>(PhantomData<P>);
 impl<P: Planet> FrameSealed for PlanetInertial<P> {}
 impl<P: Planet> Frame for PlanetInertial<P> {
     const NAME: &'static str = "PlanetInertial";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::PlanetInertial,
+        role: FrameRoleStatic::Primary,
+        tag: Some(P::NAME),
+        mint: mint_for_param(P::IS_WILDCARD),
+    };
 }
 
 /// Earth-centered Earth-fixed frame (ITRF-like). Rotates with Earth.
@@ -199,6 +241,16 @@ pub struct Ecef;
 impl FrameSealed for Ecef {}
 impl Frame for Ecef {
     const NAME: &'static str = "Ecef";
+    // Role `AltPfix` (not `Primary`) keeps this descriptor distinct from
+    // `PlanetFixed<Earth>` — identity injectivity across the sealed set.
+    // `Ecef` is the test-only legacy ITRF-like marker; production code uses
+    // `PlanetFixed<Earth>` exclusively.
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::PlanetFixed,
+        role: FrameRoleStatic::AltPfix,
+        tag: Some("Earth"),
+        mint: MintPolicy::Stable,
+    };
 }
 
 /// A body's integration frame — a non-rotating quasi-inertial frame whose
@@ -231,6 +283,17 @@ pub struct IntegrationFrame;
 impl FrameSealed for IntegrationFrame {}
 impl Frame for IntegrationFrame {
     const NAME: &'static str = "IntegrationFrame";
+    // JEOD_INV: RF.10 — IntegrationFrame is a real, kind-distinct frame that
+    // resolves per body to RootInertial or PlanetInertial<P>; `mint:
+    // PerBodyIntegration` makes FrameUid::of refuse it and direct callers to
+    // the resolved frame. The `class` here is advisory-only (the common
+    // resolution target) and is never lowered into a FrameUid.
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::PlanetInertial,
+        role: FrameRoleStatic::Primary,
+        tag: None,
+        mint: MintPolicy::PerBodyIntegration,
+    };
 }
 
 /// Mass-tree wildcard inertial-flavor frame for kinematic-propagation
@@ -277,6 +340,16 @@ pub struct MassNode;
 impl FrameSealed for MassNode {}
 impl Frame for MassNode {
     const NAME: &'static str = "MassNode";
+    // JEOD_INV: TS.01 — MassNode is the kinematic-propagation
+    // storage-boundary wildcard; `mint: Wildcard` makes FrameUid::of refuse
+    // it. The `class` is advisory-only (MassNode carries inertial-flavor
+    // scratch state) and is never lowered into a FrameUid.
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::RootInertial,
+        role: FrameRoleStatic::Primary,
+        tag: None,
+        mint: MintPolicy::Wildcard,
+    };
 }
 
 // NOTE on `NAME`: each frame's `NAME` const identifies the *frame kind*
@@ -297,6 +370,12 @@ impl_copy_phantom!([P: Planet] PlanetFixed[P]);
 impl<P: Planet> FrameSealed for PlanetFixed<P> {}
 impl<P: Planet> Frame for PlanetFixed<P> {
     const NAME: &'static str = "PlanetFixed";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::PlanetFixed,
+        role: FrameRoleStatic::Primary,
+        tag: Some(P::NAME),
+        mint: mint_for_param(P::IS_WILDCARD),
+    };
 }
 
 /// Site-anchored topocentric (ENU) frame on planet `P`.
@@ -319,6 +398,12 @@ impl_copy_phantom!([P: Planet] Topocentric[P]);
 impl<P: Planet> FrameSealed for Topocentric<P> {}
 impl<P: Planet> Frame for Topocentric<P> {
     const NAME: &'static str = "Topocentric";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::Topocentric,
+        role: FrameRoleStatic::Primary,
+        tag: Some(P::NAME),
+        mint: mint_for_param(P::IS_WILDCARD),
+    };
 }
 
 /// Body (CoM-centered) frame of vehicle `V`. Rotates with the vehicle.
@@ -327,6 +412,12 @@ pub struct BodyFrame<V: Vehicle>(PhantomData<V>);
 impl<V: Vehicle> FrameSealed for BodyFrame<V> {}
 impl<V: Vehicle> Frame for BodyFrame<V> {
     const NAME: &'static str = "BodyFrame";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::Body,
+        role: FrameRoleStatic::CompositeBody,
+        tag: Some(V::NAME),
+        mint: mint_for_param(V::IS_WILDCARD),
+    };
 }
 
 /// Structural (geometric-origin) frame of vehicle `V`. Rotates with vehicle.
@@ -335,6 +426,12 @@ pub struct StructuralFrame<V: Vehicle>(PhantomData<V>);
 impl<V: Vehicle> FrameSealed for StructuralFrame<V> {}
 impl<V: Vehicle> Frame for StructuralFrame<V> {
     const NAME: &'static str = "StructuralFrame";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::Body,
+        role: FrameRoleStatic::Structure,
+        tag: Some(V::NAME),
+        mint: mint_for_param(V::IS_WILDCARD),
+    };
 }
 
 /// Local Vertical / Local Horizontal frame relative to chief vehicle `Chief`.
@@ -345,6 +442,12 @@ pub struct Lvlh<Chief: Vehicle>(PhantomData<Chief>);
 impl<C: Vehicle> FrameSealed for Lvlh<C> {}
 impl<C: Vehicle> Frame for Lvlh<C> {
     const NAME: &'static str = "Lvlh";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::OrbitRelative,
+        role: FrameRoleStatic::Lvlh,
+        tag: Some(C::NAME),
+        mint: mint_for_param(C::IS_WILDCARD),
+    };
 }
 
 /// North-East-Down topocentric frame relative to chief vehicle `Chief`.
@@ -353,6 +456,12 @@ pub struct Ned<Chief: Vehicle>(PhantomData<Chief>);
 impl<C: Vehicle> FrameSealed for Ned<C> {}
 impl<C: Vehicle> Frame for Ned<C> {
     const NAME: &'static str = "Ned";
+    const DESCRIPTOR: FrameDescriptorStatic = FrameDescriptorStatic {
+        class: FrameClass::OrbitRelative,
+        role: FrameRoleStatic::Ned,
+        tag: Some(C::NAME),
+        mint: mint_for_param(C::IS_WILDCARD),
+    };
 }
 
 // --- Self-referential vehicle marker ----------------------------------------
@@ -389,6 +498,9 @@ pub struct SelfRef;
 impl VehicleSealed for SelfRef {}
 impl Vehicle for SelfRef {
     const NAME: &'static str = "SelfRef";
+    // JEOD_INV: TS.01 — the wildcard flag marks frames parameterized by this
+    // tag as unmintable runtime identities (FrameUid::of refuses them).
+    const IS_WILDCARD: bool = true;
 }
 
 // --- Test-only vehicle marker ------------------------------------------------

--- a/crates/astrodyn_quantities/src/frame.rs
+++ b/crates/astrodyn_quantities/src/frame.rs
@@ -85,8 +85,7 @@ pub trait Planet: PlanetSealed + Send + Sync + 'static {
     /// `true` iff this tag is a runtime-resolved storage-boundary wildcard
     /// (`SelfPlanet`) rather than a concrete planet. Defaulted `false` so
     /// `define_planet!` call sites and the built-in markers need no change;
-    /// only the wildcard overrides it. Drives the
-    /// [`MintPolicy`](crate::frame_descriptor::MintPolicy) of frames
+    /// only the wildcard overrides it. Drives the [`MintPolicy`] of frames
     /// parameterized by this tag.
     const IS_WILDCARD: bool = false;
 }
@@ -115,8 +114,7 @@ pub trait Vehicle: VehicleSealed + Send + Sync + 'static {
     /// (`SelfRef`) rather than a concrete vehicle. Defaulted `false` so
     /// `define_vehicle!` call sites, the built-in markers, and `TestVehicle`
     /// need no change; only the wildcard overrides it. Drives the
-    /// [`MintPolicy`](crate::frame_descriptor::MintPolicy) of frames
-    /// parameterized by this tag.
+    /// [`MintPolicy`] of frames parameterized by this tag.
     const IS_WILDCARD: bool = false;
 }
 

--- a/crates/astrodyn_quantities/src/frame_descriptor.rs
+++ b/crates/astrodyn_quantities/src/frame_descriptor.rs
@@ -130,6 +130,27 @@ pub enum FrameRole {
     Custom(Box<str>),
 }
 
+impl FrameRole {
+    /// `true` iff this owned role equals the borrowed `role`
+    /// variant-for-variant (string contents compared for `Custom`).
+    /// Zero-allocation sibling of `FrameRole::from(role) == *self`.
+    pub fn matches_static(&self, role: FrameRoleStatic) -> bool {
+        match (self, role) {
+            (FrameRole::Primary, FrameRoleStatic::Primary)
+            | (FrameRole::AltInertial, FrameRoleStatic::AltInertial)
+            | (FrameRole::AltPfix, FrameRoleStatic::AltPfix)
+            | (FrameRole::CoreBody, FrameRoleStatic::CoreBody)
+            | (FrameRole::CompositeBody, FrameRoleStatic::CompositeBody)
+            | (FrameRole::Structure, FrameRoleStatic::Structure)
+            | (FrameRole::VehiclePoint, FrameRoleStatic::VehiclePoint)
+            | (FrameRole::Lvlh, FrameRoleStatic::Lvlh)
+            | (FrameRole::Ned, FrameRoleStatic::Ned) => true,
+            (FrameRole::Custom(owned), FrameRoleStatic::Custom(expected)) => &**owned == expected,
+            _ => false,
+        }
+    }
+}
+
 impl From<FrameRoleStatic> for FrameRole {
     fn from(r: FrameRoleStatic) -> Self {
         match r {
@@ -340,49 +361,63 @@ impl FrameUid {
     ///
     /// Returns `false` — never panics — when `F` is not mintable (a TS.01
     /// wildcard or `IntegrationFrame`): a non-mintable type is never equal
-    /// to any concrete identity. Groundwork for the checked typed recovery
-    /// of issue #661 (PR-2).
+    /// to any concrete identity. Zero-allocation: compares structurally
+    /// against `F::DESCRIPTOR` instead of minting a throwaway uid.
+    /// Groundwork for the checked typed recovery of issue #661 (PR-2).
     pub fn is<F: Frame>(&self) -> bool {
-        match F::DESCRIPTOR.mint {
-            MintPolicy::Stable => *self == FrameUid::of::<F>(),
-            MintPolicy::Wildcard | MintPolicy::PerBodyIntegration => false,
+        let d = F::DESCRIPTOR;
+        if !matches!(d.mint, MintPolicy::Stable) {
+            return false;
         }
+        self.namespace == Namespace::LOCAL
+            && self.class == d.class
+            && self.role.matches_static(d.role)
+            && match (&self.tag, d.tag) {
+                (Tag::Named(name), Some(expected)) => &**name == expected,
+                (Tag::None, None) => true,
+                _ => false,
+            }
     }
 }
 
 impl fmt::Display for FrameUid {
-    /// Dotted display names aligned with the existing frame-tree naming
-    /// vocabulary (`"Earth.inertial"`, `"Earth.pfix"`,
-    /// `"Iss.composite_body"`; see `src/source_frames.rs`). Non-`LOCAL`
-    /// namespaces are prefixed `nsN:`. The tag's casing is preserved
-    /// verbatim — `Display` is a faithful projection of the structured
-    /// fields, not a styler.
+    /// Dotted display names for diagnostics, aligned with the frame-tree
+    /// naming vocabulary used by the `astrodyn` orchestration layer
+    /// (`"Earth.inertial"`, `"Earth.pfix"`, `"Iss.composite_body"`).
+    ///
+    /// The suffix is derived from the **role** — verbatim for every
+    /// non-`Primary` role (`Custom` roles print their own string) — with
+    /// `Primary` falling back to a class-conventional suffix. The tag's
+    /// casing is preserved, and non-`LOCAL` namespaces are prefixed `nsN:`.
+    /// Display strings are for humans; identity comparison always uses the
+    /// structured fields, never this rendering.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.namespace != Namespace::LOCAL {
             write!(f, "ns{}:", self.namespace.0)?;
         }
-        // Custom roles name their own suffix verbatim.
-        if let FrameRole::Custom(role) = &self.role {
-            return match &self.tag {
-                Tag::Named(name) => write!(f, "{name}.{role}"),
-                Tag::None => write!(f, "{role}"),
-            };
-        }
-        let suffix = match (self.class, &self.role) {
-            (FrameClass::PlanetFixed, FrameRole::AltPfix) => "pfix.alt",
-            (FrameClass::PlanetFixed, _) => "pfix",
-            (
+        // Role-first: every distinct role keeps a distinct suffix, so a
+        // rendered uid never misstates its role (FrameUid::external can
+        // construct any class/role combination).
+        let suffix: &str = match &self.role {
+            FrameRole::Custom(role) => role,
+            FrameRole::AltInertial => "inertial.alt",
+            FrameRole::AltPfix => "pfix.alt",
+            FrameRole::CoreBody => "core_body",
+            FrameRole::CompositeBody => "composite_body",
+            FrameRole::Structure => "structural",
+            FrameRole::VehiclePoint => "point",
+            FrameRole::Lvlh => "lvlh",
+            FrameRole::Ned => "ned",
+            FrameRole::Primary => match self.class {
                 FrameClass::RootInertial
                 | FrameClass::PlanetInertial
-                | FrameClass::BarycenterInertial,
-                _,
-            ) => "inertial",
-            (FrameClass::Topocentric, _) => "topo",
-            (FrameClass::Body, FrameRole::Structure) => "structural",
-            (FrameClass::Body, _) => "composite_body",
-            (FrameClass::OrbitRelative, FrameRole::Ned) => "ned",
-            (FrameClass::OrbitRelative, _) => "lvlh",
-            (FrameClass::External, _) => "external",
+                | FrameClass::BarycenterInertial => "inertial",
+                FrameClass::PlanetFixed => "pfix",
+                FrameClass::Topocentric => "topo",
+                FrameClass::Body => "body",
+                FrameClass::OrbitRelative => "orbit_relative",
+                FrameClass::External => "external",
+            },
         };
         match &self.tag {
             Tag::Named(name) => write!(f, "{name}.{suffix}"),

--- a/crates/astrodyn_quantities/src/frame_descriptor.rs
+++ b/crates/astrodyn_quantities/src/frame_descriptor.rs
@@ -1,0 +1,431 @@
+//! Runtime frame-identity vocabulary derived from the compile-time
+//! [`Frame`] tags.
+//!
+//! [`Frame::DESCRIPTOR`] lifts each sealed frame phantom to a `'static`
+//! [`FrameDescriptorStatic`]; [`FrameUid::of`] mints the owned, comparable,
+//! hashable identity value the runtime frame layer (issue #659) builds on.
+//! This module is purely additive vocabulary — it changes no physics and no
+//! existing `RefFrameKind` behavior.
+//!
+//! ## Identity model
+//!
+//! A [`FrameUid`] is a *value-level* frame identity: `(namespace, class,
+//! role, tag)`. Identities in [`Namespace::LOCAL`] are exclusively
+//! type-derived — [`FrameUid::of`] is the only mint for `LOCAL`, and
+//! [`FrameUid::external`] refuses it — so a `LOCAL` identity always traces
+//! to exactly one concrete sealed frame type. That reservation is what makes
+//! identity comparison against [`FrameUid::of`] a sound check: no
+//! externally-supplied identity can impersonate a type-derived one.
+//!
+//! ## Mint policy
+//!
+//! Not every frame *type* names one physical frame, so each descriptor
+//! carries a [`MintPolicy`] telling [`FrameUid::of`] what to do:
+//!
+//! - [`MintPolicy::Stable`] — the type pins down one physical frame; mint it.
+//! - [`MintPolicy::Wildcard`] — the type is a runtime-resolved
+//!   storage-boundary wildcard (a frame parameterized by the `SelfRef` /
+//!   `SelfPlanet` tags, or `MassNode`); minting would alias distinct
+//!   physical frames under one identity, so `of` fails loudly instead.
+//! - [`MintPolicy::PerBodyIntegration`] — `IntegrationFrame` only: a real,
+//!   kind-distinct frame (RF.10) that resolves per body; publish the
+//!   resolved frame's identity instead.
+//!
+//! JEOD_INV: TS.01 — the mint policy refuses to mint a `FrameUid` for the
+//! runtime-resolved-boundary wildcards SelfRef / SelfPlanet / MassNode; see
+//! `docs/JEOD_invariants.md` row TS.01 and the lint at
+//! `tests/self_ref_self_planet_discipline.rs`.
+
+use core::fmt;
+
+use crate::frame::Frame;
+
+/// Coarse runtime taxonomy of frame *kinds*.
+///
+/// `#[non_exhaustive]` so a later PR can add a kind (e.g. switch frames)
+/// without breaking downstream `match` arms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum FrameClass {
+    /// The simulation's root inertial node.
+    RootInertial,
+    /// A planet's inertial (non-rotating, J2000-aligned) frame.
+    PlanetInertial,
+    /// A barycenter's inertial frame (reserved; no sealed impl yet).
+    BarycenterInertial,
+    /// A planet-fixed (co-rotating) frame.
+    PlanetFixed,
+    /// A site-anchored topocentric (ENU) frame.
+    Topocentric,
+    /// A vehicle body or structural frame.
+    Body,
+    /// An orbit-relative derived frame (LVLH, NED).
+    OrbitRelative,
+    /// An externally-supplied frame not derived from a sealed tag.
+    External,
+}
+
+/// Orthogonal *role* within a [`FrameClass`] — borrowed (`'static`) form
+/// used by const descriptors.
+///
+/// Owned sibling: [`FrameRole`] (see the `From` bridge). The split exists
+/// because a `const DESCRIPTOR` must be `Copy`/`'static` while [`FrameUid`]
+/// needs owned strings for hashing and (de)serialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FrameRoleStatic {
+    /// The canonical/primary frame of its class.
+    Primary,
+    /// Alternate inertial labeling (JEOD `alt_inertial`; reserved).
+    AltInertial,
+    /// Alternate planet-fixed labeling (JEOD `alt_pfix`). Also carried by
+    /// the legacy `Ecef` marker so its descriptor stays distinct from
+    /// `PlanetFixed<Earth>` (identity injectivity).
+    AltPfix,
+    /// Core (point-mass CoM) body node (JEOD `core_body`; reserved).
+    CoreBody,
+    /// Composite (CoM) body frame — the integrated frame (JEOD
+    /// `composite_body`).
+    CompositeBody,
+    /// Structural (geometric-origin) body frame (JEOD `structure`).
+    Structure,
+    /// A discrete point on a vehicle (JEOD vehicle point; reserved).
+    VehiclePoint,
+    /// Local-vertical / local-horizontal orbit-relative role.
+    Lvlh,
+    /// North-east-down orbit-relative role.
+    Ned,
+    /// Caller-named role, borrowed for `'static` descriptors.
+    Custom(&'static str),
+}
+
+/// Orthogonal *role* within a [`FrameClass`] — owned form carried by
+/// [`FrameUid`].
+///
+/// Borrowed sibling: [`FrameRoleStatic`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum FrameRole {
+    /// See [`FrameRoleStatic::Primary`].
+    Primary,
+    /// See [`FrameRoleStatic::AltInertial`].
+    AltInertial,
+    /// See [`FrameRoleStatic::AltPfix`].
+    AltPfix,
+    /// See [`FrameRoleStatic::CoreBody`].
+    CoreBody,
+    /// See [`FrameRoleStatic::CompositeBody`].
+    CompositeBody,
+    /// See [`FrameRoleStatic::Structure`].
+    Structure,
+    /// See [`FrameRoleStatic::VehiclePoint`].
+    VehiclePoint,
+    /// See [`FrameRoleStatic::Lvlh`].
+    Lvlh,
+    /// See [`FrameRoleStatic::Ned`].
+    Ned,
+    /// Caller-named role, owned.
+    Custom(Box<str>),
+}
+
+impl From<FrameRoleStatic> for FrameRole {
+    fn from(r: FrameRoleStatic) -> Self {
+        match r {
+            FrameRoleStatic::Primary => FrameRole::Primary,
+            FrameRoleStatic::AltInertial => FrameRole::AltInertial,
+            FrameRoleStatic::AltPfix => FrameRole::AltPfix,
+            FrameRoleStatic::CoreBody => FrameRole::CoreBody,
+            FrameRoleStatic::CompositeBody => FrameRole::CompositeBody,
+            FrameRoleStatic::Structure => FrameRole::Structure,
+            FrameRoleStatic::VehiclePoint => FrameRole::VehiclePoint,
+            FrameRoleStatic::Lvlh => FrameRole::Lvlh,
+            FrameRoleStatic::Ned => FrameRole::Ned,
+            FrameRoleStatic::Custom(s) => FrameRole::Custom(s.into()),
+        }
+    }
+}
+
+/// Identity-space discriminator for [`FrameUid`]s.
+///
+/// [`Namespace::LOCAL`] (0) is **reserved for type-derived identities**
+/// ([`FrameUid::of`]); externally-supplied frames take a non-`LOCAL`
+/// namespace allocated by the composing host, so independently-produced
+/// identities can never silently alias or impersonate a type-derived one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Namespace(pub u16);
+
+impl Namespace {
+    /// Reserved namespace for type-derived identities ([`FrameUid::of`]).
+    pub const LOCAL: Namespace = Namespace(0);
+}
+
+/// Optional per-instance disambiguator: the planet/vehicle name for
+/// parameterized frames, or a producer-chosen key for external frames.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Tag {
+    /// No instance tag (singleton frames such as the root inertial node).
+    None,
+    /// A named instance (e.g. `"Earth"`, `"Iss"`, `"site:KSC-LC39A"`).
+    Named(Box<str>),
+}
+
+/// Three-way mint behavior of a frame descriptor.
+///
+/// A boolean cannot express the `IntegrationFrame` case distinctly from the
+/// TS.01 wildcards — the two refusals need different diagnostics and
+/// different fixes. See the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MintPolicy {
+    /// The type pins down exactly one physical frame; [`FrameUid::of`]
+    /// mints its identity.
+    Stable,
+    /// A runtime-resolved storage-boundary wildcard; [`FrameUid::of`]
+    /// refuses (JEOD_INV TS.01).
+    Wildcard,
+    /// `IntegrationFrame`: resolves per body to `RootInertial` or
+    /// `PlanetInertial<P>` (RF.10); [`FrameUid::of`] refuses and directs
+    /// the caller to mint the resolved frame's identity.
+    PerBodyIntegration,
+}
+
+/// The `'static` runtime descriptor attached to every sealed [`Frame`] impl
+/// via [`Frame::DESCRIPTOR`].
+///
+/// For parameterized frames the `tag` is composed from the existing
+/// `Planet::NAME` / `Vehicle::NAME` consts and the `mint` from the tag's
+/// `IS_WILDCARD` flag, so `define_planet!` / `define_vehicle!` call sites
+/// need no changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FrameDescriptorStatic {
+    /// Frame taxonomy.
+    pub class: FrameClass,
+    /// Orthogonal role within the class.
+    pub role: FrameRoleStatic,
+    /// Static instance tag (`Some(P::NAME)` / `Some(V::NAME)`), or `None`
+    /// for unparameterized frames.
+    pub tag: Option<&'static str>,
+    /// Mint behavior — what [`FrameUid::of`] does for this type.
+    pub mint: MintPolicy,
+}
+
+impl FrameDescriptorStatic {
+    /// `true` iff this descriptor belongs to a runtime-resolved
+    /// storage-boundary wildcard (the TS.01 set). Provided so test and lint
+    /// vocabulary stay aligned with the `is_wildcard` language used by the
+    /// invariant catalog and issue #659.
+    pub const fn is_wildcard(&self) -> bool {
+        matches!(self.mint, MintPolicy::Wildcard)
+    }
+}
+
+/// Maps a parameter tag's wildcard flag to the frame's [`MintPolicy`].
+///
+/// Used in the generic `impl Frame for …` blocks to compute `DESCRIPTOR`
+/// from `P::IS_WILDCARD` / `V::IS_WILDCARD` at compile time.
+pub const fn mint_for_param(is_wildcard: bool) -> MintPolicy {
+    if is_wildcard {
+        MintPolicy::Wildcard
+    } else {
+        MintPolicy::Stable
+    }
+}
+
+/// Owned, comparable, hashable runtime frame identity.
+///
+/// Obtained from a compile-time frame type via [`FrameUid::of`] (always in
+/// [`Namespace::LOCAL`]) or supplied by an external producer via
+/// [`FrameUid::external`] (never `LOCAL`). Equality and hashing are
+/// structural over all four fields, which is sound because the `LOCAL`
+/// reservation guarantees type-derived and externally-supplied identities
+/// live in disjoint namespaces.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FrameUid {
+    /// Identity-space discriminator ([`Namespace::LOCAL`] iff type-derived).
+    pub namespace: Namespace,
+    /// Frame taxonomy.
+    pub class: FrameClass,
+    /// Orthogonal role within the class.
+    pub role: FrameRole,
+    /// Optional instance tag.
+    pub tag: Tag,
+}
+
+impl FrameUid {
+    /// Mint the runtime identity of the concrete frame type `F`.
+    ///
+    /// Total for [`MintPolicy::Stable`] frames. Fails loudly otherwise:
+    ///
+    /// # Panics
+    ///
+    /// - `F` is a TS.01 storage-boundary wildcard (a frame parameterized by
+    ///   the self-referential tags, or the mass-tree scratch tag): the type
+    ///   does not name one physical frame, so no identity exists to mint.
+    /// - `F` is `IntegrationFrame` (RF.10): the physical frame resolves per
+    ///   body; mint the resolved frame's identity instead.
+    pub fn of<F: Frame>() -> FrameUid {
+        let d = F::DESCRIPTOR;
+        match d.mint {
+            MintPolicy::Stable => FrameUid {
+                namespace: Namespace::LOCAL,
+                class: d.class,
+                role: d.role.into(),
+                tag: match d.tag {
+                    Some(name) => Tag::Named(name.into()),
+                    None => Tag::None,
+                },
+            },
+            // JEOD_INV: TS.01 — refuses to mint identities for the
+            // runtime-resolved storage-boundary wildcard frames.
+            MintPolicy::Wildcard => panic!(
+                "JEOD_INV TS.01: cannot mint a FrameUid for `{}` (class {:?}): it is a \
+                 runtime-resolved storage-boundary wildcard with no concrete identity. \
+                 Resolve the entity's real vehicle / planet / per-node frame at the \
+                 storage boundary and call `FrameUid::of` on that concrete frame type \
+                 instead.",
+                F::NAME,
+                d.class
+            ),
+            // JEOD_INV: RF.10 — IntegrationFrame is kind-distinct and
+            // resolves per body; its identity is the resolved frame's.
+            MintPolicy::PerBodyIntegration => panic!(
+                "RF.10: cannot mint a FrameUid for `IntegrationFrame`: it resolves per \
+                 body to `RootInertial` or `PlanetInertial<P>`. Publish the resolved \
+                 frame's identity — mint `FrameUid::of::<RootInertial>()` or \
+                 `FrameUid::of::<PlanetInertial<P>>()` for the body's actual \
+                 integration frame instead."
+            ),
+        }
+    }
+
+    /// Construct an externally-supplied identity (a producer-defined frame
+    /// outside the sealed compile-time set).
+    ///
+    /// # Panics
+    ///
+    /// Panics if handed [`Namespace::LOCAL`], which is reserved for
+    /// type-derived identities: allowing external mints in `LOCAL` would
+    /// let a producer-supplied frame impersonate a type-derived one and
+    /// silently pass identity checks.
+    pub fn external(ns: Namespace, class: FrameClass, role: FrameRole, tag: Tag) -> FrameUid {
+        assert!(
+            ns != Namespace::LOCAL,
+            "FrameUid::external was handed Namespace::LOCAL, which is reserved for \
+             type-derived identity (FrameUid::of). Pass a non-zero namespace allocated \
+             for this producer, or use FrameUid::of::<F>() if the identity comes from \
+             a sealed Frame type."
+        );
+        FrameUid {
+            namespace: ns,
+            class,
+            role,
+            tag,
+        }
+    }
+
+    /// Relabel this identity into another namespace (e.g. re-stamping an
+    /// imported tree's identities into the import namespace).
+    #[must_use]
+    pub fn with_namespace(mut self, ns: Namespace) -> FrameUid {
+        self.namespace = ns;
+        self
+    }
+
+    /// Non-panicking predicate: does this uid equal the identity `F` would
+    /// mint?
+    ///
+    /// Returns `false` — never panics — when `F` is not mintable (a TS.01
+    /// wildcard or `IntegrationFrame`): a non-mintable type is never equal
+    /// to any concrete identity. Groundwork for the checked typed recovery
+    /// of issue #661 (PR-2).
+    pub fn is<F: Frame>(&self) -> bool {
+        match F::DESCRIPTOR.mint {
+            MintPolicy::Stable => *self == FrameUid::of::<F>(),
+            MintPolicy::Wildcard | MintPolicy::PerBodyIntegration => false,
+        }
+    }
+}
+
+impl fmt::Display for FrameUid {
+    /// Dotted display names aligned with the existing frame-tree naming
+    /// vocabulary (`"Earth.inertial"`, `"Earth.pfix"`,
+    /// `"Iss.composite_body"`; see `src/source_frames.rs`). Non-`LOCAL`
+    /// namespaces are prefixed `nsN:`. The tag's casing is preserved
+    /// verbatim — `Display` is a faithful projection of the structured
+    /// fields, not a styler.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.namespace != Namespace::LOCAL {
+            write!(f, "ns{}:", self.namespace.0)?;
+        }
+        // Custom roles name their own suffix verbatim.
+        if let FrameRole::Custom(role) = &self.role {
+            return match &self.tag {
+                Tag::Named(name) => write!(f, "{name}.{role}"),
+                Tag::None => write!(f, "{role}"),
+            };
+        }
+        let suffix = match (self.class, &self.role) {
+            (FrameClass::PlanetFixed, FrameRole::AltPfix) => "pfix.alt",
+            (FrameClass::PlanetFixed, _) => "pfix",
+            (
+                FrameClass::RootInertial
+                | FrameClass::PlanetInertial
+                | FrameClass::BarycenterInertial,
+                _,
+            ) => "inertial",
+            (FrameClass::Topocentric, _) => "topo",
+            (FrameClass::Body, FrameRole::Structure) => "structural",
+            (FrameClass::Body, _) => "composite_body",
+            (FrameClass::OrbitRelative, FrameRole::Ned) => "ned",
+            (FrameClass::OrbitRelative, _) => "lvlh",
+            (FrameClass::External, _) => "external",
+        };
+        match &self.tag {
+            Tag::Named(name) => write!(f, "{name}.{suffix}"),
+            Tag::None => write!(f, "{suffix}"),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    //! JSON round-trips for the owned identity graph, mirroring the
+    //! `cartesian_state.rs` serde-test pattern.
+
+    use super::*;
+    use crate::frame::{Earth, PlanetInertial, RootInertial};
+
+    #[test]
+    fn type_derived_uid_round_trips() {
+        let uid = FrameUid::of::<PlanetInertial<Earth>>();
+        let json = serde_json::to_string(&uid).expect("FrameUid serializes");
+        let back: FrameUid = serde_json::from_str(&json).expect("FrameUid deserializes");
+        assert_eq!(uid, back);
+    }
+
+    #[test]
+    fn external_uid_with_custom_role_round_trips() {
+        let uid = FrameUid::external(
+            Namespace(7),
+            FrameClass::External,
+            FrameRole::Custom("sensor_boresight".into()),
+            Tag::Named("ext-probe-42".into()),
+        );
+        let json = serde_json::to_string(&uid).expect("FrameUid serializes");
+        let back: FrameUid = serde_json::from_str(&json).expect("FrameUid deserializes");
+        assert_eq!(uid, back);
+    }
+
+    #[test]
+    fn untagged_uid_round_trips() {
+        let uid = FrameUid::of::<RootInertial>();
+        assert_eq!(uid.tag, Tag::None);
+        let json = serde_json::to_string(&uid).expect("FrameUid serializes");
+        let back: FrameUid = serde_json::from_str(&json).expect("FrameUid deserializes");
+        assert_eq!(uid, back);
+    }
+}

--- a/crates/astrodyn_quantities/src/lib.rs
+++ b/crates/astrodyn_quantities/src/lib.rs
@@ -174,6 +174,7 @@ pub mod diagnostics;
 pub mod dims;
 pub mod ext;
 pub mod frame;
+pub mod frame_descriptor;
 pub mod frame_transform;
 pub mod guard_macros;
 pub mod harmonic;
@@ -191,6 +192,10 @@ pub use body_attitude::BodyAttitude;
 pub use cartesian_state::CartesianState;
 pub use dims::*;
 pub use frame::*;
+pub use frame_descriptor::{
+    FrameClass, FrameDescriptorStatic, FrameRole, FrameRoleStatic, FrameUid, MintPolicy, Namespace,
+    Tag,
+};
 pub use frame_transform::*;
 pub use integ_origin::IntegOrigin;
 pub use qty3::*;

--- a/crates/astrodyn_quantities/src/prelude.rs
+++ b/crates/astrodyn_quantities/src/prelude.rs
@@ -12,6 +12,7 @@ pub use crate::frame::{
     Planet, PlanetFixed, PlanetInertial, RootInertial, Saturn, SelfPlanet, SelfRef,
     StructuralFrame, Sun, Topocentric, Vehicle,
 };
+pub use crate::frame_descriptor::{FrameClass, FrameUid};
 pub use crate::frame_transform::FrameTransform;
 pub use crate::integ_origin::IntegOrigin;
 pub use crate::qty3::Qty3;

--- a/crates/astrodyn_quantities/tests/frame_descriptor_inventory.rs
+++ b/crates/astrodyn_quantities/tests/frame_descriptor_inventory.rs
@@ -164,3 +164,45 @@ fn display_matches_dotted_convention() {
         "Earth.topo"
     );
 }
+
+#[test]
+fn display_is_role_faithful_for_external_combinations() {
+    use astrodyn_quantities::{FrameClass, FrameRole, Namespace, Tag};
+    // FrameUid::external can construct any class/role combination; the
+    // rendered suffix must reflect the actual role, never a collapsed
+    // class-conventional guess.
+    let core = FrameUid::external(
+        Namespace(1),
+        FrameClass::Body,
+        FrameRole::CoreBody,
+        Tag::Named("probe".into()),
+    );
+    assert_eq!(core.to_string(), "ns1:probe.core_body");
+    let orbit_primary = FrameUid::external(
+        Namespace(1),
+        FrameClass::OrbitRelative,
+        FrameRole::Primary,
+        Tag::Named("probe".into()),
+    );
+    assert_eq!(orbit_primary.to_string(), "ns1:probe.orbit_relative");
+}
+
+#[test]
+fn is_predicate_agrees_with_minted_equality() {
+    // The zero-allocation structural path in `FrameUid::is` must agree
+    // with the mint-then-compare definition for every Stable entry.
+    for (label, mint, uid) in inventory() {
+        if mint != MintPolicy::Stable {
+            continue;
+        }
+        let uid = uid.expect("Stable entries carry a minted uid");
+        assert!(
+            uid.is::<RootInertial>() == (uid == FrameUid::of::<RootInertial>()),
+            "`is` and minted equality disagree for `{label}` vs RootInertial"
+        );
+    }
+    // And positively: each minted uid matches its own type via `is`.
+    assert!(FrameUid::of::<PlanetFixed<Earth>>().is::<PlanetFixed<Earth>>());
+    assert!(!FrameUid::of::<PlanetFixed<Earth>>().is::<PlanetFixed<Moon>>());
+    assert!(!FrameUid::of::<PlanetFixed<Earth>>().is::<Ecef>());
+}

--- a/crates/astrodyn_quantities/tests/frame_descriptor_inventory.rs
+++ b/crates/astrodyn_quantities/tests/frame_descriptor_inventory.rs
@@ -1,0 +1,166 @@
+// JEOD_INV: TS.01 — this inventory test enumerates the storage-boundary
+// wildcard tags (SelfRef / SelfPlanet / MassNode) by token to assert the
+// Wildcard mint set is exact; see `docs/JEOD_invariants.md` row TS.01 and
+// the lint at `tests/self_ref_self_planet_discipline.rs`.
+//! Inventory test for the frame-descriptor vocabulary (issue #660).
+//!
+//! Asserts the three load-bearing properties of `Frame::DESCRIPTOR` across
+//! representative instantiations of every sealed frame impl:
+//!
+//! 1. **Injectivity** — every `Stable` instantiation mints a pairwise
+//!    distinct `FrameUid` (checked recovery in PR-2 relies on this).
+//! 2. **Wildcard exactness** — `is_wildcard()` is true for exactly the
+//!    wildcard-tagged frames and `MassNode`, nothing else.
+//! 3. **Per-body exactness** — `MintPolicy::PerBodyIntegration` is carried
+//!    by exactly `IntegrationFrame`.
+//!
+//! Local `Vehicle`/`Planet` tags are minted with the public macros so the
+//! test also exercises the downstream extension path.
+
+use astrodyn_quantities::frame::{
+    BodyFrame, Earth, Ecef, Frame, IntegrationFrame, Lvlh, MassNode, Moon, Ned, PlanetFixed,
+    PlanetInertial, RootInertial, SelfPlanet, SelfRef, StructuralFrame, Topocentric,
+};
+use astrodyn_quantities::{FrameUid, MintPolicy};
+
+/// Macro-minted local tags live in a private module so the generated
+/// `pub struct`s are not test-crate-public (workspace `missing_docs` deny).
+mod tags {
+    astrodyn_quantities::define_planet!(InvPlanet);
+    astrodyn_quantities::define_vehicle!(InvVehicle);
+}
+use tags::{InvPlanet, InvVehicle};
+
+/// Every representative instantiation in one place: `(label, mint, mintable
+/// uid if Stable)`. Extending the sealed frame set should extend this list.
+fn inventory() -> Vec<(&'static str, MintPolicy, Option<FrameUid>)> {
+    fn entry<F: Frame>(label: &'static str) -> (&'static str, MintPolicy, Option<FrameUid>) {
+        let mint = F::DESCRIPTOR.mint;
+        let uid = match mint {
+            MintPolicy::Stable => Some(FrameUid::of::<F>()),
+            _ => None,
+        };
+        (label, mint, uid)
+    }
+    vec![
+        // Unparameterized.
+        entry::<RootInertial>("RootInertial"),
+        entry::<Ecef>("Ecef"),
+        entry::<IntegrationFrame>("IntegrationFrame"),
+        entry::<MassNode>("MassNode"),
+        // Planet-parameterized, concrete tags.
+        entry::<PlanetInertial<Earth>>("PlanetInertial<Earth>"),
+        entry::<PlanetInertial<Moon>>("PlanetInertial<Moon>"),
+        entry::<PlanetFixed<Earth>>("PlanetFixed<Earth>"),
+        entry::<PlanetFixed<Moon>>("PlanetFixed<Moon>"),
+        entry::<PlanetFixed<InvPlanet>>("PlanetFixed<InvPlanet>"),
+        entry::<Topocentric<Earth>>("Topocentric<Earth>"),
+        // Vehicle-parameterized, concrete tags (macro-minted).
+        entry::<BodyFrame<InvVehicle>>("BodyFrame<InvVehicle>"),
+        entry::<StructuralFrame<InvVehicle>>("StructuralFrame<InvVehicle>"),
+        entry::<Lvlh<InvVehicle>>("Lvlh<InvVehicle>"),
+        entry::<Ned<InvVehicle>>("Ned<InvVehicle>"),
+        // Wildcard-tagged instantiations (TS.01 storage-boundary set).
+        entry::<PlanetInertial<SelfPlanet>>("PlanetInertial<SelfPlanet>"),
+        entry::<PlanetFixed<SelfPlanet>>("PlanetFixed<SelfPlanet>"),
+        entry::<Topocentric<SelfPlanet>>("Topocentric<SelfPlanet>"),
+        entry::<BodyFrame<SelfRef>>("BodyFrame<SelfRef>"),
+        entry::<StructuralFrame<SelfRef>>("StructuralFrame<SelfRef>"),
+        entry::<Lvlh<SelfRef>>("Lvlh<SelfRef>"),
+        entry::<Ned<SelfRef>>("Ned<SelfRef>"),
+    ]
+}
+
+#[test]
+fn stable_descriptors_are_pairwise_distinct() {
+    let stable: Vec<(&str, FrameUid)> = inventory()
+        .into_iter()
+        .filter_map(|(label, _, uid)| uid.map(|u| (label, u)))
+        .collect();
+    assert!(
+        stable.len() >= 12,
+        "expected at least 12 Stable instantiations in the inventory, got {}",
+        stable.len()
+    );
+    for (i, (label_a, uid_a)) in stable.iter().enumerate() {
+        for (label_b, uid_b) in stable.iter().skip(i + 1) {
+            assert!(
+                uid_a != uid_b,
+                "FrameUid collision between `{label_a}` and `{label_b}` (both mint \
+                 {uid_a}). Descriptor injectivity is load-bearing for checked typed \
+                 recovery: give one of them a distinct class/role/tag."
+            );
+        }
+    }
+}
+
+#[test]
+fn wildcard_set_is_exactly_self_ref_self_planet_massnode() {
+    let expected_wildcards = [
+        "MassNode",
+        "PlanetInertial<SelfPlanet>",
+        "PlanetFixed<SelfPlanet>",
+        "Topocentric<SelfPlanet>",
+        "BodyFrame<SelfRef>",
+        "StructuralFrame<SelfRef>",
+        "Lvlh<SelfRef>",
+        "Ned<SelfRef>",
+    ];
+    for (label, mint, _) in inventory() {
+        let should_be_wildcard = expected_wildcards.contains(&label);
+        let is_wildcard = mint == MintPolicy::Wildcard;
+        assert_eq!(
+            is_wildcard, should_be_wildcard,
+            "`{label}` has mint {mint:?}, but the TS.01 wildcard set says \
+             is_wildcard should be {should_be_wildcard}. The wildcard set must stay \
+             exactly the SelfRef/SelfPlanet-tagged instantiations plus MassNode."
+        );
+    }
+}
+
+#[test]
+fn per_body_integration_is_exactly_integration_frame() {
+    for (label, mint, _) in inventory() {
+        let should_be_per_body = label == "IntegrationFrame";
+        let is_per_body = mint == MintPolicy::PerBodyIntegration;
+        assert_eq!(
+            is_per_body, should_be_per_body,
+            "`{label}` has mint {mint:?}; MintPolicy::PerBodyIntegration must be \
+             carried by exactly IntegrationFrame (RF.10)."
+        );
+    }
+}
+
+#[test]
+fn display_matches_dotted_convention() {
+    assert_eq!(
+        FrameUid::of::<PlanetInertial<Earth>>().to_string(),
+        "Earth.inertial"
+    );
+    assert_eq!(
+        FrameUid::of::<PlanetFixed<Earth>>().to_string(),
+        "Earth.pfix"
+    );
+    assert_eq!(FrameUid::of::<Ecef>().to_string(), "Earth.pfix.alt");
+    assert_eq!(FrameUid::of::<RootInertial>().to_string(), "inertial");
+    assert_eq!(
+        FrameUid::of::<BodyFrame<InvVehicle>>().to_string(),
+        "InvVehicle.composite_body"
+    );
+    assert_eq!(
+        FrameUid::of::<StructuralFrame<InvVehicle>>().to_string(),
+        "InvVehicle.structural"
+    );
+    assert_eq!(
+        FrameUid::of::<Lvlh<InvVehicle>>().to_string(),
+        "InvVehicle.lvlh"
+    );
+    assert_eq!(
+        FrameUid::of::<Ned<InvVehicle>>().to_string(),
+        "InvVehicle.ned"
+    );
+    assert_eq!(
+        FrameUid::of::<Topocentric<Earth>>().to_string(),
+        "Earth.topo"
+    );
+}

--- a/crates/astrodyn_quantities/tests/frame_descriptor_refusals.rs
+++ b/crates/astrodyn_quantities/tests/frame_descriptor_refusals.rs
@@ -1,0 +1,81 @@
+// JEOD_INV: TS.01 — these negative tests exercise the wildcard tags
+// (SelfRef / SelfPlanet / MassNode) at the FrameUid::of refusal boundary;
+// see `docs/JEOD_invariants.md` row TS.01 and the lint at
+// `tests/self_ref_self_planet_discipline.rs`.
+//! Fail-loudly tests for the frame-identity mint boundary (issue #660):
+//! every refusal path panics with a diagnostic naming the broken invariant,
+//! and the non-panicking `is` predicate stays total.
+
+use astrodyn_quantities::frame::{
+    BodyFrame, Ecef, IntegrationFrame, MassNode, PlanetInertial, RootInertial, SelfPlanet, SelfRef,
+};
+use astrodyn_quantities::{FrameClass, FrameRole, FrameUid, Namespace, Tag};
+
+#[test]
+#[should_panic(expected = "JEOD_INV TS.01")]
+fn of_refuses_self_ref_tagged_body_frame() {
+    let _ = FrameUid::of::<BodyFrame<SelfRef>>();
+}
+
+#[test]
+#[should_panic(expected = "JEOD_INV TS.01")]
+fn of_refuses_self_planet_tagged_planet_inertial() {
+    let _ = FrameUid::of::<PlanetInertial<SelfPlanet>>();
+}
+
+#[test]
+#[should_panic(expected = "JEOD_INV TS.01")]
+fn of_refuses_mass_node() {
+    let _ = FrameUid::of::<MassNode>();
+}
+
+#[test]
+#[should_panic(expected = "RF.10")]
+fn of_refuses_integration_frame() {
+    let _ = FrameUid::of::<IntegrationFrame>();
+}
+
+#[test]
+#[should_panic(expected = "reserved for type-derived identity")]
+fn external_refuses_local_namespace() {
+    let _ = FrameUid::external(
+        Namespace::LOCAL,
+        FrameClass::External,
+        FrameRole::Custom("imposter".into()),
+        Tag::Named("Earth".into()),
+    );
+}
+
+#[test]
+fn external_accepts_non_local_namespace() {
+    let uid = FrameUid::external(
+        Namespace(7),
+        FrameClass::External,
+        FrameRole::Custom("sensor_boresight".into()),
+        Tag::Named("ext-probe-42".into()),
+    );
+    assert_eq!(uid.namespace, Namespace(7));
+    assert_eq!(uid.to_string(), "ns7:ext-probe-42.sensor_boresight");
+}
+
+#[test]
+fn is_predicate_never_panics_and_answers_honestly() {
+    let root = FrameUid::of::<RootInertial>();
+    // Matching type: true.
+    assert!(root.is::<RootInertial>());
+    // Different concrete type: false.
+    assert!(!root.is::<Ecef>());
+    // Non-mintable types: false WITHOUT panicking — a wildcard or
+    // per-body frame is never equal to a concrete identity.
+    assert!(!root.is::<MassNode>());
+    assert!(!root.is::<IntegrationFrame>());
+    assert!(!root.is::<BodyFrame<SelfRef>>());
+}
+
+#[test]
+fn external_uid_never_matches_type_derived_identity() {
+    // Even a field-for-field imitation of a type-derived identity cannot
+    // claim it from a non-LOCAL namespace: `is` compares the namespace too.
+    let imposter = FrameUid::of::<RootInertial>().with_namespace(Namespace(3));
+    assert!(!imposter.is::<RootInertial>());
+}


### PR DESCRIPTION
Implements #660 (PR-1 of the #659 migration plan — [design comment](https://github.com/simnaut/astrodyn/issues/659#issuecomment-4636317391)). Purely additive to `astrodyn_quantities`; no behavior change anywhere else.

## What this adds

- **`frame_descriptor` module** — the runtime identity vocabulary: `FrameClass` × `FrameRoleStatic`/`FrameRole` (both `#[non_exhaustive]`), `FrameDescriptorStatic`, `MintPolicy` (`Stable` / `Wildcard` / `PerBodyIntegration`), `Namespace` (`LOCAL = 0` **reserved for type-derived identity**), `Tag`, and the owned `FrameUid` (`Eq + Hash` now, for PR-2's index; serde behind the existing non-default feature).
- **`const DESCRIPTOR` on the sealed `Frame` trait**, filled across all 11 impls. In-crate-only: the seal is closed, so nothing downstream can break. Parameterized frames compose their tag from the existing `Planet::NAME`/`Vehicle::NAME` and their mint policy from a new **defaulted** `IS_WILDCARD` const (only `SelfPlanet`/`SelfRef` override it) — `define_planet!`/`define_vehicle!` call sites untouched.
- **Mint rules** (RFS-701 groundwork): `FrameUid::of` refuses the TS.01 wildcards (SelfRef/SelfPlanet-tagged frames, `MassNode`) and `IntegrationFrame` (RF.10 — "publish the per-body resolved identity"), each with its own actionable diagnostic; `FrameUid::external` refuses `Namespace::LOCAL`, so no producer-supplied identity can impersonate a type-derived one (SPICE built-ins-resolve-first rule). `is::<F>()` is the non-panicking predicate PR-2's checked recovery layers on.
- **Injectivity by construction + test**: `Ecef` (test-only legacy) takes role `AltPfix` so its descriptor stays distinct from `PlanetFixed<Earth>`; the inventory test asserts pairwise-distinct `FrameUid`s across every `Stable` instantiation, the wildcard set is exactly the TS.01 three, and `PerBodyIntegration` is exactly `IntegrationFrame`.
- **`Display`** produces dotted names aligned with the existing frame-tree vocabulary (`Earth.inertial`, `Earth.pfix`, `Iss.composite_body`; non-LOCAL namespaces prefixed `nsN:`).

## Acceptance criteria (from #660)

- [x] Purely additive: `RefFrameKind` untouched, no downstream edits, no macro changes
- [x] `cargo fmt --check` + `cargo clippy --workspace --tests -- -D warnings` clean
- [x] Wildcards exactly `{SelfRef, SelfPlanet, MassNode}`; `IntegrationFrame` is **not** a wildcard (RF.10, distinct refusal)
- [x] Descriptor injectivity + wildcard-set exactness enforced by inventory tests
- [x] TS.01 discipline lint green (existing token scan covers the new pattern; new files carry file-level markers); `invariant_coverage` green (new `// JEOD_INV: TS.01`/`RF.10` tags resolve to existing rows)
- [x] `#[should_panic]` negatives for every refusal path; serde round-trips behind the feature
- [x] Full workspace: **2164/2164 passed** including Tier 3 and `bevy_parity`

Spec trace: RFS-501 (taxonomy floor + extensibility), RFS-701 groundwork (mint rules), RFS-703 groundwork (descriptor bridge) — [Spec-Reference-Frame-Requirements](https://github.com/simnaut/astrodyn/wiki/Spec-Reference-Frame-Requirements).

Closes #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
