### PR TITLE
[#662] PR-3: runner stamps real frame identities; resolved integ-frame publication

### DIFF
--- a/crates/astrodyn_bevy/README.md
+++ b/crates/astrodyn_bevy/README.md
@@ -98,6 +98,7 @@ fn setup(mut commands: Commands) {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("iss")
         .from_orbital_elements(orbital_elements::iss(), mu)
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()

--- a/crates/astrodyn_bevy/examples/typed_mission.rs
+++ b/crates/astrodyn_bevy/examples/typed_mission.rs
@@ -28,12 +28,20 @@ use std::time::Duration;
 
 use astrodyn::recipes::{constants, earth, orbital_elements, vehicle};
 use astrodyn::{F64Ext, GravityControl, GravityGradient, SourceHandle, VehicleBuilder};
+
+/// The mission's vehicle marker: the builder's `.vehicle::<Iss>()` stage
+/// derives the frame identity `FrameUid::of::<BodyFrame<Iss>>()` from it
+/// (issue #662).
+mod tags {
+    astrodyn::define_vehicle!(Iss);
+}
 use astrodyn_bevy::{
     AstrodynAppExt, AstrodynSet, GravityAccelerationC, GravitySourceC, SourceInertialPositionC,
     TotalForceC, TranslationalStateC, VehicleConfigBevyExt,
 };
 use bevy::app::ScheduleRunnerPlugin;
 use bevy::prelude::*;
+use tags::Iss;
 
 #[derive(Resource)]
 struct StepCounter(usize);
@@ -113,6 +121,7 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
     // typed builder, lift `mu` into a typed `GravParam`.
     let mu_typed = earth_mu_raw.m3_per_s2();
     let cfg = VehicleBuilder::new()
+        .vehicle::<Iss>()
         .from_orbital_elements(orbital_elements::iss(), mu_typed)
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()

--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -1299,6 +1299,7 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
 /// app.add_systems(Startup, |mut commands: Commands| {
 ///     let earth = commands.spawn(PlanetBundle::<astrodyn::Earth>::point_mass("Earth", &EARTH)).id();
 ///     let cfg = VehicleBuilder::new()
+///         .vehicle_named("iss")
 ///         .from_orbital_elements(orbital_elements::iss(), constants::mu_ggm05c())
 ///         .three_dof_point_mass(vehicle::iss_mass())
 ///         .rk4()

--- a/crates/astrodyn_bevy/src/prelude.rs
+++ b/crates/astrodyn_bevy/src/prelude.rs
@@ -17,6 +17,7 @@
 //! use astrodyn_bevy::recipes::*;
 //!
 //! let cfg = VehicleBuilder::new()
+//!     .vehicle_named("iss")
 //!     .from_orbital_elements(orbital_elements::iss(), earth::point_mass().source.mu.m3_per_s2())
 //!     .three_dof_point_mass(vehicle::iss_mass())
 //!     .rk4()

--- a/crates/astrodyn_bevy/src/scenario.rs
+++ b/crates/astrodyn_bevy/src/scenario.rs
@@ -749,7 +749,7 @@ mod tests {
                     GravityGradient::Skip,
                 )],
             },
-            ..Default::default()
+            ..VehicleConfig::named("scenario-1")
         });
         b
     }
@@ -871,7 +871,7 @@ mod tests {
                     GravityGradient::Skip,
                 )],
             },
-            ..Default::default()
+            ..VehicleConfig::named("scenario-0")
         });
         let handles = b
             .populate_app::<astrodyn::Earth>(&mut app)

