### PR TITLE
[#693] Run the runtime-budget envelope on main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,8 +548,12 @@ jobs:
 
   runtime-budget:
     name: Runtime budget (envelope)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Main-only: the earth_moon envelope is a ~37-min job (see the `changes`
+    # job comment above and the measurement step below) — too slow to gate
+    # every PR. It runs post-merge on `main`, mirroring `perf-baseline-track`.
+    # On PRs the job is skipped (reports "skipping") and does not block; a
+    # regression that blows the envelope is caught on the merge commit.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What

Gate the `runtime-budget` CI job (`tier3_simulation_earth_moon_clem` envelope) to `main` only, so it no longer runs on PRs.

## Why

It's the slowest gate — ~37 min wall-clock (~2200 s observed against a 3000 s budget) — and it's an *envelope* check: it only fails on gross regressions, not per-component drift. Paying ~37 min on every PR for a coarse post-hoc guard is a poor feedback-loop tradeoff (this surfaced as one of two long-pole checks on #692).

## Change

```yaml
runtime-budget:
  name: Runtime budget (envelope)
- needs: changes
- if: needs.changes.outputs.code == 'true'
+ if: github.ref == 'refs/heads/main'
```

Mirrors the existing `perf-baseline-track` main-only pattern. On PRs the job is skipped (reports "skipping" and does not block — the `changes` job comment already notes "skipped satisfies required checks"); a regression that blows the envelope is caught on the merge commit to `main`, alongside the other main-only perf lanes.

## Safety

- **No dependents:** nothing `needs: runtime-budget`, so dropping its `needs: changes` is safe.
- **No branch protection** currently requires this check (main has no classic protection), so no protection/ruleset change is needed.
- The fast `compile-time-budget` envelope stays on PRs; only the ~37-min runtime envelope moves.
- YAML validated; `runtime-budget.if` resolves to `github.ref == 'refs/heads/main'`, `needs` removed.

Closes #693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
