### PR TITLE
[#695] Relocate frame-identity mints to astrodyn_quantities

### DIFF
--- a/crates/astrodyn_quantities/src/frame_identity.rs
+++ b/crates/astrodyn_quantities/src/frame_identity.rs
@@ -1,7 +1,7 @@
 //! Shared frame-identity minting conventions for hosts.
 //!
 //! The compile-time path mints identities via
-//! [`FrameUid::of`](astrodyn_quantities::frame_descriptor::FrameUid::of)
+//! [`FrameUid::of`](crate::frame_descriptor::FrameUid::of)
 //! in [`Namespace::LOCAL`] — exclusively type-derived. Some frames, however,
 //! belong to *open, instance-scoped* sets: mission configurations
 //! legitimately spawn bodies in loops and populate ground-site catalogs from
@@ -10,6 +10,15 @@
 //! shared by every host (the runner today, the Bevy adapter's `FrameUidC` in
 //! issue #664) so the mapping from a value to its identity is shared *code*,
 //! never a per-host convention that can drift.
+//!
+//! It lives in `astrodyn_quantities` — the dependency-light identity crate —
+//! rather than the umbrella `astrodyn` crate, so a firewalled pure consumer
+//! (a renderer / scene store that must not link the ephemeris or physics
+//! stack) can route through the *same* mint as a producer. That reachability
+//! is what makes the single-mint convergence invariant real for every host,
+//! not just those that link the full pipeline (issue #695). The umbrella
+//! re-exports these symbols, so `astrodyn::named_body_frame_uid` & co. are
+//! unchanged.
 //!
 //! ## Namespace allocation
 //!
@@ -31,7 +40,7 @@
 //! collisions, but distinct foreign values would silently coexist as if
 //! mission-supplied.
 
-use astrodyn_quantities::frame_descriptor::{FrameClass, FrameRole, FrameUid, Namespace, Tag};
+use crate::frame_descriptor::{FrameClass, FrameRole, FrameUid, Namespace, Tag};
 
 /// Namespace reserved for mission-supplied **value** identities — frames
 /// whose identity is a configuration value (a body name, a site key) rather
@@ -86,7 +95,7 @@ pub fn named_body_frame_uid(name: &str) -> FrameUid {
 /// typed and value spellings of a site converge on one identity.
 ///
 /// Pass the planet's marker `NAME` verbatim (e.g.
-/// [`Planet::NAME`](astrodyn_quantities::frame::Planet::NAME)); the mint is
+/// [`Planet::NAME`](crate::frame::Planet::NAME)); the mint is
 /// case-sensitive, matching [`sealed_planet_inertial_uid`]. The site
 /// `site_key` is a **label**: nothing here validates it against the geodetic
 /// anchor carried by the `FrameTransform` the site builder returns — the
@@ -147,7 +156,7 @@ pub fn pfix_sibling_uid(inertial: &FrameUid) -> FrameUid {
 /// source rotates, is [`pfix_sibling_uid`] of the returned identity —
 /// pinned equal to the typed mint for all six planets.
 pub fn sealed_planet_inertial_uid(name: &str) -> Option<FrameUid> {
-    use astrodyn_quantities::frame::{Earth, Jupiter, Mars, Moon, PlanetInertial, Saturn, Sun};
+    use crate::frame::{Earth, Jupiter, Mars, Moon, PlanetInertial, Saturn, Sun};
     Some(match name {
         "Earth" => FrameUid::of::<PlanetInertial<Earth>>(),
         "Moon" => FrameUid::of::<PlanetInertial<Moon>>(),
@@ -162,10 +171,10 @@ pub fn sealed_planet_inertial_uid(name: &str) -> Option<FrameUid> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use astrodyn_quantities::frame::BodyFrame;
-    use astrodyn_quantities::frame_descriptor::FrameUid;
+    use crate::frame::BodyFrame;
+    use crate::frame_descriptor::FrameUid;
 
-    astrodyn_quantities::define_vehicle!(IdentityTestVehicle);
+    crate::define_vehicle!(IdentityTestVehicle);
 
     #[test]
     fn named_identity_never_aliases_typed_identity() {
@@ -181,9 +190,7 @@ mod tests {
 
     #[test]
     fn pfix_sibling_matches_typed_mint_for_every_sealed_planet() {
-        use astrodyn_quantities::frame::{
-            Earth, Jupiter, Mars, Moon, PlanetFixed, PlanetInertial, Saturn, Sun,
-        };
+        use crate::frame::{Earth, Jupiter, Mars, Moon, PlanetFixed, PlanetInertial, Saturn, Sun};
         macro_rules! check {
             ($($p:ty),+) => {$(
                 assert_eq!(
@@ -204,11 +211,11 @@ mod tests {
 
     #[test]
     fn sealed_planet_dispatch_matches_typed_mint() {
-        use astrodyn_quantities::frame::{Earth, Jupiter, Mars, Moon, PlanetInertial, Saturn, Sun};
+        use crate::frame::{Earth, Jupiter, Mars, Moon, PlanetInertial, Saturn, Sun};
         macro_rules! check {
             ($($p:ty),+) => {$(
                 assert_eq!(
-                    sealed_planet_inertial_uid(<$p as astrodyn_quantities::frame::Planet>::NAME),
+                    sealed_planet_inertial_uid(<$p as crate::frame::Planet>::NAME),
                     Some(FrameUid::of::<PlanetInertial<$p>>()),
                     "name dispatch must equal the typed mint",
                 );

--- a/crates/astrodyn_quantities/src/lib.rs
+++ b/crates/astrodyn_quantities/src/lib.rs
@@ -175,6 +175,7 @@ pub mod dims;
 pub mod ext;
 pub mod frame;
 pub mod frame_descriptor;
+pub mod frame_identity;
 pub mod frame_transform;
 pub mod guard_macros;
 pub mod harmonic;
@@ -195,6 +196,10 @@ pub use frame::*;
 pub use frame_descriptor::{
     FrameClass, FrameDescriptorStatic, FrameRole, FrameRoleStatic, FrameUid, MintPolicy, Namespace,
     Tag,
+};
+pub use frame_identity::{
+    named_body_frame_uid, pfix_sibling_uid, sealed_planet_inertial_uid, topocentric_site_frame_uid,
+    MISSION_NAMED_NS,
 };
 pub use frame_transform::*;
 pub use integ_origin::IntegOrigin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@ pub mod forces;
 pub use astrodyn_frame_doc as frame_doc;
 #[cfg(feature = "frame-doc")]
 pub mod frame_doc_io;
-pub mod frame_identity;
 pub mod frame_orchestration;
 pub mod gravity;
 pub mod integrable;
@@ -367,7 +366,10 @@ pub use astrodyn_quantities::frame_descriptor::{FrameClass, FrameRole, FrameUid,
 // the Bevy adapter's `FrameEpochC` carries it per frame entity).
 pub use astrodyn_quantities::integ_origin::IntegOrigin;
 pub use astrodyn_quantities::time_scale::{SecondsSince, TDB};
-pub use frame_identity::{
+// Frame-identity minting conventions live in `astrodyn_quantities` (the
+// dependency-light identity crate) so firewalled pure consumers can route
+// through the same shared mint; re-exported here for umbrella callers (#695).
+pub use astrodyn_quantities::frame_identity::{
     named_body_frame_uid, pfix_sibling_uid, sealed_planet_inertial_uid, topocentric_site_frame_uid,
     MISSION_NAMED_NS,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,10 @@ pub use astrodyn_quantities::integ_origin::IntegOrigin;
 pub use astrodyn_quantities::time_scale::{SecondsSince, TDB};
 // Frame-identity minting conventions live in `astrodyn_quantities` (the
 // dependency-light identity crate) so firewalled pure consumers can route
-// through the same shared mint; re-exported here for umbrella callers (#695).
+// through the same shared mint (#695). Re-exported here as both the module
+// (`astrodyn::frame_identity::*`) and the root function names
+// (`astrodyn::named_body_frame_uid`) so every prior umbrella path is unchanged.
+pub use astrodyn_quantities::frame_identity;
 pub use astrodyn_quantities::frame_identity::{
     named_body_frame_uid, pfix_sibling_uid, sealed_planet_inertial_uid, topocentric_site_frame_uid,
     MISSION_NAMED_NS,


### PR DESCRIPTION
## What

Move the `frame_identity` module (the shared identity mints) from the umbrella `astrodyn` crate to the dependency-light `astrodyn_quantities`, re-exporting from the umbrella so existing callers are untouched.

## Why

The mints — `topocentric_site_frame_uid` (#688), `named_body_frame_uid`, `MISSION_NAMED_NS`, `pfix_sibling_uid`, `sealed_planet_inertial_uid` — lived in `astrodyn`, which has a **non-optional** `astrodyn_ephemeris` dependency plus the full physics stack. A **firewalled pure consumer** (a renderer / scene store linking only `astrodyn_quantities`/`astrodyn_frames`/`astrodyn_planet`, which must *not* pull ephemeris/physics) couldn't reach them — so it would hand-replicate the namespace + `"{planet}/site:{...}"` composition, the exact drift surface the single-mint convergence invariant exists to kill. Reported by the astrotui consumer on [#688](https://github.com/simnaut/astrodyn/issues/688) after #692 merged.

## Why it's safe / mechanical

`frame_identity` uses **no symbol from any crate but `astrodyn_quantities`** (`FrameUid`/`Namespace`/`Tag`/`FrameClass`/`FrameRole`/`frame::*`/`define_vehicle!`). The move:
- adds **zero dependencies** and changes **zero logic** — only `astrodyn_quantities::` → `crate::` in the `use` paths and intra-doc links;
- git tracks it as a 90% **rename**;
- re-exported from the umbrella (`pub use astrodyn_quantities::frame_identity::{…}`), so `astrodyn::named_body_frame_uid` & co., the runner, and the Bevy adapter are unchanged (verified: no workspace code referenced the old `astrodyn::frame_identity` *module path*, only the re-exported function names);
- also exposed at the `astrodyn_quantities` root for parity.

Pure consumers now route through `astrodyn_quantities::frame_identity::*` — the same code a producer calls.

## Verification

- `cargo build --workspace` — clean
- `cargo nextest run -p astrodyn_quantities` frame_identity tests — 8/8 pass (relocated intact)
- `cargo fmt --check`, `cargo clippy -p astrodyn_quantities -p astrodyn --tests -- -D warnings` — clean
- rustdoc with `-D broken_intra_doc_links -D redundant_explicit_links` — clean

Closes #695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