--- a/crates/astrodyn_bevy/src/wrench.rs
+++ b/crates/astrodyn_bevy/src/wrench.rs
@@ -1312,6 +1312,7 @@ mod tests {
         // Parent: a 3-DOF point-mass orbital body at ISS-like
         // initial conditions, integrated under spherical gravity.
         let parent_cfg = VehicleBuilder::new()
+            .vehicle_named("wrench-0")
             .from_orbital_elements(orbital_elements::iss(), constants::mu_ggm05c())
             .three_dof_point_mass(vehicle::iss_mass())
             .with_integrator(IntegratorType::Rk4)

--- a/crates/astrodyn_bevy/tests/app_ext.rs
+++ b/crates/astrodyn_bevy/tests/app_ext.rs
@@ -38,6 +38,7 @@ fn setup_iss(mut commands: Commands) {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("app-ext-0")
         .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()

--- a/crates/astrodyn_bevy/tests/at_03_geodetic_planet_fixed_rotation_required.rs
+++ b/crates/astrodyn_bevy/tests/at_03_geodetic_planet_fixed_rotation_required.rs
@@ -96,6 +96,7 @@ fn at_03_panics_on_geodetic_planet_without_planet_fixed_rotation() {
     // `planet` field at the first source entity passed to
     // `spawn_bevy`.
     let cfg = VehicleBuilder::new()
+        .vehicle_named("at-03-geodetic-planet-fixed-rotation-required-0")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()

--- a/crates/astrodyn_bevy/tests/body_action_planet_generic_contract.rs
+++ b/crates/astrodyn_bevy/tests/body_action_planet_generic_contract.rs
@@ -84,6 +84,7 @@ fn spawn_bevy_inserts_planet_tagged_translational_storage_for_mars() {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-0")
         .with_translational(body_state_initial())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -148,6 +149,7 @@ fn body_action_for_mars_writes_through_mars_tagged_storage() {
         .insert(SourceInertialPositionC::default());
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-1")
         .with_translational(body_state_initial())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -293,6 +295,7 @@ fn earth_tagged_action_does_not_mutate_mars_body() {
         .id();
 
     let cfg_mars = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-2")
         .with_translational(body_state_initial())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -302,6 +305,7 @@ fn earth_tagged_action_does_not_mutate_mars_body() {
         ))
         .build();
     let cfg_earth = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-3")
         .with_translational(TranslationalStateTyped::<RootInertial> {
             position: DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<RootInertial>(),
             velocity: DVec3::new(0.0, 7000.0, 0.0).m_per_s_at::<RootInertial>(),
@@ -447,6 +451,7 @@ fn planet_agnostic_remove_cancels_mars_pending_without_disturbing_earth() {
         .id();
 
     let cfg_mars = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-4")
         .with_translational(body_state_initial())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -456,6 +461,7 @@ fn planet_agnostic_remove_cancels_mars_pending_without_disturbing_earth() {
         ))
         .build();
     let cfg_earth = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-5")
         .with_translational(TranslationalStateTyped::<RootInertial> {
             position: DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<RootInertial>(),
             velocity: DVec3::new(0.0, 7000.0, 0.0).m_per_s_at::<RootInertial>(),
@@ -614,6 +620,7 @@ fn add_for_unregistered_planet_panics_with_named_diagnostic() {
     // the Mars `Add` message is the only misconfiguration on this
     // tick.
     let cfg_earth = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-6")
         .with_translational(TranslationalStateTyped::<RootInertial> {
             position: DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<RootInertial>(),
             velocity: DVec3::new(0.0, 7000.0, 0.0).m_per_s_at::<RootInertial>(),
@@ -681,6 +688,7 @@ fn add_body_action_for_unregistered_planet_panics_at_commands_flush() {
         ))
         .id();
     let cfg_earth = VehicleBuilder::new()
+        .vehicle_named("body-action-planet-generic-contract-7")
         .with_translational(TranslationalStateTyped::<RootInertial> {
             position: DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<RootInertial>(),
             velocity: DVec3::new(0.0, 7000.0, 0.0).m_per_s_at::<RootInertial>(),

--- a/crates/astrodyn_bevy/tests/frame_entity_dual_write_fail_loud.rs
+++ b/crates/astrodyn_bevy/tests/frame_entity_dual_write_fail_loud.rs
@@ -84,6 +84,7 @@ fn spawn_earth_and_body(app: &mut App) -> (Entity, Entity) {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("frame-entity-dual-write-fail-loud-0")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()

--- a/crates/astrodyn_bevy/tests/in_09_solar_beta_requires_sun_marker.rs
+++ b/crates/astrodyn_bevy/tests/in_09_solar_beta_requires_sun_marker.rs
@@ -96,6 +96,7 @@ fn in_09_panics_on_solar_beta_without_sun_marker() {
     // (per `crates/astrodyn_bevy/src/lib.rs::spawn_bevy_inner` —
     // see the `derived.solar_beta` row in the rustdoc enumeration).
     let cfg = VehicleBuilder::new()
+        .vehicle_named("in-09-solar-beta-requires-sun-marker-0")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()

--- a/crates/astrodyn_bevy/tests/mission_crate_sanity.rs
+++ b/crates/astrodyn_bevy/tests/mission_crate_sanity.rs
@@ -50,6 +50,7 @@ fn setup_iss(mut commands: Commands) {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("mission-crate-sanity-0")
         .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()

--- a/crates/astrodyn_bevy/tests/spawn_bevy_derived_state.rs
+++ b/crates/astrodyn_bevy/tests/spawn_bevy_derived_state.rs
@@ -107,6 +107,7 @@ fn spawn_bevy_wires_orbital_elements() {
     let (mut app, earth) = app_with_earth();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-derived-state-0")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()
@@ -165,6 +166,7 @@ fn spawn_bevy_wires_euler_angles() {
     let (mut app, earth) = app_with_earth();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-derived-state-1")
         .with_translational(iss_trans())
         .sixdof(iss_rot(), iss_mass())
         .rk4()
@@ -218,6 +220,7 @@ fn spawn_bevy_wires_lvlh() {
     let (mut app, earth) = app_with_earth();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-derived-state-2")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()
@@ -261,6 +264,7 @@ fn spawn_bevy_wires_geodetic() {
     let (mut app, earth) = app_with_earth();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-derived-state-3")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()
@@ -325,6 +329,7 @@ fn spawn_bevy_wires_solar_beta() {
     ));
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-derived-state-4")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()
@@ -382,6 +387,7 @@ fn spawn_bevy_wires_earth_lighting() {
     ));
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-derived-state-5")
         .with_translational(iss_trans())
         .three_dof_point_mass(iss_mass_kg())
         .rk4()

--- a/crates/astrodyn_bevy/tests/spawn_bevy_integ_source_and_frame_switches.rs
+++ b/crates/astrodyn_bevy/tests/spawn_bevy_integ_source_and_frame_switches.rs
@@ -118,6 +118,7 @@ fn assert_sixdof_bit_identical(label: &str, a: &SixDofState, b: &SixDofState) {
 /// `differential` flags on the gravity controls to match.
 fn earth_then_moon_config() -> VehicleConfig {
     VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-integ-source-and-frame-switches-0")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -155,6 +156,7 @@ fn spawn_bevy_translates_integ_source_index_to_entity() {
 
     // Build a config that integrates in Moon (source index 1).
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-integ-source-and-frame-switches-1")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -236,6 +238,7 @@ fn spawn_bevy_omits_integ_source_component_when_default() {
     // *presence* of `IntegSourceC` (or relying on `Without<IntegSourceC>`)
     // see the same shape as a manually-spawned root-integrated vehicle.
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-integ-source-and-frame-switches-2")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -269,6 +272,7 @@ fn spawn_bevy_omits_frame_switches_component_when_empty() {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-integ-source-and-frame-switches-3")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -301,6 +305,7 @@ fn spawn_bevy_panics_on_out_of_bounds_integ_source() {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-integ-source-and-frame-switches-4")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()
@@ -326,6 +331,7 @@ fn spawn_bevy_panics_on_out_of_bounds_frame_switch_target() {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("spawn-bevy-integ-source-and-frame-switches-5")
         .with_translational(initial_trans())
         .sixdof(initial_rot(), vehicle_mass())
         .rk4()

--- a/crates/astrodyn_bevy/tests/validation_added_trigger.rs
+++ b/crates/astrodyn_bevy/tests/validation_added_trigger.rs
@@ -50,6 +50,7 @@ fn build_app() -> (App, Entity) {
         .id();
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("validation-added-trigger-0")
         .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()
@@ -93,6 +94,7 @@ fn validation_fires_for_body_added_after_startup() {
 
     let earth_mu = earth::point_mass().source.mu;
     let bogus_cfg = VehicleBuilder::new()
+        .vehicle_named("validation-added-trigger-1")
         .from_orbital_elements(orbital_elements::iss(), earth_mu.m3_per_s2())
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()

--- a/crates/astrodyn_frames/src/orchestration.rs
+++ b/crates/astrodyn_frames/src/orchestration.rs
@@ -47,16 +47,16 @@ pub fn frame_origin(
 /// Typed sibling of [`frame_origin`] returning the frame's position and
 /// velocity already wrapped as `Position<F>` / `Velocity<F>`. The frame
 /// marker `F` is the **root frame's** marker (the result expresses the
-/// query frame's origin in root-relative coordinates) — caller asserts
-/// the root is `F`. For the Bevy adapter and `astrodyn_runner` today, the
-/// root is by construction inertial, so callers pass `F = Inertial`.
+/// query frame's origin in root-relative coordinates).
 ///
-/// **Caller-asserts boundary (transitional):** this helper does not check
-/// `F` against the root node's stamped identity, because the production
-/// hosts create their frame nodes via the untyped path (`uid: None`) until
-/// issue #662 stamps them. Once production identities are stamped, this
-/// becomes a checked lookup like `FrameTree::get_state_typed` — checking
-/// today would panic on every per-step call.
+/// **Checked lookup**: the root node's stamped identity is verified
+/// against `F` — a wrong marker fails loudly instead of silently
+/// mislabeling the result's coordinate basis.
+///
+/// # Panics
+/// - the root node is unstamped (build the tree via the stamped
+///   constructors);
+/// - the root's stored identity does not match `F`.
 ///
 /// Phase C5 of issue #71: lets consumers compute the integration-frame
 /// origin without re-lifting raw `DVec3` through `from_raw_si` at the
@@ -66,6 +66,19 @@ pub fn frame_origin_typed<F: Frame>(
     root_frame_id: FrameId,
     frame_id: FrameId,
 ) -> (Position<F>, Velocity<F>) {
+    // JEOD_INV: RF.02 — the result is expressed in the root's frame, so
+    // the requested marker must name the root node's stamped identity.
+    let root_uid = frame_tree.get(root_frame_id).uid().unwrap_or_else(|| {
+        panic!(
+            "frame_origin_typed: root frame {root_frame_id} is unstamped — cannot verify it is `{}`. Build the tree via add_root_typed / add_child_uid so the root carries an identity.",
+            core::any::type_name::<F>()
+        )
+    });
+    assert!(
+        root_uid.is::<F>(),
+        "frame_origin_typed: root frame {root_frame_id} has stored identity `{root_uid}`, but the requested marker is `{}` — the result is expressed in the root's frame, so F must name the root's identity.",
+        core::any::type_name::<F>()
+    );
     let (pos_raw, vel_raw) = frame_origin(frame_tree, root_frame_id, frame_id);
     (
         Position::<F>::from_raw_si(pos_raw),
@@ -74,24 +87,62 @@ pub fn frame_origin_typed<F: Frame>(
 }
 
 /// Typed sibling of [`FrameTree::compute_relative_state`] returning a
-/// [`RefFrameStateTyped<From, To>`]. The caller asserts the supplied
-/// frame IDs correspond to frames whose markers are `From` and `To` —
-/// the arena is heterogeneous and stores untyped `RefFrameState` per
-/// node, so this is a `from_untyped_unchecked` boundary lift.
+/// [`RefFrameStateTyped<From, To>`].
 ///
-/// **Caller-asserts boundary (transitional):** the markers are not checked
-/// against the nodes' stamped identities, because the production hosts
-/// create their frame nodes via the untyped path (`uid: None`) until issue
-/// #662 stamps them. Once production identities are stamped, this becomes
-/// a checked lookup like `FrameTree::get_state_typed` — checking today
-/// would panic on every per-step call.
+/// **Checked lookup**: both endpoints' stamped identities are verified
+/// against the requested markers — a wrong marker fails loudly instead of
+/// silently mislabeling physics.
+///
+/// # Panics
+/// - `From` or `To` is non-mintable (a storage-boundary wildcard or
+///   `IntegrationFrame`) — such a marker can never name a stored identity;
+/// - either endpoint is unstamped;
+/// - either endpoint's stored identity does not match its marker.
 ///
 /// Phase C5 of issue #71.
+// JEOD_INV: RF.02 — checked typed recovery at the orchestration boundary:
+// both endpoints' stored identities must equal the requested markers.
 pub fn compute_relative_state_typed<From: Frame, To: Frame>(
     frame_tree: &FrameTree,
     from: FrameId,
     to: FrameId,
 ) -> RefFrameStateTyped<From, To> {
+    use astrodyn_quantities::frame_descriptor::MintPolicy;
+    let check = |id: FrameId, marker: &str, name: &str, mint: MintPolicy, is_match: bool| {
+        assert!(
+            matches!(mint, MintPolicy::Stable),
+            "compute_relative_state_typed: {marker} marker `{name}` is not mintable (a runtime-resolved wildcard or IntegrationFrame) and can never name a stored identity. Resolve the concrete frame type and request that.",
+        );
+        assert!(
+            is_match,
+            "compute_relative_state_typed: frame {id} has stored identity `{}`, but the requested {marker} marker is `{name}` — identity mismatch.",
+            frame_tree
+                .get(id)
+                .uid()
+                .map(|u| u.to_string())
+                .unwrap_or_else(|| "<unstamped>".into()),
+        );
+    };
+    let stamped = |id: FrameId, marker: &str, name: &str| {
+        frame_tree.get(id).uid().unwrap_or_else(|| {
+            panic!(
+                "compute_relative_state_typed: frame {id} (`{}`) is unstamped — cannot verify it is the {marker} marker `{name}`. Stamp its identity via the typed constructors or add_child_uid.",
+                frame_tree.get(id).name
+            )
+        })
+    };
+    let from_name = core::any::type_name::<From>();
+    let to_name = core::any::type_name::<To>();
+    let from_uid = stamped(from, "From", from_name);
+    check(
+        from,
+        "From",
+        from_name,
+        From::DESCRIPTOR.mint,
+        from_uid.is::<From>(),
+    );
+    let to_uid = stamped(to, "To", to_name);
+    check(to, "To", to_name, To::DESCRIPTOR.mint, to_uid.is::<To>());
     let untyped = frame_tree.compute_relative_state(from, to);
     RefFrameStateTyped::<From, To>::from_untyped_unchecked(&untyped)
 }
@@ -105,7 +156,7 @@ mod tests {
     #[test]
     fn frame_origin_typed_matches_untyped() {
         let mut tree = FrameTree::new();
-        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+        let root = tree.add_root_typed::<RootInertial>("root".into());
         let child = tree.add_child(
             root,
             "child".into(),
@@ -129,7 +180,7 @@ mod tests {
     #[test]
     fn frame_origin_typed_root_is_zero() {
         let mut tree = FrameTree::new();
-        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
+        let root = tree.add_root_typed::<RootInertial>("root".into());
         let (typed_pos, typed_vel) = frame_origin_typed::<RootInertial>(&tree, root, root);
         assert_eq!(typed_pos.raw_si(), DVec3::ZERO);
         assert_eq!(typed_vel.raw_si(), DVec3::ZERO);
@@ -137,12 +188,13 @@ mod tests {
 
     #[test]
     fn compute_relative_state_typed_matches_untyped() {
+        use astrodyn_quantities::frame_descriptor::FrameUid;
         let mut tree = FrameTree::new();
-        let root = tree.add_root("root".into(), RefFrameKind::Inertial);
-        let child = tree.add_child(
+        let root = tree.add_root_typed::<RootInertial>("root".into());
+        let child = tree.add_child_uid(
             root,
+            FrameUid::of::<Ecef>(),
             "ecef".into(),
-            RefFrameKind::PlanetFixed,
             RefFrameState {
                 trans: RefFrameTrans {
                     position: DVec3::new(1.0, 2.0, 3.0),
@@ -150,6 +202,7 @@ mod tests {
                 },
                 rot: RefFrameRot::default(),
             },
+            None,
         );
 
         let untyped = tree.compute_relative_state(root, child);

--- a/crates/astrodyn_runner/src/branded.rs
+++ b/crates/astrodyn_runner/src/branded.rs
@@ -29,6 +29,7 @@
 //!     // the matching `'sim` lifetime so it cannot escape this closure.
 //!     let earth_idx = sim.add_source("Earth", earth::point_mass());
 //!     let cfg = VehicleBuilder::new()
+//!         .vehicle_named("iss")
 //!         .from_orbital_elements(orbital_elements::iss(), earth::point_mass().source.mu.m3_per_s2())
 //!         .three_dof_point_mass(vehicle::iss_mass())
 //!         .rk4()
@@ -363,6 +364,7 @@ impl Simulation {
     /// let r = Simulation::run(time, 60.0, |mut sim| {
     ///     let earth_idx = sim.add_source("Earth", earth::point_mass());
     ///     let cfg = VehicleBuilder::new()
+    ///         .vehicle_named("iss")
     ///         .from_orbital_elements(
     ///             orbital_elements::iss(),
     ///             earth::point_mass().source.mu.m3_per_s2(),

--- a/crates/astrodyn_runner/src/builder.rs
+++ b/crates/astrodyn_runner/src/builder.rs
@@ -31,6 +31,7 @@ impl Simulation {
             sun_source,
             moon_source,
             sources,
+            source_uids,
             source_ephem_bodies,
             bodies,
             mass_tree_names,
@@ -46,7 +47,14 @@ impl Simulation {
         sim.moon_source = moon_source;
 
         for (i, (name, source)) in sources.into_iter().enumerate() {
-            sim.add_source(name, source);
+            match source_uids.get(i).cloned().flatten() {
+                Some((inertial_uid, pfix_uid)) => {
+                    sim.add_source_with_uids(name, source, inertial_uid, pfix_uid);
+                }
+                None => {
+                    sim.add_source(name, source);
+                }
+            }
             if let Some(Some((target, observer))) = source_ephem_bodies.get(i) {
                 sim.set_source_ephemeris(i, *target, *observer);
             }

--- a/crates/astrodyn_runner/src/simulation/bodies.rs
+++ b/crates/astrodyn_runner/src/simulation/bodies.rs
@@ -17,8 +17,8 @@ use astrodyn::typed_bridge::{
 };
 use astrodyn::{
     evaluate_ground_contact_pair, ContactFacet, DragConfig, GroundFacet, IntegrationFrame,
-    MassBodyId, MassPointState, MassProperties, MassPropertiesTyped, Phase, Position, RefFrameKind,
-    RefFrameRot, RefFrameState, RefFrameTrans, SelfRef, VehicleConfig, Velocity,
+    MassBodyId, MassPointState, MassProperties, MassPropertiesTyped, Phase, Position, RefFrameRot,
+    RefFrameState, RefFrameTrans, SelfRef, VehicleConfig, Velocity,
 };
 
 use super::types::{
@@ -276,11 +276,42 @@ impl Simulation {
             })
             .unwrap_or(self.root_frame_id);
 
-        // Create body frame in tree under the integration frame.
-        let body_frame_id = self.frame_tree.add_child(
+        // RFS-303: the resolved integration frame's identity is asserted,
+        // not assumed — it must be stamped (sources/root always are) and
+        // its class must be eligible to host integration.
+        let integ_uid = self
+            .frame_tree
+            .get(integ_frame_id)
+            .uid()
+            .unwrap_or_else(|| {
+                panic!(
+                    "add_body: body {idx}'s integration frame {integ_frame_id} is \
+                     unstamped — every integration frame must carry a minted identity \
+                     before a body integrates in it. Sources are stamped by \
+                     add_source/add_source_typed and the root by Simulation::new; \
+                     register the integ_source before adding the body."
+                )
+            })
+            .clone();
+        // JEOD_INV: RF.10 — a body may only integrate in a root- or
+        // planet-inertial frame; integrating in a rotating frame without
+        // fictitious-force treatment is silently wrong physics.
+        assert!(
+            integ_uid.class.may_be_root_or_integ(),
+            "add_body: body {idx}'s integration frame has identity `{integ_uid}` \
+             (class {:?}), which is not eligible to host integration (only \
+             RootInertial / PlanetInertial / BarycenterInertial classes are). Set \
+             VehicleConfig::integ_source to a planet's inertial source, or leave it \
+             None to integrate in the root frame.",
+            integ_uid.class
+        );
+
+        // Create body frame in tree under the integration frame, stamped
+        // with the mission-supplied identity carried by the config.
+        let body_frame_id = self.frame_tree.add_child_uid(
             integ_frame_id,
+            config.frame_uid.clone(),
             format!("body_{idx}.integ"),
-            RefFrameKind::Body,
             RefFrameState {
                 trans: RefFrameTrans {
                     // VehicleConfig::trans is typed `<RootInertial>`; the
@@ -291,11 +322,28 @@ impl Simulation {
                 },
                 rot: RefFrameRot::default(),
             },
+            Some(self.time.tdb()),
         );
 
         self.bodies
             .push(SimBody::from_config(config, integ_frame_id, body_frame_id));
         idx
+    }
+
+    /// The resolved identity of `body_idx`'s integration frame —
+    /// `RootInertial` or a `PlanetInertial<P>`, never the
+    /// `IntegrationFrame` marker (RF.10: the marker resolves per body;
+    /// the runner publishes the resolution).
+    pub fn body_integ_frame_uid(&self, body_idx: usize) -> &astrodyn::FrameUid {
+        assert!(
+            body_idx < self.bodies.len(),
+            "body_integ_frame_uid: body index {body_idx} out of range ({} bodies)",
+            self.bodies.len()
+        );
+        self.frame_tree
+            .get(self.bodies[body_idx].integ_frame_id)
+            .uid()
+            .expect("integration frames are stamped at add_body (RFS-303)")
     }
 
     // JEOD_INV: DS.01 — derived state config immutable after init; read-only access only

--- a/crates/astrodyn_runner/src/simulation/frame_attach.rs
+++ b/crates/astrodyn_runner/src/simulation/frame_attach.rs
@@ -572,6 +572,8 @@ impl Simulation {
                     .left_quat_to_transformation();
                 node.state.rot.ang_vel_this = body_rot.ang_vel_body.raw_si();
             }
+            self.frame_tree
+                .set_epoch(body_frame_id, Some(self.time.tdb()));
         }
     }
 }

--- a/crates/astrodyn_runner/src/simulation/mass_tree.rs
+++ b/crates/astrodyn_runner/src/simulation/mass_tree.rs
@@ -1819,17 +1819,17 @@ mod tests {
         // not numerical correctness, so opting in to the JEOD-faithful path
         // (#485 C1) keeps the test focus on its actual subject.
         let gj_cfg = GaussJacksonConfig::with_order(8).with_allow_non_convergence(true);
-        let make_cfg = |trans: TranslationalState| VehicleConfig {
+        let make_cfg = |name: &str, trans: TranslationalState| VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&trans),
             integrator: IntegratorType::GaussJackson(gj_cfg),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(1000.0)))),
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named(name)
         };
-        let body_a = sim.add_body(make_cfg(trans_a));
-        let body_b = sim.add_body(make_cfg(trans_b));
+        let body_a = sim.add_body(make_cfg("body-a", trans_a));
+        let body_b = sim.add_body(make_cfg("body-b", trans_b));
 
         // Register both in the mass tree so we can attach later.
         let id_a = sim.add_body_to_tree(body_a, "BodyA");
@@ -1928,20 +1928,23 @@ mod tests {
             position: DVec3::new(9e6, 0.0, 0.0),
             velocity: DVec3::new(0.0, 8000.0, 0.0),
         };
-        let make = |trans: TranslationalState| VehicleConfig {
+        let make = |name: &str, trans: TranslationalState| VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&trans),
             integrator: IntegratorType::GaussJackson(gj_cfg),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(1000.0)))),
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named(name)
         };
-        let body_a = sim.add_body(make(trans));
-        let body_b = sim.add_body(make(TranslationalState {
-            position: trans.position + DVec3::new(0.0, 1.0, 0.0),
-            velocity: trans.velocity,
-        }));
+        let body_a = sim.add_body(make("body-a", trans));
+        let body_b = sim.add_body(make(
+            "body-b",
+            TranslationalState {
+                position: trans.position + DVec3::new(0.0, 1.0, 0.0),
+                velocity: trans.velocity,
+            },
+        ));
         sim.add_body_to_tree(body_a, "BodyA");
         sim.add_body_to_tree(body_b, "BodyB");
 
@@ -2006,17 +2009,17 @@ mod tests {
             },
         );
 
-        let make_cfg = |trans: TranslationalState| VehicleConfig {
+        let make_cfg = |name: &str, trans: TranslationalState| VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&trans),
             integrator: IntegratorType::Abm4,
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(1000.0)))),
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named(name)
         };
-        let body_a = sim.add_body(make_cfg(trans_a));
-        let body_b = sim.add_body(make_cfg(trans_b));
+        let body_a = sim.add_body(make_cfg("body-a", trans_a));
+        let body_b = sim.add_body(make_cfg("body-b", trans_b));
         sim.add_body_to_tree(body_a, "BodyA");
         sim.add_body_to_tree(body_b, "BodyB");
 
@@ -2097,20 +2100,23 @@ mod tests {
             position: DVec3::new(9e6, 0.0, 0.0),
             velocity: DVec3::new(0.0, 8000.0, 0.0),
         };
-        let make = |trans: TranslationalState| VehicleConfig {
+        let make = |name: &str, trans: TranslationalState| VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&trans),
             integrator: IntegratorType::Abm4,
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(1000.0)))),
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named(name)
         };
-        let body_a = sim.add_body(make(trans));
-        let body_b = sim.add_body(make(TranslationalState {
-            position: trans.position + DVec3::new(0.0, 1.0, 0.0),
-            velocity: trans.velocity,
-        }));
+        let body_a = sim.add_body(make("body-a", trans));
+        let body_b = sim.add_body(make(
+            "body-b",
+            TranslationalState {
+                position: trans.position + DVec3::new(0.0, 1.0, 0.0),
+                velocity: trans.velocity,
+            },
+        ));
         sim.add_body_to_tree(body_a, "BodyA");
         sim.add_body_to_tree(body_b, "BodyB");
 
@@ -2182,19 +2188,19 @@ mod tests {
             position: DVec3::new(9e6, 0.0, 0.0),
             velocity: DVec3::new(0.0, 8000.0, 0.0),
         };
-        let make_cfg = || VehicleConfig {
+        let make_cfg = |name: &str| VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&trans),
             integrator: IntegratorType::GaussJackson(gj_cfg),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(1000.0)))),
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named(name)
         };
-        let top = sim.add_body(make_cfg());
-        let middle = sim.add_body(make_cfg());
-        let leaf = sim.add_body(make_cfg());
-        let new_attachee = sim.add_body(make_cfg());
+        let top = sim.add_body(make_cfg("top"));
+        let middle = sim.add_body(make_cfg("middle"));
+        let leaf = sim.add_body(make_cfg("leaf"));
+        let new_attachee = sim.add_body(make_cfg("new-attachee"));
         sim.add_body_to_tree(top, "Top");
         sim.add_body_to_tree(middle, "Middle");
         sim.add_body_to_tree(leaf, "Leaf");
@@ -2328,7 +2334,7 @@ mod tests {
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-8")
         });
         let cm_id = sim.add_body_to_tree(cm, "cm");
 
@@ -2515,7 +2521,7 @@ mod tests {
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-7")
         });
 
         let cm_id = sim.add_body_to_tree(cm_idx, "cm");
@@ -2860,7 +2866,7 @@ mod tests {
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-6")
         });
         let cm_id = sim.add_body_to_tree(body_idx, "cm");
 
@@ -2948,7 +2954,7 @@ mod tests {
             gravity_controls: GravityControls {
                 controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
             },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-5")
         });
         let cm_id = sim.add_body_to_tree(body_idx, "cm");
 
@@ -3023,7 +3029,7 @@ mod tests {
             )),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-4")
         });
         sim.add_body_to_tree(parent_idx, "parent");
         sim.add_body_to_tree(child_idx, "child");
@@ -3103,7 +3109,7 @@ mod tests {
             )),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-3")
         });
         sim.add_body_to_tree(parent_idx, "parent");
         let child_id = sim.add_body_to_tree(child_idx, "child");
@@ -3192,7 +3198,7 @@ mod tests {
             )),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(100.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-2")
         });
         let intermediate_idx = sim.add_body(VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&TranslationalState {
@@ -3207,7 +3213,7 @@ mod tests {
             )),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(50.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-1")
         });
         // 3-DOF body — no `rot` field.
         let three_dof_idx = sim.add_body(VehicleConfig {
@@ -3218,7 +3224,7 @@ mod tests {
             rot: None,
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(10.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("mass-tree-0")
         });
 
         sim.add_body_to_tree(parent_a_idx, "parent_a");

--- a/crates/astrodyn_runner/src/simulation/mod.rs
+++ b/crates/astrodyn_runner/src/simulation/mod.rs
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 use glam::DMat3;
 
 use astrodyn::atmosphere::AtmosphereConfig;
-use astrodyn::{FrameId, FrameTree, MassBodyId, RefFrameKind, SimulationTime, SourceFrameIds};
+use astrodyn::{FrameId, FrameTree, MassBodyId, SimulationTime, SourceFrameIds};
 
 use crate::simulation::types::{GravityData, SimBody};
 
@@ -292,7 +292,8 @@ impl Simulation {
     /// distinct children of root by [`Self::add_source`].
     pub fn new(time: SimulationTime, dt: f64) -> Self {
         let mut frame_tree = FrameTree::new();
-        let root_frame_id = frame_tree.add_root("root".into(), RefFrameKind::Inertial);
+        let root_frame_id = frame_tree.add_root_typed::<astrodyn::RootInertial>("root".into());
+        frame_tree.set_epoch(root_frame_id, Some(time.tdb()));
         Self {
             time,
             bodies: Vec::new(),

--- a/crates/astrodyn_runner/src/simulation/sources.rs
+++ b/crates/astrodyn_runner/src/simulation/sources.rs
@@ -5,13 +5,14 @@
 //! `set_source_state`, `source_pfix_rotation`, `source_tidal_config_mut`,
 //! `source_delta_c20`.
 
+use astrodyn::FrameUid;
 use glam::DVec3;
 
 use astrodyn::{
     set_source_position as sim_set_source_position, set_source_state as sim_set_source_state,
     source_pfix_rotation as sim_source_pfix_rotation, source_position as sim_source_position,
-    FrameId, FrameTree, GravitySourceEntry, JeodQuat, RefFrameKind, RefFrameRot, RefFrameState,
-    RefFrameTrans, RotationModel, SourceFrameIds,
+    FrameId, FrameTree, GravitySourceEntry, JeodQuat, RefFrameRot, RefFrameState, RefFrameTrans,
+    RotationModel, SourceFrameIds,
 };
 
 use super::types::GravityData;
@@ -29,6 +30,72 @@ impl Simulation {
     /// If the source has a rotation model, a planet-fixed child frame is also
     /// created under the source's inertial frame.
     pub fn add_source(&mut self, name: impl Into<String>, entry: GravitySourceEntry) -> usize {
+        let name = name.into();
+        match name.as_str() {
+            "Earth" => self.add_source_typed::<astrodyn::Earth>(name, entry),
+            "Moon" => self.add_source_typed::<astrodyn::Moon>(name, entry),
+            "Sun" => self.add_source_typed::<astrodyn::Sun>(name, entry),
+            "Mars" => self.add_source_typed::<astrodyn::Mars>(name, entry),
+            "Jupiter" => self.add_source_typed::<astrodyn::Jupiter>(name, entry),
+            "Saturn" => self.add_source_typed::<astrodyn::Saturn>(name, entry),
+            other => panic!(
+                "add_source: unknown gravity-source name {other:?} — the string-dispatch \
+                 add_source only knows the six sealed planets (Earth, Moon, Sun, Mars, \
+                 Jupiter, Saturn). For any other body, call add_source_typed::<P>(name, \
+                 entry) with a Planet marker defined via define_planet! so the source \
+                 frames get real stamped identities."
+            ),
+        }
+    }
+
+    /// Typed sibling of [`Self::add_source`]: the source's frame identities
+    /// are derived from the compile-time planet marker `P`
+    /// (`FrameUid::of::<PlanetInertial<P>>()` for the inertial child,
+    /// `FrameUid::of::<PlanetFixed<P>>()` for the optional planet-fixed
+    /// child). Use this directly for planets minted downstream via
+    /// `define_planet!`; the string-dispatch `add_source` routes the six
+    /// built-in planets here.
+    ///
+    /// The `name` argument labels the frame nodes for diagnostics and
+    /// `find_by_name`; the stamped identity comes from `P`, not from
+    /// `name`. Passing a name that disagrees with `P::NAME` is allowed
+    /// (the label is cosmetic) but discouraged. `marker_only` sources
+    /// flow through the same path and are stamped identically.
+    ///
+    /// # Panics
+    /// - a second central source, or a central source with non-zero
+    ///   position (pre-existing invariants);
+    /// - a duplicate source identity: registering the same planet twice
+    ///   trips the frame tree's duplicate-identity rejection.
+    pub fn add_source_typed<P: astrodyn::Planet>(
+        &mut self,
+        name: impl Into<String>,
+        entry: GravitySourceEntry,
+    ) -> usize {
+        self.add_source_with_uids(
+            name,
+            entry,
+            FrameUid::of::<astrodyn::PlanetInertial<P>>(),
+            FrameUid::of::<astrodyn::PlanetFixed<P>>(),
+        )
+    }
+
+    /// Value-level core of source registration: the caller supplies the
+    /// minted identities for the inertial and (optional) planet-fixed
+    /// frames. [`Self::add_source_typed`] mints them from a planet marker;
+    /// the `SimulationBuilder` path carries pre-minted identities as
+    /// configuration data — identity travels as a value through config,
+    /// exactly like body identity (issue #662).
+    ///
+    /// The `pfix_uid` is registered only when the source actually creates
+    /// a planet-fixed frame (rotation model or explicit transform).
+    pub fn add_source_with_uids(
+        &mut self,
+        name: impl Into<String>,
+        entry: GravitySourceEntry,
+        inertial_uid: FrameUid,
+        pfix_uid: FrameUid,
+    ) -> usize {
         let idx = self.gravity_data.len();
         let name = name.into();
 
@@ -63,10 +130,10 @@ impl Simulation {
             );
         }
         let inertial_name = format!("{name}.inertial");
-        let inertial_id = self.frame_tree.add_child(
+        let inertial_id = self.frame_tree.add_child_uid(
             self.root_frame_id,
+            inertial_uid,
             inertial_name,
-            RefFrameKind::Inertial,
             RefFrameState {
                 trans: RefFrameTrans {
                     // RefFrameTrans is the runtime arena's untyped storage —
@@ -83,6 +150,7 @@ impl Simulation {
                 // composition fast-paths during frame-tree walks.
                 rot: RefFrameRot::default(),
             },
+            Some(self.time.tdb()),
         );
 
         // Create a planet-fixed child when the source has a rotation model or
@@ -100,14 +168,15 @@ impl Simulation {
                 } else {
                     RefFrameRot::default()
                 };
-                Some(self.frame_tree.add_child(
+                Some(self.frame_tree.add_child_uid(
                     inertial_id,
+                    pfix_uid,
                     pfix_name,
-                    RefFrameKind::PlanetFixed,
                     RefFrameState {
                         trans: RefFrameTrans::default(),
                         rot,
                     },
+                    Some(self.time.tdb()),
                 ))
             } else {
                 None

--- a/crates/astrodyn_runner/src/simulation/step/derived.rs
+++ b/crates/astrodyn_runner/src/simulation/step/derived.rs
@@ -142,6 +142,12 @@ impl Simulation {
 
 #[cfg(test)]
 mod tests {
+    /// Synthetic gravity-source markers (issue #662 strict identity).
+    mod tags {
+        astrodyn::define_planet!(Far);
+        astrodyn::define_planet!(Origin);
+    }
+
     use crate::Simulation;
     use astrodyn::JeodQuat;
     use astrodyn::{
@@ -175,7 +181,7 @@ mod tests {
         let dt = 0.1;
         let time = SimulationTime::at_j2000(default_leap_second_table());
         let mut sim = Simulation::new(time, dt);
-        let origin_src = sim.add_source(
+        let origin_src = sim.add_source_typed::<tags::Origin>(
             "Origin",
             GravitySourceEntry {
                 source: GravitySource {
@@ -196,7 +202,7 @@ mod tests {
         // Source 1: 1e9 m offset in +X. Marked non-central so the body's
         // gravity_controls flip on switch (mirrors realistic frame-switch
         // wiring; the test does not depend on the flip).
-        let far_src = sim.add_source(
+        let far_src = sim.add_source_typed::<tags::Far>(
             "Far",
             GravitySourceEntry {
                 source: GravitySource {
@@ -294,7 +300,7 @@ mod tests {
                 solar_beta: true,
                 ..Default::default()
             },
-            ..Default::default()
+            ..VehicleConfig::named("derived-veh")
         });
 
         sim.step().expect("step() must succeed");

--- a/crates/astrodyn_runner/src/simulation/step/ephemeris.rs
+++ b/crates/astrodyn_runner/src/simulation/step/ephemeris.rs
@@ -58,6 +58,8 @@ impl Simulation {
         // configurations without any ephemeris source from paying for
         // an unused conversion.
         let tdb_jd = self.time.tdb_julian_date();
+        // Frame-epoch stamp for every node this stage writes (RFS-603).
+        let frame_epoch = Some(self.time.tdb());
         let mut tdb_epoch: Option<astrodyn::Epoch> = None;
         for (i, grav) in self.gravity_data.iter_mut().enumerate() {
             match grav.rotation_model {
@@ -73,6 +75,7 @@ impl Simulation {
                             rotation,
                             grav.planet_omega,
                         );
+                        self.frame_tree.set_epoch(pfix_id, frame_epoch);
                     }
                 }
                 RotationModel::MarsIAU => {
@@ -87,6 +90,7 @@ impl Simulation {
                             rotation,
                             grav.planet_omega,
                         );
+                        self.frame_tree.set_epoch(pfix_id, frame_epoch);
                     }
                 }
                 RotationModel::MoonIAU => {
@@ -101,6 +105,7 @@ impl Simulation {
                             rotation,
                             grav.planet_omega,
                         );
+                        self.frame_tree.set_epoch(pfix_id, frame_epoch);
                     }
                 }
                 RotationModel::MoonDE421 => {
@@ -120,6 +125,7 @@ impl Simulation {
                             rotation,
                             grav.planet_omega,
                         );
+                        self.frame_tree.set_epoch(pfix_id, frame_epoch);
                     }
                 }
             }
@@ -171,6 +177,7 @@ impl Simulation {
                     let node = self.frame_tree.get_mut(fid);
                     node.state.trans.position = pos;
                     node.state.trans.velocity = vel;
+                    self.frame_tree.set_epoch(fid, Some(self.time.tdb()));
                     // Also update gravity_data velocity for relativistic corrections.
                     self.gravity_data[i].velocity = vel;
                 }

--- a/crates/astrodyn_runner/src/simulation/step/integrate.rs
+++ b/crates/astrodyn_runner/src/simulation/step/integrate.rs
@@ -870,11 +870,14 @@ impl Simulation {
             }
         }
 
-        // Sync body positions back to frame tree after integration.
+        // Sync body positions back to frame tree after integration,
+        // stamping each node's frame epoch with the step's end time.
+        let frame_epoch = Some(self.time.tdb());
         for body in &self.bodies {
             let node = self.frame_tree.get_mut(body.body_frame_id);
             node.state.trans.position = body.trans.position.raw_si();
             node.state.trans.velocity = body.trans.velocity.raw_si();
+            self.frame_tree.set_epoch(body.body_frame_id, frame_epoch);
         }
 
         // ── 8b. Frame switch (body actions) ──

--- a/crates/astrodyn_runner/src/simulation/step/kinematic.rs
+++ b/crates/astrodyn_runner/src/simulation/step/kinematic.rs
@@ -411,6 +411,12 @@ impl Simulation {
 
 #[cfg(test)]
 mod tests {
+    /// Synthetic gravity-source markers (issue #662 strict identity).
+    mod tags {
+        astrodyn::define_planet!(Offset);
+        astrodyn::define_planet!(Origin);
+    }
+
     use crate::SimulationBuilderExt;
     use astrodyn::typed_bridge::{mass_raw_to_self_ref, rot_raw_to_self_ref, trans_raw_to_typed};
     use astrodyn::{
@@ -495,7 +501,7 @@ mod tests {
             )),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-child")
         });
 
         let _ = sim.add_body_to_tree(child_idx, "child");
@@ -643,7 +649,7 @@ mod tests {
         let mut sim = Simulation::new(time, dt);
         // Add a benign root-frame source (mu=0, central) so the parent
         // body has a typed integ frame at root.
-        let _root_src = sim.add_source(
+        let _root_src = sim.add_source_typed::<tags::Origin>(
             "Origin",
             GravitySourceEntry {
                 source: GravitySource {
@@ -664,7 +670,7 @@ mod tests {
         // Add a non-central source whose inertial frame is offset
         // from root. We keep `mu=0` so the source applies no gravity
         // — the chain we test is kinematic-only, not gravitational.
-        let offset_src = sim.add_source(
+        let offset_src = sim.add_source_typed::<tags::Offset>(
             "Offset",
             GravitySourceEntry {
                 source: GravitySource {
@@ -704,7 +710,7 @@ mod tests {
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(10.0)))),
             gravity_controls: GravityControls { controls: vec![] },
             // integ_source: None ⇒ root-frame integration.
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-9")
         });
 
         // Child integrates in the offset source's inertial frame.
@@ -750,7 +756,7 @@ mod tests {
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
             integ_source: Some(offset_src),
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-8")
         });
 
         sim.add_body_to_tree(parent_idx, "parent");
@@ -884,7 +890,7 @@ mod tests {
             rot: None,
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-7")
         });
         sim.add_body_to_tree(parent_idx, "parent");
         sim.add_body_to_tree(child_idx, "child");
@@ -908,7 +914,7 @@ mod tests {
             rot: Some(rot_raw_to_self_ref(&(RotationalState::default()))),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-6")
         });
         sim.add_body_to_tree(child_idx, "child");
         sim.attach(child_idx, 0, DVec3::ZERO, DMat3::IDENTITY);
@@ -980,7 +986,7 @@ mod tests {
             )),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(10.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-5")
         });
 
         // Child appendage with derivative-class flat-plate SRP.
@@ -1023,7 +1029,7 @@ mod tests {
                 integration_order: ThermalIntegrationOrder::DerivativeRk4,
                 ..Default::default()
             })),
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-4")
         });
 
         // Build the chain and mark the child kinematic.
@@ -1095,14 +1101,14 @@ mod tests {
             rot: Some(rot_raw_to_self_ref(&(RotationalState::default()))),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-3")
         });
         let leaf_idx = sim.add_body(VehicleConfig {
             trans: trans_raw_to_typed::<RootInertial>(&TranslationalState::default()),
             rot: Some(rot_raw_to_self_ref(&(RotationalState::default()))),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(2.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-2")
         });
         sim.add_body_to_tree(root_idx, "root");
         sim.add_body_to_tree(mid_idx, "mid");
@@ -1172,7 +1178,7 @@ mod tests {
             rot: Some(rot_raw_to_self_ref(&(RotationalState::default()))),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(10.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-1")
         });
         sim.add_body_to_tree(body_b_idx, "body_b");
 
@@ -1184,7 +1190,7 @@ mod tests {
             rot: Some(rot_raw_to_self_ref(&(RotationalState::default()))),
             mass: Some(mass_raw_to_self_ref(&(MassProperties::new(5.0)))),
             gravity_controls: GravityControls { controls: vec![] },
-            ..Default::default()
+            ..VehicleConfig::named("kinematic-0")
         });
         sim.add_body_to_tree(body_c_idx, "body_c");
         sim.attach(body_c_idx, body_b_idx, link_offset, DMat3::IDENTITY);

--- a/crates/astrodyn_runner/src/simulation/step/mod.rs
+++ b/crates/astrodyn_runner/src/simulation/step/mod.rs
@@ -25,7 +25,7 @@
 
 use glam::DVec3;
 
-use astrodyn::{FrameId, IntegOrigin, Vec3Ext};
+use astrodyn::{FrameId, IntegOrigin};
 
 use super::Simulation;
 use crate::error::StepError;
@@ -87,14 +87,18 @@ impl Simulation {
     /// origin in root-relative coordinates and the runner's root is
     /// inertial by construction.
     pub fn frame_origin_typed(&self, frame_id: FrameId) -> IntegOrigin {
-        let (pos, vel) = astrodyn::frame_orchestration::frame_origin(
+        // Routed through the CHECKED typed helper (issue #662): the root
+        // node's stamped identity is verified against `RootInertial` on
+        // every per-step call, so the production path exercises the
+        // identity check rather than asserting it by convention.
+        let (pos, vel) = astrodyn::frame_orchestration::frame_origin_typed::<astrodyn::RootInertial>(
             &self.frame_tree,
             self.root_frame_id,
             frame_id,
         );
         IntegOrigin {
-            position: pos.m_at::<astrodyn::RootInertial>(),
-            velocity: vel.m_per_s_at::<astrodyn::RootInertial>(),
+            position: pos,
+            velocity: vel,
         }
     }
 

--- a/crates/astrodyn_runner/tests/central_source_integ_frame.rs
+++ b/crates/astrodyn_runner/tests/central_source_integ_frame.rs
@@ -68,7 +68,7 @@ fn leo_body_config(integ_source: Option<usize>, gravity_source_idx: usize) -> Ve
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("central-source-integ-frame-0")
     };
     cfg.integ_source = integ_source;
     cfg.derived.orbital_elements_source = Some(gravity_source_idx);

--- a/crates/astrodyn_runner/tests/frame_identity_stamping.rs
+++ b/crates/astrodyn_runner/tests/frame_identity_stamping.rs
@@ -1,0 +1,147 @@
+//! Positive tests for issue #662: the runner stamps real frame
+//! identities on every production frame node, and those identities are
+//! stable handles — a body's `FrameUid` resolves to the same `FrameId`
+//! across structural changes (frame switches), and the resolved
+//! integration-frame identity is published per body.
+
+use astrodyn::{
+    named_body_frame_uid, FrameUid, GravityControl, GravityControls, GravityGradient, GravityModel,
+    GravitySource, GravitySourceEntry, IntegratorType, PlanetInertial, Position, RootInertial,
+    RotationModel, SimulationTime, TranslationalStateTyped, VehicleConfig, Velocity, EARTH,
+};
+use astrodyn_runner::Simulation;
+use glam::DVec3;
+
+fn point_mass_entry(
+    mu: f64,
+    position: Position<RootInertial>,
+    central: bool,
+) -> GravitySourceEntry {
+    GravitySourceEntry {
+        source: GravitySource {
+            mu,
+            model: GravityModel::PointMass,
+        },
+        position,
+        velocity: Velocity::<RootInertial>::zero(),
+        t_inertial_pfix: None,
+        delta_c20: 0.0,
+        rotation_model: RotationModel::None,
+        tidal_config: None,
+        planet_omega: 0.0,
+        central,
+        marker_only: false,
+    }
+}
+
+fn leo_body(name: &str, gravity_source_idx: usize) -> VehicleConfig {
+    VehicleConfig {
+        trans: TranslationalStateTyped::<RootInertial> {
+            // allowed: typed↔raw kernel-boundary helpers used in test scaffolding
+            position: Position::<RootInertial>::from_raw_si(DVec3::new(7.0e6, 0.0, 0.0)),
+            // allowed: typed↔raw kernel-boundary helpers used in test scaffolding
+            velocity: Velocity::<RootInertial>::from_raw_si(DVec3::new(0.0, 7.5e3, 0.0)),
+        },
+        integrator: IntegratorType::Rk4,
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(
+                gravity_source_idx,
+                GravityGradient::Skip,
+            )],
+        },
+        ..VehicleConfig::named(name)
+    }
+}
+
+/// `body_integ_frame_uid` publishes the *resolved* integration-frame
+/// identity (RF.10: the `IntegrationFrame` marker resolves per body):
+/// `RootInertial` for `integ_source = None`, the source's
+/// `PlanetInertial<P>` identity for `integ_source = Some(idx)`.
+#[test]
+fn body_integ_frame_uid_publishes_resolved_identity() {
+    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
+    let mut sim = Simulation::new(time, 1.0);
+    let earth_idx = sim.add_source(
+        "Earth",
+        point_mass_entry(EARTH.shape.mu, Position::<RootInertial>::zero(), true),
+    );
+
+    let root_integrating = sim.add_body(leo_body("root-integrating", earth_idx));
+    let mut cfg = leo_body("earth-integrating", earth_idx);
+    cfg.integ_source = Some(earth_idx);
+    let earth_integrating = sim.add_body(cfg);
+
+    assert_eq!(
+        sim.body_integ_frame_uid(root_integrating),
+        &FrameUid::of::<RootInertial>(),
+        "integ_source = None resolves to the root frame's identity"
+    );
+    assert_eq!(
+        sim.body_integ_frame_uid(earth_integrating),
+        &FrameUid::of::<PlanetInertial<astrodyn::Earth>>(),
+        "integ_source = Some(earth) resolves to Earth's inertial identity"
+    );
+}
+
+/// Acceptance item from #662: a body's `FrameUid` is a stable handle —
+/// after a frame switch reparents the body's frame node, `find(&uid)`
+/// resolves to the **same** `FrameId`, and the published
+/// integration-frame identity flips to the switch target's.
+#[test]
+fn frame_switch_preserves_uid_to_frame_id_resolution() {
+    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
+    let mut sim = Simulation::new(time, 1.0);
+    let earth_idx = sim.add_source(
+        "Earth",
+        point_mass_entry(EARTH.shape.mu, Position::<RootInertial>::zero(), true),
+    );
+    let moon_idx = sim.add_source(
+        "Moon",
+        point_mass_entry(
+            4.9028e12,
+            // allowed: typed↔raw kernel-boundary helpers used in test scaffolding
+            Position::<RootInertial>::from_raw_si(DVec3::new(3.84e8, 0.0, 0.0)),
+            false,
+        ),
+    );
+
+    let mut cfg = leo_body("switcher", earth_idx);
+    cfg.frame_switches.push(astrodyn::FrameSwitchConfig {
+        target_source: moon_idx,
+        switch_sense: astrodyn::SwitchSense::OnApproach,
+        // Far larger than the ~3.8e8 m body-to-Moon distance, so the
+        // switch triggers on the first step.
+        switch_distance: 1.0e12,
+        active: true,
+    });
+    let body_idx = sim.add_body(cfg);
+
+    let uid = named_body_frame_uid("switcher");
+    let fid_before = sim
+        .frame_tree()
+        .find(&uid)
+        .expect("body frame is stamped with the mission-supplied identity at add_body");
+    assert_eq!(
+        sim.body_integ_frame_uid(body_idx),
+        &FrameUid::of::<RootInertial>(),
+        "before the switch the body integrates in root"
+    );
+
+    sim.step().expect("step with a pending frame switch");
+
+    let fid_after = sim
+        .frame_tree()
+        .find(&uid)
+        .expect("the body's identity survives the reparent");
+    assert_eq!(
+        fid_before, fid_after,
+        "a frame switch reparents the body's node; its FrameUid must keep \
+         resolving to the same FrameId"
+    );
+    assert_eq!(
+        sim.body_integ_frame_uid(body_idx),
+        &FrameUid::of::<PlanetInertial<astrodyn::Moon>>(),
+        "after the switch the published integration-frame identity is the \
+         switch target's"
+    );
+}

--- a/crates/astrodyn_runner/tests/integ_frame_translation_invariance.rs
+++ b/crates/astrodyn_runner/tests/integ_frame_translation_invariance.rs
@@ -45,6 +45,13 @@ use astrodyn::{
 };
 use astrodyn_runner::{Simulation, SimulationBuilderExt};
 
+/// Synthetic gravity-source markers: these tests anchor bodies to
+/// non-planet sources, which (per issue #662's strict identity rule)
+/// require `define_planet!`-minted markers and `add_source_typed`.
+mod tags {
+    astrodyn::define_planet!(Ssb);
+}
+
 const MU_EARTH: f64 = 3.986_004_415e14; // m^3/s^2
 const MU_BARYCENTER: f64 = 0.0; // SSB-as-central placeholder: no mass at root
 
@@ -172,7 +179,7 @@ fn body_config(integ_source: Option<usize>, gravity_source_idx: usize) -> Vehicl
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("integ-frame-translation-invariance-0")
     };
 
     cfg.integ_source = integ_source;
@@ -219,7 +226,7 @@ fn build_root_setup() -> Simulation {
 fn build_offset_setup() -> Simulation {
     let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
     let mut sb = SimulationBuilder::new(time, DT);
-    let _ssb = sb.add_source("SSB", ssb_barycenter());
+    let _ssb = sb.add_source_typed::<tags::Ssb>("SSB", ssb_barycenter());
     let earth = sb.add_source("Earth", earth_at_offset(MU_EARTH));
     let sun = sb.add_source("Sun", sun_source(SSB_TO_EARTH_OFFSET + SUN_FROM_EARTH));
     sb = sb.atmosphere(atmosphere_config(), earth).sun(sun);

--- a/crates/astrodyn_runner/tests/negative_invariants.rs
+++ b/crates/astrodyn_runner/tests/negative_invariants.rs
@@ -19,6 +19,13 @@ use glam::DVec3;
 use uom::si::f64::Mass;
 use uom::si::mass::kilogram;
 
+/// Synthetic gravity-source markers: these tests anchor bodies to
+/// non-planet sources, which (per issue #662's strict identity rule)
+/// require `define_planet!`-minted markers and `add_source_typed`.
+mod tags {
+    astrodyn::define_planet!(InertialAnchor);
+}
+
 fn trans_typed(t: &TranslationalState) -> TranslationalStateTyped<RootInertial> {
     TranslationalStateTyped::<RootInertial> {
         // allowed: typed↔raw kernel-boundary helpers used in test scaffolding
@@ -53,7 +60,7 @@ fn mass_typed(mp: &SimMassProperties) -> MassPropertiesTyped<SelfRef> {
 fn build_two_body_sim() -> (Simulation, usize) {
     let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
     let mut sim = Simulation::new(time, 1.0);
-    let inertial = sim.add_source(
+    let inertial = sim.add_source_typed::<tags::InertialAnchor>(
         "InertialAnchor",
         GravitySourceEntry {
             source: GravitySource {
@@ -80,7 +87,7 @@ fn build_two_body_sim() -> (Simulation, usize) {
         quaternion: JeodQuat::identity(),
         ang_vel_body: DVec3::ZERO,
     };
-    let make_body = || VehicleConfig {
+    let make_body = |name: &str| VehicleConfig {
         trans: trans_typed(&body_trans),
         rot: Some(rot_typed(&body_rot)),
         mass: Some(mass_typed(&mp)),
@@ -91,11 +98,123 @@ fn build_two_body_sim() -> (Simulation, usize) {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named(name)
     };
-    let a = sim.add_body(make_body());
-    let _b = sim.add_body(make_body());
+    let a = sim.add_body(make_body("body-a"));
+    let _b = sim.add_body(make_body("body-b"));
     (sim, a)
+}
+
+// Issue #662 / RFS-401 — every body's frame identity is mission-supplied
+// and unique within a simulation. Two bodies built from
+// `VehicleConfig::named("chaser")` mint the same `FrameUid`; the frame
+// tree rejects the second registration at the point of introduction
+// rather than letting two distinct bodies silently share an identity.
+#[test]
+#[should_panic(expected = "duplicate frame identity")]
+fn duplicate_body_identity_panics() {
+    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
+    let mut sim = Simulation::new(time, 1.0);
+    let inertial = sim.add_source_typed::<tags::InertialAnchor>(
+        "InertialAnchor",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: Position::<RootInertial>::zero(),
+            velocity: Velocity::<RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: astrodyn_runner::RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
+    let make_body = || VehicleConfig {
+        trans: trans_typed(&TranslationalState {
+            position: DVec3::new(1.0, 0.0, 0.0),
+            velocity: DVec3::ZERO,
+        }),
+        integrator: IntegratorType::Rk4,
+        gravity_controls: GravityControls {
+            controls: vec![GravityControl::new_spherical(
+                inertial,
+                GravityGradient::Skip,
+            )],
+        },
+        ..VehicleConfig::named("chaser")
+    };
+    sim.add_body(make_body());
+    sim.add_body(make_body()); // same name → same FrameUid → panic
+}
+
+// Issue #662 / RFS-401 — source identities are unique too: registering
+// the same planet twice mints the same `FrameUid::of::<PlanetInertial<P>>()`
+// and trips the frame tree's duplicate-identity rejection. The second
+// entry is non-central so the (older) single-central-source assert cannot
+// fire first — this pins the *identity* check specifically.
+#[test]
+#[should_panic(expected = "duplicate frame identity")]
+fn duplicate_source_identity_panics() {
+    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
+    let mut sim = Simulation::new(time, 1.0);
+    let entry = |central: bool, position: Position<RootInertial>| GravitySourceEntry {
+        source: GravitySource {
+            mu: 0.0,
+            model: GravityModel::PointMass,
+        },
+        position,
+        velocity: Velocity::<RootInertial>::zero(),
+        t_inertial_pfix: None,
+        delta_c20: 0.0,
+        rotation_model: astrodyn_runner::RotationModel::default(),
+        tidal_config: None,
+        planet_omega: 0.0,
+        central,
+        marker_only: false,
+    };
+    sim.add_source("Earth", entry(true, Position::<RootInertial>::zero()));
+    sim.add_source(
+        "Earth",
+        entry(
+            false,
+            // allowed: typed↔raw kernel-boundary helpers used in test scaffolding
+            Position::<RootInertial>::from_raw_si(DVec3::new(1.0e9, 0.0, 0.0)),
+        ),
+    );
+}
+
+// Issue #662 — the string-dispatch `add_source` is a closed set: the six
+// sealed planets. Any other name must come through `add_source_typed`
+// with a `define_planet!` marker so the source frames carry real stamped
+// identities; a silent fallback would mint an unstamped (or
+// name-collision-prone) frame.
+#[test]
+#[should_panic(expected = "unknown gravity-source name")]
+fn unknown_source_name_panics() {
+    let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
+    let mut sim = Simulation::new(time, 1.0);
+    sim.add_source(
+        "Pluto",
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: Position::<RootInertial>::zero(),
+            velocity: Velocity::<RootInertial>::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: astrodyn_runner::RotationModel::default(),
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        },
+    );
 }
 
 // JEOD_INV: IN.30 — contact pair bodies must be distinct (JEOD

--- a/crates/astrodyn_runner/tests/pipeline_earth_lighting.rs
+++ b/crates/astrodyn_runner/tests/pipeline_earth_lighting.rs
@@ -132,7 +132,7 @@ fn pipeline_earth_lighting_smoke() {
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("pipeline-earth-lighting-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_runner/tests/runner_attach_detach_momentum.rs
+++ b/crates/astrodyn_runner/tests/runner_attach_detach_momentum.rs
@@ -50,6 +50,14 @@ use glam::{DMat3, DVec3};
 use uom::si::f64::Mass;
 use uom::si::mass::kilogram;
 
+/// Synthetic gravity-source markers: these tests anchor bodies to
+/// non-planet sources, which (per issue #662's strict identity rule)
+/// require `define_planet!`-minted markers and `add_source_typed`.
+mod tags {
+    astrodyn::define_planet!(InertialAnchor);
+    astrodyn::define_planet!(Ssb);
+}
+
 // allowed: typed↔raw kernel-boundary helpers used in test scaffolding
 // (issue #397).
 fn trans_typed(t: &TranslationalState) -> TranslationalStateTyped<RootInertial> {
@@ -101,7 +109,7 @@ fn build_pair(
     // Inertial-only environment: no gravity sources contributing
     // acceleration. We still need at least one source frame for the
     // pipeline to be valid.
-    let inertial = sim.add_source(
+    let inertial = sim.add_source_typed::<tags::InertialAnchor>(
         "InertialAnchor",
         GravitySourceEntry {
             source: GravitySource {
@@ -133,7 +141,7 @@ fn build_pair(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-8")
     });
     let child_idx = sim.add_body(VehicleConfig {
         trans: trans_typed(&child_trans),
@@ -146,7 +154,7 @@ fn build_pair(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-7")
     });
 
     let parent_id = sim.add_body_to_tree(parent_idx, "Parent");
@@ -626,7 +634,7 @@ fn runner_attach_handles_interior_kinematic_parent() {
     let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
     let mut sim = Simulation::new(time, 1.0);
 
-    let inertial = sim.add_source(
+    let inertial = sim.add_source_typed::<tags::InertialAnchor>(
         "InertialAnchor",
         GravitySourceEntry {
             source: GravitySource {
@@ -656,7 +664,7 @@ fn runner_attach_handles_interior_kinematic_parent() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-6")
     });
     let b_idx = sim.add_body(VehicleConfig {
         trans: trans_typed(&b_trans),
@@ -669,7 +677,7 @@ fn runner_attach_handles_interior_kinematic_parent() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-5")
     });
     let c_idx = sim.add_body(VehicleConfig {
         trans: trans_typed(&c_trans),
@@ -682,7 +690,7 @@ fn runner_attach_handles_interior_kinematic_parent() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-4")
     });
 
     let _a_id = sim.add_body_to_tree(a_idx, "A");
@@ -844,7 +852,7 @@ fn runner_detach_lifts_through_integ_origin() {
 
     // Root = SSB barycenter (mu=0 placeholder); Earth is a non-central
     // child at SSB_TO_EARTH so `IntegOrigin{Earth} != 0`.
-    let _ssb = sb.add_source(
+    let _ssb = sb.add_source_typed::<tags::Ssb>(
         "SSB",
         GravitySourceEntry {
             source: GravitySource {
@@ -890,7 +898,7 @@ fn runner_detach_lifts_through_integ_origin() {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         integ_source: Some(earth),
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-3")
     });
     let child_idx = sb.add_body(VehicleConfig {
         trans: trans_typed(&child_trans),
@@ -901,7 +909,7 @@ fn runner_detach_lifts_through_integ_origin() {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         integ_source: Some(earth),
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-2")
     });
     let mut sim = sb.build().expect("non-root-integ pair builds");
 
@@ -1029,7 +1037,7 @@ fn from_builder_preserves_attached_bodies_initial_state() {
 
     let time = SimulationTime::at_j2000(astrodyn::default_leap_second_table());
     let mut sb = SimulationBuilder::new(time, 1.0);
-    let _inertial = sb.add_source(
+    let _inertial = sb.add_source_typed::<tags::InertialAnchor>(
         "InertialAnchor",
         GravitySourceEntry {
             source: GravitySource {
@@ -1058,7 +1066,7 @@ fn from_builder_preserves_attached_bodies_initial_state() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-1")
     });
     let child_idx = sb.add_body(VehicleConfig {
         trans: trans_typed(&child_trans),
@@ -1071,7 +1079,7 @@ fn from_builder_preserves_attached_bodies_initial_state() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("runner-attach-detach-momentum-0")
     });
     sb.register_in_mass_tree(parent_idx, "Parent");
     sb.register_in_mass_tree(child_idx, "Child");

--- a/crates/astrodyn_verif_jeod/examples/mars_orbit.rs
+++ b/crates/astrodyn_verif_jeod/examples/mars_orbit.rs
@@ -83,6 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         velocity: INIT_VEL,
     };
     let dawn = VehicleBuilder::new()
+        .vehicle_named("mars-orbiter")
         .with_translational(astrodyn::typed_bridge::trans_raw_to_typed(&trans))
         .three_dof_point_mass(vehicle::dawn_mass())
         .rk4()

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_apollo_trajectory.rs
@@ -397,7 +397,7 @@ pub fn apollo_trajectory_builder() -> ApolloBuilderHandles {
                 GravityControl::new_third_body(sun),
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-apollo-trajectory-0")
     });
 
     // Register cm in the mass tree under the canonical name "cm" so the

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_attach_detach_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_attach_detach_trajectory.rs
@@ -130,7 +130,7 @@ fn build_attach_detach_trajectory(_init: &InitialConditions) -> SimulationBuilde
         mass: Some(super::typed_helpers::mass_typed(&veh1_mass())),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("sim-attach-detach-trajectory-2")
     });
     let v2 = sb.add_body(VehicleConfig {
         trans: super::typed_helpers::trans_typed(&veh2_trans()),
@@ -138,7 +138,7 @@ fn build_attach_detach_trajectory(_init: &InitialConditions) -> SimulationBuilde
         mass: Some(super::typed_helpers::mass_typed(&veh2_mass())),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("sim-attach-detach-trajectory-1")
     });
     let v3 = sb.add_body(VehicleConfig {
         trans: super::typed_helpers::trans_typed(&veh3_trans()),
@@ -146,7 +146,7 @@ fn build_attach_detach_trajectory(_init: &InitialConditions) -> SimulationBuilde
         mass: Some(super::typed_helpers::mass_typed(&veh3_mass())),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("sim-attach-detach-trajectory-0")
     });
     sb.register_in_mass_tree(v1, "veh1");
     sb.register_in_mass_tree(v2, "veh2");

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs
@@ -88,7 +88,7 @@ fn build_orbelem_ecc(init: &InitialConditions) -> SimulationBuilder {
             orbital_elements_source: Some(earth),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-derived-state-4")
     });
     sb
 }
@@ -143,7 +143,7 @@ fn build_lvlh(init: &InitialConditions) -> SimulationBuilder {
             lvlh: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-derived-state-3")
     });
     sb
 }
@@ -249,7 +249,7 @@ fn build_ned(init: &InitialConditions, spherical: bool) -> SimulationBuilder {
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-derived-state-2")
     });
     sb
 }
@@ -412,7 +412,7 @@ fn build_euler_run2(init: &InitialConditions) -> SimulationBuilder {
             euler_sequence: Some(EulerSequence::XYZ),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-derived-state-1")
     });
     sb
 }
@@ -455,7 +455,7 @@ fn build_euler_edge(init: &InitialConditions) -> SimulationBuilder {
             euler_sequence: Some(EulerSequence::XYZ),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-derived-state-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_drag_6dof.rs
@@ -170,7 +170,7 @@ fn build_drag_6dof(
             constant_density: Some(DENSITY),
             ..Default::default()
         }),
-        ..Default::default()
+        ..VehicleConfig::named("sim-drag-6dof-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp.rs
@@ -98,7 +98,7 @@ fn build_run2_3dof(init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-13")
     });
     sb
 }
@@ -149,7 +149,7 @@ fn build_run2_6dof(init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-12")
     });
     sb
 }
@@ -302,7 +302,7 @@ fn build_run2_lvlh_rot_init(_init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-11")
     });
     sb
 }
@@ -494,7 +494,7 @@ fn build_run3_3dof(init: &InitialConditions, run_dir: &str) -> SimulationBuilder
                 earth_gradient,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-10")
     });
     sb
 }
@@ -633,7 +633,7 @@ fn build_run4_3rd_body(init: &InitialConditions) -> SimulationBuilder {
                 GravityControl::new_third_body(moon),
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-9")
     });
     sb
 }
@@ -783,7 +783,7 @@ pub fn build_battin_3rd_body(init: &InitialConditions, battin: bool) -> BattinSc
                 moon_control,
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-8")
     });
     BattinScenario {
         builder: sb,
@@ -954,7 +954,7 @@ fn build_run7(
             ],
         },
         drag,
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-7")
     });
     sb
 }
@@ -1089,7 +1089,7 @@ fn build_run5(init: &InitialConditions, case: &str) -> SimulationBuilder {
                 GravityGradient::Compute,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-6")
     });
     sb
 }
@@ -1183,7 +1183,7 @@ fn build_run6_drag(
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         drag: Some(drag_config),
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-5")
     });
     sb
 }
@@ -1300,7 +1300,7 @@ fn build_run6_maneuver(init: &InitialConditions, case: &'static str) -> Simulati
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-4")
     });
     sb
 }
@@ -1450,7 +1450,7 @@ fn build_run10(init: &InitialConditions, case: &str) -> SimulationBuilder {
             )],
         },
         compute_gravity_gradient: true,
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-3")
     });
     sb
 }
@@ -1585,7 +1585,7 @@ fn build_run5a_met(init: &InitialConditions) -> SimulationBuilder {
                 GravityGradient::Compute,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-2")
     });
     sb
 }
@@ -1656,7 +1656,7 @@ fn build_run6b_aero_traj(init: &InitialConditions, t_struct_body: DMat3) -> Simu
             ..Default::default()
         }),
         t_struct_body,
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-1")
     });
     sb
 }
@@ -1804,7 +1804,7 @@ fn build_run9_scenario(init: &InitialConditions, case: &'static str) -> Simulati
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp_combinations.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_dyncomp_combinations.rs
@@ -192,7 +192,7 @@ fn build_kepler_sim(
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         external_force: Force::<RootInertial>::from_raw_si(external_force),
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-combinations-3")
     });
     sb
 }
@@ -231,7 +231,7 @@ fn build_kepler_6dof_sim(
         external_torque: Torque::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
             external_torque,
         ),
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-combinations-2")
     });
     sb
 }
