### PR TITLE
[#678] Collapse NEXT_BODY_UID test-identity boilerplate to fixed labels

### DIFF
--- a/crates/astrodyn_bevy/examples/kepler_orbit.rs
+++ b/crates/astrodyn_bevy/examples/kepler_orbit.rs
@@ -160,10 +160,11 @@ fn setup(mut commands: Commands, mut time: ResMut<Time<Virtual>>) {
     };
 
     commands.spawn((
-        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-            "kepler-orbit-b1-{}",
-            NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ))),
+        // The vehicle's frame identity: a fixed, self-describing,
+        // mission-supplied name — this is the pattern mission code
+        // should copy (issue #662; the shared mint lives in
+        // `astrodyn::named_body_frame_uid`).
+        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("kepler-orbit-sat")),
         Name::new("Satellite"),
         TranslationalStateC::<astrodyn::Earth>::point_mass(
             trans_planet.position,
@@ -225,7 +226,3 @@ fn print_state(
         }
     }
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_bevy/src/body_action.rs
+++ b/crates/astrodyn_bevy/src/body_action.rs
@@ -856,11 +856,6 @@ pub fn add_body_action_via(
     reason = "body-action tests assert bit-exact recovery of literal-built mass values"
 )]
 mod tests {
-    /// Per-call unique suffix for swept test-body identities (#664):
-    /// helpers spawning multiple bodies per App must mint distinct
-    /// identities.
-    static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
     use super::*;
     use crate::components::{
         DynamicsConfigC, MassPropertiesC, RotationalStateC, TranslationalStateC,
@@ -896,10 +891,7 @@ mod tests {
     fn spawn_vehicle(app: &mut App) -> Entity {
         app.world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "body-action-b1-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("body-action-b1")),
                 TranslationalStateC::<astrodyn::Earth>::default(),
                 RotationalStateC::default(),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(

--- a/crates/astrodyn_bevy/src/frame_attach_system.rs
+++ b/crates/astrodyn_bevy/src/frame_attach_system.rs
@@ -750,11 +750,6 @@ pub fn propagate_frame_attached_state_post_integration_system<P: Planet>(
 
 #[cfg(test)]
 mod tests {
-    /// Per-call unique suffix for swept test-body identities (#664):
-    /// helpers spawning multiple bodies per App must mint distinct
-    /// identities.
-    static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
     use super::*;
     use crate::components::{
         DynamicsConfigC, ExternalForceC, ExternalTorqueC, FrameDerivativesC, KinematicChildC,
@@ -791,10 +786,9 @@ mod tests {
     fn spawn_test_body(app: &mut App) -> Entity {
         app.world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "frame-attach-system-b1-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "frame-attach-system-b1",
+                )),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(1.0)),
                 )),
@@ -1067,10 +1061,9 @@ mod tests {
         let parent_body = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "frame-attach-system-b2-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "frame-attach-system-b2",
+                )),
                 Name::new("frame_attached_root"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(10.0)),
@@ -1107,10 +1100,9 @@ mod tests {
         let child_body = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "frame-attach-system-b3-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "frame-attach-system-b3",
+                )),
                 Name::new("kinematic_child"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(5.0)),

--- a/crates/astrodyn_bevy/src/kinematic_propagation.rs
+++ b/crates/astrodyn_bevy/src/kinematic_propagation.rs
@@ -389,11 +389,6 @@ pub fn propagate_state_from_root_post_integration_system<P: Planet>(
 
 #[cfg(test)]
 mod tests {
-    /// Per-call unique suffix for swept test-body identities (#664):
-    /// helpers spawning multiple bodies per App must mint distinct
-    /// identities.
-    static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
     use super::*;
     use crate::components::{
         DynamicsConfigC, ExternalForceC, ExternalTorqueC, FrameDerivativesC, TotalForceC,
@@ -458,10 +453,9 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b1-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b1",
+                )),
                 Name::new("rotated_parent"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(10.0)),
@@ -482,10 +476,9 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b2-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b2",
+                )),
                 Name::new("kinematic_child"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(5.0)),
@@ -587,10 +580,9 @@ mod tests {
         let root = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b3-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b3",
+                )),
                 Name::new("root"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(10.0)),
@@ -616,10 +608,9 @@ mod tests {
         let mid = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b4-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b4",
+                )),
                 Name::new("mid"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(5.0)),
@@ -638,10 +629,9 @@ mod tests {
         let leaf = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b5-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b5",
+                )),
                 Name::new("leaf"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(2.0)),
@@ -750,10 +740,9 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b6-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b6",
+                )),
                 Name::new("rotated_parent"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(10.0)),
@@ -784,10 +773,9 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b7-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b7",
+                )),
                 Name::new("kinematic_child"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(5.0)),
