### PR TITLE
[#689] Honest topocentric contract + typed pose + runtime NED derived state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "glam 0.30.10",
  "proptest",
  "thiserror 2.0.18",
+ "uom",
 ]
 
 [[package]]

--- a/crates/astrodyn_bevy/src/components/derived.rs
+++ b/crates/astrodyn_bevy/src/components/derived.rs
@@ -56,6 +56,23 @@ pub struct GeodeticConfigC {
     pub r_pol: f64,
 }
 
+/// Runtime NED-frame computation config — the Bevy analog of the runner's
+/// `body.ned_planet: (uid, r_eq, r_pol)`. Same inputs as [`GeodeticConfigC`]:
+/// `ned_system` reads `PlanetFixedRotationC<P>` from the `planet` entity and
+/// the ellipsoid radii here. Presence of this component + `NedFrameStateC`
+/// enables per-step NED-frame computation in `AstrodynSet::DerivedState`.
+#[derive(Component, Debug, Clone)]
+#[require(NedFrameStateC)]
+pub struct NedConfigC {
+    /// Inertial-frame identity of the planet source supplying
+    /// `T_inertial→pfix` (`PlanetFixedRotationC<P>`), issue #668.
+    pub planet: astrodyn::FrameUid,
+    /// Equatorial radius of the reference ellipsoid (m).
+    pub r_eq: f64,
+    /// Polar radius of the reference ellipsoid (m).
+    pub r_pol: f64,
+}
+
 // ── Derived State Outputs ──
 
 /// Orbital elements computed each step.
@@ -106,6 +123,14 @@ pub struct LvlhFrameC(pub astrodyn::LvlhFrame);
 /// [`astrodyn::GeodeticState`] for the full rationale.
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub struct GeodeticStateC(pub astrodyn::GeodeticState);
+
+/// Runtime NED frame pose (origin + orientation) computed each step.
+///
+/// Written by `ned_system` for entities that also have `NedConfigC`. Carries
+/// the NED frame origin (the body's pfix position) and the NED-axes rotation;
+/// see [`astrodyn::NedFrame`] for the deferred origin velocity.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct NedFrameStateC(pub astrodyn::NedFrame);
 
 /// Solar beta angle (radians) computed each step.
 ///

--- a/crates/astrodyn_bevy/src/lib.rs
+++ b/crates/astrodyn_bevy/src/lib.rs
@@ -1027,6 +1027,9 @@ impl Plugin for AstrodynPlugin {
                 systems::geodetic_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::DerivedState)
                     .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
+                systems::ned_system::<astrodyn::Earth>
+                    .in_set(AstrodynSet::DerivedState)
+                    .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
                 systems::solar_beta_system::<astrodyn::Earth>
                     .in_set(AstrodynSet::DerivedState)
                     .in_set(PerPlanetSet::of::<astrodyn::Earth>()),
@@ -1346,6 +1349,9 @@ pub fn register_planet_systems<P: astrodyn::Planet>(app: &mut App) {
             systems::geodetic_system::<P>
                 .in_set(AstrodynSet::DerivedState)
                 .in_set(PerPlanetSet::of::<P>()),
+            systems::ned_system::<P>
+                .in_set(AstrodynSet::DerivedState)
+                .in_set(PerPlanetSet::of::<P>()),
             systems::solar_beta_system::<P>
                 .in_set(AstrodynSet::DerivedState)
                 .in_set(PerPlanetSet::of::<P>()),
@@ -1608,6 +1614,7 @@ impl VehicleConfigBevyExt for astrodyn::VehicleConfig {
             euler_sequence,
             lvlh,
             geodetic,
+            ned,
             solar_beta,
             earth_lighting,
         } = self.derived;
@@ -1646,6 +1653,19 @@ impl VehicleConfigBevyExt for astrodyn::VehicleConfig {
                     planet: geo.source,
                     r_eq: geo.r_eq,
                     r_pol: geo.r_pol,
+                },
+            ));
+        }
+        if let Some(n) = ned {
+            // Same arrangement as geodetic: `NedConfigC.planet` is the source
+            // identity, and `ned_system` reads `PlanetFixedRotationC` from that
+            // entity plus the ellipsoid radii here.
+            entity.insert((
+                components::NedFrameStateC::default(),
+                components::NedConfigC {
+                    planet: n.source,
+                    r_eq: n.r_eq,
+                    r_pol: n.r_pol,
                 },
             ));
         }

--- a/crates/astrodyn_bevy/src/systems/derived_state.rs
+++ b/crates/astrodyn_bevy/src/systems/derived_state.rs
@@ -243,6 +243,57 @@ pub fn geodetic_system<P: Planet>(
     }
 }
 
+/// Compute the runtime NED frame pose for entities with `NedConfigC`.
+///
+/// Placed in `AstrodynSet::DerivedState`. Mirrors [`geodetic_system`] — same
+/// `PlanetFixedRotationC<P>` lookup and fail-loudly diagnostic — and writes the
+/// NED frame origin + orientation to `NedFrameStateC`.
+///
+/// # Panics
+///
+/// Panics when `NedConfigC.planet` does not resolve to an entity carrying
+/// `PlanetFixedRotationC<P>`, identically to [`geodetic_system`]: a silent
+/// `NedFrame::default()` would write the planet-centre origin with identity
+/// axes, indistinguishable from a real sub-point. CLAUDE.md "Fail Loudly".
+pub fn ned_system<P: Planet>(
+    mut query: Query<(
+        Entity,
+        &TranslationalStateC<P>,
+        &NedConfigC,
+        &mut NedFrameStateC,
+    )>,
+    planets: Query<(&FrameUidC, &PlanetFixedRotationC<P>)>,
+) {
+    for (entity, state, config, mut ned) in &mut query {
+        // JEOD_INV: AT.03 — same wiring-miss fail-loud as `geodetic_system`:
+        // the planet entity must carry `PlanetFixedRotationC<P>` (the
+        // inertial→pfix rotation the NED kernel needs).
+        let rot = planets
+            .iter()
+            .find(|(uid, _)| uid.0 == config.planet)
+            .map(|(_, r)| r)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{entity:?} NED frame: \
+                     NedConfigC.planet = `{planet_uid}` does not resolve to \
+                     an entity carrying PlanetFixedRotationC<{p}>. Spawn the planet \
+                     source with that identity and a non-`None` `rotation_model` \
+                     (or hand-insert `PlanetFixedRotationC<{p}>` on it), or fix \
+                     the config's identity.",
+                    planet_uid = config.planet,
+                    p = std::any::type_name::<P>(),
+                )
+            });
+        use astrodyn::F64Ext;
+        ned.0 = astrodyn::compute_body_ned_frame_typed::<P>(
+            state.position,
+            rot.0.matrix_ref(),
+            config.r_eq.m(),
+            config.r_pol.m(),
+        );
+    }
+}
+
 /// Compute solar beta angle for entities with `SolarBetaC`.
 ///
 /// Requires a `SunMarker` entity to exist in the world.
@@ -544,6 +595,31 @@ mod tests {
             GeodeticStateC::default(),
         ));
         app.add_systems(Update, geodetic_system::<Earth>);
+        app.update();
+    }
+
+    /// `ned_system` shares the geodetic fail-loud guard: a `NedConfigC.planet`
+    /// that does not resolve to an entity with `PlanetFixedRotationC<P>` must
+    /// panic naming the body and the missing component, rather than writing a
+    /// silent `NedFrame::default()` (planet-centre origin, identity axes).
+    // JEOD_INV: AT.03 — planet-fixed rotation required for the NED frame
+    #[test]
+    #[should_panic(expected = "does not resolve to an entity carrying PlanetFixedRotationC")]
+    fn ned_planet_lookup_miss_panics_with_caller_fix() {
+        let mut app = create_minimal_test_app();
+        app.world_mut().spawn((
+            TranslationalStateC::<Earth>::from_untyped(TranslationalState {
+                position: DVec3::new(7e6, 0.0, 0.0),
+                velocity: DVec3::ZERO,
+            }),
+            NedConfigC {
+                planet: astrodyn::named_body_frame_uid("derived-state-no-such-source"),
+                r_eq: astrodyn::EARTH.shape.r_eq(),
+                r_pol: astrodyn::EARTH.shape.r_pol(),
+            },
+            NedFrameStateC::default(),
+        ));
+        app.add_systems(Update, ned_system::<Earth>);
         app.update();
     }
 

--- a/crates/astrodyn_dynamics/src/body_init.rs
+++ b/crates/astrodyn_dynamics/src/body_init.rs
@@ -10,7 +10,9 @@
 
 use crate::rotational::RotationalState;
 use crate::state::{TranslationalState, TranslationalStateTyped};
-use astrodyn_math::{mat3_from_rows, GeodeticState, JeodQuat, OrbitalElements};
+use astrodyn_math::{
+    local_level_ned_axes, mat3_from_rows, GeodeticState, JeodQuat, OrbitalElements,
+};
 use astrodyn_quantities::aliases::{Position, Velocity};
 use astrodyn_quantities::dims::GravParam;
 use astrodyn_quantities::ext::Vec3Ext;
