### PR TITLE
[#707] Unify glam to 0.32 (eliminate the Bevy-0.19 duplicate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build the workspace on older toolchains. README § "Minimum supported
   Rust version" and the `tooling.yml` MSRV gate updated.
 - **Unified `glam` to 0.32** ([#707](https://github.com/simnaut/astrodyn/issues/707)).
-  Bumped the workspace `glam` 0.30 → 0.32 to match Bevy 0.19's math stack,
-  eliminating the benign duplicate (`glam 0.30.10` for astrodyn physics vs
-  `0.32.1` for Bevy's internal math) the Bevy bump introduced. A one-line
-  dependency change: glam 0.31/0.32 ship no numeric-implementation changes
-  to the operations astrodyn uses (only `DVec3`/`DMat3`/`DQuat`), so the
-  full Tier 3 cross-validation and bit-identity parity suites pass with
-  unchanged tolerances and baselines.
+  Bumped the workspace `glam` 0.30 → 0.32 to match Bevy 0.19's math stack, so
+  astrodyn physics and Bevy's internal math now share a single **compiled**
+  `glam 0.32.1` (`cargo tree -d --workspace` reports no glam duplicate)
+  instead of the 0.30/0.32 split the Bevy bump left. (`Cargo.lock` still
+  lists older glam versions as `nalgebra`'s disabled optional `convert-glam*`
+  deps — never compiled, and present since before this change.) A one-line
+  dependency change: glam 0.31/0.32 ship no numeric-implementation changes to
+  the operations astrodyn uses (only `DVec3`/`DMat3`/`DQuat`), so the full
+  Tier 3 cross-validation and bit-identity parity suites pass with unchanged
+  tolerances and baselines.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own `rust-version = "1.95"`; cargo's MSRV-aware resolution refuses to
   build the workspace on older toolchains. README § "Minimum supported
   Rust version" and the `tooling.yml` MSRV gate updated.
+- **Unified `glam` to 0.32** ([#707](https://github.com/simnaut/astrodyn/issues/707)).
+  Bumped the workspace `glam` 0.30 → 0.32 to match Bevy 0.19's math stack,
+  eliminating the benign duplicate (`glam 0.30.10` for astrodyn physics vs
+  `0.32.1` for Bevy's internal math) the Bevy bump introduced. A one-line
+  dependency change: glam 0.31/0.32 ship no numeric-implementation changes
+  to the operations astrodyn uses (only `DVec3`/`DMat3`/`DQuat`), so the
+  full Tier 3 cross-validation and bit-identity parity suites pass with
+  unchanged tolerances and baselines.
 
 ### Removed
 
 - Dropped the unused `bevy_reflect` dependency and the vestigial
   `#[derive(Reflect)]` on `FrameAttachedC` — the only `Reflect` in the
   workspace, with no `register_type`/registry consumer. bevy_reflect 0.19
-  moved to glam 0.32 (the workspace stays on glam 0.30), so the derive no
-  longer resolved; since nothing introspected the type, the derive and
-  dependency were removed rather than bumping glam across the physics core.
+  moved to glam 0.32 (the workspace was still on glam 0.30 at the time; it
+  was unified to 0.32 in #707), so the derive no longer resolved; since
+  nothing introspected the type, the derive and dependency were removed
+  rather than bumping glam across the physics core in the same PR.
 
 ## [0.2.0] - 2026-06-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "astrodyn_planet",
  "astrodyn_quantities",
  "astrodyn_time",
- "glam 0.30.10",
+ "glam 0.32.1",
  "log",
  "sha2",
  "thiserror 2.0.18",
@@ -215,7 +215,7 @@ version = "0.2.0"
 dependencies = [
  "astrodyn_quantities",
  "astrodyn_verif_jeod_fixtures",
- "glam 0.30.10",
+ "glam 0.32.1",
  "uom",
 ]
 
@@ -227,7 +227,7 @@ dependencies = [
  "astrodyn_runner",
  "astrodyn_verif_jeod",
  "bevy",
- "glam 0.30.10",
+ "glam 0.32.1",
  "uom",
 ]
 
@@ -239,7 +239,7 @@ dependencies = [
  "astrodyn_math",
  "astrodyn_quantities",
  "astrodyn_verif_jeod_fixtures",
- "glam 0.30.10",
+ "glam 0.32.1",
  "proptest",
  "sha2",
  "uom",
@@ -251,7 +251,7 @@ version = "0.2.0"
 dependencies = [
  "anise",
  "astrodyn_quantities",
- "glam 0.30.10",
+ "glam 0.32.1",
  "sha2",
  "thiserror 2.0.18",
  "ureq",
@@ -275,7 +275,7 @@ dependencies = [
  "astrodyn_math",
  "astrodyn_quantities",
  "astrodyn_time",
- "glam 0.30.10",
+ "glam 0.32.1",
  "proptest",
  "thiserror 2.0.18",
  "uom",
@@ -291,7 +291,7 @@ dependencies = [
  "astrodyn_quantities",
  "astrodyn_time",
  "criterion",
- "glam 0.30.10",
+ "glam 0.32.1",
  "log",
  "pprof",
  "proptest",
@@ -313,7 +313,7 @@ dependencies = [
  "astrodyn_quantities",
  "astrodyn_time",
  "astrodyn_verif_jeod_fixtures",
- "glam 0.30.10",
+ "glam 0.32.1",
  "proptest",
  "uom",
 ]
@@ -324,7 +324,7 @@ version = "0.2.0"
 dependencies = [
  "astrodyn_quantities",
  "astrodyn_verif_jeod_fixtures",
- "glam 0.30.10",
+ "glam 0.32.1",
  "proptest",
  "thiserror 2.0.18",
  "uom",
@@ -336,7 +336,7 @@ version = "0.2.0"
 dependencies = [
  "astrodyn_math",
  "astrodyn_quantities",
- "glam 0.30.10",
+ "glam 0.32.1",
  "regex",
  "sha2",
  "uom",
@@ -346,7 +346,7 @@ dependencies = [
 name = "astrodyn_quantities"
 version = "0.2.0"
 dependencies = [
- "glam 0.30.10",
+ "glam 0.32.1",
  "proptest",
  "serde",
  "serde_json",
@@ -360,7 +360,7 @@ name = "astrodyn_runner"
 version = "0.2.0"
 dependencies = [
  "astrodyn",
- "glam 0.30.10",
+ "glam 0.32.1",
  "log",
  "uom",
 ]
@@ -386,7 +386,7 @@ dependencies = [
  "astrodyn_runner",
  "astrodyn_verif_jeod_fixtures",
  "criterion",
- "glam 0.30.10",
+ "glam 0.32.1",
  "log",
  "pprof",
  "regex",
@@ -400,7 +400,7 @@ name = "astrodyn_verif_jeod_fixtures"
 version = "0.2.0"
 dependencies = [
  "astrodyn_quantities",
- "glam 0.30.10",
+ "glam 0.32.1",
  "log",
  "regex",
  "thiserror 2.0.18",
@@ -414,7 +414,7 @@ dependencies = [
  "astrodyn",
  "astrodyn_runner",
  "astrodyn_verif_jeod_fixtures",
- "glam 0.30.10",
+ "glam 0.32.1",
  "sha2",
 ]
 
@@ -428,7 +428,7 @@ dependencies = [
  "astrodyn_verif_jeod",
  "astrodyn_verif_nesc",
  "bevy",
- "glam 0.30.10",
+ "glam 0.32.1",
  "log",
  "uom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rust-version = "1.95"
 notice = "NOTICE.md"
 
 [workspace.dependencies]
-glam = { version = "0.30", features = ["std"] }
+glam = { version = "0.32", features = ["std"] }
 bevy = { version = "0.19", default-features = false, features = [
     "bevy_log",
     "bevy_state",


### PR DESCRIPTION
Closes #707.

Follow-up to the Bevy 0.19 migration (#706), which left a benign duplicate `glam` in the tree — `glam 0.30.10` for astrodyn physics vs `0.32.1` for Bevy's internal `bevy_math`/`bevy_transform`/`bevy_reflect`. This unifies the astrodyn side onto glam 0.32, so `cargo tree -d --workspace` now shows a **single** glam 0.32.1.

## Change

A **one-line dependency bump** (`Cargo.toml` `[workspace.dependencies]`, glam `0.30` → `0.32`) plus the regenerated lock (16 lines, all `glam 0.30.10` → `0.32.1`). **No source edits were required:**

- Only `DVec3`/`DMat3`/`DQuat` are used across the workspace. `DVec2`/`DMat4`/`DAffine3` are unused, so glam 0.31's `DVec2::angle_between` removal is N/A. Euler/quaternion/slerp math is hand-rolled and glam-independent.
- glam 0.31's matrix-receiver change (`self` → `&self`) is absorbed by Rust autoref — the workspace compiles clean with zero fixups.
- glam 0.31/0.32 ship **no numeric-implementation changes** to the operations astrodyn uses; MSRV (1.68.2 < our 1.95), the `std` feature, serde, and bytemuck are all unchanged.

## Numerical re-validation — bit-identity confirmed, baselines unchanged

The load-bearing concern was the bit-identity invariant + frozen JEOD tolerances. Run on a native Linux toolchain (rustc 1.96.1):

- **`cargo nextest run --workspace`: 2278 passed, 4 skipped** — identical to the Bevy 0.19 baseline. Every `bevy_parity_*` test (exact `to_bits()` equality between `astrodyn_runner` and `astrodyn_bevy`) and every `tier3_*` cross-validation passed, including the heavy `earth_moon_clem`, against the **same** frozen tolerance literals.
- **`tier3_baseline_diff`: `OK (99 matched; 0 allowed-missing; 0 new)`** — every per-component max error matches the frozen `baselines.json` to within 1e-12.
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo tree -d --workspace`: no glam duplicate.

No `baselines.json` or tolerance-literal changes — glam 0.32 is numerically bit-identical to 0.30 for our operations, exactly as the changelog predicted.

## Non-goals

Did **not** re-add the vestigial `#[derive(Reflect)]` / `bevy_reflect` dep removed in #706 — there's still no reflection consumer (per #707's DoD). No other dependency bumps, no tolerance tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