@@ -358,7 +358,7 @@ fn build_point_mass_plus_thirdbody_conservation(_init: &InitialConditions) -> Si
                 GravityControl::new_third_body(moon),
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-combinations-1")
     });
     sb
 }
@@ -446,7 +446,7 @@ fn build_drag_point_mass_monotonic_decay(_init: &InitialConditions) -> Simulatio
             constant_density: Some(TEST3_DENSITY),
             ..Default::default()
         }),
-        ..Default::default()
+        ..VehicleConfig::named("sim-dyncomp-combinations-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
@@ -174,7 +174,7 @@ fn build_free_body_3dof(dt: f64, external_force: DVec3) -> SimulationBuilder {
         ))),
         gravity_controls: GravityControls { controls: vec![] },
         external_force: Force::<RootInertial>::from_raw_si(external_force),
-        ..Default::default()
+        ..VehicleConfig::named("sim-force-torque-response-2")
     });
     sb
 }
@@ -210,7 +210,7 @@ fn build_free_body_6dof(
         external_torque: Torque::<astrodyn::BodyFrame<astrodyn::SelfRef>>::from_raw_si(
             external_torque,
         ),
-        ..Default::default()
+        ..VehicleConfig::named("sim-force-torque-response-1")
     });
     sb
 }
@@ -508,7 +508,7 @@ fn build_force_struct_pre_step(_init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
         t_struct_body: t_struct_body_nontrivial(),
-        ..Default::default()
+        ..VehicleConfig::named("sim-force-torque-response-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_force_torque_response.rs
@@ -126,13 +126,20 @@ fn analytical_tolerances() -> Tolerances {
     }
 }
 
+/// Synthetic gravity-source marker for the empty-space root: not one of
+/// the six sealed planets, so (per issue #662's strict identity rule) it
+/// requires a `define_planet!`-minted marker and `add_source_typed`.
+mod tags {
+    astrodyn::define_planet!(CentralPoint);
+}
+
 /// A negligible gravity source kept in the frame tree but not
 /// referenced by any body. `Simulation` requires a root frame; using
 /// `central: true` with `mu = 0.0` gives us the frame without any
 /// gravitational effect. Mirrors the pre-recipe tier3 file's
 /// `add_dummy_central_source` helper exactly.
 fn add_dummy_central_source(sb: &mut SimulationBuilder) {
-    sb.add_source(
+    sb.add_source_typed::<tags::CentralPoint>(
         "central_point",
         GravitySourceEntry {
             source: GravitySource {

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_gj.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_gj.rs
@@ -93,7 +93,7 @@ fn build_gj_scenario(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-gj-0")
     });
     b
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_kinematic_propagation.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_kinematic_propagation.rs
@@ -111,7 +111,7 @@ fn build_kinematic_propagation(_init: &InitialConditions) -> SimulationBuilder {
         mass: Some(super::typed_helpers::mass_typed(&parent_mass())),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("sim-kinematic-propagation-1")
     });
     let child_idx = sb.add_body(VehicleConfig {
         trans: super::typed_helpers::trans_typed(&child_initial_trans()),
@@ -119,7 +119,7 @@ fn build_kinematic_propagation(_init: &InitialConditions) -> SimulationBuilder {
         mass: Some(super::typed_helpers::mass_typed(&child_mass())),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("sim-kinematic-propagation-0")
     });
     sb.register_in_mass_tree(parent_idx, "parent");
     sb.register_in_mass_tree(child_idx, "child");

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_lvlh_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_lvlh_extended.rs
@@ -87,7 +87,7 @@ fn build_lvlh_extended(mu_earth: f64, dt: f64, body: TranslationalState) -> Simu
             lvlh: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-lvlh-extended-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbelem_comprehensive.rs
@@ -101,7 +101,7 @@ fn build_orbelem_comprehensive(mu_earth: f64, body: TranslationalState) -> Simul
             orbital_elements_source: Some(earth),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-orbelem-comprehensive-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_docker.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_docker.rs
@@ -509,7 +509,7 @@ fn build_orbinit_docker(mu_earth: f64, body: TranslationalState) -> SimulationBu
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-orbinit-docker-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_edge.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_edge.rs
@@ -78,7 +78,7 @@ fn build_orbinit_edge(mu_earth: f64, body: TranslationalState) -> SimulationBuil
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-orbinit-edge-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_families.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_families.rs
@@ -126,7 +126,7 @@ fn build_orbinit_families(dt: f64, body: TranslationalState) -> SimulationBuilde
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-orbinit-families-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_roundtrip.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_orbinit_roundtrip.rs
@@ -118,7 +118,7 @@ fn build_orbinit_roundtrip(dt: f64, body: TranslationalState) -> SimulationBuild
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-orbinit-roundtrip-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_planetary.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_planetary.rs
@@ -53,7 +53,7 @@ fn build_planetary(init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-planetary-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_polar_motion.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_polar_motion.rs
@@ -61,7 +61,7 @@ fn build_run2p_polar_motion(init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-polar-motion-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_ref_attach.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_ref_attach.rs
@@ -108,6 +108,7 @@ fn build_ref_attach(_init: &InitialConditions) -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), DT_S);
     let _earth_idx = sb.add_source("Earth", earth::point_mass());
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("sim-ref-attach-0")
         .with_translational(astrodyn::typed_bridge::trans_raw_to_typed(
             &TranslationalState { position, velocity },
         ))

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_relative.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_relative.rs
@@ -78,7 +78,7 @@ fn build_two_body(
         } else {
             None
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-relative-1")
     });
     b.add_body(VehicleConfig {
         trans: super::typed_helpers::trans_typed(&trans_b),
@@ -92,7 +92,7 @@ fn build_two_body(
         } else {
             None
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-relative-0")
     });
     b
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_relative_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_relative_extended.rs
@@ -121,7 +121,7 @@ fn build_relative_extended(
             lvlh: lvlh_chief,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-relative-extended-1")
     });
     sb.add_body(VehicleConfig {
         trans: super::typed_helpers::trans_typed(&trans_deputy),
@@ -129,7 +129,7 @@ fn build_relative_extended(
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         derived: DerivedStateConfig::default(),
-        ..Default::default()
+        ..VehicleConfig::named("sim-relative-extended-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta.rs
@@ -140,7 +140,7 @@ fn build_solar_beta_run2(init: &InitialConditions) -> SimulationBuilder {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-solar-beta-2")
     });
     sb
 }
@@ -280,7 +280,7 @@ fn build_solar_beta_equ(init: &InitialConditions) -> SimulationBuilder {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-solar-beta-1")
     });
     sb
 }
@@ -370,7 +370,7 @@ fn build_solar_beta_obliquity(init: &InitialConditions) -> SimulationBuilder {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-solar-beta-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_solar_beta_extended.rs
@@ -132,7 +132,7 @@ fn build_solar_beta_extended(
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-solar-beta-extended-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_srp.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_srp.rs
@@ -266,7 +266,7 @@ fn build_srp(
             source_idx: earth,
             radius: EARTH.shadow_radius,
         }),
-        ..Default::default()
+        ..VehicleConfig::named("sim-srp-2")
     });
     sb
 }
@@ -558,7 +558,7 @@ fn parity_body_sixdof(earth_idx: usize, gradient: bool) -> VehicleConfig {
             controls: vec![GravityControl::new_spherical(earth_idx, gradient_mode)],
         },
         compute_gravity_gradient: gradient,
-        ..Default::default()
+        ..VehicleConfig::named("sim-srp-1")
     }
 }
 
