### PR TITLE
[#659] frame-doc: document + export the per-record streaming surface

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,15 @@ name: publish
 #   1. Verifies the tag matches `[workspace.package].version` so we
 #      can't accidentally tag `v0.1.1` while the workspace still says
 #      `0.1.0`.
-#   2. Walks the 13 publishable crates in topological order via
+#   2. Walks the 14 publishable crates in topological order via
 #      `cargo xtask publish` (which polls the sparse index between
 #      crates so the next crate's path+version dep resolves).
 #
 # Prerequisite: a repo-level `CARGO_REGISTRY_TOKEN` secret with
-# publish scope on each of the 13 `astrodyn*` crates.
+# publish scope on each of the 14 `astrodyn*` crates. (A brand-new
+# crate name — e.g. `astrodyn_frame_doc` before its first release —
+# is created by its first publish; the token only needs the
+# publish-new-crates scope for that release.)
 
 on:
   push:

--- a/crates/astrodyn_frame_doc/Cargo.toml
+++ b/crates/astrodyn_frame_doc/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "astrodyn_frame_doc"
 description = "Frame-document schema for astrodyn — self-describing serialization of reference-frame trees (snapshot + replay series) carrying identity, topology, origin, and epoch per record"
+readme = "README.md"
+keywords = ["orbital-mechanics", "aerospace", "serialization", "telemetry", "replay"]
+categories = ["aerospace", "science", "encoding"]
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+# Dev-only proptest corpus — not part of the published package.
+exclude = ["proptest-regressions/**"]
 
 [dependencies]
 # Identity vocabulary only (FrameUid + its components). `astrodyn_quantities`

--- a/crates/astrodyn_frame_doc/LICENSE-APACHE
+++ b/crates/astrodyn_frame_doc/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 The astrodyn_bevy Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/astrodyn_frame_doc/LICENSE-MIT
+++ b/crates/astrodyn_frame_doc/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The astrodyn_bevy Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/crates/astrodyn_frame_doc/README.md
+++ b/crates/astrodyn_frame_doc/README.md
@@ -1,0 +1,63 @@
+# astrodyn_frame_doc
+
+Frame-document schema for the
+[astrodyn](https://github.com/simnaut/astrodyn) orbital-dynamics
+workspace: the self-describing serialized form of a reference-frame
+tree — snapshots and replay series — carrying **identity, topology,
+origin, and epoch on every record**.
+
+This crate holds **only the document types and their
+(de)serialization** — no physics. A read-only consumer (renderer,
+logger, analyzer, live telemetry view) links this crate plus the
+identity vocabulary it re-exports from `astrodyn_quantities`, and can
+interpret a recorded run without ever depending on the producer's
+code.
+
+## Document model
+
+Two forms share one record vocabulary:
+
+- **`FrameDocument`** — a snapshot: header + interned `FrameUid` table
+  + one `FrameRecord` per frame node.
+- **`FrameSeries`** — replay v1: header + uid table + a sequence of
+  topology-stable `FrameSegment`s of per-epoch rows. Any topology
+  change (a frame-switch reparent, an attach) closes the segment, so
+  segment boundaries double as seek keyframes.
+
+Every record names the parent uid its state is relative to, carries
+its epoch, and declares its **origin**: `Integrated` (authoritative
+body state), `Derived` (re-derivable from a model id + epoch), or
+`Injected` (caller-supplied ground truth). Rotation serializes as
+whichever representation was canonical at the write site
+(`CanonicalRotation::{Quat, Matrix}`) and the other is re-derived on
+load — what makes serialize → reload → continue **bit-identical**.
+
+## Per-record / streaming consumers
+
+The record types (`DocHeader`, `FrameRecord`, `EpochRow`, `FrameUid`,
+…) are a **supported, stable surface** for independent serialization —
+e.g. a live binary feed that sends the header + uid table as a
+handshake and then streams per-epoch rows. The piecewise validators
+(`validate_header`, `validate_uid_table`, `validate_record`) are the
+loose-piece equivalents of the whole-document `validate()` entry
+points. See the crate docs for the handshake, keyframe, format, and
+stability rules.
+
+## Encoding and stability
+
+Whole-document convenience API is plain-decimal JSON; `f64` round-trips
+are bit-exact (consumers parsing JSON themselves need `serde_json`'s
+`float_roundtrip` feature). Binary `f64` encodings are inherently
+bit-exact. Non-finite values are rejected loudly in any encoding. The
+wire schema evolves only through `SCHEMA_VERSION`; these types *are*
+the schema, so changes are semver-visible on the crate and additive
+where possible.
+
+## License
+
+Dual-licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.

--- a/crates/astrodyn_frame_doc/src/document.rs
+++ b/crates/astrodyn_frame_doc/src/document.rs
@@ -356,10 +356,16 @@ impl FrameDocument {
     }
 }
 
-/// Shared uid-table validation (snapshot + series): every interned
-/// identity must be distinct — two table entries holding the same
-/// identity would let records alias one frame through "distinct" indices.
-pub(crate) fn validate_uid_table(uids: &[FrameUid]) -> Result<(), DocError> {
+/// Validate an interned uid table on its own: every identity must be
+/// distinct — two table entries holding the same identity would let
+/// records alias one frame through "distinct" indices.
+///
+/// Public for **per-record / streaming consumers** (see the crate docs):
+/// a live feed receives the header + uid table as its handshake and
+/// must validate both before interpreting any row, exactly as
+/// [`FrameDocument::validate`] / [`FrameSeries::validate`](crate::FrameSeries::validate)
+/// do for the whole-document forms.
+pub fn validate_uid_table(uids: &[FrameUid]) -> Result<(), DocError> {
     let mut seen: std::collections::HashMap<&FrameUid, usize> =
         std::collections::HashMap::with_capacity(uids.len());
     for (i, uid) in uids.iter().enumerate() {
@@ -371,8 +377,14 @@ pub(crate) fn validate_uid_table(uids: &[FrameUid]) -> Result<(), DocError> {
     Ok(())
 }
 
-/// Shared header validation (snapshot + series).
-pub(crate) fn validate_header(header: &DocHeader) -> Result<(), DocError> {
+/// Validate a [`DocHeader`] on its own: schema version, the in-band
+/// numeric [`Conventions`] against this build's, and finiteness of the
+/// time anchors — **before any state number is interpreted**.
+///
+/// Public for **per-record / streaming consumers** (see the crate
+/// docs): this is the handshake gate of a live feed, the same check
+/// the whole-document `validate()` entry points run first.
+pub fn validate_header(header: &DocHeader) -> Result<(), DocError> {
     if header.schema_version != SCHEMA_VERSION {
         return Err(DocError::UnsupportedVersion {
             found: header.schema_version,
@@ -411,8 +423,22 @@ pub(crate) fn validate_header(header: &DocHeader) -> Result<(), DocError> {
     Ok(())
 }
 
-/// Shared per-record validation (snapshot + series rows).
-pub(crate) fn validate_record(
+/// Validate a single [`FrameRecord`] against a uid table of
+/// `uid_table_len` entries: index bounds (`uid_index`, `parent`),
+/// self-parenting, and finiteness of every state field. `record_pos`
+/// only labels the error.
+///
+/// Public for **per-record / streaming consumers** (see the crate
+/// docs): a loose row arriving over a socket gets exactly the per-record
+/// half of [`FrameDocument::validate`]. What this deliberately does NOT
+/// check — because a loose record cannot — are the cross-record
+/// invariants: topology (cycle-freedom, declared-parent consistency
+/// against the consumer's folded tree) and the series invariants
+/// (row completeness, constant topology within a segment). Streaming
+/// consumers own those checks; each record's declared `parent` exists
+/// precisely so a mismatch surfaces as a loud inconsistency rather
+/// than a silent reinterpretation.
+pub fn validate_record(
     rec: &FrameRecord,
     record_pos: usize,
     uid_table_len: usize,

--- a/crates/astrodyn_frame_doc/src/lib.rs
+++ b/crates/astrodyn_frame_doc/src/lib.rs
@@ -50,13 +50,95 @@
 //! **in-band** ([`Conventions`]); [`FrameDocument::validate`] checks them
 //! before any state is interpreted, so a consumer that never links astrodyn
 //! cannot silently misread a changed convention.
+//!
+//! ## Per-record / streaming consumers
+//!
+//! The record types — [`DocHeader`], [`FrameRecord`], [`EpochRow`],
+//! [`FrameUid`] and their components — are a **supported, stable surface**
+//! for independent serialization, not internals behind the whole-document
+//! JSON API. `to_json_string` / `from_json_str` are conveniences over the
+//! same `serde` derives; a live feed may serialize records individually
+//! (e.g. a binary serde format over a socket) under these rules:
+//!
+//! - **Handshake = header + uid table.** Records reference identities
+//!   positionally (`FrameRecord::uid_index` / `parent` index into the
+//!   interned `Vec<FrameUid>`), so transmit [`DocHeader`] and the uid
+//!   table once, then per-epoch [`EpochRow`]s. Validate the handshake
+//!   *before interpreting any number* via [`validate_header`] and
+//!   [`validate_uid_table`], and each arriving row via
+//!   [`validate_record`] — the loose-piece equivalents of the
+//!   whole-document `validate()` entry points.
+//! - **Topology changes are segment boundaries.** A reparent or attach
+//!   changes what `parent` means; mirror replay v1's rule on a live feed
+//!   by re-sending header + uid table as a fresh keyframe. Per-record
+//!   `parent` keeps every row self-checking: verify it against your
+//!   folded topology and treat a mismatch as a loud inconsistency, never
+//!   a reinterpretation. (Cross-record invariants — cycle-freedom, row
+//!   completeness, constant topology within a segment — are the
+//!   container `validate()`s' job and become the *consumer's* job on a
+//!   stream.)
+//! - **Format notes.** Positional formats (postcard/bincode) bind to
+//!   field *order*, self-describing formats to field *names*; pin this
+//!   crate's version on both ends and gate on
+//!   [`DocHeader::schema_version`] at handshake. Binary `f64` encodings
+//!   are inherently bit-exact — the shortest-round-trip /
+//!   `float_roundtrip` requirement above is JSON-specific. Non-finite
+//!   values remain invalid in any encoding.
+//! - **Stability.** The wire schema evolves only through
+//!   [`SCHEMA_VERSION`]; these Rust types *are* the schema, so field
+//!   changes imply a version bump and a semver-visible crate change.
+//!   Evolution is additive where possible (enums such as [`Origin`] /
+//!   [`CanonicalRotation`] may gain variants behind a version bump);
+//!   existing fields are not silently re-shaped.
+//!
+//! ```
+//! use astrodyn_frame_doc::{
+//!     validate_header, validate_record, validate_uid_table, CanonicalRotation, Conventions,
+//!     DocHeader, EpochRow, FrameRecord, FrameUid, Origin, TransRecord, SCHEMA_VERSION,
+//! };
+//! use astrodyn_quantities::frame::RootInertial;
+//!
+//! // ── Producer side: handshake, then rows ──
+//! let header = DocHeader {
+//!     schema_version: SCHEMA_VERSION,
+//!     conventions: Conventions::current(),
+//!     simtime: 0.0,
+//!     tai_tjt_at_epoch: 11544.499257592593,
+//! };
+//! let uids = vec![FrameUid::of::<RootInertial>()];
+//! let row = EpochRow {
+//!     simtime: 0.0,
+//!     records: vec![FrameRecord {
+//!         name: "root".into(),
+//!         uid_index: 0,
+//!         parent: None,
+//!         epoch: Some(0.0),
+//!         trans: TransRecord {
+//!             position: [0.0; 3],
+//!             velocity: [0.0; 3],
+//!         },
+//!         rotation: CanonicalRotation::Quat([1.0, 0.0, 0.0, 0.0]),
+//!         ang_vel_this: [0.0; 3],
+//!         origin: Origin::Injected,
+//!     }],
+//! };
+//!
+//! // ── Consumer side: validate the handshake before any number, then
+//! //    each arriving row against the handshake's uid table. ──
+//! validate_header(&header).expect("handshake header");
+//! validate_uid_table(&uids).expect("handshake uid table");
+//! for (pos, rec) in row.records.iter().enumerate() {
+//!     validate_record(rec, pos, uids.len()).expect("arriving row");
+//!     // ...then check rec.parent against your folded topology.
+//! }
+//! ```
 
 mod document;
 mod series;
 
 pub use document::{
-    CanonicalRotation, Conventions, DocError, DocHeader, FrameDocument, FrameRecord, Origin,
-    TransRecord, SCHEMA_VERSION,
+    validate_header, validate_record, validate_uid_table, CanonicalRotation, Conventions, DocError,
+    DocHeader, FrameDocument, FrameRecord, Origin, TransRecord, SCHEMA_VERSION,
 };
 pub use series::{EpochRow, FrameSegment, FrameSeries, SeriesBuilder};
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -609,11 +609,16 @@ fn generate_orientation_kernels(argv: Vec<String>) {
 
 // Topological order for `cargo xtask publish`. Each entry must be
 // publishable using only registry copies of the entries above it. The
-// layers are: (0) astrodyn_quantities; (1) astrodyn_math, _time,
-// _ephemeris, _atmosphere; (2) _planet, _frames, _dynamics; (3)
-// _gravity, _interactions; (4) astrodyn (root); (5) _bevy, _runner.
+// layers are: (0) astrodyn_quantities; (1) astrodyn_frame_doc,
+// astrodyn_math, _time, _ephemeris, _atmosphere; (2) _planet, _frames,
+// _dynamics; (3) _gravity, _interactions; (4) astrodyn (root); (5)
+// _bevy, _runner.
 const PUBLISH_ORDER: &[&str] = &[
     "astrodyn_quantities",
+    // Identity + wire schema only; depends solely on _quantities. Must
+    // precede `astrodyn`, whose optional `frame-doc` feature carries a
+    // versioned dep on it (issue #663).
+    "astrodyn_frame_doc",
     "astrodyn_math",
     "astrodyn_time",
     "astrodyn_ephemeris",
@@ -824,7 +829,7 @@ fn wait_for_index(crate_name: &str, expected_version: &str) {
 }
 
 // Read `[workspace.package].version` from the workspace `Cargo.toml`.
-// All 13 publishable crates inherit this value via
+// All 14 publishable crates inherit this value via
 // `version.workspace = true`, so we only need to find it once.
 fn workspace_version() -> String {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Follow-up to the astrotui consumer question on #659 ([comment](https://github.com/simnaut/astrodyn/issues/659#issuecomment-4641946767)): *are the per-record types a stable surface for independent (binary, streaming) serialization?*

The answer given was yes — that's the schema crate's reason to exist (RFS-602) — but the crate neither documented it nor made it actionable: the piecewise validators were `pub(crate)`, so a streaming consumer could not validate a handshake header/uid-table or a loose row without wrapping pieces in a fake `FrameDocument`.

## Changes

**Streaming surface (docs + visibility only; no behavior):**
- **Export `validate_header` / `validate_uid_table` / `validate_record`** — the loose-piece equivalents of the whole-document `validate()` entry points, with docs stating exactly what a per-record check covers and which cross-record invariants (topology consistency, row completeness, constant-topology-per-segment) become the *consumer's* job on a stream.
- **New module-doc section "Per-record / streaming consumers"** codifying the four commitments from the #659 answer: supported-surface statement, handshake = header + uid table, topology changes as keyframe boundaries, format notes (positional vs named serde; binary f64 inherently bit-exact; `float_roundtrip` is JSON-specific), and the stability policy (`SCHEMA_VERSION` governs; the types are the schema; additive evolution).
- **Doctest** walking the producer handshake → consumer validate-then-rows flow.

**crates.io publish readiness (second commit):** `astrodyn_frame_doc` (new in #663) was never wired into the release machinery — which silently blocks the next workspace release, since the gateway's optional `frame-doc` feature carries a versioned dep that can't resolve on the registry. It becomes the **14th publishable crate**: readme/keywords/categories + per-crate LICENSE copies per the `astrodyn_quantities` convention, dev-only proptest corpus excluded from the package, and an entry in xtask's `PUBLISH_ORDER` (after `astrodyn_quantities`, its only dependency; before `astrodyn`) with the 13→14 counts updated in `publish.yml`.

`cargo package --list` verified (src + manifest + README + licenses, no test corpus). Full package verification needs `astrodyn_quantities` 0.2.0 on the registry — exactly the topological ordering the xtask walk provides on release day.

**Release-day note:** the first publish of a brand-new crate name *creates* it on crates.io — the `CARGO_REGISTRY_TOKEN` used for the next release needs the publish-new-crates scope for `astrodyn_frame_doc` (after that, the usual per-crate scope applies).

Crate tests 19/19 + doctests green; rustdoc `-D warnings` clean; xtask builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)