### PR TITLE
CI: add Claude Code review + @claude mention workflows (ported from astrotui)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,54 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.rs"
+    #   - "crates/**/*.rs"
+
+# Cancel superseded review runs on rapid-fire pushes — a review of a stale
+# commit is pure waste, and the new run reviews the new head anyway.
+concurrency:
+  group: claude-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    # Skip PRs from forks: repository secrets (CLAUDE_CODE_OAUTH_TOKEN) aren't available
+    # to fork PRs, so the action would only produce noisy failures.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # post review findings as inline comments
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          # Allowlist the inline-comment MCP tool (+ gh/read tools) so the review can post
+          # findings as INLINE PR comments instead of only a top-level summary — without it
+          # the action can't attach line comments and falls back to one big comment
+          # (anthropics/claude-code-action docs/solutions.md). We deliberately keep the
+          # plugin's quality filters intact (its >=80 confidence bar and the default
+          # classify_inline_comments=true, which drops probe/test comments): precision over
+          # volume, no bar-lowering. Depth/criteria come from Opus + the repo CLAUDE.md.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          claude_args: >-
+            --model claude-opus-4-8
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,55 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Only trusted actors (repo owner/members/collaborators) may trigger Claude, so
+    # arbitrary users can't burn the CLAUDE_CODE_OAUTH_TOKEN quota via an @claude mention.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'


### PR DESCRIPTION
## Summary

Ports both Claude CI workflows from astrotui:

**`claude-code-review.yml`** — PR-triggered review via `anthropics/claude-code-action@v1` with the `code-review` plugin, posting findings as inline PR comments. Carried over with astrotui's latest refinements intact (inline-comment MCP tool allowlist, no `high` arg, Opus 4.8, plugin quality filters untouched).

**`claude.yml`** — on-demand `@claude` mention handling in issues, PR comments, and reviews, gated to trusted actors (owner/member/collaborator) so arbitrary users can't burn the OAuth token quota.

Adaptations for this repo:
- `actions/checkout@v6` to match `ci.yml`
- review workflow: `concurrency` group with `cancel-in-progress: true` — consistent with this repo's practice of canceling superseded PR runs
- Rust path globs in the commented-out `paths` example

`CLAUDE_CODE_OAUTH_TOKEN` is set in repo secrets. Note: the review job **skips on this PR by design** — `claude-code-action` refuses to execute a workflow definition that differs from the one on the default branch, so it activates on the first PR after this merges. The `@claude` mention workflow has the same constraint; both go live post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)