@@ -845,10 +833,9 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "kinematic-propagation-b8-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid(
+                    "kinematic-propagation-b8",
+                )),
                 Name::new("rooted_parent"),
                 MassPropertiesC::from(astrodyn::typed_bridge::mass_raw_to_self_ref(
                     &(MassProperties::new(10.0)),

--- a/crates/astrodyn_bevy/src/wrench.rs
+++ b/crates/astrodyn_bevy/src/wrench.rs
@@ -564,11 +564,6 @@ pub fn wrench_aggregation_system(
 
 #[cfg(test)]
 mod tests {
-    /// Per-call unique suffix for swept test-body identities (#664):
-    /// helpers spawning multiple bodies per App must mint distinct
-    /// identities.
-    static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
     use super::*;
     use crate::components::{
         DynamicsConfigC, ExternalForceC, ExternalTorqueC, FrameDerivativesC, MassChildOf,
@@ -663,10 +658,7 @@ mod tests {
         let entity = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b1-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b1")),
                 mp_c_from_raw(core),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -703,10 +695,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b2-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b2")),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -718,10 +707,7 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b3-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b3")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::new(parent, DVec3::new(1.0, 0.0, 0.0)),
                 TotalForceC::default(),
@@ -768,10 +754,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b4-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b4")),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -784,10 +767,7 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b5-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b5")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::new(parent, DVec3::new(1.0, 0.0, 0.0)),
                 TotalForceC::default(),
@@ -851,10 +831,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b6-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b6")),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -871,10 +848,7 @@ mod tests {
         let _child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b7-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b7")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::with_rotation(parent, DVec3::new(1.0, 0.0, 0.0), t_pc),
                 TotalForceC::default(),
@@ -922,10 +896,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b8-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b8")),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -943,10 +914,7 @@ mod tests {
         let _child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b9-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b9")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::with_rotation(parent, DVec3::new(1.0, 0.0, 0.0), t_pc),
                 TotalForceC::default(),
@@ -1006,10 +974,7 @@ mod tests {
         let rot_parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b10-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b10")),
                 Name::new("rotated_parent"),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
@@ -1028,10 +993,7 @@ mod tests {
         let _rot_child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b11-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b11")),
                 Name::new("rotated_child"),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::with_rotation(rot_parent, DVec3::new(1.0, 0.0, 0.0), t_pc),
@@ -1051,10 +1013,7 @@ mod tests {
         let id_parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b12-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b12")),
                 Name::new("identity_parent"),
                 mp_c_from_raw(MassProperties::new(8.0)),
                 TotalForceC::default(),
@@ -1067,10 +1026,7 @@ mod tests {
         let _id_child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b13-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b13")),
                 Name::new("identity_child"),
                 mp_c_from_raw(MassProperties::new(2.0)),
                 MassChildOf::new(id_parent, DVec3::new(0.0, 1.0, 0.0)),
@@ -1146,10 +1102,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b14-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b14")),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -1161,10 +1114,7 @@ mod tests {
         let _a = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b15-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b15")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::new(parent, DVec3::new(0.0, 1.0, 0.0)),
                 TotalForceC::default(),
@@ -1177,10 +1127,7 @@ mod tests {
         let _b = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b16-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b16")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::new(parent, DVec3::new(0.0, -1.0, 0.0)),
                 TotalForceC::default(),
@@ -1281,10 +1228,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b17-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b17")),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
                 FrameDerivativesC::default(),
@@ -1300,10 +1244,7 @@ mod tests {
         let _child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b18-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b18")),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::new(parent, DVec3::new(1.0, 0.0, 0.0)),
                 TotalForceC::default(),
@@ -1437,10 +1378,7 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b19-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b19")),
                 Name::new("child"),
                 mp_c_from_raw(MassProperties::new(100.0)),
                 MassChildOf::new(parent, DVec3::new(0.5, 0.0, 0.0)),
@@ -1587,10 +1525,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b20-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b20")),
                 Name::new("parent"),
                 mp_c_from_raw(MassProperties::new(10.0)),
                 TotalForceC::default(),
@@ -1631,10 +1566,7 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b21-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b21")),
                 Name::new("child_appendage"),
                 mp_c_from_raw(MassProperties::new(1.0)),
                 MassChildOf::new(parent, DVec3::new(1.0, 0.0, 0.0)),
@@ -1785,10 +1717,7 @@ mod tests {
         let parent = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b22-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b22")),
                 Name::new("parent"),
                 mp_c_from_raw(parent_mass),
                 TotalForceC::default(),
@@ -1817,10 +1746,7 @@ mod tests {
         let child = app
             .world_mut()
             .spawn((
-                crate::components::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "wrench-b23-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                crate::components::FrameUidC(astrodyn::named_body_frame_uid("wrench-b23")),
                 Name::new("child"),
                 mp_c_from_raw(MassProperties::new(5.0)),
                 MassChildOf::new(parent, DVec3::new(1.0, 0.0, 0.0)),

--- a/crates/astrodyn_bevy/tests/bevy_frame_tree_despawn_cleanup.rs
+++ b/crates/astrodyn_bevy/tests/bevy_frame_tree_despawn_cleanup.rs
@@ -124,10 +124,9 @@ fn body_despawn_despawns_body_frame_entity() {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-frame-tree-despawn-cleanup-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-frame-tree-despawn-cleanup-b1",
+            )),
             Name::new("vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState {
                 position: DVec3::new(7e6, 0.0, 0.0),
@@ -213,7 +212,3 @@ fn rotation_none_then_source_despawn_does_not_leak_retired_pfix_entity() {
         "retired pfix entity must be despawned when its owning source despawns"
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_bevy/tests/bevy_mass_point_ref_wiring.rs
+++ b/crates/astrodyn_bevy/tests/bevy_mass_point_ref_wiring.rs
@@ -65,10 +65,9 @@ fn mass_point_ref_inserted_on_body_with_mass_properties() {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-mass-point-ref-wiring-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-mass-point-ref-wiring-b1",
+            )),
             Name::new("vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_state()),
             RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
@@ -120,10 +119,9 @@ fn mass_point_ref_inserted_when_mass_acquired_after_registration() {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-mass-point-ref-wiring-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-mass-point-ref-wiring-b2",
+            )),
             Name::new("late_mass"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_state()),
             RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
@@ -187,10 +185,9 @@ fn mass_point_ref_removed_when_mass_lost_after_registration() {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-mass-point-ref-wiring-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-mass-point-ref-wiring-b3",
+            )),
             Name::new("loses_mass"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_state()),
             RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
@@ -239,10 +236,9 @@ fn mass_point_ref_omitted_for_kinematic_only_body() {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-mass-point-ref-wiring-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-mass-point-ref-wiring-b4",
+            )),
             Name::new("kinematic"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_state()),
             RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(
@@ -267,7 +263,3 @@ fn mass_point_ref_omitted_for_kinematic_only_body() {
         "MassPointRef should be absent on a body without MassPropertiesC"
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_bevy/tests/frame_origin_systemparam.rs
+++ b/crates/astrodyn_bevy/tests/frame_origin_systemparam.rs
@@ -72,10 +72,9 @@ fn build_app(planet_name: &str, planet: &PlanetConfig) -> (App, Entity, Entity) 
     let body_e = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "frame-origin-systemparam-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "frame-origin-systemparam-b1",
+            )),
             Name::new("body"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             RotationalStateC::from(astrodyn::typed_bridge::rot_raw_to_self_ref(&(rot))),
@@ -204,7 +203,3 @@ fn after_diff_mission_code_shape_compiles() {
 
     let _id = app.world_mut().register_system(read_body_origin_in_root);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_bevy/tests/validation_fail_loud.rs
+++ b/crates/astrodyn_bevy/tests/validation_fail_loud.rs
@@ -136,10 +136,7 @@ fn validate_jeod_invariants_should_panic_on_rotational_without_mass() {
         .spawn(PlanetBundle::<Earth>::point_mass("Earth", &EARTH))
         .id();
     app.world_mut().spawn((
-        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-            "validation-fail-loud-b1-{}",
-            NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ))),
+        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("validation-fail-loud-b1")),
         Name::new("MisconfiguredSixDof"),
         TranslationalStateC::<Earth>(TranslationalStateTyped::<PlanetInertial<Earth>> {
             position: DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<PlanetInertial<Earth>>(),
@@ -190,10 +187,7 @@ fn validate_jeod_invariants_panics_on_rotational_without_mass() {
     // is present (default) so `RotationalWithoutRotState` is *not*
     // raised, narrowing the failure set to one entry.
     app.world_mut().spawn((
-        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-            "validation-fail-loud-b2-{}",
-            NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ))),
+        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("validation-fail-loud-b2")),
         Name::new("MisconfiguredSixDof"),
         TranslationalStateC::<Earth>(TranslationalStateTyped::<PlanetInertial<Earth>> {
             position: DVec3::new(7_000_000.0, 0.0, 0.0).m_at::<PlanetInertial<Earth>>(),
@@ -254,10 +248,7 @@ fn validate_jeod_invariants_warns_on_uninitialized_translational_state() {
         .id();
 
     app.world_mut().spawn((
-        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-            "validation-fail-loud-b3-{}",
-            NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ))),
+        astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("validation-fail-loud-b3")),
         Name::new("ZeroState"),
         TranslationalStateC::<Earth>(TranslationalStateTyped::<PlanetInertial<Earth>> {
             position: DVec3::ZERO.m_at::<PlanetInertial<Earth>>(),
@@ -311,7 +302,3 @@ fn validate_jeod_invariants_warns_on_uninitialized_translational_state() {
         );
     }
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_context_attach_to_frame.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_context_attach_to_frame.rs
@@ -94,10 +94,9 @@ fn build_test_app() -> (App, Entity, Entity) {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-context-attach-to-frame-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-context-attach-to-frame-b1",
+            )),
             Name::new("body"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState::default()),
             RotationalStateC::from(RotationalStateTyped::<SelfRef>::default()),
@@ -249,7 +248,3 @@ fn attach_to_frame_pfix_routes_to_pfix_frame_entity() {
     assert_eq!(attached.offset, captured_offset);
     assert_eq!(attached.t_parent_body, captured_rot);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity.rs
@@ -101,10 +101,7 @@ fn build_app() -> (App, Entity, Entity) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-b1")),
             Name::new("Vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
             RotationalStateC::from(initial_rot()),
@@ -276,10 +273,7 @@ fn bevy_parity_rkf45_matches_simulation_bit_identical() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-b2")),
             Name::new("Vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
             RotationalStateC::from(initial_rot()),
@@ -336,7 +330,3 @@ fn bevy_parity_rkf45_matches_simulation_bit_identical() {
 
     assert_sixdof_bit_identical("Bevy RKF45 vs Sim RKF45", &bevy_state, &sim_state);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs
@@ -217,10 +217,9 @@ fn build_bevy_app() -> (App, Entity, ApolloTopology) {
         let entity = app
             .world_mut()
             .spawn((
-                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "bevy-parity-apollo-trajectory-b1-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                    "bevy-parity-apollo-trajectory-b1",
+                )),
                 MassBodyIdC(mass_id),
                 MassPropertiesC(typed_bridge::mass_raw_to_self_ref(&core)),
                 TranslationalStateC::<astrodyn::Earth>::default(),
@@ -536,7 +535,3 @@ fn bevy_parity_apollo_trajectory() {
         }
     }
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_apollo_trajectory.rs
@@ -209,7 +209,7 @@ fn build_bevy_app() -> (App, Entity, ApolloTopology) {
     let mut mass_id_to_entity: std::collections::HashMap<MassBodyId, Entity> =
         std::collections::HashMap::new();
     mass_id_to_entity.insert(topology.cm, cm_entity);
-    for &mass_id in &tree_only {
+    for (i, &mass_id) in tree_only.iter().enumerate() {
         let core = {
             let tree_r = app.world().resource::<MassTreeR>();
             tree_r.0.get(mass_id).core_properties
@@ -217,9 +217,12 @@ fn build_bevy_app() -> (App, Entity, ApolloTopology) {
         let entity = app
             .world_mut()
             .spawn((
-                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
-                    "bevy-parity-apollo-trajectory-b1",
-                )),
+                // One spawn per tree node in a single App: the label must
+                // vary per iteration — deterministically, via the loop
+                // index rather than a counter.
+                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
+                    "bevy-parity-apollo-trajectory-b1-{i}"
+                ))),
                 MassBodyIdC(mass_id),
                 MassPropertiesC(typed_bridge::mass_raw_to_self_ref(&core)),
                 TranslationalStateC::<astrodyn::Earth>::default(),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_detach_momentum.rs
@@ -94,10 +94,9 @@ fn build_two_body_world(
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b1",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -113,10 +112,9 @@ fn build_two_body_world(
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b2",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -1303,10 +1301,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_runs_combine
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b3",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -1325,10 +1322,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_runs_combine
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b4",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -1686,10 +1682,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_rewrites_chi
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b5-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b5",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -1708,10 +1703,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_cross_integ_frame_rewrites_chi
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b6-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b6",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -1945,10 +1939,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_post_frame_switch_same_integ_f
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b7-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b7",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -1971,10 +1964,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_post_frame_switch_same_integ_f
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b8-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b8",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState {
@@ -2155,10 +2147,9 @@ fn bevy_parity_attach_detach_momentum_bevy_detached_body_skips_force_pipeline() 
     let body_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b9-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b9",
+            )),
             Name::new("Body"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans),
@@ -2894,10 +2885,9 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b10-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b10",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -2916,10 +2906,9 @@ fn bevy_parity_attach_detach_momentum_bevy_runner_parity_cross_integ_frame_attac
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b11-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b11",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -3202,10 +3191,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_parents_succee
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b12-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b12",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -3227,10 +3215,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_parents_succee
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b13-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b13",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -3344,10 +3331,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_malformed_frame_node_panics() 
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b14-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b14",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -3363,10 +3349,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_malformed_frame_node_panics() 
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b15-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b15",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -3462,10 +3447,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_equal_but_illegal_parents_pani
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b16-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b16",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -3481,10 +3465,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_equal_but_illegal_parents_pani
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b17-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b17",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -3606,10 +3589,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_stray_parent_p
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b18-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b18",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -3625,10 +3607,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_root_equivalent_stray_parent_p
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b19-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b19",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -3854,10 +3835,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_child_of_
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b20-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b20",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -3873,10 +3853,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_child_of_
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b21-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b21",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -3978,10 +3957,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_body_with_no_frame_ent
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b22-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b22",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -3997,10 +3975,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_body_with_no_frame_ent
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b23-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b23",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -4113,10 +4090,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_child_on_mass_only_par
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b24-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b24",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -4208,10 +4184,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_translati
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b25-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b25",
+            )),
             Name::new("Parent"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(parent_trans),
@@ -4227,10 +4202,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_frame_entity_without_translati
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b26-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b26",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -4372,10 +4346,9 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_dynamic_child_on_mass_only_par
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-detach-momentum-b27-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-detach-momentum-b27",
+            )),
             Name::new("Child"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(child_trans),
@@ -4508,7 +4481,3 @@ fn bevy_parity_attach_detach_momentum_bevy_attach_mass_only_succeeds_without_jeo
          rejected by the fence despite the mass-only carve-out."
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_attach_non_root_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_attach_non_root_integ_source.rs
@@ -175,10 +175,9 @@ fn build_lunar_app() -> (App, Entity, Entity, Entity, astrodyn::MassBodyId) {
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-non-root-integ-source-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-non-root-integ-source-b1",
+            )),
             Name::new("Parent"),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(parent_mass()),
@@ -195,10 +194,9 @@ fn build_lunar_app() -> (App, Entity, Entity, Entity, astrodyn::MassBodyId) {
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-attach-non-root-integ-source-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-attach-non-root-integ-source-b2",
+            )),
             Name::new("Child"),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(child_mass()),
@@ -492,7 +490,3 @@ fn bevy_parity_attach_non_root_integ_source_parent_was_detached() {
 // The positive cross-integ-frame parity test lands together with
 // the fence's replacement (the frame-tree reparent + per-body lift
 // implementation) in the cross-integ-frame attach work.
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_init_lvlh_rot.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_init_lvlh_rot.rs
@@ -78,10 +78,9 @@ fn build_app() -> (App, Entity) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-body-action-init-lvlh-rot-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-body-action-init-lvlh-rot-b1",
+            )),
             // Placeholder translational state — `InitLvlhRot` only
             // touches the rotational component; the trans state is
             // unused by the action and irrelevant to the assertion.
@@ -236,7 +235,3 @@ fn bevy_parity_body_action_init_lvlh_rot_init_lvlh_rot_lvlh_rate_frame_dispatche
     let dw = (state.ang_vel_body - expected.ang_vel_body).length();
     assert!(dw < 1e-14, "lvlh-rate-frame ang vel mismatch: dw = {dw}");
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_lifecycle.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_body_action_lifecycle.rs
@@ -175,10 +175,9 @@ fn build_app() -> (App, Entity) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-body-action-lifecycle-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-body-action-lifecycle-b1",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
             RotationalStateC::from(
                 astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
@@ -508,10 +507,9 @@ fn bevy_parity_body_action_lifecycle_body_action_init_trans_resets_abm4_history(
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-body-action-lifecycle-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-body-action-lifecycle-b2",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
             RotationalStateC::from(
                 astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
@@ -684,10 +682,9 @@ fn bevy_parity_body_action_lifecycle_body_action_init_mass_resets_abm4_history()
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-body-action-lifecycle-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-body-action-lifecycle-b3",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
             RotationalStateC::from(
                 astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
@@ -863,10 +860,9 @@ fn bevy_parity_body_action_lifecycle_body_action_startup_message_applies_exactly
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-body-action-lifecycle-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-body-action-lifecycle-b4",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(iss_typical_state()),
             RotationalStateC::from(
                 astrodyn::typed_bridge::rot_raw_to_typed::<astrodyn::SelfRef>(
@@ -975,7 +971,3 @@ fn bevy_parity_body_action_lifecycle_body_action_startup_message_applies_exactly
          re-pushed it onto `BodyActionsR.pending`."
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
@@ -318,10 +318,9 @@ fn spawn_body(
 ) -> Entity {
     app.world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-chained-attach-event-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-chained-attach-event-b1",
+            )),
             Name::new(name.to_string()),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(mass),
@@ -648,7 +647,3 @@ fn fire_bevy_attach(app: &mut App, child: Entity, parent: Entity, offset: DVec3,
             t_parent_child: astrodyn::FrameTransform::from_matrix(t_pc),
         });
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_chained_attach_event.rs
@@ -318,9 +318,13 @@ fn spawn_body(
 ) -> Entity {
     app.world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
-                "bevy-parity-chained-attach-event-b1",
-            )),
+            // Identity derived from the helper's per-call `name`: three
+            // vehicles spawn through this one helper in a single App, so
+            // the label must vary per call — deterministically, via the
+            // caller-supplied name rather than a counter.
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
+                "bevy-parity-chained-attach-event-{name}"
+            ))),
             Name::new(name.to_string()),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(mass),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
@@ -60,10 +60,9 @@ fn bevy_parity_derived_states() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b1",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -211,10 +210,9 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b2",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
@@ -357,10 +355,9 @@ fn bevy_parity_derived_state_eccentric_derived_states() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b3",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(ecc_trans),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -523,10 +520,9 @@ fn bevy_parity_derived_state_polar_geodetic() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b4",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(polar_trans),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
@@ -663,10 +659,9 @@ fn bevy_parity_derived_state_equatorial_solar_beta() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b5-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b5",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -767,10 +762,9 @@ fn run_euler_parity(label: &str, trans: TranslationalState, sequence: EulerSeque
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b6-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b6",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -864,10 +858,9 @@ fn run_lvlh_parity(label: &str, trans: TranslationalState) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b7-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b7",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -964,10 +957,9 @@ fn run_ned_parity(label: &str, trans: TranslationalState, r_eq: f64, r_pol: f64)
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b8-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b8",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             DynamicsConfigC(DynamicsConfig {
                 translational_dynamics: true,
@@ -1069,10 +1061,9 @@ fn run_orbelem_parity(label: &str, trans: TranslationalState) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b9-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b9",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -1204,10 +1195,9 @@ fn bevy_parity_derived_state_orbelem() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b10-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b10",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(ecc_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -1287,10 +1277,9 @@ fn bevy_parity_derived_state_solar_beta() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-derived-state-b11-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-derived-state-b11",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(inc_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -1341,7 +1330,3 @@ fn bevy_parity_derived_state_solar_beta() {
     assert_bits_eq("Bevy vs Sim", "solar_beta", bevy_beta, sim_beta);
     println!("  Bevy vs Sim solar beta: bit-identical");
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_detach_non_root_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_detach_non_root_integ_source.rs
@@ -166,10 +166,9 @@ fn run_lift_and_lower(moon_velocity: DVec3) {
     let parent_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-detach-non-root-integ-source-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-detach-non-root-integ-source-b1",
+            )),
             Name::new("Parent"),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(
@@ -190,10 +189,9 @@ fn run_lift_and_lower(moon_velocity: DVec3) {
     let child_entity = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-detach-non-root-integ-source-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-detach-non-root-integ-source-b2",
+            )),
             Name::new("Child"),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(
@@ -422,7 +420,3 @@ fn bevy_parity_detach_non_root_integ_source_lift_and_lower() {
 fn bevy_parity_detach_non_root_integ_source_lift_and_lower_with_source_velocity() {
     run_lift_and_lower(MOON_VELOCITY);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_drag.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_drag.rs
@@ -77,10 +77,7 @@ fn bevy_parity_drag_atmosphere_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-drag-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-drag-b1")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -200,10 +197,7 @@ fn bevy_parity_drag_constant_density_drag_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-drag-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-drag-b2")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -312,10 +306,7 @@ fn bevy_parity_drag_met_atmosphere_drag_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-drag-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-drag-b3")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -421,10 +412,7 @@ fn bevy_parity_drag_met_run5a() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-drag-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-drag-b4")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -545,10 +533,7 @@ fn bevy_parity_drag_run6b() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-drag-b5-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-drag-b5")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -609,7 +594,3 @@ fn bevy_parity_drag_run6b() {
     };
     assert_sixdof_eq("Bevy vs Sim (drag run6b)", &bevy_state, &sim_state);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_environment.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_environment.rs
@@ -64,10 +64,9 @@ fn bevy_parity_frame_attach_environment_frame_attach_gravity_sees_propagated_sta
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-frame-attach-environment-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-frame-attach-environment-b1",
+            )),
             Name::new("frame_attached_body"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState::default()),
             RotationalStateC::from(RotationalStateTyped::<SelfRef>::default()),
@@ -152,7 +151,3 @@ fn bevy_parity_frame_attach_environment_frame_attach_gravity_sees_propagated_sta
          reflect the body's pre-tick default-zero position."
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_non_root_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_attach_non_root_integ_source.rs
@@ -126,10 +126,9 @@ fn bevy_parity_frame_attach_non_root_integ_source_lowers_to_integ_frame() {
     let body = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-frame-attach-non-root-integ-source-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-frame-attach-non-root-integ-source-b1",
+            )),
             Name::new("Lunar"),
             DynamicsConfigC(six_dof_config()),
             MassPropertiesC::from(body_mass()),
@@ -278,7 +277,3 @@ fn bevy_parity_frame_attach_non_root_integ_source_lowers_to_integ_frame() {
          root frame, integ frame at rest in root): got {body_vel:?}"
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_frame_switch.rs
@@ -116,10 +116,9 @@ fn bevy_parity_frame_switch_earth_to_moon_matches_simulation() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-frame-switch-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-frame-switch-b1",
+            )),
             Name::new("EarthToMoon"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
             RotationalStateC::from(initial_rot()),
@@ -362,10 +361,9 @@ fn bevy_parity_frame_switch_on_departure_matches_simulation() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-frame-switch-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-frame-switch-b2",
+            )),
             Name::new("EarthDeparture"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(initial_trans()),
             RotationalStateC::from(initial_rot()),
@@ -488,7 +486,3 @@ fn bevy_parity_frame_switch_on_departure_matches_simulation() {
         );
     }
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_gj.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_gj.rs
@@ -163,10 +163,7 @@ fn run_gj_bootstrap_parity(
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-gj-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-gj-b1")),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             GravityControlsC(GravityControls {
@@ -251,7 +248,3 @@ fn bevy_parity_gj_bootstrap_tsf() {
         1000,
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_gravity_torque.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_gravity_torque.rs
@@ -46,10 +46,9 @@ fn bevy_parity_gravity_torque_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-gravity-torque-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-gravity-torque-b1",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -262,10 +261,9 @@ fn run_gravity_torque_parity(
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-gravity-torque-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-gravity-torque-b2",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             RotationalStateC::from(rot),
             MassPropertiesC::from(iss_mass()),
@@ -379,10 +377,9 @@ fn run_external_parity(
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-gravity-torque-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-gravity-torque-b3",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(rot),
             MassPropertiesC::from(iss_mass()),
@@ -494,7 +491,3 @@ fn bevy_parity_gravity_torque_run9d_force_torque_rate() {
         }
     });
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_highfidelity.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_highfidelity.rs
@@ -59,10 +59,9 @@ fn bevy_parity_highfidelity_sh4x4_rnp() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-highfidelity-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-highfidelity-b1",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC(astrodyn::DynamicsConfig {
                 translational_dynamics: true,
@@ -184,10 +183,9 @@ fn bevy_parity_highfidelity_tidal_sh4x4() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-highfidelity-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-highfidelity-b2",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC(astrodyn::DynamicsConfig {
                 translational_dynamics: true,
@@ -265,10 +263,9 @@ fn bevy_parity_highfidelity_run2p_polar_motion() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-highfidelity-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-highfidelity-b3",
+            )),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -349,10 +346,9 @@ fn run_gj_parity(label: &str, config: GaussJacksonConfig, dt: f64, n_steps: usiz
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-highfidelity-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-highfidelity-b4",
+            )),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(gj_trans),
             GravityControlsC(GravityControls {
@@ -446,7 +442,3 @@ fn bevy_parity_highfidelity_gj_dt1() {
         1000,
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_integ_source.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_integ_source.rs
@@ -165,10 +165,9 @@ fn bevy_parity_integ_source_lunar_orbit_matches_simulation() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-integ-source-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-integ-source-b1",
+            )),
             Name::new("Lunar"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_initial_trans()),
             RotationalStateC::from(initial_rot()),
@@ -326,10 +325,9 @@ fn bevy_parity_integ_source_moving_moon_matches_simulation() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-integ-source-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-integ-source-b2",
+            )),
             Name::new("Lunar"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_initial_trans()),
             RotationalStateC::from(initial_rot()),
@@ -477,10 +475,9 @@ fn bevy_parity_integ_source_root_matches_legacy_no_op() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-integ-source-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-integ-source-b3",
+            )),
             Name::new("Vehicle"),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             RotationalStateC::from(initial_rot()),
@@ -662,10 +659,9 @@ fn bevy_parity_integ_source_solar_beta_in_lunar_integ_frame() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-integ-source-b4-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-integ-source-b4",
+            )),
             Name::new("Lunar"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_tilted),
             RotationalStateC::from(initial_rot()),
@@ -898,10 +894,9 @@ fn bevy_parity_integ_source_flat_plate_srp_in_lunar_integ_frame() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-integ-source-b5-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-integ-source-b5",
+            )),
             Name::new("Lunar-SRP"),
             TranslationalStateC::<astrodyn::Moon>::from_untyped(lunar_tilted),
             RotationalStateC::from(initial_rot()),