@@ -664,7 +664,7 @@ fn build_flat_plate_with_shadow(_init: &InitialConditions) -> SimulationBuilder 
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("sim-srp-0")
     };
     // Override translational ICs to match the hand-rolled scenario
     // (GEO-radius circular orbit, not LEO-ISS).

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_tide_verif.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_tide_verif.rs
@@ -223,7 +223,7 @@ fn build_tide(init: &InitialConditions, split_gravity: bool) -> SimulationBuilde
             },
         },
         compute_gravity_gradient: true,
-        ..Default::default()
+        ..VehicleConfig::named("sim-tide-verif-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_torque_simple.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_torque_simple.rs
@@ -225,7 +225,7 @@ fn build_torque_simple(init: &InitialConditions, cfg: RunConfig) -> SimulationBu
             ],
         },
         compute_gravity_gradient: cfg.earth_gradient,
-        ..Default::default()
+        ..VehicleConfig::named("sim-torque-simple-0")
     });
 
     sb

--- a/crates/astrodyn_verif_jeod/src/setups/earth_moon_clem.rs
+++ b/crates/astrodyn_verif_jeod/src/setups/earth_moon_clem.rs
@@ -137,6 +137,7 @@ pub fn earth_moon_clem(dt: f64, initial_state: Option<(DVec3, DVec3)>) -> Simula
 
     let (pos, vel) = initial_state.unwrap_or((INIT_POS, INIT_VEL));
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("earth-moon-clem-0")
         .with_translational(astrodyn::typed_bridge::trans_raw_to_root(
             &TranslationalState {
                 position: pos,

--- a/crates/astrodyn_verif_jeod/src/setups/earth_moon_rosetta.rs
+++ b/crates/astrodyn_verif_jeod/src/setups/earth_moon_rosetta.rs
@@ -105,6 +105,7 @@ pub fn earth_moon_rosetta(dt: f64, initial_state: Option<(DVec3, DVec3)>) -> Sim
 
     let (pos, vel) = initial_state.unwrap_or((INIT_POS, INIT_VEL));
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("earth-moon-rosetta-0")
         .with_translational(astrodyn::typed_bridge::trans_raw_to_root(
             &TranslationalState {
                 position: pos,

--- a/crates/astrodyn_verif_jeod/tests/pre_step_smoke.rs
+++ b/crates/astrodyn_verif_jeod/tests/pre_step_smoke.rs
@@ -133,7 +133,7 @@ fn scenario(init: &InitialConditions) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("pre-step-smoke-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_jeod/tests/tier3_apollo8_frame_switch.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_apollo8_frame_switch.rs
@@ -194,7 +194,7 @@ fn build_apollo8_sim(enable_frame_switch: bool) -> (Simulation, usize, usize) {
         } else {
             vec![]
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-apollo8-frame-switch-0")
     });
 
     sim.validate().expect("validation failed");

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_attach_detach_trajectory.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_attach_detach_trajectory.rs
@@ -285,7 +285,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh1_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-attach-detach-trajectory-2")
     });
     let v2 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh2_initial_trans()),
@@ -295,7 +295,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh2_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-attach-detach-trajectory-1")
     });
     let v3 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh3_initial_trans()),
