### PR TITLE
Finalize 0.2.0 changelog: set release date and compare link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-06-08
 
 Second release. Headlined by the **frame-identity** work
 ([#659](https://github.com/simnaut/astrodyn/issues/659) / #660–#664 /
@@ -175,6 +175,6 @@ Fourteen workspace crates at this version:
   `run_verification` scenario rigs) and `astrodyn_verif_parity`
   (runner ↔ Bevy bit-identical parity tests).
 
-[0.2.0]: https://github.com/simnaut/astrodyn/compare/v0.1.1...HEAD
+[0.2.0]: https://github.com/simnaut/astrodyn/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/simnaut/astrodyn/releases/tag/v0.1.1
 [0.1.0]: https://github.com/simnaut/astrodyn/releases/tag/v0.1.0


### PR DESCRIPTION
Cuts the **0.2.0** release. The workspace version bump (`0.1.1 → 0.2.0`), docs.rs metadata, LICENSE holder, and the changelog *body* were already prepared in #681 — this is the final step before tagging.

## Changes
- `CHANGELOG.md`: `## [0.2.0] - Unreleased` → `## [0.2.0] - 2026-06-08`
- `CHANGELOG.md`: compare link `v0.1.1...HEAD` → `v0.1.1...v0.2.0`

Changelog-only; no source touched.

## Release readiness (verified on `main` @ `85ba7f4f`)
- ✅ CI green on HEAD (CI + Tooling + docs)
- ✅ Workspace version already at `0.2.0`; all path-dep pins at `0.2.0`
- ✅ All 14 publishable crates have READMEs
- ✅ `xtask` `PUBLISH_ORDER` includes the new `astrodyn_frame_doc` in correct topological slot
- ✅ Scope confirmed: #697 explicitly **not** included in 0.2.0

## After merge
Pushing the `v0.2.0` tag triggers `publish.yml`, which verifies `tag == [workspace.package].version` and publishes the 14 crates in topological order.

⚠️ Out-of-band prerequisites (cannot verify from the tree):
- `CARGO_REGISTRY_TOKEN` needs **publish-new-crates** scope for the first-ever `astrodyn_frame_doc` publish.
- Recommend running `cargo run -p xtask -- publish --dry-run` before tagging to confirm each crate packages cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)