@@ -1054,7 +1049,3 @@ fn bevy_parity_integ_source_flat_plate_srp_in_lunar_integ_frame() {
     );
     let _ = bevy_torque;
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_lighting.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_lighting.rs
@@ -84,10 +84,7 @@ fn run_earth_lighting_parity(label: &str, veh_pos: DVec3, sun_pos: DVec3, moon_p
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-lighting-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-lighting-b1")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState {
                 position: veh_pos,
                 velocity: DVec3::new(0.0, 7668.56, 0.0),
@@ -308,10 +305,7 @@ fn bevy_parity_lighting_earth_lighting_pipeline() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-lighting-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-lighting-b2")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -515,10 +509,7 @@ fn bevy_parity_lighting_earth_lighting_non_root_integ_source() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-lighting-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-lighting-b3")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(TranslationalState {
                 position: body_moon_rel_pos,
                 velocity: body_moon_rel_vel,
@@ -624,7 +615,3 @@ fn bevy_parity_lighting_earth_lighting_non_root_integ_source() {
         sim_lighting,
     );
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_abm4.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_abm4.rs
@@ -98,10 +98,9 @@ fn build_two_body_app(
     let body_a = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-mass-attach-detach-with-abm4-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-mass-attach-detach-with-abm4-b1",
+            )),
             Name::new("VehicleA"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_a),
@@ -124,10 +123,9 @@ fn build_two_body_app(
     let body_b = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-mass-attach-detach-with-abm4-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-mass-attach-detach-with-abm4-b2",
+            )),
             Name::new("VehicleB"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_b),
