### PR TITLE
[#389] Reclassify drag_ver as a permanent (non-propagating) parity gap

### DIFF
--- a/crates/astrodyn_verif_parity/tests/parity_coverage.rs
+++ b/crates/astrodyn_verif_parity/tests/parity_coverage.rs
@@ -111,11 +111,6 @@ const DEFERRED_GAPS: &[(&str, &str)] = &[
         "pre-recipe sibling exercising attach_to_frame — recipe factory \
          not yet defined; needs `pre_step` Bevy support too (#389 follow-up)",
     ),
-    (
-        "drag_ver",
-        "pre-recipe sibling — drag-family recipe factory not yet defined \
-         (#389 follow-up)",
-    ),
     // `lsode` (tier3_sim_lsode.rs) covered by two parity wrappers, both
     // satisfying this topic implicitly via the prefix-match in
     // `is_covered_by_parity` (so neither is listed in a gap array):
@@ -202,6 +197,13 @@ const PERMANENT_GAPS: &[(&str, &str)] = &[
     (
         "drag_analytical",
         "analytical drag verification — out of trait scope (no propagation)",
+    ),
+    (
+        "drag_ver",
+        "SIM_VER_DRAG is a non-propagating force-model verification — calls \
+         `compute_ballistic_drag` directly at JEOD-logged velocities, no \
+         `Simulation::step()`. Out of `VerificationCaseParityExt` trait scope; \
+         same shape as `drag_analytical`.",
     ),
     (
         "csr_compare",


### PR DESCRIPTION
Refs #389 (no closing keyword — per the maintainer note, follow-up PRs reference this meta-issue without auto-closing it).

Item 1 of the [prep plan](https://github.com/simnaut/astrodyn/issues/389#issuecomment) on #389: the clean `drag_ver` reclassification.

## What

`drag_ver` (`crates/astrodyn_verif_jeod/tests/tier3_sim_drag_ver.rs`, JEOD `SIM_VER_DRAG`) is a **non-propagating** force-model verification. It schedules JEOD's `inertial_vel` analytically (`7500·cos(t·π/180)`, `7500·sin(t·π/180)`), builds an `AtmosphereState`, then calls `compute_ballistic_drag(...)` directly at each CSV row — **zero** `Simulation::step()` / `SimulationBuilder` references.

The `VerificationCaseParityExt::run_and_assert_parity` trait fundamentally drives a stepped `Simulation` on both the runner and Bevy runtimes and asserts bit-identical state. With no propagation, there is nothing for the trait to drive — no recipe factory can change that. So the existing `DEFERRED_GAPS` rationale ("drag-family recipe factory not yet defined", which implies a wrapper is expected to land) was a **misclassification**. The topic is structurally identical to `drag_analytical`, already in `PERMANENT_GAPS`.

## Change

Move the `("drag_ver", …)` entry from `DEFERRED_GAPS` → `PERMANENT_GAPS` with an accurate reason. One-file, data-only edit to `parity_coverage.rs`. After this, the only remaining `DEFERRED_GAPS` entry is the genuinely multi-step `dyncomp_run_attach_to_ref_frame` lifecycle work (Item 2 of the plan, left for a later cycle).

## Verified

- `cargo nextest run -p astrodyn_verif_parity --test parity_coverage` — green (superset invariant holds; no stale/redundant gap flagged).
- `cargo fmt --check` + `cargo clippy --workspace --tests -- -D warnings` — clean.
- `cargo nextest run --workspace -E 'not test(tier3_) and not test(bevy_parity)'` — 1613 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)