@@ -305,7 +305,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh3_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-attach-detach-trajectory-0")
     });
     sim.add_body_to_tree(v1, "veh1");
     sim.add_body_to_tree(v2, "veh2");

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_complex_attach_detach.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_complex_attach_detach.rs
@@ -356,7 +356,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh1_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-complex-attach-detach-2")
     });
     let v2 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh2_initial_trans()),
@@ -366,7 +366,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh2_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-complex-attach-detach-1")
     });
     let v3 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh3_initial_trans()),
@@ -376,7 +376,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh3_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-complex-attach-detach-0")
     });
     sim.add_body_to_tree(v1, "veh1");
     sim.add_body_to_tree(v2, "veh2");

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_contact.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_contact.rs
@@ -202,7 +202,7 @@ fn make_two_body_sim(mass: f64, inertia_diag: DVec3) -> Simulation {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-7")
     });
 
     let id2 = sim.add_body(VehicleConfig {
@@ -219,7 +219,7 @@ fn make_two_body_sim(mass: f64, inertia_diag: DVec3) -> Simulation {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-6")
     });
     assert_eq!(id1, 0);
     assert_eq!(id2, 1);
@@ -857,7 +857,7 @@ fn tier3_contact_line_side_to_side() {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-5")
     });
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
@@ -873,7 +873,7 @@ fn tier3_contact_line_side_to_side() {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-4")
     });
     sim.validate().unwrap();
 
@@ -963,7 +963,7 @@ fn tier3_contact_point_off_center() {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-3")
     });
     sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&TranslationalState {
@@ -979,7 +979,7 @@ fn tier3_contact_point_off_center() {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: GravityControls { controls: vec![] },
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-2")
     });
     sim.validate().unwrap();
 
@@ -1336,7 +1336,7 @@ fn make_ground_contact_sim() -> (Simulation, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: earth_grav.clone(),
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-1")
     });
 
     // veh2 — point sphere 10 m radially outward from veh1.
