### PR TITLE
[#686] Skip claude-review on Dependabot PRs (no Actions secrets)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,9 +16,20 @@ concurrency:
 
 jobs:
   claude-review:
-    # Skip PRs from forks: repository secrets (CLAUDE_CODE_OAUTH_TOKEN) aren't available
-    # to fork PRs, so the action would only produce noisy failures.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip when the run can't reach CLAUDE_CODE_OAUTH_TOKEN, since the action
+    # would only produce a fast, noisy failure:
+    #   - Fork PRs: repository secrets aren't exposed to fork-head workflows.
+    #   - Dependabot PRs: GitHub routes Dependabot-triggered `pull_request`
+    #     runs through a separate secrets store, so the regular Actions secret
+    #     is empty (the action dies in ~15s with no auth). #686.
+    # `claude-review` is a required check; a skipped job reports success to
+    # branch protection, so skipping here unblocks these PRs rather than
+    # wedging them. Keyed on `github.actor` (not the PR author) on purpose: a
+    # human pushing to a Dependabot branch makes secrets available again, and
+    # the review then correctly runs.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes #686.

## Problem

`claude-review` is a required status check, but it fails on every Dependabot PR — #658 failed on all four runs of its branch. The job dies in ~15s (a genuine Opus review takes minutes), and the PR sits `BLOCKED` even with the whole test matrix green.

## Root cause

The action authenticates with `secrets.CLAUDE_CODE_OAUTH_TOKEN`, and GitHub withholds regular Actions secrets from **Dependabot-triggered** `pull_request` runs (Dependabot uses a separate secrets store). No token → instant failure. The workflow already skips **forks** for this exact reason (`claude-code-review.yml`), but Dependabot PRs are same-repo and slip past that guard.

## Fix

Extend the existing job-level `if` to also skip `dependabot[bot]`:

```yaml
if: >-
  github.event.pull_request.head.repo.full_name == github.repository
  && github.actor != 'dependabot[bot]'
```

A skipped required check reports success to branch protection — the same mechanism the #684 Changed-paths gate relies on — so this unblocks Dependabot PRs without reducing review coverage on any human PR. Keyed on `github.actor` rather than the PR author on purpose: if a human pushes to a Dependabot branch, the event actor becomes the human, secrets are available, and the review correctly still runs.

This PR is human-authored, so claude-review runs on it normally (self-test of the unchanged path).

## Follow-up after merge

`@dependabot rebase` #658 so its next run inherits the fixed `if` and unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)