### PR TITLE
fix(deps): clear current cargo-deny failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -29,15 +29,6 @@ feature-depth = 1
 version = 2
 yanked = "deny"
 ignore = [
-    # `paste 1.0.15` — RUSTSEC-2024-0436. The maintainer declared the crate
-    # complete and stopped accepting changes; this is an administrative
-    # status, not a vulnerability. `paste` reaches us transitively via the
-    # `anise` ephemeris dep (`anise` → `nalgebra` → `simba` → `paste`); the
-    # Bevy macro chain dropped its own `paste` dependency as of Bevy 0.19,
-    # so this now hangs off the ephemeris stack alone. We can drop this
-    # entry once that chain no longer pulls `paste`
-    # (`cargo tree -i paste --workspace` returns nothing).
-    "RUSTSEC-2024-0436",
     # `proc-macro-error2 2.0.1` — RUSTSEC-2026-0173. The author declared the
     # crate unmaintained (and the original `proc-macro-error` it forked);
     # an administrative status, not a vulnerability. It reaches us
@@ -66,6 +57,14 @@ ignore = [
     # returns nothing below 0.41).
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # `spin 0.10.0` — yanked upstream after Bevy 0.19 shipped with
+    # `bevy_platform` requiring the `0.10` release line. There is no
+    # non-yanked, semver-compatible replacement; Bevy's move to spin 0.12.2 is
+    # still open upstream and currently fails Bevy's no-std checks:
+    # https://github.com/bevyengine/bevy/pull/25324. This exact PackageSpec
+    # keeps every other yanked crate denied. Remove it as soon as a compatible
+    # Bevy patch release moves off spin 0.10.0.
+    "spin@0.10.0",
 ]
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Updates crossbeam-epoch from 0.9.18 to 0.9.20, clearing RUSTSEC-2026-0204 from the benchmark/dev-dependency graph.
- Removes the obsolete RUSTSEC-2024-0436 paste waiver now that paste is no longer in the dependency graph.
- Adds an exact spin@0.10.0 yanked-package exception while Bevy 0.19 requires the 0.10 release line. All other yanked packages remain denied.

## Rationale

The current Tooling workflow is blocked by both the crossbeam advisory and the yanked spin release.

crossbeam-epoch has a compatible patched release, so the lockfile is updated directly. spin is also present in Bevy 0.19 runtime dependencies, and there is no non-yanked semver-compatible 0.10 release. Bevy upstream PR [#25324](https://github.com/bevyengine/bevy/pull/25324) moves to spin 0.12.2, but remains open and currently fails Bevy no-std checks. The exact PackageSpec exception avoids an unsupported Bevy fork while keeping the rest of the yanked-crate gate strict.

Failed workflow: https://github.com/simnaut/astrodyn/actions/runs/30893962895

## Verification

- cargo-deny 0.20.2 --all-features check
- cargo check --workspace --all-targets
- cargo test --workspace --lib
- git diff --check