@@ -1059,20 +1061,17 @@ pub fn init_rot_from_ned(
 ///
 /// These vectors form the rows of the PCPF-to-NED transformation matrix.
 ///
+/// The axis arithmetic is the shared [`astrodyn_math::local_level_ned_axes`]
+/// kernel — the single source of truth also consumed by
+/// [`astrodyn_math::topocentric_enu_transform`] (which permutes NED → ENU).
+/// Keeping the kernel here unchanged preserves this function's exact
+/// floating-point output, and with it the Tier-3 NED-init freeze.
+///
 /// # Arguments
 /// * `lat` - Geodetic latitude (rad)
 /// * `lon` - Geodetic longitude (rad)
 pub fn compute_ned_rotation(lat: f64, lon: f64) -> DMat3 {
-    let sin_lat = lat.sin();
-    let cos_lat = lat.cos();
-    let sin_lon = lon.sin();
-    let cos_lon = lon.cos();
-
-    // Rows of the PCPF-to-NED transformation matrix
-    let north = DVec3::new(-sin_lat * cos_lon, -sin_lat * sin_lon, cos_lat);
-    let east = DVec3::new(-sin_lon, cos_lon, 0.0);
-    let down = DVec3::new(-cos_lat * cos_lon, -cos_lat * sin_lon, -sin_lat);
-
+    let (north, east, down) = local_level_ned_axes(lat, lon);
     mat3_from_rows(north, east, down)
 }
 
@@ -1644,6 +1643,22 @@ mod tests {
                 "NED rotation determinant != 1 at lat={}, lon={}",
                 lat,
                 lon
+            );
+        }
+    }
+
+    // `compute_ned_rotation` must stay a thin lay-out of the shared
+    // `astrodyn_math::local_level_ned_axes` kernel. Locking the delegation
+    // here means a future kernel edit that diverges from the bit-frozen NED
+    // arithmetic trips this fast unit test rather than a slow Tier-3 run.
+    #[test]
+    fn compute_ned_rotation_matches_shared_kernel() {
+        for &(lat, lon) in &[(0.6, -2.06), (-0.21, 1.34), (1.561, 2.53)] {
+            let (north, east, down) = astrodyn_math::local_level_ned_axes(lat, lon);
+            assert_eq!(
+                compute_ned_rotation(lat, lon),
+                astrodyn_math::mat3_from_rows(north, east, down),
+                "compute_ned_rotation must delegate to local_level_ned_axes"
             );
         }
     }

--- a/crates/astrodyn_frames/Cargo.toml
+++ b/crates/astrodyn_frames/Cargo.toml
@@ -18,6 +18,7 @@ astrodyn_math = { path = "../astrodyn_math", version = "0.2.0" }
 astrodyn_quantities = { path = "../astrodyn_quantities", version = "0.2.0" }
 glam = { workspace = true }
 thiserror = { workspace = true }
+uom = { workspace = true }
 
 [dev-dependencies]
 astrodyn_math = { path = "../astrodyn_math", version = "0.2.0", features = ["test-utils"] }

--- a/crates/astrodyn_frames/src/lib.rs
+++ b/crates/astrodyn_frames/src/lib.rs
@@ -73,6 +73,7 @@ pub mod ref_frame_state;
 pub mod rotation_j2000;
 pub mod rotation_mars;
 pub mod rotation_moon;
+pub mod topocentric_pose;
 
 pub use frame_storage::{
     common_ancestor, compose_to_ancestor, compute_relative_state, FrameStorage,
@@ -82,3 +83,4 @@ pub use orchestration::{
     compute_relative_state_typed, frame_origin, frame_origin_typed, sync_pfix_rotation,
 };
 pub use ref_frame_state::*;
+pub use topocentric_pose::topocentric_enu_state;

--- a/crates/astrodyn_frames/src/ref_frame_state.rs
+++ b/crates/astrodyn_frames/src/ref_frame_state.rs
@@ -15,8 +15,10 @@ use core::marker::PhantomData;
 use astrodyn_math::JeodQuat;
 use astrodyn_quantities::aliases::{AngularVelocity, Position, Velocity};
 use astrodyn_quantities::frame::Frame;
+use astrodyn_quantities::qty3::Qty3;
 use astrodyn_quantities::quat::{LeftTransform, NormalizedQuat, ScalarFirst};
 use glam::{DMat3, DVec3};
+use uom::si::Dimension;
 
 /// Translational state of a frame relative to its parent.
 ///
@@ -563,6 +565,50 @@ impl<P: Frame, C: Frame> RefFrameStateTyped<P, C> {
     ) -> RefFrameStateTyped<P, D> {
         let composed_untyped = self.to_untyped().incr_right(&s_cd.to_untyped());
         RefFrameStateTyped::<P, D>::from_untyped_unchecked(&composed_untyped)
+    }
+
+    /// Map a **position** expressed in the parent frame `P` into the child
+    /// frame `C`, **including the origin offset**:
+    /// `p_C = R_{P→C} · (p_P − s_P)`, where `s_P = self.trans.position` is the
+    /// child origin in `P` and `R_{P→C} = self.rot.t_parent_this()`.
+    ///
+    /// This is the operation a rotation-only
+    /// [`FrameTransform`](astrodyn_quantities::frame_transform::FrameTransform)
+    /// cannot express — it omits the `− s_P` shift, so applying *it* to a
+    /// position leaves the point rooted at the parent origin. Use this to place
+    /// a point known in the parent frame into an origin-anchored child frame
+    /// (e.g. a topocentric site; see [`crate::topocentric_pose`]).
+    #[inline]
+    pub fn position_parent_to_child(&self, p_parent: Position<P>) -> Position<C> {
+        let shifted = p_parent.raw_si() - self.trans.position.raw_si();
+        Position::<C>::from_raw_si(self.rot.t_parent_this() * shifted)
+    }
+
+    /// Inverse of [`Self::position_parent_to_child`]: map a position in the
+    /// child frame `C` back to the parent `P`, `p_P = Rᵀ · p_C + s_P`.
+    #[inline]
+    pub fn position_child_to_parent(&self, p_child: Position<C>) -> Position<P> {
+        let rotated = self.rot.t_parent_this().transpose() * p_child.raw_si();
+        Position::<P>::from_raw_si(rotated + self.trans.position.raw_si())
+    }
+
+    /// Rotate a **free vector** (no origin offset) from `P` to `C`:
+    /// `v_C = R_{P→C} · v_P`. Use for `Velocity`/`Acceleration`/any direction
+    /// quantity.
+    ///
+    /// This is a pure axis transform — it deliberately omits the `ω×r`
+    /// frame-rate coupling. It is therefore exact for a **static (zero-rate)
+    /// pose** such as a topocentric site, and only a building block for a
+    /// moving frame. The full kinematic transform of a rotating frame's
+    /// velocity goes through [`Self::negate`] / [`Self::incr_right`], which
+    /// carry the rate terms; this method does not, by design (named to make
+    /// the omission explicit).
+    #[inline]
+    pub fn rotate_vector_parent_to_child<D: ?Sized + Dimension>(
+        &self,
+        v_parent: Qty3<D, P>,
+    ) -> Qty3<D, C> {
+        Qty3::<D, C>::from_raw_si(self.rot.t_parent_this() * v_parent.raw_si())
     }
 }
 