@@ -286,9 +284,13 @@ fn bevy_parity_mass_attach_detach_with_abm4_mass_attach_resets_full_ancestor_cha
         |app: &mut App, id: astrodyn::MassBodyId, mass: f64, name: &str| -> Entity {
             app.world_mut()
                 .spawn((
+                    // Identity derived from the helper's per-call `name`:
+                    // the chain spawns several bodies through this one
+                    // closure in a single App, so the label must vary per
+                    // call — deterministically, via the caller-supplied
+                    // name rather than a counter.
                     astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                        "bevy-parity-mass-attach-detach-with-abm4-b3-{}",
-                        NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        "bevy-parity-mass-attach-detach-with-abm4-{name}"
                     ))),
                     Name::new(name.to_string()),
                     DynamicsConfigC::default(),
@@ -380,7 +382,3 @@ fn bevy_parity_mass_attach_detach_with_abm4_mass_attach_resets_full_ancestor_cha
     assert!(!read_abm4_topology_dirty(app.world(), e_top));
     let _ = e_leaf;
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_gj.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_mass_attach_detach_with_gj.rs
@@ -95,10 +95,9 @@ fn build_two_body_app(
     let body_a = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-mass-attach-detach-with-gj-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-mass-attach-detach-with-gj-b1",
+            )),
             Name::new("VehicleA"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_a),