@@ -1354,7 +1354,7 @@ fn make_ground_contact_sim() -> (Simulation, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(mass_props))),
         gravity_controls: earth_grav,
         compute_gravity_gradient: false,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-contact-0")
     });
     assert_eq!(veh1, 0);
     assert_eq!(veh2, 1);

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_contact.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_contact.rs
@@ -149,11 +149,18 @@ fn load_contact_csv(path: &Path) -> Vec<ContactRecord> {
 
 // ── Simulation harness ──────────────────────────────────────────────
 
+/// Synthetic gravity-source marker for the empty-space root: not one of
+/// the six sealed planets, so (per issue #662's strict identity rule) it
+/// requires a `define_planet!`-minted marker and `add_source_typed`.
+mod tags {
+    astrodyn::define_planet!(Space);
+}
+
 /// Add an inertial-only gravity "source" with mu=0 so the Simulation has a
 /// root frame. Matches JEOD's `EphemerisMode_EmptySpace` which provides the
 /// Space.inertial root frame with no gravitational body.
 fn add_empty_space_root(sim: &mut Simulation) {
-    sim.add_source(
+    sim.add_source_typed::<tags::Space>(
         "Space",
         GravitySourceEntry {
             source: GravitySource {

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_analytical.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_drag_analytical.rs
@@ -117,7 +117,7 @@ fn make_drag_sim(
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         drag: Some(drag_config),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-drag-analytical-1")
     });
 
     sim.validate().unwrap();
@@ -576,7 +576,7 @@ fn make_drag_sim_with_wind(
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
         drag: Some(drag_config),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-drag-analytical-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_dyncomp_run_attach_to_ref_frame.rs
@@ -361,7 +361,7 @@ fn build_sim(t0: &DyncompRecord) -> (Simulation, usize, usize) {
             ..Default::default()
         }),
         compute_gravity_gradient: true,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-dyncomp-run-attach-to-ref-frame-0")
     });
 
     // Materialise the SimulationBuilder into the runtime Simulation.

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_analytical.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_analytical.rs
@@ -97,7 +97,7 @@ fn make_sim(integrator: IntegratorType, dt: f64) -> Simulation {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-integ-analytical-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_comparison.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_comparison.rs
@@ -93,7 +93,7 @@ fn make_sim(integrator: IntegratorType, dt: f64) -> Simulation {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-integ-comparison-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_gj_orders.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_integ_gj_orders.rs
@@ -99,7 +99,7 @@ fn gj_energy_error(order: usize) -> f64 {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-integ-gj-orders-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_kinematic_propagation.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_kinematic_propagation.rs
@@ -304,7 +304,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh1_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-kinematic-propagation-2")
     });
     let v2 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh2_initial_trans()),
@@ -314,7 +314,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh2_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-kinematic-propagation-1")
     });
     let v3 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh3_initial_trans()),
@@ -324,7 +324,7 @@ fn build_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(astrodyn::typed_bridge::mass_raw_to_self_ref(&(veh3_mass()))),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-kinematic-propagation-0")
     });
     sim.add_body_to_tree(v1, "veh1");
     sim.add_body_to_tree(v2, "veh2");

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_lsode.rs
@@ -200,7 +200,7 @@ fn run_integ_test(
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-lsode-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_lvlh_relative.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_lvlh_relative.rs
@@ -81,7 +81,7 @@ fn run_lvlhrel_scenario(label: &str, csv_name: &str) {
             position: init.ref_pos,
             velocity: init.ref_vel,
         }),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-lvlh-relative-1")
     });
 
     // Body 1: subject vehicle
@@ -90,7 +90,7 @@ fn run_lvlhrel_scenario(label: &str, csv_name: &str) {
             position: init.subj_pos,
             velocity: init.subj_vel,
         }),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-lvlh-relative-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_mars_orbit.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_mars_orbit.rs
@@ -153,7 +153,7 @@ fn tier3_simulation_mars_dawn() {
                 GravityControl::new_third_body(sun),
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-mars-orbit-1")
     });
 
     sim.validate().unwrap();
@@ -287,7 +287,7 @@ fn build_phobos_sim(init_pos: DVec3, init_vel: DVec3) -> Simulation {
                 GravityControl::new_third_body(sun),
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-mars-orbit-0")
     });
     sim.validate().unwrap();
     sim

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_mercury.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_mercury.rs
@@ -87,7 +87,7 @@ fn propagate_mercury_periapses(
         gravity_controls: GravityControls {
             controls: vec![ctrl],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-mercury-2")
     });
 
     sim.validate().unwrap();
@@ -286,7 +286,7 @@ fn tier3_simulation_mercury_relativistic_effect() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(sun_n, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-mercury-1")
     });
     sim_n.validate().unwrap();
     let steps = (total_time / dt) as usize;
@@ -317,7 +317,7 @@ fn tier3_simulation_mercury_relativistic_effect() {
         gravity_controls: GravityControls {
             controls: vec![ctrl],
         },
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-mercury-0")
     });
     sim_r.validate().unwrap();
     sim_r.step_n(steps).expect("step_n failed");

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_ref_attach.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_ref_attach.rs
@@ -196,6 +196,7 @@ fn build_ref_attach_sim() -> Simulation {
     let mut sb = SimulationBuilder::new(epoch::j2000(), DT_S);
     let _earth_idx = sb.add_source("Earth", earth::point_mass());
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("tier3-sim-ref-attach-0")
         .with_translational(astrodyn::typed_bridge::trans_raw_to_typed(
             &TranslationalState { position, velocity },
         ))

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_shadow_2a.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_shadow_2a.rs
@@ -138,7 +138,7 @@ fn run_shadow_comparison(csv_filename: &str, label: &str, test_name: &str, frac_
             albedo: 0.0,
             diffuse: 0.5,
         }),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-shadow-2a-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_srp_basic.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_srp_basic.rs
@@ -162,7 +162,7 @@ fn run_srp_basic_test(csv_filename: &str, label: &str) {
             t_pow4_cached: vec![init_temp.powi(4); num_plates],
             ..Default::default()
         })),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-srp-basic-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_srp_rk4_thermal.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_srp_rk4_thermal.rs
@@ -98,7 +98,7 @@ fn run_with_order(order: ThermalIntegrationOrder) -> (f64, DVec3) {
             integration_order: order,
             ..Default::default()
         })),
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-srp-rk4-thermal-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_jeod/tests/tier3_sim_time_reversal.rs
+++ b/crates/astrodyn_verif_jeod/tests/tier3_sim_time_reversal.rs
@@ -205,7 +205,7 @@ fn add_standard_body(
         )),
         gravity_controls: controls,
         drag,
-        ..Default::default()
+        ..VehicleConfig::named("tier3-sim-time-reversal-1")
     })
 }
 
@@ -672,7 +672,7 @@ fn tier3_sim_time_reversal_run9d() {
                 gravity_controls: GravityControls {
                     controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
                 },
-                ..Default::default()
+                ..VehicleConfig::named("tier3-sim-time-reversal-0")
             })
         },
         |sim, body, interval_start, _end| {

--- a/crates/astrodyn_verif_nesc/src/cc8.rs
+++ b/crates/astrodyn_verif_nesc/src/cc8.rs
@@ -167,6 +167,7 @@ pub fn cc8_builder() -> SimulationBuilder {
     // 6. Body. `nesc_apollo_lm()` returns the published mass + inertia
     // tensor (incl. off-diagonal) + CoM offset.
     let vehicle_cfg = VehicleBuilder::new()
+        .vehicle_named("cc8-0")
         .with_translational(trans)
         .sixdof(rot, vehicle::nesc_apollo_lm())
         .rk4()

--- a/crates/astrodyn_verif_parity/tests/bevy_parity.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity.rs
@@ -156,7 +156,7 @@ fn run_simulation_steps() -> SixDofState {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..astrodyn::VehicleConfig::named("bevy-parity-1")
     });
 
     sim.validate().unwrap();
@@ -296,7 +296,7 @@ fn bevy_parity_rkf45_matches_simulation_bit_identical() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..astrodyn::VehicleConfig::named("bevy-parity-0")
     });
 
     sim.validate().unwrap();

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_apollo8_frame_switch.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_apollo8_frame_switch.rs
@@ -196,7 +196,7 @@ fn apollo8_builder(enable_switch: bool) -> SimulationBuilder {
         } else {
             vec![]
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-apollo8-frame-switch-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
@@ -57,6 +57,8 @@ use std::time::Duration;
 mod tags {
     astrodyn::define_planet!(InertialAnchor);
     astrodyn::define_planet!(Ssb);
+    astrodyn::define_planet!(SourceA);
+    astrodyn::define_planet!(SourceB);
 }
 
 /// Build a Bevy app with two free-flying bodies registered in a shared
@@ -2896,7 +2898,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
             marker_only: false,
         },
     );
-    let runner_source_a = sim.add_source(
+    let runner_source_a = sim.add_source_typed::<tags::SourceA>(
         "SourceA",
         RunnerGravitySourceEntry {
             source: RunnerGravitySource {
@@ -2914,7 +2916,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
             marker_only: false,
         },
     );
-    let runner_source_b = sim.add_source(
+    let runner_source_b = sim.add_source_typed::<tags::SourceB>(
         "SourceB",
         RunnerGravitySourceEntry {
             source: RunnerGravitySource {

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
@@ -51,6 +51,14 @@ use bevy::prelude::*;
 use glam::{DMat3, DVec3};
 use std::time::Duration;
 
+/// Synthetic gravity-source markers: these tests anchor bodies to
+/// non-planet sources, which (per issue #662's strict identity rule)
+/// require `define_planet!`-minted markers and `add_source_typed`.
+mod tags {
+    astrodyn::define_planet!(InertialAnchor);
+    astrodyn::define_planet!(Ssb);
+}
+
 /// Build a Bevy app with two free-flying bodies registered in a shared
 /// `MassTreeR`, both carrying full 6-DOF state. No gravity sources —
 /// the bodies are inertial coasters so attach/detach math is the only
@@ -2455,7 +2463,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_attach_detach_momentum(
     // evaluation between snapshot and writeback contributes nothing.
     let time = RunnerSimulationTime::at_j2000(astrodyn::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
-    let inertial = sim.add_source(
+    let inertial = sim.add_source_typed::<tags::InertialAnchor>(
         "InertialAnchor",
         RunnerGravitySourceEntry {
             source: RunnerGravitySource {
@@ -2484,7 +2492,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_attach_detach_momentum(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..astrodyn::VehicleConfig::named("bevy-parity-attach-detach-momentum-3")
     });
     let child_idx = sim.add_body(RunnerVehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&child_trans),
@@ -2497,7 +2505,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_attach_detach_momentum(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..astrodyn::VehicleConfig::named("bevy-parity-attach-detach-momentum-2")
     });
     sim.add_body_to_tree(parent_idx, "Parent");
     sim.add_body_to_tree(child_idx, "Child");
@@ -2870,7 +2878,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
     // the equivalent of `IntegSourceC` here.
     let time = RunnerSimulationTime::at_j2000(astrodyn::default_leap_second_table());
     let mut sim = Simulation::new(time, dt);
-    let _ssb = sim.add_source(
+    let _ssb = sim.add_source_typed::<tags::Ssb>(
         "SSB",
         RunnerGravitySourceEntry {
             source: RunnerGravitySource {
@@ -2936,7 +2944,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
             )],
         },
         integ_source: Some(runner_source_a),
-        ..Default::default()
+        ..astrodyn::VehicleConfig::named("bevy-parity-attach-detach-momentum-1")
     });
     let child_idx = sim.add_body(RunnerVehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&child_trans),
@@ -2950,7 +2958,7 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
             )],
         },
         integ_source: Some(runner_source_b),
-        ..Default::default()
+        ..astrodyn::VehicleConfig::named("bevy-parity-attach-detach-momentum-0")
     });
     sim.add_body_to_tree(parent_idx, "Parent");
     sim.add_body_to_tree(child_idx, "Child");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
@@ -235,7 +235,7 @@ fn build_runner_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(veh1_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-chained-attach-event-2")
     });
     let v2 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh2_trans()),
@@ -243,7 +243,7 @@ fn build_runner_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(veh2_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-chained-attach-event-1")
     });
     let v3 = sim.add_body(VehicleConfig {
         trans: astrodyn::typed_bridge::trans_raw_to_root(&veh3_trans()),
@@ -251,7 +251,7 @@ fn build_runner_sim() -> (Simulation, usize, usize, usize) {
         mass: Some(veh3_mass()),
         gravity_controls: GravityControls { controls: vec![] },
         integrator: IntegratorType::Rk4,
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-chained-attach-event-0")
     });
     sim.add_body_to_tree(v1, "veh1");
     sim.add_body_to_tree(v2, "veh2");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
@@ -252,7 +252,7 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-9")
     };
     sim.add_body(body);
 
@@ -406,7 +406,7 @@ fn bevy_parity_derived_state_eccentric_derived_states() {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-8")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -541,7 +541,7 @@ fn bevy_parity_derived_state_polar_geodetic() {
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-7")
     });
 
     sim.validate().unwrap();
@@ -671,7 +671,7 @@ fn bevy_parity_derived_state_equatorial_solar_beta() {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-6")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -745,7 +745,7 @@ fn run_euler_parity(label: &str, trans: TranslationalState, sequence: EulerSeque
             euler_sequence: Some(sequence),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-5")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -827,7 +827,7 @@ fn run_lvlh_parity(label: &str, trans: TranslationalState) {
             lvlh: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-4")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -946,7 +946,7 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-3")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -1021,7 +1021,7 @@ fn run_orbelem_parity(label: &str, trans: TranslationalState) {
             orbital_elements_source: Some(earth_idx),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-2")
     });
     sim.validate().unwrap();
     sim.step().expect("step failed");
@@ -1146,7 +1146,7 @@ fn bevy_parity_derived_state_orbelem() {
             orbital_elements_source: Some(earth_idx),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -1225,7 +1225,7 @@ fn bevy_parity_derived_state_solar_beta() {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-derived-state-0")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
@@ -246,7 +246,7 @@ fn bevy_parity_frame_switch_earth_to_moon_matches_simulation() {
             switch_distance: SWITCH_RADIUS,
             active: true,
         }],
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-frame-switch-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -417,7 +417,7 @@ fn bevy_parity_frame_switch_on_departure_matches_simulation() {
             switch_distance: departure_threshold,
             active: true,
         }],
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-frame-switch-0")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_gj.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_gj.rs
@@ -195,7 +195,7 @@ fn run_gj_bootstrap_parity(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-gj-0")
     });
     sim.validate().unwrap();
     sim.step_n(n_steps).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_gravity_torque.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_gravity_torque.rs
@@ -211,7 +211,7 @@ fn bevy_parity_gravity_torque_external_torque_per_body() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-gravity-torque-2")
     });
     sim.validate().unwrap();
 
@@ -289,7 +289,7 @@ fn run_gravity_torque_parity(
             )],
         },
         compute_gravity_gradient: true,
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-gravity-torque-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -396,7 +396,7 @@ fn run_external_parity(
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-gravity-torque-0")
     });
     sim.validate().unwrap();
 

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_highfidelity.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_highfidelity.rs
@@ -105,7 +105,7 @@ fn bevy_parity_highfidelity_sh4x4_rnp() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-highfidelity-3")
     });
 
     sim.validate().unwrap();
@@ -223,7 +223,7 @@ fn bevy_parity_highfidelity_tidal_sh4x4() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-highfidelity-2")
     });
 
     sim.validate().unwrap();
@@ -281,7 +281,7 @@ fn bevy_parity_highfidelity_run2p_polar_motion() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-highfidelity-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -361,7 +361,7 @@ fn run_gj_parity(label: &str, config: GaussJacksonConfig, dt: f64, n_steps: usiz
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-highfidelity-0")
     });
     sim.validate().unwrap();
     sim.step_n(n_steps).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_integ_source.rs
@@ -241,7 +241,7 @@ fn bevy_parity_integ_source_lunar_orbit_matches_simulation() {
             ],
         },
         integ_source: Some(moon_idx),
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-integ-source-4")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -370,7 +370,7 @@ fn bevy_parity_integ_source_moving_moon_matches_simulation() {
             ],
         },
         integ_source: Some(moon_idx),
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-integ-source-3")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -481,7 +481,7 @@ fn bevy_parity_integ_source_root_matches_legacy_no_op() {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-integ-source-2")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -672,7 +672,7 @@ fn bevy_parity_integ_source_solar_beta_in_lunar_integ_frame() {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-integ-source-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -907,7 +907,7 @@ fn bevy_parity_integ_source_flat_plate_srp_in_lunar_integ_frame() {
             t_pow4_cached: vec![init_temp.powi(4); 1],
             ..Default::default()
         })),
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-integ-source-0")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lighting.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lighting.rs
@@ -154,7 +154,7 @@ fn run_earth_lighting_parity(label: &str, veh_pos: DVec3, sun_pos: DVec3, moon_p
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-lighting-2")
     });
     sim.validate().unwrap();
     sim.step().expect("step failed");
@@ -366,7 +366,7 @@ fn bevy_parity_lighting_earth_lighting_pipeline() {
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-lighting-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -569,7 +569,7 @@ fn bevy_parity_lighting_earth_lighting_non_root_integ_source() {
             }),
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-lighting-0")
     });
     sim.validate().unwrap();
     sim.step().expect("step failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lsode.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lsode.rs
@@ -156,7 +156,7 @@ fn build_lsode_scenario(initial_state: TranslationalState) -> SimulationBuilder 
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-lsode-0")
     });
     b
 }

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lsode_abm4.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lsode_abm4.rs
@@ -155,7 +155,7 @@ fn build_abm4_scenario(initial_state: TranslationalState) -> SimulationBuilder {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-lsode-abm4-0")
     });
     b
 }

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
@@ -116,7 +116,7 @@ fn run_planetary_parity(label: &str, trans: TranslationalState) {
                 GravityGradient::Skip,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-7")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -270,7 +270,7 @@ fn bevy_parity_point_mass_orbinit_cross_consistency() {
                     GravityGradient::Skip,
                 )],
             },
-            ..Default::default()
+            ..VehicleConfig::named("bevy-parity-point-mass-6")
         });
         sim.validate().unwrap();
         sim.step().expect("step failed");
@@ -347,7 +347,7 @@ fn bevy_parity_point_mass_time_reversal_round_trip() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-5")
     });
     sim.validate().unwrap();
 
@@ -406,7 +406,7 @@ fn bevy_parity_point_mass_relative_state_consistency() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-4")
     });
 
     let mut trans_b = iss_trans().to_untyped();
@@ -423,7 +423,7 @@ fn bevy_parity_point_mass_relative_state_consistency() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-3")
     });
 
     sim.validate().unwrap();
@@ -552,7 +552,7 @@ fn bevy_parity_point_mass_mars_rotation_dispatch() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(mars, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-2")
     });
 
     sim.validate().unwrap();