--- a/crates/astrodyn_frames/src/topocentric_pose.rs
+++ b/crates/astrodyn_frames/src/topocentric_pose.rs
@@ -1,0 +1,204 @@
+//! Typed origin-anchored topocentric (East-North-Up) pose.
+//!
+//! [`topocentric_enu_state`] builds the full pfix→site pose — origin **and**
+//! orientation — as a typed [`RefFrameStateTyped<PlanetFixed<P>,
+//! Topocentric<P>>`]. This is the typed analog of JEOD's `NorthEastDown`
+//! `RefFrame` (orientation + translation), and the origin-carrying companion to
+//! the rotation-only [`astrodyn_math::topocentric_enu_transform`]: where that
+//! function returns just the `.rot` half (a `FrameTransform`, which cannot move
+//! a `Position` off the planet centre), this builder carries the site origin so
+//! a `Position` can be transformed site-relative via
+//! [`RefFrameStateTyped::position_parent_to_child`].
+//!
+//! The pose is **static** wrt the planet-fixed frame — zero velocity, zero
+//! angular rate. Composing it up to an inertial frame (which adds the planet's
+//! `ω×r` terms) is the caller's job via [`RefFrameStateTyped::incr_right`] with
+//! the inertial→pfix state, exactly as
+//! `astrodyn_dynamics::body_init::ned_reference_frame_state` does for the
+//! untyped NED frame.
+
+use astrodyn_math::{local_level_ned_axes, GeodeticStateTyped, JeodQuat};
+use astrodyn_quantities::aliases::{AngularVelocity, Position, Velocity};
+use astrodyn_quantities::frame::{Planet, PlanetFixed, Topocentric};
+use astrodyn_quantities::quat::NormalizedQuat;
+use glam::DMat3;
+use uom::si::f64::Length;
+use uom::si::length::meter;
+
+use crate::ref_frame_state::{RefFrameRotTyped, RefFrameStateTyped, RefFrameTransTyped};
+
+/// Build the typed pfix→ENU pose for the geodetic site `site` on planet `P`.
+///
+/// The returned [`RefFrameStateTyped<PlanetFixed<P>, Topocentric<P>>`] carries:
+/// - **origin** = the site's geodetic→PCPF Cartesian position, including
+///   altitude (via [`GeodeticState::to_planet_fixed`](astrodyn_math::GeodeticState::to_planet_fixed)),
+/// - **orientation** = the PCPF→ENU rotation (the same axes as
+///   [`astrodyn_math::topocentric_enu_transform`], from the shared
+///   [`astrodyn_math::local_level_ned_axes`] kernel),
+/// - **zero** velocity and angular rate (the site is fixed wrt the rotating
+///   planet).
+///
+/// `r_eq` / `r_pol` are the planet's equatorial / polar radii.
+///
+/// # Origin-shift, the whole point
+///
+/// Apply [`RefFrameStateTyped::position_parent_to_child`] to a
+/// `Position<PlanetFixed<P>>` to get the **site-relative** position
+/// `R·(p − s)` — the operation the rotation-only `FrameTransform` cannot
+/// express. Free vectors (`Velocity`/`Acceleration`) go through
+/// [`RefFrameStateTyped::rotate_vector_parent_to_child`].
+///
+/// # Note on the cached rotation matrix
+///
+/// The rotation is stored quaternion-canonically (JEOD_INV RF.04), so
+/// `state.rot.t_parent_this()` agrees with
+/// `topocentric_enu_transform::<P>(site).matrix()` only to within a few ULPs
+/// (the typed path round-trips through the quaternion; `from_matrix` is
+/// matrix-preserving). Both describe the same rotation.
+pub fn topocentric_enu_state<P: Planet>(
+    site: &GeodeticStateTyped,
+    r_eq: Length,
+    r_pol: Length,
+) -> RefFrameStateTyped<PlanetFixed<P>, Topocentric<P>> {
+    let geo = (*site).into_raw();
+
+    // Origin in PCPF, full ellipsoid conversion (altitude included).
+    let origin = geo.to_planet_fixed(r_eq.get::<meter>(), r_pol.get::<meter>());
+
+    // ENU axes from the shared kernel, using the same lat/lon as the origin.
+    let (north, east, down) = local_level_ned_axes(geo.latitude, geo.longitude);
+    let t_pfix_enu = DMat3::from_cols(east, north, -down).transpose();
+
+    // RF.04 canonical path: derive the quaternion from the matrix; the typed
+    // rotation re-derives its cached matrix from the quaternion.
+    let q = NormalizedQuat::renormalize(JeodQuat::left_quat_from_transformation(&t_pfix_enu))
+        .expect("ENU rotation matrix is orthonormal, so its quaternion is non-zero");
+
+    let trans = RefFrameTransTyped {
+        position: Position::<PlanetFixed<P>>::from_raw_si(origin),
+        velocity: Velocity::<PlanetFixed<P>>::zero(),
+    };
+    let rot = RefFrameRotTyped::<PlanetFixed<P>, Topocentric<P>>::new(
+        q,
+        AngularVelocity::<Topocentric<P>>::zero(),
+    );
+    RefFrameStateTyped::new(trans, rot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrodyn_math::test_utils::approx_eq_vec3;
+    use astrodyn_math::topocentric_enu_transform;
+    use astrodyn_quantities::frame::Earth;
+    use glam::DVec3;
+    use uom::si::angle::degree;
+    use uom::si::f64::Angle;
+
+    // WGS84 (the radii the NED/orbinit fixtures use).
+    const R_EQ: f64 = 6_378_137.0;
+    const R_POL: f64 = 6_356_752.314_245;
+
+    fn site(lat_deg: f64, lon_deg: f64, alt_m: f64) -> GeodeticStateTyped {
+        GeodeticStateTyped {
+            latitude: Angle::new::<degree>(lat_deg),
+            longitude: Angle::new::<degree>(lon_deg),
+            altitude: Length::new::<meter>(alt_m),
+        }
+    }
+
+    fn earth_pose(
+        lat: f64,
+        lon: f64,
+        alt: f64,
+    ) -> RefFrameStateTyped<PlanetFixed<Earth>, Topocentric<Earth>> {
+        topocentric_enu_state::<Earth>(
+            &site(lat, lon, alt),
+            Length::new::<meter>(R_EQ),
+            Length::new::<meter>(R_POL),
+        )
+    }
+
+    // The pose origin is the full geodetic→PCPF cartesian (altitude included),
+    // bit-exact to a direct conversion; velocity and rate are zero.
+    #[test]
+    fn origin_is_geodetic_cartesian() {
+        let s = site(34.5, -118.25, 700.0);
+        let pose = earth_pose(34.5, -118.25, 700.0);
+        let expected = s.into_raw().to_planet_fixed(R_EQ, R_POL);
+        assert_eq!(
+            pose.trans.position.raw_si(),
+            expected,
+            "origin must include altitude"
+        );
+        assert_eq!(pose.trans.velocity.raw_si(), DVec3::ZERO);
+        assert_eq!(pose.rot.ang_vel_this().raw_si(), DVec3::ZERO);
+    }
+
+    // The pose rotation describes the same ENU axes as the rotation-only
+    // transform — to ULP level, since the typed path round-trips through the
+    // canonical quaternion (RF.04) while `from_matrix` is matrix-preserving.
+    #[test]
+    fn rotation_matches_topo_transform() {
+        let s = site(-12.0, 77.0, 0.0);
+        let pose = earth_pose(-12.0, 77.0, 0.0);
+        let transform = topocentric_enu_transform::<Earth>(&s).matrix();
+        let r = pose.rot.t_parent_this();
+        assert!(
+            approx_eq_vec3(r.x_axis, transform.x_axis, 1e-12)
+                && approx_eq_vec3(r.y_axis, transform.y_axis, 1e-12)
+                && approx_eq_vec3(r.z_axis, transform.z_axis, 1e-12),
+            "pose rotation diverges from topocentric_enu_transform: {r:?} vs {transform:?}"
+        );
+    }
+
+    // The load-bearing distinction from a rotation-only `FrameTransform`: a
+    // `Position` at the site origin maps to the child-frame origin (zero),
+    // because the pose subtracts the origin offset `R·(s − s) = 0`. A
+    // rotation-only apply would leave it ~6400 km from zero.
+    #[test]
+    fn site_origin_maps_to_child_zero() {
+        let pose = earth_pose(51.6, -0.13, 25.0);
+        let origin_pcpf = pose.trans.position; // Position<PlanetFixed<Earth>>
+        let in_enu = pose.position_parent_to_child(origin_pcpf);
+        assert!(
+            in_enu.raw_si().length() < 1e-6,
+            "site origin must map to ENU zero, got {:?}",
+            in_enu.raw_si()
+        );
+    }
+
+    // Position pose-apply round-trips through its inverse.
+    #[test]
+    fn position_round_trips() {
+        let pose = earth_pose(34.5, -118.25, 700.0);
+        let p = Position::<PlanetFixed<Earth>>::from_raw_si(DVec3::new(
+            6_300_000.0,
+            100_000.0,
+            3_600_000.0,
+        ));
+        let there = pose.position_parent_to_child(p);
+        let back = pose.position_child_to_parent(there);
+        assert!(
+            (back.raw_si() - p.raw_si()).length() < 1e-6,
+            "round trip drifted: {:?} vs {:?}",
+            back.raw_si(),
+            p.raw_si()
+        );
+    }
+
+    // Free-vector rotate matches the rotation-only transform (both are pure
+    // rotation; no origin shift on a Velocity).
+    #[test]
+    fn rotate_vector_matches_transform() {
+        let s = site(34.5, -118.25, 0.0);
+        let pose = earth_pose(34.5, -118.25, 0.0);
+        let v = Velocity::<PlanetFixed<Earth>>::from_raw_si(DVec3::new(12.0, -7.0, 3.0));
+        let via_pose = pose.rotate_vector_parent_to_child(v).raw_si();
+        let via_transform = topocentric_enu_transform::<Earth>(&s).apply(v).raw_si();
+        assert!(
+            approx_eq_vec3(via_pose, via_transform, 1e-12),
+            "rotate_vector diverged: {via_pose:?} vs {via_transform:?}"
+        );
+    }
+}

--- a/crates/astrodyn_math/src/lib.rs
+++ b/crates/astrodyn_math/src/lib.rs
@@ -81,6 +81,7 @@ pub mod error;
 pub mod euler_angles;
 pub mod geodetic;
 pub mod lvlh;
+pub mod ned;
 pub mod orbital_elements;
 pub mod quaternion;
 pub mod solar_beta;
@@ -104,9 +105,10 @@ pub use geodetic::{
     geodetic_to_cartesian_typed, GeodeticState, GeodeticStateTyped,
 };
 pub use lvlh::{compute_lvlh_frame_typed, LvlhFrame};
+pub use ned::{compute_body_ned_frame, compute_body_ned_frame_typed, NedFrame};
 pub use orbital_elements::OrbitalElements;
 pub use solar_beta::{
     compute_body_solar_beta, compute_body_solar_beta_typed, solar_beta_angle_typed,
 };
-pub use topocentric::topocentric_enu_transform;
+pub use topocentric::{local_level_ned_axes, topocentric_enu_transform};
 pub use types::*;

--- a/crates/astrodyn_math/src/ned.rs
+++ b/crates/astrodyn_math/src/ned.rs
@@ -1,0 +1,178 @@
+//! Runtime North-East-Down (NED) frame for a moving body — the per-step
+//! analog of JEOD's `NedDerivedState`
+//! (`models/dynamics/derived_state/src/ned_derived_state.cc`).
+//!
+//! Where [`crate::topocentric`] builds a *fixed-site* ENU rotation and the
+//! `astrodyn_frames` typed pose anchors a fixed site, this module tracks the
+//! NED frame at a **subject body's instantaneous sub-point**: each step the
+//! frame origin is the body's planet-fixed (pfix) position, and the axes are
+//! the NED triad at that point's geodetic latitude/longitude.
+//!
+//! JEOD computes this as `compute_relative_state(pfix)` (body state relative to
+//! the rotating pfix frame) followed by `build_ned_orientation()`. The NED
+//! frame is **stationary wrt pfix** (zero rate); its parent is the pfix frame,
+//! not the inertial frame (contrast [`crate::lvlh::LvlhFrame`], whose parent is
+//! the planet-inertial frame and which rotates at orbital rate).
+
+use glam::{DMat3, DVec3};
+
+use astrodyn_quantities::aliases::Position;
+use astrodyn_quantities::frame::{Planet, PlanetInertial};
+use uom::si::f64::Length;
+use uom::si::length::meter;
+
+use crate::geodetic::GeodeticState;
+use crate::topocentric::local_level_ned_axes;
+use crate::types::mat3_from_rows;
+
+/// Runtime NED frame pose: the NED frame of a body's current sub-point,
+/// expressed relative to the planet-fixed (pfix) parent frame.
+///
+/// Carries the **origin** (the body's pfix position — JEOD's
+/// `ned_state.cart_coords`) and the **orientation** (NED axes at the
+/// sub-point), plus the structurally-zero rate. Mirrors
+/// [`crate::lvlh::LvlhFrame`], but the parent frame is **pfix** (planet-fixed),
+/// not inertial, and the frame is stationary wrt that parent.
+///
+/// # Deferred: origin velocity
+///
+/// JEOD's NED frame also carries an origin *velocity* — the body's
+/// pfix-relative velocity `R·v_inertial − ω_pfix × r_pfix`
+/// (`set_ned_trans_states`). It is **not** modelled here: JEOD's SIM_NED never
+/// logs it (so there is no cross-validation reference), and computing it
+/// requires the planet's rotation *rate* `ω_pfix`, which the Bevy adapter does
+/// not currently surface on the planet entity (only the rotation matrix, via
+/// `PlanetFixedRotationC`). Adding it would need planet-rate plumbing across
+/// both adapters; deferred to keep the runner and Bevy outputs in parity.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NedFrame {
+    /// Transformation matrix from the pfix parent frame to the NED frame.
+    /// Rows are the North/East/Down axes expressed in pfix
+    /// (JEOD `ned_frame.state.rot.T_parent_this`).
+    pub t_parent_this: DMat3,
+    /// Angular velocity of the NED frame wrt pfix, in NED coordinates (rad/s).
+    /// **Always zero** — the NED frame is fixed to the rotating planet, so it
+    /// has no rate relative to pfix (JEOD zeroes `ang_vel_this` in
+    /// `build_ned_orientation`). Kept explicit to document the invariant.
+    pub ang_vel_this: DVec3,
+    /// NED frame origin (the body's sub-point) in pfix coordinates (m).
+    /// JEOD `ned_state.cart_coords` / `ned_frame.state.trans.position`.
+    pub position: DVec3,
+}
+
+impl Default for NedFrame {
+    fn default() -> Self {
+        Self {
+            t_parent_this: DMat3::IDENTITY,
+            ang_vel_this: DVec3::ZERO,
+            position: DVec3::ZERO,
+        }
+    }
+}
+
+/// Build the runtime [`NedFrame`] pose for a body from its inertial position
+/// and the planet-fixed frame's rotation.
+///
+/// Port of JEOD `NedDerivedState::update` → `compute_ned_frame` (the
+/// origin/orientation part): the body's pfix position is taken (the
+/// `compute_relative_state(pfix)` position), then the NED axes are built from
+/// the geodetic latitude/longitude of that sub-point (`build_ned_orientation`).
+/// The pfix frame shares the planet-inertial origin (planet centre), so the
+/// body's pfix position is simply `R·r_inertial`. See the [`NedFrame`] docs for
+/// the deferred origin velocity.
+///
+/// # Arguments
+/// * `position` — body position in the planet-inertial frame (m).
+/// * `t_inertial_pfix` — inertial→pfix rotation (the pfix node's
+///   `t_parent_this`).
+/// * `r_eq` / `r_pol` — planet equatorial / polar radii (m).
+///
+/// Geodetic preconditions (`PF.01`–`PF.05`: position far from centre, finite
+/// input, Borkowski convergence) are inherited from
+/// [`GeodeticState::from_planet_fixed`].
+pub fn compute_body_ned_frame(
+    position: DVec3,
+    t_inertial_pfix: &DMat3,
+    r_eq: f64,
+    r_pol: f64,
+) -> NedFrame {
+    // Body position relative to the rotating pfix frame (origins coincide at
+    // the planet centre).
+    let pos_pfix = *t_inertial_pfix * position;
+
+    // NED axes at the sub-point's geodetic latitude/longitude. Same shared
+    // kernel as `astrodyn_dynamics::compute_ned_rotation` and the ENU builder.
+    let geo = GeodeticState::from_planet_fixed(pos_pfix, r_eq, r_pol);
+    let (north, east, down) = local_level_ned_axes(geo.latitude, geo.longitude);
+    let t_pfix_ned = mat3_from_rows(north, east, down);
+
+    NedFrame {
+        t_parent_this: t_pfix_ned,
+        ang_vel_this: DVec3::ZERO,
+        position: pos_pfix,
+    }
+}
+
+/// Typed sibling of [`compute_body_ned_frame`]. Accepts a typed planet-inertial
+/// position and `uom` radii; bit-identical numerics to the f64 surface (both
+/// drop to `raw_si()` at the kernel boundary).
+pub fn compute_body_ned_frame_typed<P: Planet>(
+    position: Position<PlanetInertial<P>>,
+    t_inertial_pfix: &DMat3,
+    r_eq: Length,
+    r_pol: Length,
+) -> NedFrame {
+    compute_body_ned_frame(
+        position.raw_si(),
+        t_inertial_pfix,
+        r_eq.get::<meter>(),
+        r_pol.get::<meter>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const R_EQ: f64 = 6_378_137.0;
+    const R_POL: f64 = 6_356_752.314_245;
+
+    // With an identity inertial→pfix rotation the NED origin is just the
+    // inertial position, and the orientation matches the shared NED kernel at
+    // the sub-point's geodetic lat/lon. The frame is stationary wrt pfix.
+    #[test]
+    fn identity_pfix_origin_and_axes() {
+        let r = DVec3::new(6_500_000.0, 200_000.0, 3_000_000.0);
+        let ned = compute_body_ned_frame(r, &DMat3::IDENTITY, R_EQ, R_POL);
+        assert_eq!(
+            ned.position, r,
+            "origin must be R·r_inertial (= r at identity)"
+        );
+        assert_eq!(ned.ang_vel_this, DVec3::ZERO, "NED rate wrt pfix is zero");
+
+        let geo = GeodeticState::from_planet_fixed(r, R_EQ, R_POL);
+        let (n, e, d) = local_level_ned_axes(geo.latitude, geo.longitude);
+        assert_eq!(ned.t_parent_this, mat3_from_rows(n, e, d));
+    }
+
+    // A non-identity pfix rotation rotates both the origin and the axes: the
+    // origin is `R·r`, and the NED axes are built at the geodetic lat/lon of
+    // that rotated sub-point (so the orientation matches the shared kernel
+    // evaluated on `R·r`, not on the inertial `r`).
+    #[test]
+    fn rotated_pfix_uses_subpoint_axes() {
+        let r = DVec3::new(5_000_000.0, -3_000_000.0, 2_500_000.0);
+        // 30° about z as the inertial→pfix rotation.
+        let (s, c) = (30.0_f64).to_radians().sin_cos();
+        let t = mat3_from_rows(
+            DVec3::new(c, s, 0.0),
+            DVec3::new(-s, c, 0.0),
+            DVec3::new(0.0, 0.0, 1.0),
+        );
+        let ned = compute_body_ned_frame(r, &t, R_EQ, R_POL);
+        assert_eq!(ned.position, t * r, "origin must be R·r");
+        let geo = GeodeticState::from_planet_fixed(t * r, R_EQ, R_POL);
+        let (n, e, d) = local_level_ned_axes(geo.latitude, geo.longitude);
+        assert_eq!(ned.t_parent_this, mat3_from_rows(n, e, d));
+    }
+}

--- a/crates/astrodyn_math/src/topocentric.rs
+++ b/crates/astrodyn_math/src/topocentric.rs
@@ -33,26 +33,68 @@ use uom::si::angle::radian;
 
 use crate::geodetic::GeodeticStateTyped;
 
-/// Rotation from planet `P`'s body-fixed (PCPF) frame to the East-North-Up
-/// frame anchored at geodetic site `site`.
+/// Local-level (NED) basis axes at geodetic `(lat, lon)` (radians), expressed
+/// in PCPF, as the three row vectors `(north, east, down)` of the PCPF→NED
+/// rotation.
 ///
-/// Apply it to a `Position`/`Velocity`/`Acceleration` in `PlanetFixed<P>` to
-/// get the same quantity in the site-local ENU frame; compose with the
-/// ephemeris `FrameTransform<RootInertial, PlanetFixed<P>>` for an inertial→ENU
-/// chain. The returned transform depends only on the site's geodetic
-/// latitude/longitude (see the module docs).
+/// Single source of truth for both the NED rotation
+/// (`astrodyn_dynamics::compute_ned_rotation`, which lays these rows into a
+/// matrix via `mat3_from_rows`) and the ENU rotation
+/// ([`topocentric_enu_transform`], which permutes to `(east, north, −down)`).
+/// The arithmetic here is bit-identical to the historical `compute_ned_rotation`
+/// body — four separate `.sin()`/`.cos()` calls and the same row expressions —
+/// so the Tier-3 NED-init freeze is preserved when that function delegates here.
+///
+/// JEOD source: `NorthEastDown::build_ned_orientation`
+/// (`models/utils/planet_fixed/north_east_down/src/north_east_down.cc`).
+pub fn local_level_ned_axes(lat: f64, lon: f64) -> (DVec3, DVec3, DVec3) {
+    let sin_lat = lat.sin();
+    let cos_lat = lat.cos();
+    let sin_lon = lon.sin();
+    let cos_lon = lon.cos();
+
+    let north = DVec3::new(-sin_lat * cos_lon, -sin_lat * sin_lon, cos_lat);
+    let east = DVec3::new(-sin_lon, cos_lon, 0.0);
+    let down = DVec3::new(-cos_lat * cos_lon, -cos_lat * sin_lon, -sin_lat);
+    (north, east, down)
+}
+
+/// Rotation from planet `P`'s body-fixed (PCPF) frame to the East-North-Up
+/// axes of the geodetic site `site`.
+///
+/// This is **orientation only** — a proper rotation, no origin shift.
+///
+/// - `Velocity`/`Acceleration` (free vectors) and direction vectors: apply
+///   directly to re-express them in ENU axes. This is the intended use.
+/// - `Position`: `apply` yields the PCPF position re-expressed in ENU *axes*,
+///   still rooted at the planet **centre** — NOT site-relative. Site-relative
+///   is `R·(p − s)`; `apply` computes only `R·p`, off by the site radius
+///   (~6378 km on Earth's surface). To transform a `Position` into a site-
+///   anchored frame, use a construct that carries the origin: the typed
+///   `topocentric_enu_state` /
+///   `RefFrameStateTyped<PlanetFixed<P>, Topocentric<P>>` (rotation **and**
+///   origin) in `astrodyn_frames`, or
+///   `astrodyn_dynamics::body_init::ned_reference_frame_state`. A rotation-only
+///   `FrameTransform` structurally cannot carry the offset (see the module
+///   docs and issue #689).
+///
+/// Compose with the ephemeris `FrameTransform<RootInertial, PlanetFixed<P>>`
+/// for an inertial→ENU axis chain. The transform depends only on the site's
+/// geodetic latitude/longitude; altitude is ignored.
 pub fn topocentric_enu_transform<P: Planet>(
     site: &GeodeticStateTyped,
 ) -> FrameTransform<PlanetFixed<P>, Topocentric<P>> {
-    let (sinlat, coslat) = site.latitude.get::<radian>().sin_cos();
-    let (sinlon, coslon) = site.longitude.get::<radian>().sin_cos();
+    // Shared site-orientation kernel: `(north, east, down)` rows of the
+    // PCPF→NED rotation. ENU permutes to `(east, north, up)` with `up = −down`
+    // (exact f64 negation), so this is the same rotation as the NED builder.
+    let (north, east, down) = local_level_ned_axes(
+        site.latitude.get::<radian>(),
+        site.longitude.get::<radian>(),
+    );
 
-    // ENU basis axes expressed in PCPF coordinates (the rows of the PCPF→ENU
-    // rotation). `from_cols(...).transpose()` lays these vectors in as rows.
-    let east = DVec3::new(-sinlon, coslon, 0.0);
-    let north = DVec3::new(-sinlat * coslon, -sinlat * sinlon, coslat);
-    let up = DVec3::new(coslat * coslon, coslat * sinlon, sinlat);
-    let pcpf_to_enu = DMat3::from_cols(east, north, up).transpose();
+    // ENU basis axes as the rows of the PCPF→ENU rotation.
+    // `from_cols(...).transpose()` lays these vectors in as rows.
+    let pcpf_to_enu = DMat3::from_cols(east, north, -down).transpose();
 
     FrameTransform::from_matrix(pcpf_to_enu)
 }
@@ -62,7 +104,7 @@ mod tests {
     use super::*;
     use astrodyn_quantities::frame::Earth;
     use astrodyn_quantities::prelude::{PlanetFixed, Vec3Ext};
-    use uom::si::angle::degree;
+    use uom::si::angle::{degree, radian};
     use uom::si::f64::{Angle, Length};
     use uom::si::length::meter;
 
@@ -71,6 +113,43 @@ mod tests {
             latitude: Angle::new::<degree>(lat_deg),
             longitude: Angle::new::<degree>(lon_deg),
             altitude: Length::new::<meter>(0.0),
+        }
+    }
+
+    // ENU is the same rotation as NED up to a fixed row permutation + sign:
+    // row 0 = East, row 1 = North, row 2 = Up = −Down. Pin this bit-exactly
+    // (feeding the kernel the same radian values the transform used, so any
+    // mismatch is the permutation, not a lat/lon ULP) so a future change that
+    // diverges the ENU builder from the shared NED kernel is caught here, not
+    // in a slow Tier-3 run. `from_matrix` preserves the input matrix
+    // bit-exactly, so `.matrix()` rows equal the constructed `(east, north,
+    // −down)`.
+    #[test]
+    fn enu_rows_are_permuted_ned() {
+        for &(lat_deg, lon_deg) in &[(34.5, -118.25), (-12.0, 77.0), (89.5, 145.0)] {
+            let s = site(lat_deg, lon_deg);
+            let lat = s.latitude.get::<radian>();
+            let lon = s.longitude.get::<radian>();
+            let enu = topocentric_enu_transform::<Earth>(&s).matrix();
+            let (north, east, down) = local_level_ned_axes(lat, lon);
+            // glam stores column-major; reconstruct rows from the column array.
+            let c = enu.to_cols_array_2d();
+            let row = |i: usize| DVec3::new(c[0][i], c[1][i], c[2][i]);
+            assert_eq!(
+                row(0),
+                east,
+                "ENU row 0 must be NED East at {lat_deg},{lon_deg}"
+            );
+            assert_eq!(
+                row(1),
+                north,
+                "ENU row 1 must be NED North at {lat_deg},{lon_deg}"
+            );
+            assert_eq!(
+                row(2),
+                -down,
+                "ENU row 2 (Up) must be −(NED Down) at {lat_deg},{lon_deg}"
+            );
         }
     }
 

--- a/crates/astrodyn_runner/src/simulation/step/derived.rs
+++ b/crates/astrodyn_runner/src/simulation/step/derived.rs
@@ -106,6 +106,27 @@ impl Simulation {
                 }
             }
 