@@ -121,10 +120,9 @@ fn build_two_body_app(
     let body_b = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-mass-attach-detach-with-gj-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                "bevy-parity-mass-attach-detach-with-gj-b2",
+            )),
             Name::new("VehicleB"),
             DynamicsConfigC::default(),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans_b),
@@ -279,9 +277,13 @@ fn bevy_parity_mass_attach_detach_with_gj_mass_attach_with_gj_resets_full_ancest
         |app: &mut App, id: astrodyn::MassBodyId, mass: f64, name: &str| -> Entity {
             app.world_mut()
                 .spawn((
+                    // Identity derived from the helper's per-call `name`:
+                    // the chain spawns several bodies through this one
+                    // closure in a single App, so the label must vary per
+                    // call — deterministically, via the caller-supplied
+                    // name rather than a counter.
                     astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                        "bevy-parity-mass-attach-detach-with-gj-b3-{}",
-                        NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        "bevy-parity-mass-attach-detach-with-gj-{name}"
                     ))),
                     Name::new(name.to_string()),
                     DynamicsConfigC::default(),
@@ -417,7 +419,3 @@ fn bevy_parity_mass_attach_detach_with_gj_mass_detach_with_gj_resets_integrator(
     // No IG.37 panic on subsequent steps.
     step_bevy(&mut app, 5, sim_dt);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_point_mass.rs
@@ -48,10 +48,7 @@ fn bevy_parity_point_mass_sixdof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-point-mass-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-point-mass-b1")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -105,10 +102,7 @@ fn run_planetary_parity(label: &str, trans: TranslationalState) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-point-mass-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-point-mass-b2")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -194,10 +188,7 @@ fn bevy_parity_point_mass_run2_6dof() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-point-mass-b3-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-point-mass-b3")),
             TranslationalStateC::<astrodyn::Earth>::from(iss_trans()),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -274,10 +265,9 @@ fn bevy_parity_point_mass_orbinit_cross_consistency() {
         let vehicle = app
             .world_mut()
             .spawn((
-                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "bevy-parity-point-mass-b4-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                    "bevy-parity-point-mass-b4",
+                )),
                 TranslationalStateC::<astrodyn::Earth>::from_untyped(*trans),
                 DynamicsConfigC::default(),
                 GravityControlsC(GravityControls {
@@ -752,10 +742,7 @@ fn run_atmosphere_parity(label: &str, trans: TranslationalState) {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-point-mass-b5-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-point-mass-b5")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
             RotationalStateC::from(tumble_rot()),
             MassPropertiesC::from(iss_mass()),
@@ -818,7 +805,3 @@ fn bevy_parity_point_mass_run5c_atmosphere_max() {
     };
     run_atmosphere_parity("run5c_atmos_max", ecc_trans);
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_third_body.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_third_body.rs
@@ -59,10 +59,7 @@ fn bevy_parity_third_body_solar_beta_equ() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-third-body-b1-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-third-body-b1")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(equ_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -159,10 +156,7 @@ fn bevy_parity_third_body_solar_beta_obliquity() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-third-body-b2-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-third-body-b2")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(obl_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -328,10 +322,9 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
     let vehicle = if sixdof {
         app.world_mut()
             .spawn((
-                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "bevy-parity-third-body-b3-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                    "bevy-parity-third-body-b3",
+                )),
                 TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
                 RotationalStateC::from(tumble_rot()),
                 MassPropertiesC::from(iss_mass()),
@@ -342,10 +335,9 @@ fn run_3rd_body_parity(label: &str, trans: TranslationalState, include_moon: boo
     } else {
         app.world_mut()
             .spawn((
-                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                    "bevy-parity-third-body-b4-{}",
-                    NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                ))),
+                astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(
+                    "bevy-parity-third-body-b4",
+                )),
                 TranslationalStateC::<astrodyn::Earth>::from_untyped(trans),
                 DynamicsConfigC(config),
                 GravityControlsC(GravityControls { controls }),
@@ -576,10 +568,7 @@ fn bevy_parity_third_body_mars_dawn() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-third-body-b5-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-third-body-b5")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(mars_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -704,10 +693,7 @@ fn bevy_parity_third_body_mercury_relativistic() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-third-body-b6-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-third-body-b6")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(mercury_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -811,10 +797,7 @@ fn bevy_parity_third_body_relativistic_moving_source() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-third-body-b7-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-third-body-b7")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(mercury_trans),
             DynamicsConfigC::default(),
             GravityControlsC(GravityControls {
@@ -974,10 +957,7 @@ fn bevy_parity_third_body_earth_moon_clem() {
     let vehicle = app
         .world_mut()
         .spawn((
-            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid(&format!(
-                "bevy-parity-third-body-b8-{}",
-                NEXT_BODY_UID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ))),
+            astrodyn_bevy::FrameUidC(astrodyn::named_body_frame_uid("bevy-parity-third-body-b8")),
             TranslationalStateC::<astrodyn::Earth>::from_untyped(clem_trans),
             astrodyn_bevy::MassPropertiesC::from(mass_props),
             DynamicsConfigC::default(),
@@ -1071,7 +1051,3 @@ fn bevy_parity_third_body_earth_moon_clem() {
     assert_trans_eq("Bevy vs Sim (earth_moon_clem)", &bevy_trans, &sim_trans);
     println!("  Earth-Moon Clementine SRP: bit-identical");
 }
-
-/// Per-call unique suffix for swept test-body identities (#664): helpers
-/// spawning multiple bodies per App must mint distinct identities.
-static NEXT_BODY_UID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);


### PR DESCRIPTION
Closes #678.

## What

The #664 identity sweep left a 5-line counter-mint block at every raw test-body spawn plus a file-local `static NEXT_BODY_UID: AtomicUsize` per file. All of it is gone — **141 sites across 32 files**, every one now a single line:

```rust
FrameUidC(astrodyn::named_body_frame_uid("file-test-bN")),
```

## Why fixed labels instead of the issue's headline "shared helper"

A fresh census showed the counter is needed **nowhere**: identity collisions only exist within one App/World (`FrameUidIndexR` is per-App; nextest isolates tests), and the sweep already gave every spawn site a unique per-site prefix. Fixed labels therefore satisfy uniqueness everywhere while making identities **deterministic** (run-order-independent — better for debugging and frame-doc diffs), and `named_body_frame_uid` already *is* the shared mint — no new API, no `mod common;` plumbing. #678's own §3 right-sizing and acceptance wording ("helper-owned counter **or fixed labels**") sanction exactly this.

The one genuine multi-call-per-App case — the attach-chain `mk_body` closures in `bevy_parity_mass_attach_detach_with_{abm4,gj}`, which spawn several bodies through one closure in a single App — derives its label from the helper's per-call `name` parameter: distinct per call, still deterministic. (The RF.14 duplicate-identity panic caught this exact case on the first local run — the net working as designed.)

`kepler_orbit.rs`, the issue's sharpest case, now models the mission-author pattern: a fixed, self-describing identity with a comment pointing at the shared mint.

**Out of scope** (per #678 discussion): the `ext_uid` counters in `astrodyn_frames` test mods — an in-crate structural-test pattern that genuinely mints many uids per tree.

## Verification

- `grep -rn NEXT_BODY_UID crates/ src/` → empty (the acceptance grep-gate)
- Unit + Tier 2: **1600/1600**
- Parity fast lane (CI PR filter): green — covers every touched parity file; the heavy buckets contain no touched files
- `kepler_orbit` example smoke-run clean
- Tests/examples only; zero production code, zero physics

🤖 Generated with [Claude Code](https://claude.com/claude-code)