@@ -629,7 +629,7 @@ fn bevy_parity_point_mass_multi_source_rotation() {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-1")
     });
 
     sim.validate().unwrap();
@@ -738,7 +738,7 @@ fn run_atmosphere_parity(label: &str, trans: TranslationalState) {
                 GravityGradient::Compute,
             )],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-point-mass-0")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_third_body.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_third_body.rs
@@ -101,7 +101,7 @@ fn bevy_parity_third_body_solar_beta_equ() {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-6")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -194,7 +194,7 @@ fn bevy_parity_third_body_solar_beta_obliquity() {
             solar_beta: true,
             ..Default::default()
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-5")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -388,7 +388,7 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
         gravity_controls: GravityControls {
             controls: sim_controls,
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-4")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -582,7 +582,7 @@ fn bevy_parity_third_body_mars_dawn() {
                 sim_sun_ctrl,
             ],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-3")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -662,7 +662,7 @@ fn bevy_parity_third_body_mercury_relativistic() {
         gravity_controls: GravityControls {
             controls: vec![sim_sun_ctrl],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-2")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -765,7 +765,7 @@ fn bevy_parity_third_body_relativistic_moving_source() {
         gravity_controls: GravityControls {
             controls: vec![sim_sun_ctrl],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-1")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");
@@ -940,7 +940,7 @@ fn bevy_parity_third_body_earth_moon_clem() {
             albedo,
             diffuse,
         }),
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-third-body-0")
     });
     sim.validate().unwrap();
     sim.step_n(NUM_STEPS).expect("step_n failed");

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_time_reversal.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_time_reversal.rs
@@ -210,7 +210,7 @@ fn build_reversal_run1_builder(init: &ReversalRow) -> SimulationBuilder {
         gravity_controls: GravityControls {
             controls: vec![GravityControl::new_spherical(earth, GravityGradient::Skip)],
         },
-        ..Default::default()
+        ..VehicleConfig::named("bevy-parity-time-reversal-0")
     });
     sb
 }

--- a/crates/astrodyn_verif_parity/tests/common/mod.rs
+++ b/crates/astrodyn_verif_parity/tests/common/mod.rs
@@ -245,7 +245,7 @@ pub fn new_sim_body_sixdof(earth_idx: usize, gradient: bool) -> VehicleConfig {
             controls: vec![GravityControl::new_spherical(earth_idx, gradient_mode)],
         },
         compute_gravity_gradient: gradient,
-        ..Default::default()
+        ..VehicleConfig::named("mod-0")
     }
 }
 