+            // Runtime NED frame pose (NOT a shift site). Same pfix-rotation
+            // lookup as geodetic; the frame origin is the body's pfix position
+            // and the axes are the NED triad at that sub-point.
+            if let Some((ref src_uid, r_eq, r_pol)) = body.ned_planet {
+                let pfix_rot = uid_to_idx
+                    .get(src_uid)
+                    .and_then(|&i| self.source_frame_ids.get(i))
+                    .and_then(|sfids| sfids.pfix)
+                    .map(|pfix_id| self.frame_tree.get(pfix_id).state.rot.t_parent_this);
+                if let Some(t_pfix) = pfix_rot {
+                    body.ned_frame = Some(astrodyn::compute_body_ned_frame(
+                        body.trans.position.raw_si(),
+                        &t_pfix,
+                        r_eq,
+                        r_pol,
+                    ));
+                } else {
+                    body.ned_frame = None;
+                }
+            }
+
             // Solar beta — JEOD_INV: RF.10 — uses root-inertial sun_pos.
             // The typed sibling `compute_body_solar_beta_typed` takes
             // `Position<RootInertial>` and `Velocity<RootInertial>`, so any

--- a/crates/astrodyn_runner/src/simulation/types.rs
+++ b/crates/astrodyn_runner/src/simulation/types.rs
@@ -31,8 +31,8 @@ use astrodyn::{
     Acceleration, AerodynamicForce, AngularAcceleration, AtmosphereState, BodyFrame, DragConfig,
     DynamicsConfig, EulerSequence, FrameDerivatives, FrameSwitchConfig, GeodeticState,
     GravityAccelerationTyped, GravityControls, GravitySource, LvlhFrame, MassPropertiesTyped,
-    OrbitalElements, RadiationForce, RootInertial, RotationModel, RotationalStateTyped, SelfPlanet,
-    SelfRef, SrpModel, TotalForce, TranslationalStateTyped, VehicleConfig,
+    NedFrame, OrbitalElements, RadiationForce, RootInertial, RotationModel, RotationalStateTyped,
+    SelfPlanet, SelfRef, SrpModel, TotalForce, TranslationalStateTyped, VehicleConfig,
 };
 use astrodyn::{ContactFacet, FrameId, GroundFacet, IntegrationFrame, MassBodyId, MassPointState};
 
