### PR TITLE
Release prep 0.2.0: changelog, docs.rs metadata, LICENSE holder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-05-19
+## [0.2.0] - Unreleased
+
+Second release. Headlined by the **frame-identity** work
+([#659](https://github.com/simnaut/astrodyn/issues/659) / #660–#664 /
+#668): every reference frame now carries a stable `FrameUid`, every
+cross-source reference resolves through it, and a new
+`astrodyn_frame_doc` crate captures that identity in a self-describing,
+replayable wire schema.
+
+### Added
+
+- **`astrodyn_frame_doc` crate** (#663) — frame-document schema: a
+  self-describing serialized form of a reference-frame tree (snapshot
+  `FrameDocument` + replay-series `FrameSeries`) carrying identity,
+  topology, origin, and epoch on every record, with bit-exact `f64`
+  round-trips. Per-record validators (`validate_header`,
+  `validate_uid_table`, `validate_record`) support independent
+  streaming consumers (#659). The gateway exposes it behind a new,
+  off-by-default `frame-doc` feature (`astrodyn::frame_doc` +
+  `astrodyn::frame_doc_io`), keeping the production build serde-free.
+- **Frame identity vocabulary** (#660) — `FrameUid` plus
+  `Frame::DESCRIPTOR` on the sealed `Frame` trait.
+- **`CartesianState<F>`** (#650) — typed position + velocity state
+  record with opt-in serde (the gateway's `serde` feature forwards to
+  it).
+- **New frames and presets**: Moon mean-Earth (ME) frame for DEM
+  georeferencing (#652); site-anchored topocentric ENU frame (#651);
+  generic IAU body-fixed rotation beyond Moon/Mars (#653); a typed
+  `Ephemeris` rotation accessor (#648); Jupiter + Saturn shape presets
+  (#649).
+- **LSODE integrator family** (#615/#616/#617) — non-stiff Adams and
+  stiff BDF (Newton corrector + Jacobian) integrators, wired through
+  the Bevy adapter with a parity test.
 
 ### Changed
 
@@ -13,13 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own `rust-version = "1.89"`; cargo's MSRV-aware resolution refuses
   to build the workspace on older toolchains. README § "Minimum
   supported Rust version" updated.
+- Docs and package metadata reframed to describe astrodyn as an
+  engine-agnostic framework rather than a Bevy-first library (#647).
 
 ### Breaking
 
+- **Frame identity is now required throughout** (#661/#664/#668).
+  `RefFrameKind` was removed; `FrameUid` is required on `FrameTree`
+  nodes behind a checked typed boundary (`validate()` + namespace
+  rules); and the former `SourceId` collapsed so every cross-source
+  reference is a `FrameUid`. Downstream code that built frames without
+  identities, or referenced frames via the old `SourceId` /
+  `RefFrameKind` types, must migrate to `FrameUid`.
 - `astrodyn::source_frames::SourceFrameIds` gained a `pub central: bool`
   field (originally landed in #568 without a version bump). Downstream
   code constructing this struct via struct literal must add the new
-  field. Detected and gated by the new `cargo-semver-checks` CI job.
+  field. Detected and gated by the `cargo-semver-checks` CI job.
 
 ### Tooling
 
@@ -38,6 +79,25 @@ Bundled as part of [#527](https://github.com/simnaut/astrodyn/issues/527):
 - CI ergonomics: cancel-superseded `concurrency:` blocks on both
   `ci.yml` and the new `tooling.yml`, plus `RUST_BACKTRACE=1` so
   Tier 3 / parity panics emit stack traces.
+- Claude Code review + `@claude` mention workflows (#666).
+
+### Verification
+
+- Large Tier 2 / Tier 3 cross-validation expansion against JEOD Trick
+  sims: SIM_orbinit (full 46/46 init-variant matrix), SIM_verif_attach_mass,
+  SIM_dyncomp, SIM_MET, SIM_tide_verif, SIM_7_time_reversal, SIM_VER_DRAG
+  (with the `DRAG_OPT_CONST` aero option), SIM_RNP_J2000_prop, and the
+  SIM_csr_compare gravity-acceleration octant sweep. Added Rosetta
+  swing-by and Phobos mission benchmarks (#203/#204).
+
+### Crates
+
+Fourteen publishable workspace crates at this version — the thirteen
+from 0.1.0 plus the new `astrodyn_frame_doc`. Four `publish = false`
+verification crates: `astrodyn_verif_jeod`, the new
+`astrodyn_verif_jeod_fixtures` (pure JEOD-data parsers, no pipeline
+dependency) and `astrodyn_verif_nesc` (NESC GN&C Lunar Check Cases
+track), and `astrodyn_verif_parity`.
 
 ## [0.1.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,6 @@ Fourteen workspace crates at this version:
   `run_verification` scenario rigs) and `astrodyn_verif_parity`
   (runner ↔ Bevy bit-identical parity tests).
 
-[0.2.0]: https://github.com/simnaut/astrodyn/releases/tag/v0.2.0
+[0.2.0]: https://github.com/simnaut/astrodyn/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/simnaut/astrodyn/releases/tag/v0.1.1
 [0.1.0]: https://github.com/simnaut/astrodyn/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,24 @@ verification crates: `astrodyn_verif_jeod`, the new
 dependency) and `astrodyn_verif_nesc` (NESC GN&C Lunar Check Cases
 track), and `astrodyn_verif_parity`.
 
+## [0.1.1] - 2026-05-11
+
+Same-day patch release following the initial 0.1.0 publish.
+
+### Changed
+
+- **Ephemeris kernels are distributed via GitHub Releases** (the
+  `kernels-v1` tag) rather than bundled in the published crate (#476),
+  keeping the `astrodyn_ephemeris` `.crate` small. See the
+  [Environment](https://github.com/simnaut/astrodyn/wiki/Environment)
+  wiki for kernel handling.
+
+### Added
+
+- `force_torque_response` recipe extracted as a reusable surface, with a
+  `bevy_parity` wrapper (#477).
+- `bevy_parity` wrappers for `drag_verif` and `drag_rot_verif` (#475).
+
 ## [0.1.0] - 2026-04-28
 
 Initial public release. The original phased implementation plan
@@ -158,4 +176,5 @@ Fourteen workspace crates at this version:
   (runner ↔ Bevy bit-identical parity tests).
 
 [0.2.0]: https://github.com/simnaut/astrodyn/releases/tag/v0.2.0
+[0.1.1]: https://github.com/simnaut/astrodyn/releases/tag/v0.1.1
 [0.1.0]: https://github.com/simnaut/astrodyn/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ exclude = [
     "CHANGELOG.md",
 ]
 
+# Build docs with every feature so the optional `frame-doc` surface
+# (`astrodyn::frame_doc` + `astrodyn::frame_doc_io`) and the `serde`
+# forwarding both render on docs.rs. Matches the per-crate convention
+# (`all-features = true` on every published `astrodyn_*` member).
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 astrodyn_quantities = { path = "crates/astrodyn_quantities", version = "0.2.0" }
 astrodyn_math = { path = "crates/astrodyn_math", version = "0.2.0" }

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_atmosphere/LICENSE-APACHE
+++ b/crates/astrodyn_atmosphere/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_atmosphere/LICENSE-MIT
+++ b/crates/astrodyn_atmosphere/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_bevy/LICENSE-APACHE
+++ b/crates/astrodyn_bevy/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_bevy/LICENSE-MIT
+++ b/crates/astrodyn_bevy/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_dynamics/LICENSE-APACHE
+++ b/crates/astrodyn_dynamics/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_dynamics/LICENSE-MIT
+++ b/crates/astrodyn_dynamics/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_ephemeris/LICENSE-APACHE
+++ b/crates/astrodyn_ephemeris/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_ephemeris/LICENSE-MIT
+++ b/crates/astrodyn_ephemeris/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_frame_doc/Cargo.toml
+++ b/crates/astrodyn_frame_doc/Cargo.toml
@@ -12,6 +12,9 @@ rust-version.workspace = true
 # Dev-only proptest corpus — not part of the published package.
 exclude = ["proptest-regressions/**"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 # Identity vocabulary only (FrameUid + its components). `astrodyn_quantities`
 # is the type-facade layer (no physics algorithms); its `serde` feature gates

--- a/crates/astrodyn_frame_doc/LICENSE-APACHE
+++ b/crates/astrodyn_frame_doc/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_frame_doc/LICENSE-MIT
+++ b/crates/astrodyn_frame_doc/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_frames/LICENSE-APACHE
+++ b/crates/astrodyn_frames/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_frames/LICENSE-MIT
+++ b/crates/astrodyn_frames/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_gravity/LICENSE-APACHE
+++ b/crates/astrodyn_gravity/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_gravity/LICENSE-MIT
+++ b/crates/astrodyn_gravity/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_interactions/LICENSE-APACHE
+++ b/crates/astrodyn_interactions/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_interactions/LICENSE-MIT
+++ b/crates/astrodyn_interactions/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_math/LICENSE-APACHE
+++ b/crates/astrodyn_math/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_math/LICENSE-MIT
+++ b/crates/astrodyn_math/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_planet/LICENSE-APACHE
+++ b/crates/astrodyn_planet/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_planet/LICENSE-MIT
+++ b/crates/astrodyn_planet/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_quantities/LICENSE-APACHE
+++ b/crates/astrodyn_quantities/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_quantities/LICENSE-MIT
+++ b/crates/astrodyn_quantities/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_runner/LICENSE-APACHE
+++ b/crates/astrodyn_runner/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_runner/LICENSE-MIT
+++ b/crates/astrodyn_runner/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/astrodyn_time/LICENSE-APACHE
+++ b/crates/astrodyn_time/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 The astrodyn_bevy Authors
+   Copyright 2026 The astrodyn Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/astrodyn_time/LICENSE-MIT
+++ b/crates/astrodyn_time/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 The astrodyn_bevy Authors
+Copyright (c) 2026 The astrodyn Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Prep for cutting the 0.2.0 crates release. Documentation, metadata, and
licensing polish only — no code or physics changes.

## Changelog

- **Rewrite the `[0.2.0]` section** to cover the work that landed after the
  entry was first drafted: the frame-identity series (`FrameUid` required
  throughout, `RefFrameKind` removed, `SourceId` → `FrameUid` collapse), the
  new `astrodyn_frame_doc` crate and off-by-default `frame-doc` gateway
  feature, `CartesianState<F>`, the new frames/presets (Moon ME, ENU
  topocentric, generic IAU rotation, typed `Ephemeris` rotation accessor,
  Jupiter/Saturn), the LSODE integrator family, the Tier 2/3 cross-validation
  expansion, and the corrected crate roster (14 publishable + 4
  `publish = false`). Marked **Unreleased** so the date is stamped at tag time
  rather than carrying a stale one.
- **Backfill the missing `[0.1.1]` section** (2026-05-11). v0.1.1 was tagged
  and published but never recorded; the file jumped 0.1.0 → 0.2.0. Content
  reconstructed from the `v0.1.0..v0.1.1` range: ephemeris kernels moved to
  GitHub Releases distribution (#476), the `force_torque_response` recipe
  extraction (#477), and two `bevy_parity` wrappers (#475).

## docs.rs metadata

- Add `[package.metadata.docs.rs] all-features = true` to the **root
  `astrodyn`** crate so the optional `frame-doc` surface (`astrodyn::frame_doc`
  + `astrodyn::frame_doc_io`) and `serde` forwarding render on docs.rs.
- Add the same block to **`astrodyn_frame_doc`** (new in #663/#680), matching
  every other published `astrodyn_*` member.

## LICENSE copyright holder

- Normalize the copyright holder in **every** `LICENSE-MIT` / `LICENSE-APACHE`
  (root + all 13 per-crate copies, 28 files) from `The astrodyn_bevy Authors`
  to `The astrodyn Authors`. The `astrodyn_bevy` string was a workspace-wide
  leftover from before the engine-agnostic split; the project ships many
  non-Bevy crates, so the holder names the project, not the adapter.

## Notes / follow-ups (not in this PR)

The actual publish blocker — wiring `astrodyn_frame_doc` into xtask's
`PUBLISH_ORDER` so the root crate's optional `frame-doc` dep resolves on the
registry — landed in #680 and is merged into `main` (synced into this branch).

At tag time:

- Stamp the real date on the `[0.2.0]` changelog heading.
- `CARGO_REGISTRY_TOKEN` needs publish-new-crates scope for the first
  `astrodyn_frame_doc` publish.

https://claude.ai/code/session_01Y1JAfLcfoZGmdbHBnxBBjs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1JAfLcfoZGmdbHBnxBBjs)_