--- a/src/frame_identity.rs
+++ b/src/frame_identity.rs
@@ -1,0 +1,78 @@
+//! Shared frame-identity minting conventions for hosts.
+//!
+//! The compile-time path mints identities via
+//! [`FrameUid::of`](astrodyn_quantities::frame_descriptor::FrameUid::of)
+//! in [`Namespace::LOCAL`] — exclusively type-derived. Bodies, however, are
+//! an *open, instance-scoped* set: mission configurations legitimately
+//! spawn them in loops, so their identity is a mission-supplied **value**
+//! (a name), not a type. This module is the single home of that
+//! convention, shared by every host (the runner today, the Bevy adapter's
+//! `FrameUidC` in issue #664) so the mapping from a body name to its
+//! identity is shared *code*, never a per-host convention that can drift.
+//!
+//! ## Namespace allocation
+//!
+//! | Namespace | Owner | Mint |
+//! |---|---|---|
+//! | `LOCAL` (0) | type-derived identities | `FrameUid::of::<F>()` only |
+//! | [`MISSION_NAMED_NS`] (1) | mission-named bodies | [`named_body_frame_uid`] |
+//! | ≥ 2 | host-allocated (imports, external producers) | `FrameUid::external` / `FrameTree::import_subtree` |
+//!
+//! Hosts importing foreign frame trees **must allocate a namespace ≥ 2**:
+//! reusing namespace 1 would let an imported body impersonate a
+//! mission-named body — the duplicate-identity check catches exact
+//! collisions, but distinct foreign names would silently coexist as if
+//! mission-named.
+
+use astrodyn_quantities::frame_descriptor::{FrameClass, FrameRole, FrameUid, Namespace, Tag};
+
+/// Namespace reserved for mission-supplied *named* bodies — bodies whose
+/// identity is a configuration value (`VehicleConfig::named`,
+/// `VehicleBuilder::vehicle_named`) rather than a compile-time `Vehicle`
+/// marker. Type-derived identities live in [`Namespace::LOCAL`]; a named
+/// `"iss"` body and a `BodyFrame<Iss>` body therefore never alias.
+pub const MISSION_NAMED_NS: Namespace = Namespace(1);
+
+/// Mint the runtime identity of a mission-named body's composite-body
+/// frame. The single shared mint for [`MISSION_NAMED_NS`] — the runner and
+/// the Bevy adapter both route named-body identity through here, so the
+/// convention cannot drift between hosts.
+pub fn named_body_frame_uid(name: &str) -> FrameUid {
+    FrameUid::external(
+        MISSION_NAMED_NS,
+        FrameClass::Body,
+        FrameRole::CompositeBody,
+        Tag::Named(name.into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrodyn_quantities::frame::BodyFrame;
+    use astrodyn_quantities::frame_descriptor::FrameUid;
+
+    astrodyn_quantities::define_vehicle!(IdentityTestVehicle);
+
+    #[test]
+    fn named_identity_never_aliases_typed_identity() {
+        // Even a named body whose name exactly matches a Vehicle marker's
+        // NAME lives in a different namespace — impersonation of a
+        // type-derived identity is impossible by construction.
+        let named = named_body_frame_uid("IdentityTestVehicle");
+        let typed = FrameUid::of::<BodyFrame<IdentityTestVehicle>>();
+        assert_ne!(named, typed);
+        assert_eq!(named.namespace, MISSION_NAMED_NS);
+        assert!(!named.is::<BodyFrame<IdentityTestVehicle>>());
+    }
+
+    #[test]
+    fn named_identities_are_name_keyed() {
+        assert_eq!(named_body_frame_uid("iss"), named_body_frame_uid("iss"));
+        assert_ne!(named_body_frame_uid("iss"), named_body_frame_uid("soyuz"));
+        assert_eq!(
+            named_body_frame_uid("iss").to_string(),
+            "ns1:iss.composite_body"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 //!
 //! let mu = earth::point_mass().source.mu.m3_per_s2();
 //! let cfg = VehicleBuilder::new()
+//!     .vehicle_named("iss")
 //!     .from_orbital_elements(orbital_elements::iss(), mu)
 //!     .three_dof_point_mass(vehicle::iss_mass())
 //!     .rk4()
@@ -88,6 +89,7 @@ pub mod attach;
 pub mod body_action;
 pub mod derived;
 pub mod forces;
+pub mod frame_identity;
 pub mod frame_orchestration;
 pub mod gravity;
 pub mod integrable;
@@ -350,6 +352,7 @@ pub use astrodyn_quantities::frame::{
 // multi-source and producer-defined identity.
 pub use astrodyn_quantities::frame_descriptor::{FrameClass, FrameRole, FrameUid, Namespace, Tag};
 pub use astrodyn_quantities::integ_origin::IntegOrigin;
+pub use frame_identity::{named_body_frame_uid, MISSION_NAMED_NS};
 // Macros that mint downstream `Vehicle`/`Planet` markers. Re-exported so
 // mission crates depending only on `astrodyn` don't need a direct
 // `astrodyn_quantities` line in their `Cargo.toml`. The macro body resolves

--- a/src/recipes/scenarios/apollo.rs
+++ b/src/recipes/scenarios/apollo.rs
@@ -78,6 +78,7 @@ pub fn apollo_translunar() -> SimulationBuilder {
     };
 
     let csm = VehicleBuilder::new()
+        .vehicle_named("apollo-csm")
         .with_translational(csm_state)
         .three_dof_point_mass(vehicle::apollo_csm_mass())
         .rk4()

--- a/src/recipes/scenarios/clementine_lunar.rs
+++ b/src/recipes/scenarios/clementine_lunar.rs
@@ -69,6 +69,7 @@ pub fn clementine_lunar() -> SimulationBuilder {
     };
 
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("clementine")
         .with_translational(trans)
         .three_dof_point_mass(vehicle::clementine_mass())
         .rk4()

--- a/src/recipes/scenarios/geostationary.rs
+++ b/src/recipes/scenarios/geostationary.rs
@@ -26,6 +26,7 @@ pub fn geo() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), 300.0);
     let earth_idx = sb.add_source("Earth", earth::point_mass());
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("geo-sat")
         .from_orbital_elements(orbital_elements::geostationary(), constants::mu_ggm05c())
         .three_dof_point_mass(vehicle::unit_sphere_mass())
         .rk4()

--- a/src/recipes/scenarios/iss_leo.rs
+++ b/src/recipes/scenarios/iss_leo.rs
@@ -30,6 +30,7 @@ pub fn iss_leo() -> SimulationBuilder {
     let mut sb = SimulationBuilder::new(epoch::j2000(), 60.0);
     let earth_idx = sb.add_source("Earth", earth::point_mass());
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("iss")
         .from_orbital_elements(orbital_elements::iss(), constants::mu_ggm05c())
         .three_dof_point_mass(vehicle::iss_mass())
         .rk4()
@@ -76,6 +77,7 @@ pub fn iss_leo_drag() -> SimulationBuilder {
         MassProperties::with_inertia(420_000.0, glam::DMat3::IDENTITY * 1.0e6, glam::DVec3::ZERO);
 
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("iss")
         .from_orbital_elements(
             orbital_elements::leo_400km_circular_iss_inclination(),
             constants::mu_ggm05c(),

--- a/src/recipes/scenarios/mars_orbit.rs
+++ b/src/recipes/scenarios/mars_orbit.rs
@@ -53,6 +53,7 @@ pub fn mars_orbit() -> SimulationBuilder {
     };
 
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("mars-orbiter")
         .with_translational(trans)
         .three_dof_point_mass(vehicle::dawn_mass())
         .rk4()

--- a/src/recipes/scenarios/mercury.rs
+++ b/src/recipes/scenarios/mercury.rs
@@ -42,6 +42,7 @@ pub fn mercury_relativistic() -> SimulationBuilder {
     ctrl.relativistic = true;
 
     let vehicle = VehicleBuilder::new()
+        .vehicle_named("mercury-probe")
         .with_translational(trans)
         .three_dof_point_mass(uom::si::f64::Mass::new::<uom::si::mass::kilogram>(3.301e23))
         .rk4()

--- a/src/simulation_builder.rs
+++ b/src/simulation_builder.rs
@@ -19,6 +19,7 @@
 //! materialize the builder without extra accessors. Pre-release status
 //! (#58) makes that exposure acceptable; Phase 10 may re-encapsulate.
 
+use astrodyn_quantities::frame_descriptor::FrameUid;
 use glam::{DMat3, DVec3};
 
 use crate::atmosphere::AtmosphereConfig;
@@ -64,6 +65,12 @@ pub struct SimulationBuilder {
     pub moon_source: Option<usize>,
     /// Gravity sources keyed by name in declaration order.
     pub sources: Vec<(String, GravitySourceEntry)>,
+    /// Pre-minted frame identities `(inertial, pfix)` per source; index
+    /// matches [`Self::sources`]. `Some` for sources added via
+    /// [`Self::add_source_typed`] (identity travels as configuration
+    /// data); `None` falls back to the runner's sealed-planet name
+    /// dispatch at materialization.
+    pub source_uids: Vec<Option<(FrameUid, FrameUid)>>,
     /// Per-source `(body, parent)` ephemeris bodies; index matches
     /// [`Self::sources`]. `None` for sources that do not move via DE4xx.
     pub source_ephem_bodies: Vec<Option<(EphemerisBody, EphemerisBody)>>,
@@ -89,6 +96,7 @@ impl SimulationBuilder {
             sun_source: None,
             moon_source: None,
             sources: Vec::new(),
+            source_uids: Vec::new(),
             source_ephem_bodies: Vec::new(),
             bodies: Vec::new(),
             mass_tree_names: Vec::new(),
@@ -147,8 +155,29 @@ impl SimulationBuilder {
     /// Add a gravity source with a name for the frame tree. Returns its index.
     pub fn add_source(&mut self, name: impl Into<String>, entry: GravitySourceEntry) -> usize {
         let idx = self.sources.len();
+        self.source_uids.push(None);
         self.sources.push((name.into(), entry));
         self.source_ephem_bodies.push(None);
+        idx
+    }
+
+    /// Typed sibling of [`Self::add_source`]: mints the source's frame
+    /// identities from the planet marker `P` and carries them as
+    /// configuration data to the consumer (the runner's
+    /// `add_source_with_uids`, or the Bevy adapter in issue #664). Use for
+    /// planets minted downstream via `define_planet!`; the six built-in
+    /// planets may use the plain `add_source` name dispatch.
+    pub fn add_source_typed<P: astrodyn_quantities::frame::Planet>(
+        &mut self,
+        name: impl Into<String>,
+        entry: GravitySourceEntry,
+    ) -> usize {
+        let idx = self.sources.len();
+        self.source_uids.push(Some((
+            FrameUid::of::<astrodyn_quantities::frame::PlanetInertial<P>>(),
+            FrameUid::of::<astrodyn_quantities::frame::PlanetFixed<P>>(),
+        )));
+        self.sources.push((name.into(), entry));
         idx
     }
 

--- a/src/simulation_builder.rs
+++ b/src/simulation_builder.rs
@@ -178,6 +178,7 @@ impl SimulationBuilder {
             FrameUid::of::<astrodyn_quantities::frame::PlanetFixed<P>>(),
         )));
         self.sources.push((name.into(), entry));
+        self.source_ephem_bodies.push(None);
         idx
     }
 
@@ -328,5 +329,58 @@ impl SimulationBuilder {
             t_parent_child,
         });
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{GravityModel, GravitySource};
+
+    mod tags {
+        crate::define_planet!(BuilderTestPlanet);
+    }
+
+    fn entry() -> GravitySourceEntry {
+        GravitySourceEntry {
+            source: GravitySource {
+                mu: 0.0,
+                model: GravityModel::PointMass,
+            },
+            position: astrodyn_quantities::aliases::Position::zero(),
+            velocity: astrodyn_quantities::aliases::Velocity::zero(),
+            t_inertial_pfix: None,
+            delta_c20: 0.0,
+            rotation_model: crate::RotationModel::None,
+            tidal_config: None,
+            planet_omega: 0.0,
+            central: true,
+            marker_only: false,
+        }
+    }
+
+    /// `sources`, `source_uids`, and `source_ephem_bodies` are parallel
+    /// vectors consumed positionally by both the runner's `from_builder`
+    /// and the Bevy adapter's `populate_app` — every registration path
+    /// must push to all three. A missed push desyncs the indices and
+    /// fails the consumer's length assert (or worse, mis-wires ephemeris
+    /// updates to the wrong source).
+    #[test]
+    fn source_registration_keeps_parallel_vecs_in_sync() {
+        let time = crate::SimulationTime::at_j2000(crate::default_leap_second_table());
+        let mut sb = SimulationBuilder::new(time, 1.0);
+        sb.add_source("Earth", entry());
+        sb.add_source_typed::<tags::BuilderTestPlanet>("BuilderTestPlanet", entry());
+        assert_eq!(sb.sources.len(), 2);
+        assert_eq!(sb.source_uids.len(), 2);
+        assert_eq!(sb.source_ephem_bodies.len(), 2);
+        assert!(
+            sb.source_uids[0].is_none(),
+            "name-dispatch path carries no uid"
+        );
+        assert!(
+            sb.source_uids[1].is_some(),
+            "typed path carries minted uids"
+        );
     }
 }

--- a/src/vehicle_builder.rs
+++ b/src/vehicle_builder.rs
@@ -31,6 +31,7 @@
 //! use astrodyn_quantities::ext::F64Ext;
 //!
 //! let cfg = VehicleBuilder::new()
+//!     .vehicle_named("iss")
 //!     // `orbital_elements::iss()` returns `OrbitalElements<Earth>` and
 //!     // `constants::mu_ggm05c()` returns `GravParam<Earth>` — sharing
 //!     // the planet phantom is what `from_orbital_elements` requires.
@@ -41,6 +42,7 @@
 //! assert!(cfg.mass.is_some());
 //! ```
 
+use astrodyn_quantities::frame_descriptor::FrameUid;
 use core::marker::PhantomData;
 
 use glam::DMat3;
@@ -76,17 +78,23 @@ mod sealed {
     pub trait Sealed {}
 }
 
-/// Marker trait for the four states of the typestate
+/// Marker trait for the five states of the typestate
 /// [`VehicleBuilder`]. Sealed downstream — implementors are limited to
-/// [`NeedsState`], [`NeedsMass`], [`HasIntegrator`], [`Ready`].
+/// [`NeedsIdentity`], [`NeedsState`], [`NeedsMass`], [`HasIntegrator`],
+/// [`Ready`].
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a valid `VehicleBuilder` state. Use \
-        `NeedsState`, `NeedsMass`, `HasIntegrator`, or `Ready`.",
+        `NeedsIdentity`, `NeedsState`, `NeedsMass`, `HasIntegrator`, or `Ready`.",
     label = "not a `BuildState`"
 )]
 pub trait BuildState: sealed::Sealed {}
 
-/// Stage 0: nothing configured yet. Call
+/// Stage 0: no identity yet. Every vehicle requires a mission-supplied
+/// frame identity (JEOD heritage: `DynBody` registration requires a
+/// name). Call [`VehicleBuilder::vehicle`] (typed marker) or
+/// [`VehicleBuilder::vehicle_named`] (mission-named value) to advance.
+pub struct NeedsIdentity;
+/// Stage 1: identity set, no state yet. Call
 /// [`VehicleBuilder::with_translational`] or
 /// [`VehicleBuilder::from_orbital_elements`] to advance.
 pub struct NeedsState;
@@ -103,22 +111,25 @@ pub struct HasIntegrator;
 /// can be added; [`VehicleBuilder::build`] is available.
 pub struct Ready;
 
+impl sealed::Sealed for NeedsIdentity {}
 impl sealed::Sealed for NeedsState {}
 impl sealed::Sealed for NeedsMass {}
 impl sealed::Sealed for HasIntegrator {}
 impl sealed::Sealed for Ready {}
+impl BuildState for NeedsIdentity {}
 impl BuildState for NeedsState {}
 impl BuildState for NeedsMass {}
 impl BuildState for HasIntegrator {}
 impl BuildState for Ready {}
 
 /// Typestate vehicle builder. The `S: BuildState` parameter advances
-/// through [`NeedsState`] → [`NeedsMass`] → [`HasIntegrator`] →
-/// [`Ready`] as required configuration is supplied. Methods that
-/// require a particular state are only in-scope for that state's
-/// `impl` block, so missing-step calls are compile errors.
+/// through [`NeedsIdentity`] → [`NeedsState`] → [`NeedsMass`] →
+/// [`HasIntegrator`] → [`Ready`] as required configuration is supplied.
+/// Methods that require a particular state are only in-scope for that
+/// state's `impl` block, so missing-step calls are compile errors.
 ///
-/// The order is `with_translational`/`from_orbital_elements` →
+/// The order is `vehicle`/`vehicle_named` →
+/// `with_translational`/`from_orbital_elements` →
 /// `three_dof_point_mass`/`sixdof` →
 /// `rk4`/`rkf45`/`gauss_jackson`/`with_integrator` → `build`. See
 /// module-level docs for examples.
@@ -129,7 +140,8 @@ impl BuildState for Ready {}
 /// compile-time gating from Phase 5. `build()` returns the full
 /// [`VehicleConfig`] (the type that goes into `SimulationBuilder::add_body`
 /// and through `Simulation`).
-pub struct VehicleBuilder<S: BuildState = NeedsState> {
+pub struct VehicleBuilder<S: BuildState = NeedsIdentity> {
+    frame_uid: Option<FrameUid>,
     trans: Option<TranslationalStateTyped<RootInertial>>,
     rot: Option<RotationalStateTyped<SelfRef>>,
     mass: Option<MassPropertiesTyped<SelfRef>>,
@@ -150,15 +162,16 @@ pub struct VehicleBuilder<S: BuildState = NeedsState> {
     _state: PhantomData<S>,
 }
 
-impl Default for VehicleBuilder<NeedsState> {
+impl Default for VehicleBuilder<NeedsIdentity> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl<S: BuildState> VehicleBuilder<S> {
-    fn empty() -> VehicleBuilder<NeedsState> {
+    fn empty() -> VehicleBuilder<NeedsIdentity> {
         VehicleBuilder {
+            frame_uid: None,
             trans: None,
             rot: None,
             mass: None,
@@ -182,6 +195,7 @@ impl<S: BuildState> VehicleBuilder<S> {
 
     fn transition<T: BuildState>(self) -> VehicleBuilder<T> {
         VehicleBuilder {
+            frame_uid: self.frame_uid,
             trans: self.trans,
             rot: self.rot,
             mass: self.mass,
@@ -202,14 +216,37 @@ impl<S: BuildState> VehicleBuilder<S> {
     }
 }
 
-impl VehicleBuilder<NeedsState> {
-    /// Create a fresh builder. The compiler will require
-    /// `.with_translational(...)` or `.from_orbital_elements(...)`
+impl VehicleBuilder<NeedsIdentity> {
+    /// Create a fresh builder. The compiler requires an identity
+    /// (`.vehicle::<V>()` or `.vehicle_named(..)`) first, then
+    /// `.with_translational(...)` / `.from_orbital_elements(...)`,
     /// before any mass / integrator method becomes available.
     pub fn new() -> Self {
         Self::empty()
     }
 
+    /// Supply the vehicle's identity from a compile-time `Vehicle`
+    /// marker: `FrameUid::of::<BodyFrame<V>>()` (namespace `LOCAL`).
+    /// For mission code with `define_vehicle!` tags.
+    pub fn vehicle<V: astrodyn_quantities::frame::Vehicle>(mut self) -> VehicleBuilder<NeedsState> {
+        self.frame_uid = Some(FrameUid::of::<astrodyn_quantities::frame::BodyFrame<V>>());
+        self.transition()
+    }
+
+    /// Supply the vehicle's identity as a mission-named value (the
+    /// shared [`crate::named_body_frame_uid`] mint in
+    /// [`crate::MISSION_NAMED_NS`]). The value form exists because
+    /// vehicles are an open, instance-scoped set — loops mint
+    /// per-iteration *values*, which no compile-time tag can do. Names
+    /// must be distinct within one simulation (duplicates fail loudly at
+    /// registration).
+    pub fn vehicle_named(mut self, name: impl Into<String>) -> VehicleBuilder<NeedsState> {
+        self.frame_uid = Some(crate::named_body_frame_uid(&name.into()));
+        self.transition()
+    }
+}
+
+impl VehicleBuilder<NeedsState> {
     /// Set the initial translational state (typed).
     pub fn with_translational(
         mut self,
@@ -513,6 +550,9 @@ impl VehicleBuilder<Ready> {
     /// advanced to [`Ready`].
     pub fn build(self) -> VehicleConfig {
         VehicleConfig {
+            frame_uid: self
+                .frame_uid
+                .expect("typestate guarantees vehicle identity"),
             trans: self
                 .trans
                 .expect("typestate guarantees translational state"),
@@ -565,6 +605,7 @@ mod tests {
     #[test]
     fn three_dof_happy_path() {
         let cfg = VehicleBuilder::new()
+            .vehicle_named("test-veh-2")
             .with_translational(iss_trans())
             .three_dof_point_mass(420_000.0.kg())
             .rk4()
@@ -592,6 +633,7 @@ mod tests {
         let inertia = DMat3::IDENTITY * 100.0;
         let mass = MassProperties::with_inertia(420_000.0, inertia, DVec3::ZERO);
         let cfg = VehicleBuilder::new()
+            .vehicle_named("test-veh-3")
             .with_translational(iss_trans())
             .sixdof(rot, mass)
             .rk4()
@@ -614,6 +656,7 @@ mod tests {
         use astrodyn_interactions::DragConfig;
         use astrodyn_quantities::aliases::{Position, Velocity};
         let cfg = VehicleBuilder::new()
+            .vehicle_named("test-veh-4")
             .with_translational(TranslationalStateTyped::<RootInertial> {
                 position: Position::<RootInertial>::from_raw_si(DVec3::new(7_000_000.0, 0.0, 0.0)),
                 velocity: Velocity::<RootInertial>::from_raw_si(DVec3::new(0.0, 7_500.0, 0.0)),
@@ -645,6 +688,7 @@ mod tests {
     #[test]
     fn builder_accepts_source_handle_and_bare_usize_interchangeably() {
         let typed = VehicleBuilder::new()
+            .vehicle_named("test-veh-5")
             .with_translational(iss_trans())
             .three_dof_point_mass(420_000.0.kg())
             .rk4()
@@ -654,6 +698,7 @@ mod tests {
             .geodetic(SourceHandle::central(), &crate::EARTH)
             .build();
         let untyped = VehicleBuilder::new()
+            .vehicle_named("test-veh-6")
             .with_translational(iss_trans())
             .three_dof_point_mass(420_000.0.kg())
             .rk4()

--- a/src/vehicle_config.rs
+++ b/src/vehicle_config.rs
@@ -20,6 +20,7 @@ use astrodyn_interactions::DragConfig;
 use astrodyn_dynamics::state::TranslationalStateTyped;
 use astrodyn_dynamics::{MassPropertiesTyped, RotationalStateTyped};
 use astrodyn_quantities::frame::{RootInertial, SelfRef};
+use astrodyn_quantities::frame_descriptor::FrameUid;
 
 // ── Frame switching ─────────────────────────────────────────────────────
 
@@ -154,6 +155,15 @@ pub struct DerivedStateConfig {
 /// results are read back via the adapter's own output view (the
 /// standalone runner exposes one; the Bevy adapter reads components).
 pub struct VehicleConfig {
+    /// Mission-supplied runtime identity for this vehicle's composite-body
+    /// frame. **Required — no default**: a defaulted identity would be
+    /// identity-by-accident and would let two bodies silently collide.
+    /// Construct configs via [`VehicleConfig::for_vehicle`] (typed,
+    /// `FrameUid::of::<BodyFrame<V>>()`), [`VehicleConfig::named`]
+    /// (mission-named value identity), [`VehicleConfig::for_uid`], or the
+    /// `VehicleBuilder` identity stage (`.vehicle::<V>()` /
+    /// `.vehicle_named(..)`).
+    pub frame_uid: FrameUid,
     // ── Initial state ──
     /// Translational state in the root-inertial frame, typed
     /// end-to-end. The runner re-tags as `<IntegrationFrame>` at
@@ -235,9 +245,14 @@ pub struct VehicleConfig {
     pub frame_switches: Vec<FrameSwitchConfig>,
 }
 
-impl Default for VehicleConfig {
-    fn default() -> Self {
+impl VehicleConfig {
+    /// Base constructor carrying a caller-supplied frame identity; every
+    /// other field takes its neutral default. The identity-bearing
+    /// replacement for the removed `impl Default` (a defaulted identity
+    /// would be identity-by-accident).
+    pub fn for_uid(frame_uid: FrameUid) -> Self {
         Self {
+            frame_uid,
             trans: TranslationalStateTyped::<RootInertial>::default(),
             rot: None,
             mass: None,
@@ -258,5 +273,18 @@ impl Default for VehicleConfig {
             integ_source: None,
             frame_switches: Vec::new(),
         }
+    }
+
+    /// Typed base constructor: identity derived from the compile-time
+    /// vehicle marker (`FrameUid::of::<BodyFrame<V>>()`, namespace LOCAL).
+    pub fn for_vehicle<V: astrodyn_quantities::frame::Vehicle>() -> Self {
+        Self::for_uid(FrameUid::of::<astrodyn_quantities::frame::BodyFrame<V>>())
+    }
+
+    /// Named base constructor: mission-named value identity in
+    /// [`crate::MISSION_NAMED_NS`] via the shared
+    /// [`crate::named_body_frame_uid`] mint.
+    pub fn named(name: impl Into<String>) -> Self {
+        Self::for_uid(crate::named_body_frame_uid(&name.into()))
     }
 }

--- a/tests/vehicle_builder_typestate.rs
+++ b/tests/vehicle_builder_typestate.rs
@@ -41,6 +41,7 @@ fn iss_trans() -> TranslationalStateTyped<RootInertial> {
 #[test]
 fn three_dof_rk4_round_trip() {
     let cfg: VehicleConfig = VehicleBuilder::new()
+        .vehicle_named("vehicle-builder-typestate-0")
         .with_translational(iss_trans())
         .three_dof_point_mass(420_000.0.kg())
         .rk4()
@@ -71,6 +72,7 @@ fn six_dof_rkf45_with_options() {
         ..Default::default()
     };
     let cfg = VehicleBuilder::new()
+        .vehicle_named("vehicle-builder-typestate-1")
         .with_translational(iss_trans())
         .sixdof(rot, mass)
         .rkf45()
@@ -89,6 +91,7 @@ fn six_dof_rkf45_with_options() {
 #[test]
 fn gauss_jackson_integrator_selection() {
     let cfg = VehicleBuilder::new()
+        .vehicle_named("vehicle-builder-typestate-2")
         .with_translational(iss_trans())
         .three_dof_point_mass(1_000.0.kg())
         .gauss_jackson(GaussJacksonConfig::default())
@@ -109,6 +112,7 @@ fn from_orbital_elements_round_trip() {
         .expect("ISS-class state has well-defined orbital elements");
 
     let cfg = VehicleBuilder::new()
+        .vehicle_named("vehicle-builder-typestate-3")
         .from_orbital_elements(oe.clone(), earth_mu)
         .three_dof_point_mass(420_000.0.kg())
         .rk4()


### PR DESCRIPTION
Part of #659 — PR-3 of the migration plan in the [design comment](https://github.com/simnaut/astrodyn/issues/659#issuecomment-4636317391). Depends on PR-2 (#667, merged). Closes #662.

After this PR, **no production frame node is unstamped**: every node the runner creates carries a minted `FrameUid` and a TDB epoch, refreshed at each per-step writeback, and the orchestration typed helpers verify stamped identities instead of asserting them by convention.

## What this does

### Identity is required, and travels as a value
- `VehicleConfig` gains a required `frame_uid: FrameUid`; **`impl Default` is removed** (a default identity is identity-by-accident). Base constructors: `for_uid` / `for_vehicle::<V>` / `named(name)`.
- `VehicleBuilder` gains a first typestate stage `NeedsIdentity`: `.vehicle::<V>()` (typed, `LOCAL` namespace) or `.vehicle_named("…")` (value form — loops mint per-iteration values). Identity ≠ type.
- NEW `src/frame_identity.rs` gateway module: `MISSION_NAMED_NS` (`Namespace(1)`) + `named_body_frame_uid()` — the single shared mint for mission-named bodies (the Bevy adapter routes through the same code in PR-5 #664, so the convention cannot drift between hosts). Namespace table documented: `LOCAL`(0) type-derived, 1 mission-named, ≥2 host-allocated imports.

### Runner stamps at registration (PR-2 primitives)
- Root: `add_root_typed::<RootInertial>` + `set_epoch`.
- Sources: `add_source` is now a **strict sealed-planet dispatch** (six arms); unknown names panic, directing to the new `add_source_typed::<P: Planet>` for `define_planet!` markers. Value-level core `add_source_with_uids` carries pre-minted identities for the `SimulationBuilder` path (`source_uids` parallel vec). Inertial/pfix nodes created via `add_child_uid` + epoch — identical `RefFrameState`, node-name format strings unchanged.
- Bodies: `add_body` asserts the resolved integration frame is stamped and class-eligible (`// JEOD_INV: RF.10`), then stamps the body node with the mission-supplied `config.frame_uid`.
- Per-step epoch stamping after every pfix rotation sync, source position writeback, body-state writeback, and attached-body write (metadata only — state writes and their order unchanged).

### Resolved integ-frame publication
`Simulation::body_integ_frame_uid(idx)` publishes each body's **resolved** integration-frame identity (`RootInertial` or `PlanetInertial<P>`) — never the `IntegrationFrame` marker (RF.10: the marker resolves per body).

### Checked flip (g2)
`frame_origin_typed` / `compute_relative_state_typed` now verify stamped identities (`JEOD_INV: RF.02`); the transitional "becomes checkable after PR-3" doc notes are gone. `Simulation::frame_origin_typed` routes through the checked helper, so the per-step production path exercises the check.

### Migration sweep
58 builder chains gain the identity stage; ~200 config literals swap `..Default::default()` → `..VehicleConfig::named("<label>")`. Scenario recipes labeled (iss, apollo-csm, clementine, geo-sat, mars-orbiter, mercury-probe); parity suites thread identity through the common `new_sim_body_sixdof` helper; synthetic non-planet sources migrate to local `define_planet!` tags + `add_source_typed`. The duplicate-identity check caught real shared-closure bugs during the sweep (one label reused across 2–4 bodies).

## Acceptance trace

- **RFS-401** (identity in production): every production node stamped at creation; duplicate-uid rejection live on production paths.
- **RFS-303** (resolved-integ-frame invariant asserted, not assumed): `add_body` asserts the integ node is stamped + `may_be_root_or_integ()` before the body registers; `body_integ_frame_uid` publishes the resolution.
- **Frame-switch uid-index consistency**: `frame_identity_stamping.rs` proves a switch reparents the body node while its `FrameUid` keeps resolving to the same `FrameId`, with the published integ identity flipping to the target.
- **Bit-identical physics**: uid/epoch are metadata; unit + Tier 2 bucket 1548/1548 locally; Tier 3 + `bevy_parity` ride CI.
- **Step bench (g2 gate)**: 44.43 µs vs main 43.97 µs measured under identical machine conditions (~+1%, `FrameUid::is` is zero-alloc integer compares).

## PR-2 assumption checklist (from #662)

- [x] Stamp every production construction site — no production node has `uid: None` after this PR.
- [x] Use the PR-2 primitives (`add_child_uid` for runtime-resolved identity, typed constructors where static, `set_epoch` for epochs).
- [x] Flip the orchestration helpers to checked; transitional doc notes removed.
- [x] Duplicate-uid rejection live on production paths + negative tests (duplicate body, duplicate source, unknown source name).

## Deferred

`SourceId` collapse → #668 (its own sub-issue under #659), as amended in the issue body.

## Tests

- NEW `crates/astrodyn_runner/tests/frame_identity_stamping.rs` (resolved-identity publication; frame-switch uid stability).
- `negative_invariants.rs`: `duplicate_body_identity_panics`, `duplicate_source_identity_panics` (second registration non-central so the *identity* check fires, not the single-central assert), `unknown_source_name_panics`.
- `src/frame_identity.rs` unit tests: named identity never aliases typed; name-keyed equality; `Display` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