@@ -195,6 +195,8 @@ pub struct VehicleOutput {
     pub lvlh_frame: Option<LvlhFrame>,
     /// Geodetic state (latitude, longitude, altitude).
     pub geodetic_state: Option<GeodeticState>,
+    /// Runtime NED frame pose (origin + orientation) from the latest step.
+    pub ned_frame: Option<NedFrame>,
     /// Solar beta angle (radians).
     pub solar_beta: Option<f64>,
     /// Earth lighting state (sun/moon occlusion, albedo).
@@ -311,6 +313,7 @@ pub(crate) struct SimBody {
     pub euler_sequence: Option<EulerSequence>,
     pub compute_lvlh: bool,
     pub geodetic_planet: Option<(astrodyn::FrameUid, f64, f64)>,
+    pub ned_planet: Option<(astrodyn::FrameUid, f64, f64)>,
     pub compute_solar_beta: bool,
     pub earth_lighting_config: Option<(f64, f64, f64)>,
 
@@ -319,6 +322,7 @@ pub(crate) struct SimBody {
     pub euler_angles: Option<[f64; 3]>,
     pub lvlh_frame: Option<LvlhFrame>,
     pub geodetic_state: Option<GeodeticState>,
+    pub ned_frame: Option<NedFrame>,
     pub solar_beta: Option<f64>,
     pub earth_lighting: Option<astrodyn::EarthLightingState>,
 
@@ -399,6 +403,7 @@ impl SimBody {
             euler_sequence: config.derived.euler_sequence,
             compute_lvlh: config.derived.lvlh,
             geodetic_planet: config.derived.geodetic.map(|g| (g.source, g.r_eq, g.r_pol)),
+            ned_planet: config.derived.ned.map(|n| (n.source, n.r_eq, n.r_pol)),
             compute_solar_beta: config.derived.solar_beta,
             earth_lighting_config: config
                 .derived
@@ -409,6 +414,7 @@ impl SimBody {
             euler_angles: None,
             lvlh_frame: None,
             geodetic_state: None,
+            ned_frame: None,
             solar_beta: None,
             earth_lighting: None,
 
@@ -441,6 +447,7 @@ impl SimBody {
             euler_angles: self.euler_angles,
             lvlh_frame: self.lvlh_frame,
             geodetic_state: self.geodetic_state,
+            ned_frame: self.ned_frame,
             solar_beta: self.solar_beta,
             earth_lighting: self.earth_lighting.clone(),
         }

--- a/crates/astrodyn_runner/src/simulation/validate.rs
+++ b/crates/astrodyn_runner/src/simulation/validate.rs
@@ -104,6 +104,16 @@ impl Simulation {
                 }
             }
 
+            // Validate ned_planet identity resolves
+            if let Some((ref uid, _, _)) = body.ned_planet {
+                if !uid_to_idx.contains_key(uid) {
+                    all_errors.push(ValidationError::NedPlanetUnresolved {
+                        target: uid.clone(),
+                        num_sources,
+                    });
+                }
+            }
+
             // Validate orbital_elements_source identity resolves
             if let Some(ref uid) = body.orbital_elements_source {
                 if !uid_to_idx.contains_key(uid) {
@@ -227,6 +237,7 @@ impl Simulation {
                         || body.euler_sequence.is_some()
                         || body.compute_lvlh
                         || body.geodetic_planet.is_some()
+                        || body.ned_planet.is_some()
                         || body.compute_solar_beta
                         || body.earth_lighting_config.is_some();
                     if has_root_dependent_feature {

--- a/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/mod.rs
@@ -1058,6 +1058,7 @@ impl ExtrasAccumulator {
                 ("altitude", 0.0, "m"),
                 ("latitude", 0.0, "rad"),
                 ("longitude", 0.0, "rad"),
+                ("ned_origin", 0.0, "m"),
             ],
             ExtrasComparator::Euler | ExtrasComparator::DyncompEuler => vec![
                 ("euler_roll", 0.0, "rad"),
@@ -1144,6 +1145,17 @@ impl ExtrasAccumulator {
                 self.update_max("altitude", (geo.altitude - ref_alt).abs());
                 self.update_max("latitude", (geo.latitude - ref_lat).abs());
                 self.update_max("longitude", angle_diff(geo.longitude, ref_lon));
+
+                // NED frame origin (`ned_state.cart_coords`) = the body's
+                // pfix position. Worst-component error vs the JEOD log.
+                let ned = body
+                    .ned_frame
+                    .as_ref()
+                    .unwrap_or_else(|| panic!("{case_name}: ned_frame not computed at idx {idx}"));
+                self.update_max(
+                    "ned_origin",
+                    (ned.position - r.cart_coords).abs().max_element(),
+                );
             }
             (ExtrasComparator::Euler, CsvRecords::Euler(recs)) => {
                 let r = &recs[idx];

--- a/crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs
+++ b/crates/astrodyn_verif_jeod/src/run_verification/sim_derived_state.rs
@@ -258,6 +258,14 @@ fn build_ned(init: &InitialConditions, spherical: bool) -> SimulationBuilder {
                 r_eq,
                 r_pol,
             }),
+            // Runtime NED frame: cross-validates the frame origin
+            // (`cart_coords`) against the JEOD SIM_NED log; orientation is
+            // unit-tested in `astrodyn_math::ned` (JEOD never logs it).
+            ned: Some(astrodyn::NedConfig {
+                source: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
+                r_eq,
+                r_pol,
+            }),
             ..Default::default()
         },
         ..VehicleConfig::named("sim-derived-state-2")
@@ -288,6 +296,7 @@ pub fn ned_ell_inc() -> VerificationCase {
                 ("altitude", 8.938e-4),
                 ("latitude", 4.182e-8),
                 ("longitude", 6.493e-8),
+                ("ned_origin", 3.640e-1),
             ],
         },
         extras: Some(ExtrasComparator::Ned { spherical: false }),
@@ -316,6 +325,7 @@ pub fn ned_ell_polar() -> VerificationCase {
                 ("altitude", 2.123e-4),
                 ("latitude", 1.089e-8),
                 ("longitude", 3.349e-5),
+                ("ned_origin", 3.701e-1),
             ],
         },
         extras: Some(ExtrasComparator::Ned { spherical: false }),
@@ -339,6 +349,7 @@ pub fn ned_sph_inc() -> VerificationCase {
                 ("altitude", 4.02e-7),
                 ("latitude", 4.181e-8),
                 ("longitude", 6.493e-8),
+                ("ned_origin", 3.640e-1),
             ],
         },
         extras: Some(ExtrasComparator::Ned { spherical: true }),
@@ -362,6 +373,7 @@ pub fn ned_sph_polar() -> VerificationCase {
                 ("altitude", 3.984e-7),
                 ("latitude", 1.083e-8),
                 ("longitude", 3.349e-5),
+                ("ned_origin", 3.701e-1),
             ],
         },
         extras: Some(ExtrasComparator::Ned { spherical: true }),

--- a/crates/astrodyn_verif_jeod_fixtures/src/tier3_csv.rs
+++ b/crates/astrodyn_verif_jeod_fixtures/src/tier3_csv.rs
@@ -177,6 +177,9 @@ pub fn load_lvlh_csv(path: &Path) -> Vec<LvlhRecord> {
 pub struct NedRecord {
     /// Sample time in seconds.
     pub time: f64,
+    /// NED frame origin (the body's sub-point) in planet-fixed coordinates,
+    /// metres — JEOD `ned_state.cart_coords`.
+    pub cart_coords: DVec3,
     /// Geodetic altitude in metres.
     pub ellip_altitude: f64,
     /// Geodetic latitude in radians.
@@ -213,6 +216,7 @@ pub fn load_ned_csv(path: &Path) -> Vec<NedRecord> {
         let p = |idx: usize| -> f64 { f[idx].trim().parse().unwrap() };
         records.push(NedRecord {
             time: p(0),
+            cart_coords: DVec3::new(p(1), p(2), p(3)),
             ellip_altitude: p(4),
             ellip_latitude: p(6),
             ellip_longitude: p(8),

--- a/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
+++ b/crates/astrodyn_verif_parity/tests/bevy_parity_derived_state.rs
@@ -4,16 +4,16 @@
 
 mod common;
 
-use astrodyn::{DerivedStateConfig, GeodeticConfig, GravitySourceEntry, VehicleConfig};
+use astrodyn::{DerivedStateConfig, GeodeticConfig, GravitySourceEntry, NedConfig, VehicleConfig};
 use astrodyn::{
     DynamicsConfig, EulerSequence, GravityControl, GravityControls, GravityGradient, GravityModel,
     GravitySource, PlanetShape, SixDofState, TranslationalState,
 };
 use astrodyn_bevy::{
     DynamicsConfigC, EulerAnglesC, EulerAnglesConfigC, GeodeticConfigC, GeodeticStateC,
-    GravityControlsC, GravitySourceC, IntegrationDtR, LvlhFrameC, MassPropertiesC,
-    OrbitalElementsC, OrbitalElementsConfigC, PlanetC, PlanetFixedRotationC, RotationalStateC,
-    SolarBetaC, SourceInertialPositionC, SunMarker, TranslationalStateC,
+    GravityControlsC, GravitySourceC, IntegrationDtR, LvlhFrameC, MassPropertiesC, NedConfigC,
+    NedFrameStateC, OrbitalElementsC, OrbitalElementsConfigC, PlanetC, PlanetFixedRotationC,
+    RotationalStateC, SolarBetaC, SourceInertialPositionC, SunMarker, TranslationalStateC,
 };
 use astrodyn_runner::RotationModel;
 use bevy::prelude::*;
@@ -230,6 +230,11 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
                 r_eq: earth_shape.r_eq(),
                 r_pol: earth_shape.r_pol(),
             },
+            NedConfigC {
+                planet: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
+                r_eq: earth_shape.r_eq(),
+                r_pol: earth_shape.r_pol(),
+            },
         ))
         .id();
 
@@ -237,6 +242,7 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
 
     let bevy_trans = read_trans(app.world(), vehicle);
     let bevy_geodetic = app.world().get::<GeodeticStateC>(vehicle).unwrap().0;
+    let bevy_ned = app.world().get::<NedFrameStateC>(vehicle).unwrap().0;
 
     // ── Simulation ──
     let time = astrodyn::SimulationTime::at_j2000(astrodyn::default_leap_second_table());
@@ -267,6 +273,11 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
         },
         derived: DerivedStateConfig {
             geodetic: Some(GeodeticConfig {
+                source: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
+                r_eq: earth_shape.r_eq(),
+                r_pol: earth_shape.r_pol(),
+            }),
+            ned: Some(NedConfig {
                 source: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
                 r_eq: earth_shape.r_eq(),
                 r_pol: earth_shape.r_pol(),
@@ -306,6 +317,9 @@ fn bevy_parity_derived_state_geodetic_derived_state() {
         sim_geodetic.altitude,
     );
     println!("  Bevy vs Sim geodetic: bit-identical (lat, lon, alt)");
+
+    let sim_ned = sim_body.ned_frame.expect("NED frame computed");
+    assert_ned_eq("Bevy vs Sim NED", &bevy_ned, &sim_ned);
 }
 
 // ── Scenario M: Eccentric orbit with derived states ──
@@ -540,6 +554,11 @@ fn bevy_parity_derived_state_polar_geodetic() {
                 r_eq: earth_shape.r_eq(),
                 r_pol: earth_shape.r_pol(),
             },
+            NedConfigC {
+                planet: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
+                r_eq: earth_shape.r_eq(),
+                r_pol: earth_shape.r_pol(),
+            },
         ))
         .id();
 
@@ -547,6 +566,7 @@ fn bevy_parity_derived_state_polar_geodetic() {
 
     let bevy_trans = read_trans(app.world(), vehicle);
     let bevy_geodetic = app.world().get::<GeodeticStateC>(vehicle).unwrap().0;
+    let bevy_ned = app.world().get::<NedFrameStateC>(vehicle).unwrap().0;
 
     // ── Simulation ──
     let time = astrodyn::SimulationTime::at_j2000(astrodyn::default_leap_second_table());
@@ -577,6 +597,11 @@ fn bevy_parity_derived_state_polar_geodetic() {
         },
         derived: DerivedStateConfig {
             geodetic: Some(GeodeticConfig {
+                source: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
+                r_eq: r_sph,
+                r_pol: r_sph,
+            }),
+            ned: Some(NedConfig {
                 source: astrodyn::FrameUid::of::<astrodyn::PlanetInertial<astrodyn::Earth>>(),
                 r_eq: r_sph,
                 r_pol: r_sph,
@@ -615,6 +640,9 @@ fn bevy_parity_derived_state_polar_geodetic() {
         sim_geodetic.altitude,
     );
     println!("  Bevy vs Sim polar geodetic: bit-identical");
+
+    let sim_ned = sim_body.ned_frame.expect("NED frame computed");
+    assert_ned_eq("Bevy vs Sim (polar) NED", &bevy_ned, &sim_ned);
 }
 
 // ── Scenario O: Equatorial orbit with solar beta ──

--- a/crates/astrodyn_verif_parity/tests/common/mod.rs
+++ b/crates/astrodyn_verif_parity/tests/common/mod.rs
@@ -325,6 +325,35 @@ pub fn assert_lvlh_eq(label: &str, a: &astrodyn::LvlhFrame, b: &astrodyn::LvlhFr
     println!("  {label}: bit-identical (18 LVLH frame components)");
 }
 
+/// Assert two NED frame poses are bit-identical (origin + orientation +
+/// the structurally-zero rate). Mirrors [`assert_lvlh_eq`] minus the
+/// origin velocity, which the NED frame does not carry.
+pub fn assert_ned_eq(label: &str, a: &astrodyn::NedFrame, b: &astrodyn::NedFrame) {
+    for i in 0..3 {
+        for j in 0..3 {
+            assert_bits_eq(
+                label,
+                &format!("t_parent_this[{i}][{j}]"),
+                a.t_parent_this.col(j)[i],
+                b.t_parent_this.col(j)[i],
+            );
+        }
+        assert_bits_eq(
+            label,
+            &format!("ang_vel[{i}]"),
+            a.ang_vel_this[i],
+            b.ang_vel_this[i],
+        );
+        assert_bits_eq(
+            label,
+            &format!("position[{i}]"),
+            a.position[i],
+            b.position[i],
+        );
+    }
+    println!("  {label}: bit-identical (15 NED frame components)");
+}
+
 // ── Lighting assertion helpers ──
 
 pub fn assert_lighting_body_eq(

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -444,7 +444,7 @@ pub fn compute_body_lvlh_frame(position: DVec3, velocity: DVec3) -> LvlhFrame {
     )
 }
 
-pub use astrodyn_math::{compute_body_geodetic, compute_body_solar_beta};
+pub use astrodyn_math::{compute_body_geodetic, compute_body_ned_frame, compute_body_solar_beta};
 
 /// Compute the relative state between two bodies.
 ///
@@ -648,7 +648,9 @@ pub fn compute_body_lvlh_frame_typed<P: astrodyn_quantities::frame::Planet>(
     LvlhFrame::compute(position, velocity)
 }
 
-pub use astrodyn_math::{compute_body_geodetic_typed, compute_body_solar_beta_typed};
+pub use astrodyn_math::{
+    compute_body_geodetic_typed, compute_body_ned_frame_typed, compute_body_solar_beta_typed,
+};
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,10 @@ pub use body_action::{BodyAction, LvlhAngularVelocityFrame, OrbitalElementSet};
 pub use derived::{
     compute_body_euler_angles, compute_body_euler_angles_typed, compute_body_geodetic,
     compute_body_geodetic_typed, compute_body_lvlh_frame, compute_body_lvlh_frame_typed,
-    compute_body_solar_beta, compute_body_solar_beta_typed, compute_lvlh_relative_state,
-    compute_lvlh_relative_state_typed, compute_orbital_elements, compute_orbital_elements_typed,
-    compute_relative_state, LvlhRelativeState, RelativeState, RelativeTranslation,
+    compute_body_ned_frame, compute_body_ned_frame_typed, compute_body_solar_beta,
+    compute_body_solar_beta_typed, compute_lvlh_relative_state, compute_lvlh_relative_state_typed,
+    compute_orbital_elements, compute_orbital_elements_typed, compute_relative_state,
+    LvlhRelativeState, RelativeState, RelativeTranslation,
 };
 pub use forces::{collect_and_resolve_forces, collect_and_resolve_forces_typed};
 pub use frame_orchestration::{
@@ -193,8 +194,8 @@ pub use vehicle_builder::{
     BuildState, HasIntegrator, NeedsMass, NeedsState, Ready, VehicleBuilder,
 };
 pub use vehicle_config::{
-    DerivedStateConfig, EarthLightingConfig, FrameSwitchConfig, GeodeticConfig, ShadowBody,
-    SrpModel, SwitchSense, VehicleConfig,
+    DerivedStateConfig, EarthLightingConfig, FrameSwitchConfig, GeodeticConfig, NedConfig,
+    ShadowBody, SrpModel, SwitchSense, VehicleConfig,
 };
 pub use wrench::{aggregate_wrenches_via_storage, edge_geometry_from_composites, EdgeGeometry};
 
@@ -289,10 +290,13 @@ pub use astrodyn_interactions::{
 // constructs or reads frame nodes; `frame_compute_relative_state_via_storage`
 // drives cross-frame state queries. `FrameTree` (concrete arena) is the
 // reference arena-storage implementation — used by `astrodyn_runner`'s
-// `Simulation` state container.
+// `Simulation` state container. The typed siblings (`RefFrameStateTyped` et al.)
+// plus `topocentric_enu_state` expose the origin-anchored typed pose — the
+// site-relative `Position` transform a rotation-only `FrameTransform` can't do.
 pub use astrodyn_frames::{
-    compute_relative_state as frame_compute_relative_state_via_storage, FrameId, FrameStorage,
-    FrameTree, FrameTreeError, RefFrameRot, RefFrameState, RefFrameTrans,
+    compute_relative_state as frame_compute_relative_state_via_storage, topocentric_enu_state,
+    FrameId, FrameStorage, FrameTree, FrameTreeError, RefFrameRot, RefFrameRotTyped, RefFrameState,
+    RefFrameStateTyped, RefFrameTrans, RefFrameTransTyped,
 };
 
 // astrodyn_time: simulation-time + leap-second + epoch surface that
@@ -418,7 +422,9 @@ pub fn dimensionless(value: f64) -> Ratio {
 pub use astrodyn_math::JeodQuat;
 
 // astrodyn_math: derived state types
-pub use astrodyn_math::{EulerSequence, GeodeticState, LvlhFrame, OrbitalElements, OrbitalError};
+pub use astrodyn_math::{
+    EulerSequence, GeodeticState, LvlhFrame, NedFrame, OrbitalElements, OrbitalError,
+};
 // Geodetic conversions + site-anchored topocentric (ENU) frame builder, so a
 // consumer can build a site anchor and a local-horizon frame entirely through
 // the facade (e.g. a landing-site camera over DEM terrain). The ENU builder

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -54,6 +54,11 @@ pub enum ValidationError {
         target: FrameUid,
         num_sources: usize,
     },
+    /// `ned` source identity does not resolve to a registered source.
+    NedPlanetUnresolved {
+        target: FrameUid,
+        num_sources: usize,
+    },
     /// `orbital_elements_source` identity does not resolve to a registered source.
     OrbitalElementsSourceUnresolved {
         target: FrameUid,
@@ -241,6 +246,17 @@ impl std::fmt::Display for ValidationError {
                     f,
                     "geodetic source `{target}` does not resolve to a registered gravity \
                      source ({num_sources} sources registered). Reference the geodetic \
+                     planet by its inertial-frame identity."
+                )
+            }
+            Self::NedPlanetUnresolved {
+                target,
+                num_sources,
+            } => {
+                write!(
+                    f,
+                    "NED source `{target}` does not resolve to a registered gravity \
+                     source ({num_sources} sources registered). Reference the NED \
                      planet by its inertial-frame identity."
                 )
             }

--- a/src/vehicle_config.rs
+++ b/src/vehicle_config.rs
@@ -116,10 +116,12 @@ pub struct GeodeticConfig {
 // ── NED frame (runtime) ─────────────────────────────────────────────────
 
 /// Runtime NED-frame computation configuration (the per-step analog of
-/// JEOD's `NedDerivedState`). Needs the same inputs as [`GeodeticConfig`] —
-/// the planet-fixed rotation source plus ellipsoid radii — and additionally
-/// reads the source's planet-rotation rate for the NED frame's pfix-relative
-/// velocity.
+/// JEOD's `NedDerivedState`). Takes the same inputs as [`GeodeticConfig`] —
+/// the planet-fixed rotation source plus ellipsoid radii. The computed
+/// [`NedFrame`](astrodyn_math::NedFrame) carries the frame **origin and
+/// orientation**; the origin velocity is deferred (it would require the
+/// source's planet-rotation rate, which the adapters do not surface — see the
+/// `NedFrame` docs).
 #[derive(Debug, Clone)]
 pub struct NedConfig {
     /// The reference planet's inertial-frame identity (issue #668). The

--- a/src/vehicle_config.rs
+++ b/src/vehicle_config.rs
@@ -113,6 +113,24 @@ pub struct GeodeticConfig {
     pub r_pol: f64,
 }
 
+// ── NED frame (runtime) ─────────────────────────────────────────────────
+
+/// Runtime NED-frame computation configuration (the per-step analog of
+/// JEOD's `NedDerivedState`). Needs the same inputs as [`GeodeticConfig`] —
+/// the planet-fixed rotation source plus ellipsoid radii — and additionally
+/// reads the source's planet-rotation rate for the NED frame's pfix-relative
+/// velocity.
+#[derive(Debug, Clone)]
+pub struct NedConfig {
+    /// The reference planet's inertial-frame identity (issue #668). The
+    /// source must have `t_inertial_pfix` for the planet-fixed rotation.
+    pub source: FrameUid,
+    /// Equatorial radius (m).
+    pub r_eq: f64,
+    /// Polar radius (m).
+    pub r_pol: f64,
+}
+
 // ── Earth lighting ──────────────────────────────────────────────────────
 
 /// Earth lighting computation configuration.
@@ -140,6 +158,8 @@ pub struct DerivedStateConfig {
     pub lvlh: bool,
     /// Geodetic computation config. `None` = skip.
     pub geodetic: Option<GeodeticConfig>,
+    /// Runtime NED-frame computation config. `None` = skip.
+    pub ned: Option<NedConfig>,
     /// Whether to compute solar beta angle. Requires `sun_source` on Simulation.
     pub solar_beta: bool,
     /// Earth lighting config. Requires `sun_source` and `moon_source`.


### PR DESCRIPTION
Resolves #689.

## Background

`topocentric_enu_transform` (#659) returns a rotation-only
`FrameTransform<PlanetFixed<P>, Topocentric<P>>`. #689 flagged that its
function docstring invited mis-applying it to a `Position` (silently
rotating-without-translating, off by the site radius ~6378 km), and that
origin-anchored topocentric frames weren't modelled on the typed surface.

Investigation against JEOD sharpened the picture: the origin-anchored pose was
**already ported, untyped** (`ned_reference_frame_state`, driving
`InitFullNed`/`InitTransNed`, Tier-3-tested). The real gaps were the docstring
footgun and the missing *typed* origin-carrying construct. JEOD's
`NorthEastDown` is a full `RefFrame` used by `DynBodyInitNedState` (init-time,
ported) and `NedDerivedState` (runtime, previously unported).

## What changed

- **A — docstring.** `topocentric_enu_transform`'s function docstring now
  states it is orientation-only and spells out the `Position` trap, pointing at
  the origin-carrying constructs.
- **B1 — de-duplication.** ENU and NED orientations now share one
  `astrodyn_math::local_level_ned_axes` kernel. NED's bit-frozen arithmetic is
  preserved, so the Tier-3 NED-init freeze holds bit-for-bit.
- **B2 — typed pose.** New
  `astrodyn_frames::topocentric_enu_state::<P>(site, r_eq, r_pol) ->
  RefFrameStateTyped<PlanetFixed<P>, Topocentric<P>>` (origin **and**
  orientation), plus a general `Position` pose-apply on `RefFrameStateTyped`
  (`position_parent_to_child`/`_child_to_parent` = `R·(p − s)`,
  `rotate_vector_parent_to_child` for free vectors) — the typed construct that
  carries the origin a rotation-only `FrameTransform` structurally cannot.
- **B3 — runtime NED derived state.** Port of JEOD `NedDerivedState`: the
  `compute_body_ned_frame` kernel, runner stage + Bevy `ned_system`, and
  `NedConfig`/`NedConfigC`. The NED frame **origin** (`cart_coords`) is
  cross-validated against JEOD's SIM_NED log; orientation is unit-tested (JEOD
  never logs it); origin **velocity** is deferred (JEOD never logs it; would
  need planet-rate plumbing into the Bevy adapter to keep runner/Bevy parity)
  and documented on `NedFrame`.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --tests -D warnings`,
  `cargo test --test invariant_coverage` — all clean.
- Full suite green: **1613 unit + Tier 2**, **663 Tier-3 + bevy_parity**
  (incl. the NED Tier-3 origin cross-validation and the Tier-3 NED-init
  bit-stability freeze, which holds unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
