### PR TITLE
[#690] Ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,16 @@ ignore = [
     # `paste`. Tracked in https://github.com/bevyengine/bevy as the chain
     # migrates.
     "RUSTSEC-2024-0436",
+    # `proc-macro-error2 2.0.1` — RUSTSEC-2026-0173. The author declared the
+    # crate unmaintained (and the original `proc-macro-error` it forked);
+    # an administrative status, not a vulnerability. It reaches us
+    # transitively via the `anise` ephemeris dep
+    # (`anise` → `tabled` → `tabled_derive` → `proc-macro-error2`). Drop this
+    # entry once a future `anise`/`tabled` release no longer pulls
+    # `proc-macro-error2` (`cargo tree -i proc-macro-error2 --workspace`
+    # returns nothing). Tracked in
+    # https://github.com/simnaut/astrodyn/issues/690.
+    "RUSTSEC-2026-0173",
 ]
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Part of #690 — the tracking issue stays **open** to hold the drop condition on the books; this PR does not close it.

## What

Adds `RUSTSEC-2026-0173` to `[advisories].ignore` in `deny.toml`.

## Why

`proc-macro-error2` was declared unmaintained today (RUSTSEC-2026-0173) — an administrative status, **not** a vulnerability. `cargo-deny` queries the live RUSTSEC database, so the advisory immediately started failing the `cargo-deny` job across the whole repo on an unchanged `Cargo.lock`. It reaches us four levels down a dependency we don't control:

```
proc-macro-error2 → tabled_derive → tabled → anise (ephemeris) → astrodyn_*
```

The entry mirrors the existing `RUSTSEC-2024-0436` (`paste`, unmaintained via Bevy) ignore — same convention, same class of transitive administrative advisory — and its comment names the transitive chain, the `cargo tree -i proc-macro-error2` drop check, and links #690.

## Not a required check

`cargo-deny` isn't a required status check, so this was never blocking merges — but it was persistent red noise on `main` and every PR. This restores the green signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)